### PR TITLE
 Add support for tag variables within manifest

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/ImageBuilder.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/ImageBuilder.cs
@@ -82,7 +82,7 @@ namespace Microsoft.DotNet.ImageBuilder
 
                 ExecuteHelper.Execute(
                     "docker",
-                    $"build -t {string.Join(" -t ", image.Tags)} {image.Platform.Model.Dockerfile}",
+                    $"build -t {string.Join(" -t ", image.AllTags)} {image.Platform.Model.Dockerfile}",
                     Options.IsDryRun);
             }
         }
@@ -121,7 +121,7 @@ namespace Microsoft.DotNet.ImageBuilder
             {
                 foreach (ImageInfo image in repo.Images)
                 {
-                    foreach (string tag in image.Model.SharedTags)
+                    foreach (string tag in image.SharedTags)
                     {
                         StringBuilder manifestYml = new StringBuilder();
                         manifestYml.AppendLine($"image: {repo.Model.Name}:{tag}");

--- a/src/Microsoft.DotNet.ImageBuilder/Model/Manifest.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/Model/Manifest.cs
@@ -12,6 +12,8 @@ namespace Microsoft.DotNet.ImageBuilder.Model
         [JsonProperty(Required = Required.Always)]
         public Repo[] Repos { get; set; }
 
+        public IDictionary<string, string> TagVariables { get; set; }
+
         public IDictionary<string, string[]> TestCommands { get; set; }
 
         public Manifest()

--- a/src/Microsoft.DotNet.ImageBuilder/ViewModel/ManifestInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/ViewModel/ManifestInfo.cs
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             string json = File.ReadAllText(repoJsonPath);
             manifestInfo.Model = JsonConvert.DeserializeObject<Manifest>(json);
             manifestInfo.Repos = manifestInfo.Model.Repos
-                .Select(image => RepoInfo.Create(image, manifestInfo.DockerOS))
+                .Select(image => RepoInfo.Create(image, manifestInfo.Model, manifestInfo.DockerOS))
                 .ToArray();
             manifestInfo.Images = manifestInfo.Repos
                 .SelectMany(repo => repo.Images)

--- a/src/Microsoft.DotNet.ImageBuilder/ViewModel/ModelExtensions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/ViewModel/ModelExtensions.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.ImageBuilder.Model;
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.ImageBuilder.ViewModel
+{
+    public static class ModelExtensions
+    {
+        public static string SubstituteTagVariables(this Manifest manifest, string tag)
+        {
+            if (manifest.TagVariables != null)
+            {
+                foreach (KeyValuePair<string, string> kvp in manifest.TagVariables)
+                {
+                    tag = tag.Replace($"$({kvp.Key})", kvp.Value);
+                }
+            }
+
+            return tag;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/ViewModel/PlatformInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/ViewModel/PlatformInfo.cs
@@ -24,14 +24,14 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         {
         }
 
-        public static PlatformInfo Create(Platform model, string repoName)
+        public static PlatformInfo Create(Platform model, Manifest manifest, string repoName)
         {
             PlatformInfo platformInfo = new PlatformInfo();
             platformInfo.Model = model;
             platformInfo.InitializeFromImage();
             platformInfo.IsExternalFromImage = !platformInfo.FromImage.StartsWith($"{repoName}:");
             platformInfo.Tags = model.Tags
-                .Select(tag => $"{repoName}:{tag}")
+                .Select(tag => $"{repoName}:{manifest.SubstituteTagVariables(tag)}")
                 .ToArray();
 
             return platformInfo;

--- a/src/Microsoft.DotNet.ImageBuilder/ViewModel/RepoInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/ViewModel/RepoInfo.cs
@@ -19,12 +19,12 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         {
         }
 
-        public static RepoInfo Create(Repo model, string dockerOS)
+        public static RepoInfo Create(Repo model, Manifest manifest, string dockerOS)
         {
             RepoInfo repoInfo = new RepoInfo();
             repoInfo.Model = model;
             repoInfo.Images = model.Images
-                .Select(image => ImageInfo.Create(image, model.Name, dockerOS))
+                .Select(image => ImageInfo.Create(image, manifest, model.Name, dockerOS))
                 .ToArray();
 
             return repoInfo;


### PR DESCRIPTION
Added support for tagVariables within the manifest that can be referenced within the various tags.

```
"tagVariables": {
  "nanoServerVersion": "10.0.14393.1198"
}
...
"windows": {
  "dockerfile": "1.0/runtime/nanoserver",
  "tags": [
    "1.0.5-runtime-nanoserver",
    "1.0.5-runtime-nanoserver-$(nanoServerVersion)",
    "1.0-runtime-nanoserver",
    "1.0-runtime-nanoserver-$(nanoServerVersion)"
  ]
}
```
fixes #5