### PR TITLE
Add support for changing the repo owner via options

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/DockerHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/DockerHelper.cs
@@ -42,5 +42,10 @@ namespace Microsoft.DotNet.ImageBuilder
             Process process = ExecuteHelper.Execute(startInfo, false, errorMessage);
             return process.StandardOutput.ReadToEnd().Trim();
         }
+
+        public static string ReplaceImageOwner(string image, string newOwner)
+        {
+            return newOwner + image.Substring(image.IndexOf('/'));
+        }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/ImageBuilder.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/ImageBuilder.cs
@@ -229,7 +229,9 @@ namespace Microsoft.DotNet.ImageBuilder
             {
                 string dockerfileContents = File.ReadAllText(dockerfilePath);
 
-                foreach (string fromImage in image.ActivePlatform.FromImages.SkipWhile(Manifest.IsExternalImage))
+                IEnumerable<string> fromImages = image.ActivePlatform.FromImages
+                    .Where(fromImage => !Manifest.IsExternalImage(fromImage));
+                foreach (string fromImage in fromImages)
                 {
                     Regex fromRegex = new Regex($@"FROM\s+{Regex.Escape(fromImage)}[^\S\r\n]*");
                     string newFromImage = DockerHelper.ReplaceImageOwner(fromImage, Options.RepoOwner);

--- a/src/Microsoft.DotNet.ImageBuilder/Options.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/Options.cs
@@ -18,16 +18,16 @@ Summary:  Builds all Dockerfiles detected in the current folder and sub-folders 
 Usage:  image-builder [options]
 
 Options:
-      --repo-owner                      An alternative repo owner which overrides what is specified in the manifest
       --architecture                    The architecture of the Docker images to build (default is the current OS architecture)
       --command                         Build command to execute (Build/PublishManifest/UpdateReadme)
       --dry-run                         Dry run of what images get built and order they would get built in
   -h, --help                            Show help information
       --manifest                        Path to json file which describes the repo
-      --repo                            Repo to build (Default is to build all)
       --password                        Password for the Docker registry the images are pushed to
       --path                            Path of the directory to build (Default is to build all)
       --push                            Push built images to Docker registry
+      --repo                            Repo to build (Default is to build all)
+      --repo-owner                      An alternative repo owner which overrides what is specified in the manifest
       --skip-pulling                    Skip explicitly pulling the base images of the Dockerfiles
       --skip-test                       Skip running the tests
       --test-var list                   Named variables to substitute into the test commands (name=value)
@@ -60,11 +60,7 @@ Options:
             for (int i = 0; i < args.Length; i++)
             {
                 string arg = args[i];
-                if (string.Equals(arg, "--repo-owner", StringComparison.Ordinal))
-                {
-                    options.RepoOwner = GetArgValue(args, ref i, "repo-owner");
-                }
-                else if (string.Equals(arg, "--architecture", StringComparison.Ordinal))
+                if (string.Equals(arg, "--architecture", StringComparison.Ordinal))
                 {
                     string architecture = GetArgValue(args, ref i, "architecture");
                     options.Architecture = (Architecture)Enum.Parse(typeof(Architecture), architecture, true);
@@ -90,6 +86,10 @@ Options:
                 else if (string.Equals(arg, "--repo", StringComparison.Ordinal))
                 {
                     options.Repo = GetArgValue(args, ref i, "repo");
+                }
+                else if (string.Equals(arg, "--repo-owner", StringComparison.Ordinal))
+                {
+                    options.RepoOwner = GetArgValue(args, ref i, "repo-owner");
                 }
                 else if (string.Equals(arg, "--push", StringComparison.Ordinal))
                 {

--- a/src/Microsoft.DotNet.ImageBuilder/Options.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/Options.cs
@@ -18,6 +18,7 @@ Summary:  Builds all Dockerfiles detected in the current folder and sub-folders 
 Usage:  image-builder [options]
 
 Options:
+      --repo-owner                      An alternative repo owner which overrides what is specified in the manifest
       --architecture                    The architecture of the Docker images to build (default is the current OS architecture)
       --command                         Build command to execute (Build/PublishManifest/UpdateReadme)
       --dry-run                         Dry run of what images get built and order they would get built in
@@ -33,6 +34,7 @@ Options:
       --username                        Username for the Docker registry the images are pushed to
 ";
 
+        public string RepoOwner { get; private set; }
         public Architecture Architecture { get; private set; } = DockerHelper.GetArchitecture();
         public CommandType Command { get; private set; }
         public bool IsDryRun { get; private set; }
@@ -58,7 +60,11 @@ Options:
             for (int i = 0; i < args.Length; i++)
             {
                 string arg = args[i];
-                if (string.Equals(arg, "--architecture", StringComparison.Ordinal))
+                if (string.Equals(arg, "--repo-owner", StringComparison.Ordinal))
+                {
+                    options.RepoOwner = GetArgValue(args, ref i, "repo-owner");
+                }
+                else if (string.Equals(arg, "--architecture", StringComparison.Ordinal))
                 {
                     string architecture = GetArgValue(args, ref i, "architecture");
                     options.Architecture = (Architecture)Enum.Parse(typeof(Architecture), architecture, true);

--- a/src/Microsoft.DotNet.ImageBuilder/ViewModel/ManifestInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/ViewModel/ManifestInfo.cs
@@ -34,7 +34,11 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         }
 
         public static ManifestInfo Create(
-            string repoJsonPath, Architecture dockerArchitecture, string includeRepo, string includePath)
+            string repoJsonPath,
+            Architecture dockerArchitecture,
+            string includeRepo,
+            string includePath,
+            string repoOwner)
         {
             ManifestInfo manifestInfo = new ManifestInfo();
             manifestInfo.DockerOS = DockerHelper.GetOS();
@@ -43,7 +47,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             manifestInfo.Repos = manifestInfo.Model.Repos
                 .Where(repo => string.IsNullOrWhiteSpace(includeRepo) || repo.Name == includeRepo)
                 .Select(repo => RepoInfo.Create(
-                    repo, manifestInfo.Model, dockerArchitecture, manifestInfo.DockerOS, includePath))
+                    repo, manifestInfo.Model, dockerArchitecture, manifestInfo.DockerOS, includePath, repoOwner))
                 .ToArray();
             manifestInfo.Images = manifestInfo.Repos
                 .SelectMany(repo => repo.Images)

--- a/src/Microsoft.DotNet.ImageBuilder/ViewModel/RepoInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/ViewModel/RepoInfo.cs
@@ -12,6 +12,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 {
     public class RepoInfo
     {
+        public string Name { get; private set; }
         public IEnumerable<ImageInfo> Images { get; private set; }
         public Repo Model { get; private set; }
 
@@ -20,13 +21,20 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         }
 
         public static RepoInfo Create(
-            Repo model, Manifest manifest, Architecture dockerArchitecture, string dockerOS, string includePath)
+            Repo model,
+            Manifest manifest,
+            Architecture dockerArchitecture,
+            string dockerOS,
+            string includePath,
+            string repoOwner)
         {
             RepoInfo repoInfo = new RepoInfo();
             repoInfo.Model = model;
+            repoInfo.Name = string.IsNullOrWhiteSpace(repoOwner) ?
+                model.Name : DockerHelper.ReplaceImageOwner(model.Name, repoOwner);
             repoInfo.Images = model.Images
                 .Select(image => ImageInfo.Create(
-                    image, manifest, model.Name, dockerArchitecture, dockerOS, includePath))
+                    image, manifest, repoInfo.Name, dockerArchitecture, dockerOS, includePath))
                 .ToArray();
 
             return repoInfo;


### PR DESCRIPTION
Looking for feedback on the new option.  I can imagine a scenario in which specifying an entirely different repo may be useful.  That would require the mapping of old repo to new repo since the manifest can contain multiple repos.  The repo owner functionality I added satisfies the current requirements from the dotnet core repos.  Having to specify a map makes it clunky for this scenario which is why I didn't add it.  Adding another option down the road to specify a completely different repo is certainly possible.