### PR TITLE
Support for global variable substitution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@
 # Visual Studio Code cache/options directory
 .vscode/
 .vs
+
+# Visual Studio debug profile
 /Microsoft.DotNet.ImageBuilder/src/Properties/launchSettings.json

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 # Visual Studio Code cache/options directory
 .vscode/
 .vs
+/Microsoft.DotNet.ImageBuilder/src/Properties/launchSettings.json

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@
 .vs
 
 # Visual Studio debug profile
-/Microsoft.DotNet.ImageBuilder/src/Properties/launchSettings.json
+**/launchSettings.json

--- a/Microsoft.DotNet.ImageBuilder/src/GitHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/GitHelper.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             ProcessStartInfo startInfo = new ProcessStartInfo("git", $"log -1 --format=format:%h {filePath}");
             startInfo.RedirectStandardOutput = true;
             Process gitLogProcess = ExecuteHelper.Execute(
-                startInfo, false, $"Unable to retrieve the commit for {filePath}");
+                startInfo, false, $"Unable to retrieve the latest commit SHA for {filePath}");
             return gitLogProcess.StandardOutput.ReadToEnd().Trim();
         }
     }

--- a/Microsoft.DotNet.ImageBuilder/src/GitHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/GitHelper.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace Microsoft.DotNet.ImageBuilder.ViewModel
+{
+    public static class GitHelper
+    {
+        public static string GetCommitSha(string filePath)
+        {
+            ProcessStartInfo startInfo = new ProcessStartInfo("git", $"log -1 --format=format:%h {filePath}");
+            startInfo.RedirectStandardOutput = true;
+            Process gitLogProcess = ExecuteHelper.Execute(
+                startInfo, false, $"Unable to retrieve the commit for {filePath}");
+            return gitLogProcess.StandardOutput.ReadToEnd().Trim();
+        }
+    }
+}

