### PR TITLE
Add support for multiple os images per multi-arch tag

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/Commands/BuildCommand.cs
@@ -39,8 +39,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             {
                 foreach (PlatformInfo platform in image.ActivePlatforms)
                 {
-                    string dockerfilePath;
-                    bool createdPrivateDockerfile = UpdateDockerfileFromCommands(platform, out dockerfilePath);
+                    bool createdPrivateDockerfile = UpdateDockerfileFromCommands(platform, out string dockerfilePath);
 
                     try
                     {

--- a/src/Microsoft.DotNet.ImageBuilder/ViewModel/ImageInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/ViewModel/ImageInfo.cs
@@ -10,8 +10,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 {
     public class ImageInfo
     {
-        public PlatformInfo ActivePlatform { get; private set; }
-        public IEnumerable<string> ActiveFullyQualifiedTags { get; private set; }
+        public IEnumerable<PlatformInfo> ActivePlatforms { get; private set; }
         public Image Model { get; private set; }
         public IEnumerable<PlatformInfo> Platforms { get; set; }
         public IEnumerable<TagInfo> SharedTags { get; private set; }
@@ -40,15 +39,9 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
                 .Select(platform => PlatformInfo.Create(platform, manifest, repoName))
                 .ToArray();
 
-            Platform activePlatformModel = manifestFilter.GetActivePlatform(model);
-            if (activePlatformModel != null)
-            {
-                imageInfo.ActivePlatform = imageInfo.Platforms
-                    .First(platform => platform.Model == activePlatformModel);
-                imageInfo.ActiveFullyQualifiedTags = imageInfo.SharedTags
-                    .Select(tag => tag.FullyQualifiedName)
-                    .Concat(imageInfo.ActivePlatform.Tags.Select(tag => tag.FullyQualifiedName));
-            }
+            IEnumerable<Platform> activePlatformModels = manifestFilter.GetActivePlatforms(model);
+            imageInfo.ActivePlatforms = imageInfo.Platforms
+                    .Where(platform => activePlatformModels.Contains(platform.Model));
 
             return imageInfo;
         }

--- a/src/Microsoft.DotNet.ImageBuilder/ViewModel/ManifestFilter.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/ViewModel/ManifestFilter.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.ImageBuilder.Model;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -20,11 +21,11 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         {
         }
 
-        public Platform GetActivePlatform(Image image)
+        public IEnumerable<Platform> GetActivePlatforms(Image image)
         {
             return GetPlatforms(image)
-                .Where(platform => platform.OS == DockerOS && platform.Architecture == DockerArchitecture)
-                .SingleOrDefault();
+                .Where(platform => string.Equals(platform.OS, DockerOS, StringComparison.OrdinalIgnoreCase)
+                    && platform.Architecture == DockerArchitecture);
         }
 
         public IEnumerable<Platform> GetPlatforms(Image image)


### PR DESCRIPTION
These changes allow for manifest tag to reference to more than one image per platform which will be for different OS versions.

This functionality is need as part of https://github.com/dotnet/dotnet-docker/issues/298.