### PR TITLE
Add command to generate tags section of readme

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/Commands/GenerateTagsReadmeCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/Commands/GenerateTagsReadmeCommand.cs
@@ -1,0 +1,79 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.ImageBuilder.Model;
+using Microsoft.DotNet.ImageBuilder.ViewModel;
+using System;
+using System.Linq;
+using System.Text;
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    public class GenerateTagsReadmeCommand : Command<GenerateTagsReadmeOptions>
+    {
+        public GenerateTagsReadmeCommand() : base()
+        {
+        }
+
+        public override void Execute()
+        {
+            WriteHeading("GENERATING TAGS README");
+            foreach (RepoInfo repo in Manifest.Repos)
+            {
+                StringBuilder tagsReadme = new StringBuilder();
+
+                var platformGroups = repo.Images
+                    .OrderBy(image => image.Model.ReadmeOrder)
+                    .SelectMany(image => image.Platforms.Select(platform => new { Image = image, Platform = platform }))
+                    .GroupBy(tuple => new { tuple.Platform.Model.OS, tuple.Platform.Model.Architecture });
+
+                foreach (var platformGroup in platformGroups)
+                {
+                    string os = platformGroup.Key.OS.Substring(0, 1).ToUpper() + platformGroup.Key.OS.Substring(1);
+                    string arch = GetArchitectureDisplayName(platformGroup.Key.Architecture);
+                    tagsReadme.AppendLine($"# Supported {os} {arch} tags");
+                    tagsReadme.AppendLine();
+                    foreach (var tuple in platformGroup)
+                    {
+                        string tags = GetDocumentedTags(tuple.Platform.Tags)
+                            .Concat(GetDocumentedTags(tuple.Image.SharedTags))
+                            .Select(tag => $"`{tag}`")
+                            .Aggregate((working, next) => $"{working}, {next}");
+                        string dockerfile = $"{tuple.Platform.Model.Dockerfile}/Dockerfile";
+                        tagsReadme.AppendLine($"- [{tags} (*{dockerfile}*)]({Options.SourceUrl}/{dockerfile})");
+                    }
+
+                    tagsReadme.AppendLine();
+                }
+
+                Console.WriteLine($"-- {repo.Name} Tags Readme:");
+                Console.WriteLine(tagsReadme);
+            }
+        }
+
+        private IEnumerable<string> GetDocumentedTags(IEnumerable<TagInfo> tagInfos)
+        {
+            return tagInfos.Where(tag => !tag.Model.IsUndocumented)
+                .Select(tag => tag.Name);
+        }
+
+        private string GetArchitectureDisplayName(Architecture architecture)
+        {
+            string displayName;
+
+            switch (architecture)
+            {
+                case Architecture.ARM:
+                    displayName = "arm32";
+                    break;
+                default:
+                    displayName = architecture.ToString().ToLowerInvariant();
+                    break;
+            }
+
+            return displayName;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/Commands/GenerateTagsReadmeCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/Commands/GenerateTagsReadmeCommand.cs
@@ -53,13 +53,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             }
         }
 
-        private IEnumerable<string> GetDocumentedTags(IEnumerable<TagInfo> tagInfos)
+        private static IEnumerable<string> GetDocumentedTags(IEnumerable<TagInfo> tagInfos)
         {
             return tagInfos.Where(tag => !tag.Model.IsUndocumented)
                 .Select(tag => tag.Name);
         }
 
