### PR TITLE
Add support for building ARM images

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/DockerHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/DockerHelper.cs
@@ -24,7 +24,7 @@ namespace Microsoft.DotNet.ImageBuilder
                     architecture = Architecture.ARM;
                     break;
                 default:
-                    throw new NotSupportedException("Unknown Docker Architecture");
+                    throw new PlatformNotSupportedException("Unknown Docker Architecture");
             }
 
             return architecture;

--- a/src/Microsoft.DotNet.ImageBuilder/DockerHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/DockerHelper.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.ImageBuilder.Model;
+using System;
+using System.Diagnostics;
+
+namespace Microsoft.DotNet.ImageBuilder
+{
+    public static class DockerHelper
+    {
+        public static Architecture GetArchitecture()
+        {
+            Architecture architecture;
+
+            string infoArchitecture = ExecuteCommand("info", ".Architecture", "Failed to detect Docker architecture");
+            switch (infoArchitecture)
+            {
+                case "x86_64":
+                    architecture = Architecture.AMD64;
+                    break;
+                case "arm_32":
+                    architecture = Architecture.ARM;
+                    break;
+                default:
+                    throw new NotSupportedException("Unknown Docker Architecture");
+            }
+
+            return architecture;
+        }
+
+        public static string GetOS()
+        {
+            return ExecuteCommand("version", ".Server.Os", "Failed to detect Docker OS");
+        }
+
+        private static string ExecuteCommand(string command, string outputFormat, string errorMessage)
+        {
+            ProcessStartInfo startInfo = new ProcessStartInfo("docker", $"{command} -f \"{{{{ {outputFormat} }}}}\"");
+            startInfo.RedirectStandardOutput = true;
+            Process process = ExecuteHelper.Execute(startInfo, false, errorMessage);
+            return process.StandardOutput.ReadToEnd().Trim();
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/ImageBuilder.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/ImageBuilder.cs
@@ -71,13 +71,13 @@ namespace Microsoft.DotNet.ImageBuilder
         private static void BuildImages()
         {
             WriteHeading("BUILDING IMAGES");
-            foreach (ImageInfo image in Manifest.Images.Where(image => image.Platform != null))
+            foreach (ImageInfo image in Manifest.Images.Where(image => image.ActivePlatform != null))
             {
-                Console.WriteLine($"-- BUILDING: {image.Platform.Model.Dockerfile}");
+                Console.WriteLine($"-- BUILDING: {image.ActivePlatform.Model.Dockerfile}");
                 if (!Options.IsSkipPullingEnabled)
                 {
                     // Ensure latest base images exist locally before building
-                    foreach (string fromImage in image.Platform.FromImages.Where(Manifest.IsExternalImage))
+                    foreach (string fromImage in image.ActivePlatform.FromImages.Where(Manifest.IsExternalImage))
                     {
                         ExecuteHelper.ExecuteWithRetry("docker", $"pull {fromImage}", Options.IsDryRun);
                     }
@@ -85,7 +85,7 @@ namespace Microsoft.DotNet.ImageBuilder
 
                 ExecuteHelper.Execute(
                     "docker",
-                    $"build -t {string.Join(" -t ", image.AllTags)} {image.Platform.Model.Dockerfile}",
+                    $"build -t {string.Join(" -t ", image.ActiveTags)} {image.ActivePlatform.Model.Dockerfile}",
                     Options.IsDryRun);
             }
         }
@@ -132,14 +132,18 @@ namespace Microsoft.DotNet.ImageBuilder
                         manifestYml.AppendLine($"image: {tag}");
                         manifestYml.AppendLine("manifests:");
 
-                        foreach (KeyValuePair<string, Platform> kvp in image.Model.Platforms)
+                        foreach (Platform platform in image.Model.Platforms)
                         {
-                            string platformTag = Manifest.Model.SubstituteTagVariables(kvp.Value.Tags.First());
+                            string platformTag = Manifest.Model.SubstituteTagVariables(platform.Tags.First());
                             manifestYml.AppendLine($"  -");
                             manifestYml.AppendLine($"    image: {repo.Model.Name}:{platformTag}");
                             manifestYml.AppendLine($"    platform:");
-                            manifestYml.AppendLine($"      architecture: amd64");
-                            manifestYml.AppendLine($"      os: {kvp.Key}");
+                            manifestYml.AppendLine($"      architecture: {platform.Architecture}");
+                            manifestYml.AppendLine($"      os: {platform.OS}");
+                            if (platform.Variant != null)
+                            {
+                                manifestYml.AppendLine($"      variant: {platform.Variant}");
+                            }
                         }
 
                         Console.WriteLine($"-- PUBLISHING MANIFEST:{Environment.NewLine}{manifestYml}");
@@ -172,7 +176,7 @@ namespace Microsoft.DotNet.ImageBuilder
                         executeMessageOverride: $"{loginArgsWithoutPassword} ********");
                 }
 
-                foreach (string tag in Manifest.PlatformTags)
+                foreach (string tag in Manifest.ActivePlatformTags)
                 {
                     ExecuteHelper.ExecuteWithRetry("docker", $"push {tag}", Options.IsDryRun);
                 }
@@ -213,14 +217,14 @@ namespace Microsoft.DotNet.ImageBuilder
         private static void ReadManifest()
         {
             WriteHeading("READING MANIFEST");
-            Manifest = ManifestInfo.Create(Options.Manifest, Options.Repo, Options.Path);
+            Manifest = ManifestInfo.Create(Options);
             Console.WriteLine(JsonConvert.SerializeObject(Manifest, Formatting.Indented));
         }
 
         private static void WriteBuildSummary()
         {
             WriteHeading("IMAGES BUILT");
-            foreach (string tag in Manifest.PlatformTags)
+            foreach (string tag in Manifest.ActivePlatformTags)
             {
                 Console.WriteLine(tag);
             }

--- a/src/Microsoft.DotNet.ImageBuilder/ImageBuilder.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/ImageBuilder.cs
@@ -217,7 +217,7 @@ namespace Microsoft.DotNet.ImageBuilder
         private static void ReadManifest()
         {
             WriteHeading("READING MANIFEST");
-            Manifest = ManifestInfo.Create(Options);
+            Manifest = ManifestInfo.Create(Options.Manifest, Options.Architecture, Options.Repo, Options.Path);
             Console.WriteLine(JsonConvert.SerializeObject(Manifest, Formatting.Indented));
         }
 

--- a/src/Microsoft.DotNet.ImageBuilder/Model/Architecture.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/Model/Architecture.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.ImageBuilder.Model
+{
+    // Enum values must align with the $GOARCH values specified at https://golang.org/doc/install/source#environment
+    public enum Architecture
+    {
+        ARM,
+        AMD64,
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/Model/Image.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/Model/Image.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.ImageBuilder.Model
         public string[] SharedTags { get; set; }
 
         [JsonProperty(Required = Required.Always)]
-        public IDictionary<string, Platform> Platforms { get; set; }
+        public Platform[] Platforms { get; set; }
 
         public Image()
         {

--- a/src/Microsoft.DotNet.ImageBuilder/Model/Platform.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/Model/Platform.cs
@@ -3,16 +3,28 @@
 // See the LICENSE file in the project root for more information.
 
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System.ComponentModel;
 
 namespace Microsoft.DotNet.ImageBuilder.Model
 {
     public class Platform
     {
+        [DefaultValue(Architecture.AMD64)]
+        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        public Architecture Architecture { get; set; }
+
         [JsonProperty(Required = Required.Always)]
         public string Dockerfile { get; set; }
 
         [JsonProperty(Required = Required.Always)]
+        public string OS { get; set; }
+
+        [JsonProperty(Required = Required.Always)]
         public string[] Tags { get; set; }
+
+        public string Variant { get; set; }
 
         public Platform()
         {

--- a/src/Microsoft.DotNet.ImageBuilder/Options.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/Options.cs
@@ -62,7 +62,6 @@ Options:
                 {
                     string architecture = GetArgValue(args, ref i, "architecture");
                     options.Architecture = (Architecture)Enum.Parse(typeof(Architecture), architecture, true);
-
                 }
                 else if (string.Equals(arg, "--command", StringComparison.Ordinal))
                 {

--- a/src/Microsoft.DotNet.ImageBuilder/Options.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/Options.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.DotNet.ImageBuilder.Model;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -17,6 +18,7 @@ Summary:  Builds all Dockerfiles detected in the current folder and sub-folders 
 Usage:  image-builder [options]
 
 Options:
+      --architecture                    The architecture of the Docker images to build (default is the current OS architecture)
       --command                         Build command to execute (Build/PublishManifest/UpdateReadme)
       --dry-run                         Dry run of what images get built and order they would get built in
   -h, --help                            Show help information
@@ -31,6 +33,7 @@ Options:
       --username                        Username for the Docker registry the images are pushed to
 ";
 
+        public Architecture Architecture { get; private set; } = DockerHelper.GetArchitecture();
         public CommandType Command { get; private set; }
         public bool IsDryRun { get; private set; }
         public bool IsHelpRequest { get; private set; }
@@ -55,7 +58,13 @@ Options:
             for (int i = 0; i < args.Length; i++)
             {
                 string arg = args[i];
-                if (string.Equals(arg, "--command", StringComparison.Ordinal))
+                if (string.Equals(arg, "--architecture", StringComparison.Ordinal))
+                {
+                    string architecture = GetArgValue(args, ref i, "architecture");
+                    options.Architecture = (Architecture)Enum.Parse(typeof(Architecture), architecture, true);
+
+                }
+                else if (string.Equals(arg, "--command", StringComparison.Ordinal))
                 {
                     string commandType = GetArgValue(args, ref i, "command");
                     options.Command = (CommandType)Enum.Parse(typeof(CommandType), commandType, true);

--- a/src/Microsoft.DotNet.ImageBuilder/ViewModel/ImageInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/ViewModel/ImageInfo.cs
@@ -20,7 +20,12 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         }
 
         public static ImageInfo Create(
-            Image model, Manifest manifest, string repoName, Options options, string dockerOS)
+            Image model,
+            Manifest manifest,
+            string repoName,
+            Architecture dockerArchitecture,
+            string dockerOS,
+            string includePath)
         {
             ImageInfo imageInfo = new ImageInfo();
             imageInfo.Model = model;
@@ -37,8 +42,8 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             }
 
             imageInfo.ActivePlatform = model.Platforms
-                .Where(platform => platform.OS == dockerOS && platform.Architecture == options.Architecture)
-                .Where(platform => string.IsNullOrWhiteSpace(options.Path) || platform.Dockerfile.StartsWith(options.Path))
+                .Where(platform => platform.OS == dockerOS && platform.Architecture == dockerArchitecture)
+                .Where(platform => string.IsNullOrWhiteSpace(includePath) || platform.Dockerfile.StartsWith(includePath))
                 .Select(platform => PlatformInfo.Create(platform, manifest, repoName))
                 .SingleOrDefault();
 

--- a/src/Microsoft.DotNet.ImageBuilder/ViewModel/ManifestInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/ViewModel/ManifestInfo.cs
@@ -32,15 +32,17 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         {
         }
 
-        public static ManifestInfo Create(Options options)
+        public static ManifestInfo Create(
+            string repoJsonPath, Architecture dockerArchitecture, string includeRepo, string includePath)
         {
             ManifestInfo manifestInfo = new ManifestInfo();
             manifestInfo.DockerOS = DockerHelper.GetOS();
-            string json = File.ReadAllText(options.Manifest);
+            string json = File.ReadAllText(repoJsonPath);
             manifestInfo.Model = JsonConvert.DeserializeObject<Manifest>(json);
             manifestInfo.Repos = manifestInfo.Model.Repos
-                .Where(repo => string.IsNullOrWhiteSpace(options.Repo) || repo.Name == options.Repo)
-                .Select(repo => RepoInfo.Create(repo, manifestInfo.Model, options, manifestInfo.DockerOS))
+                .Where(repo => string.IsNullOrWhiteSpace(includeRepo) || repo.Name == includeRepo)
+                .Select(repo => RepoInfo.Create(
+                    repo, manifestInfo.Model, dockerArchitecture, manifestInfo.DockerOS, includePath))
                 .ToArray();
             manifestInfo.Images = manifestInfo.Repos
                 .SelectMany(repo => repo.Images)

--- a/src/Microsoft.DotNet.ImageBuilder/ViewModel/RepoInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/ViewModel/RepoInfo.cs
@@ -19,12 +19,12 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         {
         }
 
-        public static RepoInfo Create(Repo model, Manifest manifest, string dockerOS, string includePath)
+        public static RepoInfo Create(Repo model, Manifest manifest, Options options, string dockerOS)
         {
             RepoInfo repoInfo = new RepoInfo();
             repoInfo.Model = model;
             repoInfo.Images = model.Images
-                .Select(image => ImageInfo.Create(image, manifest, model.Name, dockerOS, includePath))
+                .Select(image => ImageInfo.Create(image, manifest, model.Name, options, dockerOS))
                 .ToArray();
 
             return repoInfo;

--- a/src/Microsoft.DotNet.ImageBuilder/ViewModel/RepoInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/ViewModel/RepoInfo.cs
@@ -19,12 +19,14 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         {
         }
 
-        public static RepoInfo Create(Repo model, Manifest manifest, Options options, string dockerOS)
+        public static RepoInfo Create(
+            Repo model, Manifest manifest, Architecture dockerArchitecture, string dockerOS, string includePath)
         {
             RepoInfo repoInfo = new RepoInfo();
             repoInfo.Model = model;
             repoInfo.Images = model.Images
-                .Select(image => ImageInfo.Create(image, manifest, model.Name, options, dockerOS))
+                .Select(image => ImageInfo.Create(
+                    image, manifest, model.Name, dockerArchitecture, dockerOS, includePath))
                 .ToArray();
 
             return repoInfo;


### PR DESCRIPTION
This required a schema change to the manifest.  The following is an example of the new schema used in the dotnet-docker-nightly repo.

```
{
  "sharedTags": [
    "2.0.0-preview3-runtime",
    "2.0-runtime",
    "2-runtime"
  ],
  "platforms": [
    {
      "dockerfile": "2.0/runtime/stretch",
      "os": "linux",
      "tags": [
        "2.0.0-preview3-runtime-stretch"
      ]
    },
    {
      "architecture": "arm",
      "dockerfile": "2.0/runtime/stretch/arm32v7",
      "os": "linux",
      "tags": [
        "2.0.0-preview3-runtime-stretch-arm32v7",
        "2.0-runtime-stretch-arm32v7",
        "2-runtime-stretch-arm32v7"
      ],
      "variant": "armv7"
    },
    {
      "dockerfile": "2.0/runtime/nanoserver",
      "os": "windows",
      "tags": [
        "2.0.0-preview3-runtime-nanoserver",
        "2.0.0-preview3-runtime-nanoserver-$(nanoServerVersion)",
        "2.0-runtime-nanoserver",
        "2.0-runtime-nanoserver-$(nanoServerVersion)",
        "2-runtime-nanoserver",
        "2-runtime-nanoserver-$(nanoServerVersion)"
      ]
    }
  ]
}
```

Related #19 