### PR TITLE
Enable build hooks in ImageBuilder

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -92,13 +92,14 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 scriptPath = Path.ChangeExtension(scriptPath, ".ps1");
                 if (!File.Exists(scriptPath))
                 {
-                    Console.WriteLine($"Failed to locate build hook {scriptPath}'");
                     return;
                 }
+
                 startInfo = new ProcessStartInfo(
                     RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "PowerShell" : "pwsh", 
                     $"-NoProfile -File \"{scriptPath}\"");
             }
+
             ExecuteHelper.Execute(startInfo, Options.IsDryRun, $"Failed to execute build hook '{scriptPath}'");
         }
 


### PR DESCRIPTION
Currently, _ImageBuilder_ does not offer any hooks.  A hook enables running a custom script before or after a Docker command. Refer to https://github.com/dotnet/docker-tools/issues/65

These changes add support for `pre-build` and `post-build`.  Contract for `InvokeBuildHook`, is -

1. Check if the named script is available in a folder named `hooks` in the build content. If yes, then executes the script as a Shell script.
2. If the script was not found in step-1, then look for a PowerShell script. This means named script with an extension `.ps1`.  If found , then execute that PowerShell script.