--- a/Microsoft.DotNet.ImageBuilder/src/Utilities.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Utilities.cs
@@ -4,22 +4,67 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.DotNet.ImageBuilder
 {
     public static class Utilities
     {
-        public static string SubstituteVariables(IDictionary<string, string> variables, string expression)
+        private static string TimeStamp { get; } = DateTime.UtcNow.ToString("yyyymmddhhmmss");
+        private const string TagVariablePattern = "\\$\\((?<variable>[\\w]+)\\)";
+
+        public static string SubstituteVariables(
+            IDictionary<string, string> variables,
+            string expression,
+            Func<string, string> getVariableValue = null)
         {
-            if (variables != null)
+            foreach (Match match in Regex.Matches(expression, TagVariablePattern))
             {
-                foreach (KeyValuePair<string, string> kvp in variables)
+                string variableName = match.Groups[1].Value;
+                string variableValue = null;
+                if (variables == null || !variables.TryGetValue(variableName, out variableValue))
                 {
-                    expression = expression.Replace($"$({kvp.Key})", kvp.Value);
+                    if (getVariableValue != null)
+                    {
+                        variableValue = getVariableValue(variableName);
+                    }
+                    if (variableValue == null && match.Value == "$(timeStamp)")
+                    {
+                        variableValue = TimeStamp;
+                    }
                 }
+                if (variableValue == null)
+                {
+                    throw new InvalidDataException(
+                            $"Unable to determine the value for the given variable. Variable: {match.Value}");
+                }
+                expression = expression.Replace(match.Value, variableValue);
             }
 
             return expression;
+        }
+
+        public static Func<string, string> GetSha(string filePath, bool isDryRun = false)
+        {
+            return delegate (string variableName)
+            {
+                if (!File.Exists(filePath))
+                {
+                    throw new FileNotFoundException($"Unable to find the file.", filePath);
+                }
+                if (!string.Equals("dockerfileSha", variableName))
+                {
+                    return null;
+                }
+
+                ProcessStartInfo startInfo = new ProcessStartInfo("git", $"log -1 --format=format:%h {filePath}");
+                startInfo.RedirectStandardOutput = true;
+                Process gitLogProcess = ExecuteHelper.Execute(
+                    startInfo, isDryRun, $"Unable to retrieve the commit timestamp for {filePath}");
+                return isDryRun ? "" : gitLogProcess.StandardOutput.ReadToEnd().Trim();
+            };
         }
 
         public static void WriteHeading(string heading)

--- a/Microsoft.DotNet.ImageBuilder/src/Utilities.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Utilities.cs
@@ -10,14 +10,14 @@ namespace Microsoft.DotNet.ImageBuilder
 {
     public static class Utilities
     {
+        private static string TagVariablePattern = $"\\$\\((?<{VariableGroupName}>[\\w]+)\\)";
         private static string TimeStamp { get; } = DateTime.UtcNow.ToString("yyyymmddhhmmss");
         private const string VariableGroupName = "variable";
-        private static string TagVariablePattern = $"\\$\\((?<{VariableGroupName}>[\\w]+)\\)";
 
         public static string SubstituteVariables(
             IDictionary<string, string> userVariables,
             string expression,
-            Func<string, string> getSystemValue = null)
+            Func<string, string> getContextBasedSystemValue = null)
         {
             foreach (Match match in Regex.Matches(expression, TagVariablePattern))
             {
@@ -25,9 +25,9 @@ namespace Microsoft.DotNet.ImageBuilder
                 string variableValue = null;
                 if (userVariables == null || !userVariables.TryGetValue(variableName, out variableValue))
                 {
-                    if (getSystemValue != null)
+                    if (getContextBasedSystemValue != null)
                     {
-                        variableValue = getSystemValue(variableName);
+                        variableValue = getContextBasedSystemValue(variableName);
                     }
                     if (variableValue == null && variableName == "TimeStamp")
                     {

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestFilter.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestFilter.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.ImageBuilder.Model;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/ModelExtensions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/ModelExtensions.cs
@@ -11,11 +11,6 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 {
     public static class ModelExtensions
     {
-        public static string SubstituteTagVariables(this Manifest manifest, string tag)
-        {
-            return Utilities.SubstituteVariables(manifest.TagVariables, tag);
-        }
-
         public static void Validate(this Manifest manifest)
         {
             foreach (Repo repo in manifest.Repos)

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
@@ -43,8 +43,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             }
 
             platformInfo.Tags = model.Tags
-                .Select(kvp => TagInfo.Create(
-                    kvp.Key, kvp.Value, manifest, repoName, platformInfo.BuildContextPath, platformInfo.DockerfilePath))
+                .Select(kvp => TagInfo.Create(kvp.Key, kvp.Value, manifest, repoName, platformInfo.BuildContextPath))
                 .ToArray();
 
             platformInfo.InitializeFromImages();

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
@@ -43,7 +43,8 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             }
 
             platformInfo.Tags = model.Tags
-                .Select(kvp => TagInfo.Create(kvp.Key, kvp.Value, manifest, repoName, platformInfo.DockerfilePath))
+                .Select(kvp => TagInfo.Create(
+                    kvp.Key, kvp.Value, manifest, repoName, platformInfo.BuildContextPath, platformInfo.DockerfilePath))
                 .ToArray();
 
             platformInfo.InitializeFromImages();

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
@@ -29,9 +29,6 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         {
             PlatformInfo platformInfo = new PlatformInfo();
             platformInfo.Model = model;
-            platformInfo.Tags = model.Tags
-                .Select(kvp => TagInfo.Create(kvp.Key, kvp.Value, manifest, repoName))
-                .ToArray();
 
             if (File.Exists(model.Dockerfile))
             {
@@ -44,6 +41,10 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
                 platformInfo.DockerfilePath = Path.Combine(model.Dockerfile, "Dockerfile");
                 platformInfo.BuildContextPath = model.Dockerfile;
             }
+
+            platformInfo.Tags = model.Tags
+                .Select(kvp => TagInfo.Create(kvp.Key, kvp.Value, manifest, repoName, platformInfo.DockerfilePath))
+                .ToArray();
 
             platformInfo.InitializeFromImages();
 

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/TagInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/TagInfo.cs
@@ -9,7 +9,6 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
     public class TagInfo
     {
         private string BuildContextPath { get; set; }
-        private string DockerfilePath { get; set; }
         public string FullyQualifiedName { get; private set; }
         public Tag Model { get; private set; }
         public string Name { get; private set; }
@@ -23,13 +22,11 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             Tag model,
             Manifest manifest,
             string repoName,
-            string buildContextPath = null,
-            string dockerfilePath = null)
+            string buildContextPath = null)
         {
             TagInfo tagInfo = new TagInfo();
             tagInfo.Model = model;
             tagInfo.BuildContextPath = buildContextPath;
-            tagInfo.DockerfilePath = dockerfilePath;
             tagInfo.Name = Utilities.SubstituteVariables(manifest.TagVariables, name, tagInfo.GetSubstituteValue);
             tagInfo.FullyQualifiedName = $"{repoName}:{tagInfo.Name}";
 

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/TagInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/TagInfo.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.ImageBuilder.Model;
+using System;
 
 namespace Microsoft.DotNet.ImageBuilder.ViewModel
 {
@@ -11,16 +12,17 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         public string FullyQualifiedName { get; private set; }
         public Tag Model { get; private set; }
         public string Name { get; private set; }
-
         private TagInfo()
         {
         }
 
-        public static TagInfo Create(string name, Tag model, Manifest manifest, string repoName)
+        public static TagInfo Create(string name, Tag model, Manifest manifest, string repoName, string filePath = "")
         {
             TagInfo tagInfo = new TagInfo();
             tagInfo.Model = model;
-            tagInfo.Name = manifest.SubstituteTagVariables(name);
+            Func<string, string> GetSha = Utilities.GetSha(filePath);
+            tagInfo.Name = Utilities.SubstituteVariables(
+                variables: manifest.TagVariables, expression: name, getVariableValue: GetSha);
             tagInfo.FullyQualifiedName = $"{repoName}:{tagInfo.Name}";
 
             return tagInfo;

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/TagInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/TagInfo.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.ImageBuilder.Model;
-using System.IO;
 
 namespace Microsoft.DotNet.ImageBuilder.ViewModel
 {
@@ -39,16 +38,12 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 
         public string GetSubstituteValue(string variableName)
         {
-            string commitSha = null;
-            if (variableName == "DockerfileGitCommitSha")
+            string variableValue = null;
+            if (variableName == "DockerfileGitCommitSha" && this.BuildContextPath != null)
             {
-                if (!File.Exists(this.DockerfilePath))
-                {
-                    throw new FileNotFoundException("Unable to locate the file.", this.DockerfilePath);
-                }
-                commitSha = GitHelper.GetCommitSha(this.BuildContextPath);
+                variableValue = GitHelper.GetCommitSha(this.BuildContextPath);
             }
-            return commitSha;
+            return variableValue;
         }
     }
 }

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/TagInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/TagInfo.cs
@@ -3,12 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.ImageBuilder.Model;
-using System;
 
 namespace Microsoft.DotNet.ImageBuilder.ViewModel
 {
     public class TagInfo
     {
+        public string DockerfilePath { get; set; }
         public string FullyQualifiedName { get; private set; }
         public Tag Model { get; private set; }
         public string Name { get; private set; }
@@ -16,16 +16,25 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         {
         }
 
-        public static TagInfo Create(string name, Tag model, Manifest manifest, string repoName, string filePath = "")
+        public static TagInfo Create(string name, Tag model, Manifest manifest, string repoName, string dockerfilePath = "")
         {
             TagInfo tagInfo = new TagInfo();
             tagInfo.Model = model;
-            Func<string, string> GetSha = Utilities.GetSha(filePath);
-            tagInfo.Name = Utilities.SubstituteVariables(
-                variables: manifest.TagVariables, expression: name, getVariableValue: GetSha);
+            tagInfo.DockerfilePath = dockerfilePath;
+            tagInfo.Name = Utilities.SubstituteVariables(manifest.TagVariables, name, tagInfo.GetDockerfileGitCommitSha);
             tagInfo.FullyQualifiedName = $"{repoName}:{tagInfo.Name}";
 
             return tagInfo;
+        }
+
+        public string GetDockerfileGitCommitSha(string variableName)
+        {
+            string commitSha = null;
+            if (variableName == "DockerfileGitCommitSha")
+            {
+                commitSha = Utilities.GetAbbreviatedCommitSha(DockerfilePath);
+            }
+            return commitSha;
         }
     }
 }


### PR DESCRIPTION
Adds the ability to _ImageBuilder_ to substitute global variables with corresponding values in manifest.json. Dockerfile commit SHA and timestamp variable substitution is enabled.

Refer to https://github.com/dotnet/docker-tools/issues/63