### PR TITLE
ToLower arch when creating manifest for publish

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/ImageBuilder.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/ImageBuilder.cs
@@ -115,7 +115,7 @@ namespace Microsoft.DotNet.ImageBuilder
                             manifestYml.AppendLine($"  -");
                             manifestYml.AppendLine($"    image: {repo.Name}:{platformTag}");
                             manifestYml.AppendLine($"    platform:");
-                            manifestYml.AppendLine($"      architecture: {platform.Architecture.ToString().ToLower()}");
+                            manifestYml.AppendLine($"      architecture: {platform.Architecture.ToString().ToLowerInvariant()}");
                             manifestYml.AppendLine($"      os: {platform.OS}");
                             if (platform.Variant != null)
                             {

--- a/src/Microsoft.DotNet.ImageBuilder/ImageBuilder.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/ImageBuilder.cs
@@ -115,7 +115,7 @@ namespace Microsoft.DotNet.ImageBuilder
                             manifestYml.AppendLine($"  -");
                             manifestYml.AppendLine($"    image: {repo.Name}:{platformTag}");
                             manifestYml.AppendLine($"    platform:");
-                            manifestYml.AppendLine($"      architecture: {platform.Architecture}");
+                            manifestYml.AppendLine($"      architecture: {platform.Architecture.ToString().ToLower()}");
                             manifestYml.AppendLine($"      os: {platform.OS}");
                             if (platform.Variant != null)
                             {


### PR DESCRIPTION
This change is needed because the Docker manifest tool used for publishing the multi-arch tags is case sensitive.