### PR TITLE
Add regex support on path argument in ImageBuilder

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/Commands/BuildOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/Commands/BuildOptions.cs
@@ -4,10 +4,9 @@
 
 using Microsoft.DotNet.ImageBuilder.Model;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
+using System;
 using System.Collections.Generic;
 using System.CommandLine;
-using System.Collections.ObjectModel;
-using System;
 using System.Linq;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
@@ -44,7 +43,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             Architecture = DefineArchitectureOption(syntax);
 
             string path = null;
-            syntax.DefineOption("path", ref path, "Path of the directory to build (Default is to build all)");
+            syntax.DefineOption(
+                "path", 
+                ref path,
+                "Directory path containing the Dockerfiles to build - wildcard chars * and ? supported (default is to build all)");
             Path = path;
 
             bool isPushEnabled = false;

--- a/src/Microsoft.DotNet.ImageBuilder/Commands/Command.TOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/Commands/Command.TOptions.cs
@@ -6,7 +6,6 @@ using Microsoft.DotNet.ImageBuilder.Model;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
 using Newtonsoft.Json;
 using System;
-using System.CommandLine;
 using System.IO;
 using System.Threading.Tasks;
 

--- a/src/Microsoft.DotNet.ImageBuilder/Commands/GenerateTagsReadmeOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/Commands/GenerateTagsReadmeOptions.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.CommandLine;
-using System.Diagnostics;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {

--- a/src/Microsoft.DotNet.ImageBuilder/Commands/PublishManifestCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/Commands/PublishManifestCommand.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.ImageBuilder.Model;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.ImageBuilder/Commands/UpdateVersionsCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/Commands/UpdateVersionsCommand.cs
@@ -7,7 +7,6 @@ using Microsoft.DotNet.VersionTools.Automation.GitHubApi;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Net.Http;

--- a/src/Microsoft.DotNet.ImageBuilder/Commands/UpdateVersionsOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/Commands/UpdateVersionsOptions.cs
@@ -5,7 +5,6 @@
 using Microsoft.DotNet.ImageBuilder.Model;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
 using System.CommandLine;
-using System.IO;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {

--- a/src/Microsoft.DotNet.ImageBuilder/ImageBuilder.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/ImageBuilder.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.ImageBuilder.Commands;
-using Newtonsoft.Json.Linq;
 using System;
 using System.CommandLine;
 using System.Linq;

--- a/src/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.sln
+++ b/src/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26927.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.ImageBuilder", "Microsoft.DotNet.ImageBuilder.csproj", "{EA5BEDCF-A3E9-4E97-B9C0-8FCD0656EA02}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{EA5BEDCF-A3E9-4E97-B9C0-8FCD0656EA02}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EA5BEDCF-A3E9-4E97-B9C0-8FCD0656EA02}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EA5BEDCF-A3E9-4E97-B9C0-8FCD0656EA02}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EA5BEDCF-A3E9-4E97-B9C0-8FCD0656EA02}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {24AFE8C1-D5A2-447C-A655-6A6959D1EF75}
+	EndGlobalSection
+EndGlobal

--- a/src/Microsoft.DotNet.ImageBuilder/Model/Tag.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/Model/Tag.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 namespace Microsoft.DotNet.ImageBuilder.Model
 {
     public class Tag

--- a/src/Microsoft.DotNet.ImageBuilder/Model/Tag.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/Model/Tag.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.ImageBuilder.Model
 {

--- a/src/Microsoft.DotNet.ImageBuilder/ViewModel/ManifestFilter.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/ViewModel/ManifestFilter.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         {
             bool isPathBlank = string.IsNullOrWhiteSpace(IncludePath);
             string pattern = isPathBlank ? 
-                string.Empty : "^" + Regex.Escape(IncludePath).Replace(@"\*", ".*").Replace(@"\?", ".");
+                null : "^" + Regex.Escape(IncludePath).Replace(@"\*", ".*").Replace(@"\?", ".");
 
             return image.Platforms
                 .Where(platform => isPathBlank || Regex.IsMatch(platform.Dockerfile, pattern, RegexOptions.IgnoreCase));

--- a/src/Microsoft.DotNet.ImageBuilder/ViewModel/ManifestFilter.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/ViewModel/ManifestFilter.cs
@@ -29,12 +29,12 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 
         public IEnumerable<Platform> GetPlatforms(Image image)
         {
+            bool isPathBlank = string.IsNullOrWhiteSpace(IncludePath);
+            string pattern = isPathBlank ? 
+                string.Empty : "^" + Regex.Escape(IncludePath).Replace(@"\*", ".*").Replace(@"\?", ".");
+
             return image.Platforms
-                .Where(platform => string.IsNullOrWhiteSpace(IncludePath)
-                    || Regex.IsMatch(
-                        platform.Dockerfile,
-                        "^" + Regex.Escape(IncludePath).Replace(@"\*", ".*").Replace(@"\?", "."),
-                        RegexOptions.IgnoreCase));
+                .Where(platform => isPathBlank || Regex.IsMatch(platform.Dockerfile, pattern, RegexOptions.IgnoreCase));
         }
 
         public IEnumerable<Repo> GetRepos(Manifest manifest)

--- a/src/Microsoft.DotNet.ImageBuilder/ViewModel/ManifestFilter.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/ViewModel/ManifestFilter.cs
@@ -5,6 +5,7 @@
 using Microsoft.DotNet.ImageBuilder.Model;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.DotNet.ImageBuilder.ViewModel
 {
@@ -29,7 +30,11 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         public IEnumerable<Platform> GetPlatforms(Image image)
         {
             return image.Platforms
-                .Where(platform => string.IsNullOrWhiteSpace(IncludePath) || platform.Dockerfile.StartsWith(IncludePath));
+                .Where(platform => string.IsNullOrWhiteSpace(IncludePath)
+                    || Regex.IsMatch(
+                        platform.Dockerfile,
+                        "^" + Regex.Escape(IncludePath).Replace(@"\*", ".*").Replace(@"\?", "."),
+                        RegexOptions.IgnoreCase));
         }
 
         public IEnumerable<Repo> GetRepos(Manifest manifest)


### PR DESCRIPTION
These changes add regex support on _path_ argument in _ImageBuilder_. Wildcard characters `*` and `?` are supported. For example, passing `build --repo microsoft/dotnet-nightly --path "*sdk*"` would build all images that contain the word `sdk` in Dockerfile path.

Changes also include -

- A solution file to open ImageBuilder project in Visual Studio
- Remove and sort _using_ across the solution