-        private string GetArchitectureDisplayName(Architecture architecture)
+        private static string GetArchitectureDisplayName(Architecture architecture)
         {
             string displayName;
 

--- a/src/Microsoft.DotNet.ImageBuilder/Commands/GenerateTagsReadmeOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/Commands/GenerateTagsReadmeOptions.cs
@@ -25,11 +25,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             string sourceUrl = null;
             Argument sourceUrlArg = syntax.DefineParameter("source-url", ref sourceUrl, "Base URL of the Dockerfile sources");
             SourceUrl = sourceUrl;
-
-            if (!sourceUrlArg.IsSpecified)
-            {
-                syntax.ReportError($"`{sourceUrlArg.Name}` must be specified.");
-            }
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/Commands/GenerateTagsReadmeOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/Commands/GenerateTagsReadmeOptions.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.CommandLine;
+using System.Diagnostics;
+
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    public class GenerateTagsReadmeOptions : Options
+    {
+        protected override string CommandHelp => "Generate the tags section of the readme";
+        protected override string CommandName => "generateTagsReadme";
+
+        public string SourceUrl { get; set; }
+
+        public GenerateTagsReadmeOptions() : base()
+        {
+        }
+
+        public override void ParseCommandLine(ArgumentSyntax syntax)
+        {
+            base.ParseCommandLine(syntax);
+
+            string sourceUrl = null;
+            string sourceUrlName = "source-url";
+            Argument sourceUrlArg = syntax.DefineOption(sourceUrlName, ref sourceUrl, true, "Base URL of the Dockerfile sources");
+            SourceUrl = sourceUrl;
+
+            if (!sourceUrlArg.IsSpecified)
+            {
+                syntax.ReportError($"`{sourceUrlName}` must be specified.");
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/Commands/GenerateTagsReadmeOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/Commands/GenerateTagsReadmeOptions.cs
@@ -23,13 +23,12 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             base.ParseCommandLine(syntax);
 
             string sourceUrl = null;
-            string sourceUrlName = "source-url";
-            Argument sourceUrlArg = syntax.DefineOption(sourceUrlName, ref sourceUrl, true, "Base URL of the Dockerfile sources");
+            Argument sourceUrlArg = syntax.DefineParameter("source-url", ref sourceUrl, "Base URL of the Dockerfile sources");
             SourceUrl = sourceUrl;
 
             if (!sourceUrlArg.IsSpecified)
             {
-                syntax.ReportError($"`{sourceUrlName}` must be specified.");
+                syntax.ReportError($"`{sourceUrlArg.Name}` must be specified.");
             }
         }
     }

--- a/src/Microsoft.DotNet.ImageBuilder/Commands/PublishManifestCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/Commands/PublishManifestCommand.cs
@@ -24,30 +24,29 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             {
                 foreach (ImageInfo image in repo.Images)
                 {
-                    foreach (string tag in image.SharedFullyQualifiedTags)
+                    foreach (TagInfo tag in image.SharedTags)
                     {
                         StringBuilder manifestYml = new StringBuilder();
-                        manifestYml.AppendLine($"image: {tag}");
+                        manifestYml.AppendLine($"image: {tag.Name}");
                         manifestYml.AppendLine("manifests:");
 
-                        foreach (Platform platform in image.Model.Platforms)
+                        foreach (PlatformInfo platform in image.Platforms)
                         {
-                            string platformTag = Manifest.Model.SubstituteTagVariables(platform.Tags.First());
                             manifestYml.AppendLine($"  -");
-                            manifestYml.AppendLine($"    image: {repo.Name}:{platformTag}");
+                            manifestYml.AppendLine($"    image: {platform.Tags.First().FullyQualifiedName}");
                             manifestYml.AppendLine($"    platform:");
-                            manifestYml.AppendLine($"      architecture: {platform.Architecture.ToString().ToLowerInvariant()}");
-                            manifestYml.AppendLine($"      os: {platform.OS}");
-                            if (platform.Variant != null)
+                            manifestYml.AppendLine($"      architecture: {platform.Model.Architecture.ToString().ToLowerInvariant()}");
+                            manifestYml.AppendLine($"      os: {platform.Model.OS}");
+                            if (platform.Model.Variant != null)
                             {
-                                manifestYml.AppendLine($"      variant: {platform.Variant}");
+                                manifestYml.AppendLine($"      variant: {platform.Model.Variant}");
                             }
                         }
 
                         Console.WriteLine($"-- PUBLISHING MANIFEST:{Environment.NewLine}{manifestYml}");
                         File.WriteAllText("manifest.yml", manifestYml.ToString());
 
-                        // ExecuteWithRetry because the manifest-tool fails periodically with communicating 
+                        // ExecuteWithRetry because the manifest-tool fails periodically with communicating
                         // with the Docker Registry.
                         ExecuteHelper.ExecuteWithRetry(
                             "manifest-tool",

--- a/src/Microsoft.DotNet.ImageBuilder/Dockerfile
+++ b/src/Microsoft.DotNet.ImageBuilder/Dockerfile
@@ -2,7 +2,7 @@
 #     docker build -t image-builder .
 #     docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v <local path to build>:/repo -w /repo image-builder <image-build args>
 
-FROM microsoft/dotnet:1.1-sdk
+FROM microsoft/dotnet:2.0-sdk
 
 # Install Docker
 RUN apt-get update \

--- a/src/Microsoft.DotNet.ImageBuilder/Dockerfile.nanoserver
+++ b/src/Microsoft.DotNet.ImageBuilder/Dockerfile.nanoserver
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:1.1-sdk-nanoserver
+FROM microsoft/dotnet:2.0-sdk-nanoserver
 
 # Build image-builder
 WORKDIR Microsoft.DotNet.ImageBuilder

--- a/src/Microsoft.DotNet.ImageBuilder/ImageBuilder.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/ImageBuilder.cs
@@ -33,6 +33,16 @@ namespace Microsoft.DotNet.ImageBuilder
                     }
                 });
 
+                // Workaround for https://github.com/dotnet/corefxlab/issues/1689
+                foreach (Argument arg in argSyntax.GetActiveArguments())
+                {
+                    if (arg.IsParameter && !arg.IsSpecified)
+                    {
+                        Console.Error.WriteLine($"error: `{arg.Name}` must be specified.");
+                        Environment.Exit(1);
+                    }
+                }
+
                 if (argSyntax.ActiveCommand != null)
                 {
                     ICommand command = commands.Single(c => c.Options == argSyntax.ActiveCommand.Value);

--- a/src/Microsoft.DotNet.ImageBuilder/ImageBuilder.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/ImageBuilder.cs
@@ -20,6 +20,7 @@ namespace Microsoft.DotNet.ImageBuilder
             {
                 ICommand[] commands = {
                     new BuildCommand(),
+                    new GenerateTagsReadmeCommand(),
                     new PublishManifestCommand(),
                     new UpdateReadmeCommand(),
                 };

--- a/src/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.csproj
+++ b/src/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <RootNamespace>Microsoft.DotNet.ImageBuilder</RootNamespace>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.ImageBuilder/Model/Image.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/Model/Image.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace Microsoft.DotNet.ImageBuilder.Model
 {
@@ -13,7 +14,7 @@ namespace Microsoft.DotNet.ImageBuilder.Model
 
         public int ReadmeOrder { get; set; }
 
-        public Tag[] SharedTags { get; set; }
+        public IDictionary<string, Tag> SharedTags { get; set; }
 
         public Image()
         {

--- a/src/Microsoft.DotNet.ImageBuilder/Model/Platform.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/Model/Platform.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.ImageBuilder.Model
         public string OS { get; set; }
 
         [JsonProperty(Required = Required.Always)]
-        public string[] Tags { get; set; }
+        public Tag[] Tags { get; set; }
 
         public string Variant { get; set; }
 

--- a/src/Microsoft.DotNet.ImageBuilder/Model/Platform.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/Model/Platform.cs
@@ -4,6 +4,7 @@
 
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using System.Collections.Generic;
 using System.ComponentModel;
 
 namespace Microsoft.DotNet.ImageBuilder.Model
@@ -22,7 +23,7 @@ namespace Microsoft.DotNet.ImageBuilder.Model
         public string OS { get; set; }
 
         [JsonProperty(Required = Required.Always)]
-        public Tag[] Tags { get; set; }
+        public IDictionary<string, Tag> Tags { get; set; }
 
         public string Variant { get; set; }
 

--- a/src/Microsoft.DotNet.ImageBuilder/Model/Tag.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/Model/Tag.cs
@@ -10,9 +10,6 @@ namespace Microsoft.DotNet.ImageBuilder.Model
     {
         public bool IsUndocumented { get; set; }
 
-        [JsonProperty(Required = Required.Always)]
-        public string Name { get; set; }
-
         public Tag()
         {
         }

--- a/src/Microsoft.DotNet.ImageBuilder/Model/Tag.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/Model/Tag.cs
@@ -6,16 +6,14 @@ using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.ImageBuilder.Model
 {
-    public class Image
+    public class Tag
     {
+        public bool IsUndocumented { get; set; }
+
         [JsonProperty(Required = Required.Always)]
-        public Platform[] Platforms { get; set; }
+        public string Name { get; set; }
 
-        public int ReadmeOrder { get; set; }
-
-        public Tag[] SharedTags { get; set; }
-
-        public Image()
+        public Tag()
         {
         }
     }

--- a/src/Microsoft.DotNet.ImageBuilder/ViewModel/ImageInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/ViewModel/ImageInfo.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             else
             {
                 imageInfo.SharedTags = model.SharedTags
-                    .Select(tag => TagInfo.Create(tag, manifest, repoName))
+                    .Select(kvp => TagInfo.Create(kvp.Key, kvp.Value, manifest, repoName))
                     .ToArray();
             }
 

--- a/src/Microsoft.DotNet.ImageBuilder/ViewModel/ManifestFilter.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/ViewModel/ManifestFilter.cs
@@ -19,12 +19,17 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         {
         }
 
-        public Platform GetPlatform(Image image)
+        public Platform GetActivePlatform(Image image)
+        {
+            return GetPlatforms(image)
+                .Where(platform => platform.OS == DockerOS && platform.Architecture == DockerArchitecture)
+                .SingleOrDefault();
+        }
+
+        public IEnumerable<Platform> GetPlatforms(Image image)
         {
             return image.Platforms
-                .Where(platform => platform.OS == DockerOS && platform.Architecture == DockerArchitecture)
-                .Where(platform => string.IsNullOrWhiteSpace(IncludePath) || platform.Dockerfile.StartsWith(IncludePath))
-                .SingleOrDefault();
+                .Where(platform => string.IsNullOrWhiteSpace(IncludePath) || platform.Dockerfile.StartsWith(IncludePath));
         }
 
         public IEnumerable<Repo> GetRepos(Manifest manifest)

--- a/src/Microsoft.DotNet.ImageBuilder/ViewModel/ManifestInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/ViewModel/ManifestInfo.cs
@@ -35,7 +35,8 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
                 .Where(image => image.ActivePlatform != null)
                 .ToArray();
             manifestInfo.ActivePlatformFullyQualifiedTags = manifestInfo.ActiveImages
-                .SelectMany(image => image.ActivePlatform.FullyQualifiedTags)
+                .SelectMany(image => image.ActivePlatform.Tags)
+                .Select(tag => tag.FullyQualifiedName)
                 .ToArray();
             manifestInfo.TestCommands = manifestFilter.GetTestCommands(manifestInfo.Model);
 

--- a/src/Microsoft.DotNet.ImageBuilder/ViewModel/PlatformInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/ViewModel/PlatformInfo.cs
@@ -15,10 +15,9 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
     {
         private static Regex FromRegex { get; } = new Regex(@"FROM\s+(?<fromImage>\S+)");
 
-
         public IEnumerable<string> FromImages { get; private set; }
         public Platform Model { get; private set; }
-        public IEnumerable<string> FullyQualifiedTags { get; private set; }
+        public IEnumerable<TagInfo> Tags { get; private set; }
 
         private PlatformInfo()
         {
@@ -29,8 +28,8 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             PlatformInfo platformInfo = new PlatformInfo();
             platformInfo.Model = model;
             platformInfo.InitializeFromImage();
-            platformInfo.FullyQualifiedTags = model.Tags
-                .Select(tag => $"{repoName}:{manifest.SubstituteTagVariables(tag)}")
+            platformInfo.Tags = model.Tags
+                .Select(tag => TagInfo.Create(tag, manifest, repoName))
                 .ToArray();
 
             return platformInfo;

--- a/src/Microsoft.DotNet.ImageBuilder/ViewModel/PlatformInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/ViewModel/PlatformInfo.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             platformInfo.Model = model;
             platformInfo.InitializeFromImage();
             platformInfo.Tags = model.Tags
-                .Select(tag => TagInfo.Create(tag, manifest, repoName))
+                .Select(kvp => TagInfo.Create(kvp.Key, kvp.Value, manifest, repoName))
                 .ToArray();
 
             return platformInfo;

--- a/src/Microsoft.DotNet.ImageBuilder/ViewModel/TagInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/ViewModel/TagInfo.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.ImageBuilder.Model;
+
+namespace Microsoft.DotNet.ImageBuilder.ViewModel
+{
+    public class TagInfo
+    {
+        public string FullyQualifiedName { get; private set; }
+        public Tag Model { get; private set; }
+        public string Name { get; private set; }
+
+        private TagInfo()
+        {
+        }
+
+        public static TagInfo Create(Tag model, Manifest manifest, string repoName)
+        {
+            TagInfo tagInfo = new TagInfo();
+            tagInfo.Model = model;
+            tagInfo.Name = manifest.SubstituteTagVariables(model.Name);
+            tagInfo.FullyQualifiedName = $"{repoName}:{tagInfo.Name}";
+
+            return tagInfo;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/ViewModel/TagInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/ViewModel/TagInfo.cs
@@ -16,11 +16,11 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         {
         }
 
-        public static TagInfo Create(Tag model, Manifest manifest, string repoName)
+        public static TagInfo Create(string name, Tag model, Manifest manifest, string repoName)
         {
             TagInfo tagInfo = new TagInfo();
             tagInfo.Model = model;
-            tagInfo.Name = manifest.SubstituteTagVariables(model.Name);
+            tagInfo.Name = manifest.SubstituteTagVariables(name);
             tagInfo.FullyQualifiedName = $"{repoName}:{tagInfo.Name}";
 
             return tagInfo;


### PR DESCRIPTION
This required a change to the manifest schema in order to capture the required metadata.  I applied the needed [changes](https://github.com/MichaelSimons/dotnet-docker-nightly/commit/39741d5a206239d795e732087f367d6cf18ce472#diff-4b1eb3dc48c4e16d49db5b42298fe654) to the microsoft/dotnet-nightly repo if you want to take a look.  I'm not crazy about the verbosity of the tags element but I can see benefits to being able to add additional metadata over time.  I'm certainly open to feedback.

related #10 