### PR TITLE
Make manifest-tool version explicit

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/Dockerfile
+++ b/src/Microsoft.DotNet.ImageBuilder/Dockerfile
@@ -19,7 +19,8 @@ RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
     && rm -rf /var/lib/apt/lists/*
 
 # Install manifest-tool
-RUN curl -fsSL "https://github.com/estesp/manifest-tool/releases/download/v0.5.0/manifest-tool-linux-amd64" -o /usr/local/bin/manifest-tool \
+RUN curl -fsSL "https://github.com/estesp/manifest-tool/releases/download/v0.5.0/manifest-tool-linux-amd64" \
+        -o /usr/local/bin/manifest-tool \
     && chmod +x /usr/local/bin/manifest-tool
 
 # Build Microsoft.DotNet.ImageBuilder

--- a/src/Microsoft.DotNet.ImageBuilder/Dockerfile
+++ b/src/Microsoft.DotNet.ImageBuilder/Dockerfile
@@ -18,38 +18,9 @@ RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
         docker-ce \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Go
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        g++ \
-        gcc \
-        libc6-dev \
-        make \
-        pkg-config \
-    && rm -rf /var/lib/apt/lists/*
-
-ENV GOLANG_VERSION 1.8.1
-ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 a579ab19d5237e263254f1eac5352efcf1d70b9dacadb6d6bb12b0911ede8994
-
-RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
-    && echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \
-    && tar -C /usr/local -xzf golang.tar.gz \
-    && rm golang.tar.gz
-
-ENV GOPATH /go
-ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
-
-RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
-WORKDIR $GOPATH
-
 # Install manifest-tool
-RUN cd $GOPATH/src \
-    && mkdir -p github.com/estesp \
-    && cd github.com/estesp \
-    && git clone https://github.com/estesp/manifest-tool \
-    && cd manifest-tool \
-    && make binary \
-    && make install
+RUN curl -fsSL "https://github.com/estesp/manifest-tool/releases/download/v0.5.0/manifest-tool-linux-amd64" -o /usr/local/bin/manifest-tool \
+    && chmod +x /usr/local/bin/manifest-tool
 
 # Build Microsoft.DotNet.ImageBuilder
 WORKDIR Microsoft.DotNet.ImageBuilder


### PR DESCRIPTION
Modified the Dockerfile to utilize the manifest-tool's released artifacts.  This greatly simplifies the Dockerfile as well as ties the it to a set version of the manifest-tool.

Fixes #13 