### PR TITLE
Add support to login to registry server other than Docker Hub

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -117,11 +117,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             {
                 Utilities.WriteHeading("PUSHING IMAGES");
 
-                if (Options.Username != null)
-                {
-                    DockerHelper.Login(Options.Username, Options.Password, Options.Server, Options.IsDryRun);
-                }
-
+                DockerHelper.Login(Options.Username, Options.Password, Options.Server, Options.IsDryRun);
                 try
                 {
                     foreach (string tag in BuiltTags)
@@ -131,10 +127,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 }
                 finally
                 {
-                    if (Options.Username != null)
-                    {
-                        DockerHelper.Logout(Options.Server, Options.IsDryRun);
-                    }
+                    DockerHelper.Logout(Options.Server, Options.IsDryRun);
                 }
             }
         }

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -119,17 +119,22 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
                 if (Options.Username != null)
                 {
-                    DockerHelper.Login(Options.Username, Options.Password, Options.IsDryRun);
+                    DockerHelper.Login(Options.Username, Options.Password, Options.Server, Options.IsDryRun);
                 }
 
-                foreach (string tag in BuiltTags)
+                try
                 {
-                    ExecuteHelper.ExecuteWithRetry("docker", $"push {tag}", Options.IsDryRun);
+                    foreach (string tag in BuiltTags)
+                    {
+                        ExecuteHelper.ExecuteWithRetry("docker", $"push {tag}", Options.IsDryRun);
+                    }
                 }
-
-                if (Options.Username != null)
+                finally
                 {
-                    ExecuteHelper.Execute("docker", $"logout", Options.IsDryRun);
+                    if (Options.Username != null)
+                    {
+                        DockerHelper.Logout(Options.Server, Options.IsDryRun);
+                    }
                 }
             }
         }

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/DockerRegistryOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/DockerRegistryOptions.cs
@@ -10,6 +10,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     {
         public string Password { get; set; }
         public string RepoOwner { get; set; }
+        public string Server { get; set; }
         public string Username { get; set; }
 
         protected DockerRegistryOptions()
@@ -33,6 +34,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 ref repoOwner,
                 "An alternative repo owner which overrides what is specified in the manifest");
             RepoOwner = repoOwner;
+
+            string server = null;
+            syntax.DefineOption(
+                "server",
+                ref server,
+                "Docker Registry server the images are pushed to (default is Docker Hub)");
+            Server = server;
 
             string username = null;
             syntax.DefineOption(

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestCommand.cs
@@ -35,7 +35,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     Console.WriteLine($"-- PUBLISHING MANIFEST:{Environment.NewLine}{manifest}");
                     File.WriteAllText("manifest.yml", manifest);
 
-                    // ExecuteWithRetry because the manifest-tool fails periodically with communicating
+                    // ExecuteWithRetry because the manifest-tool fails periodically while communicating
                     // with the Docker Registry.
                     ExecuteHelper.ExecuteWithRetry("manifest-tool", "push from-spec manifest.yml", Options.IsDryRun);
                 }

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestCommand.cs
@@ -21,48 +21,61 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public override Task ExecuteAsync()
         {
             Utilities.WriteHeading("GENERATING MANIFESTS");
-            IEnumerable<ImageInfo> multiArchImages = Manifest.Repos
-                .SelectMany(repo => repo.Images)
-                .Where(image => image.SharedTags.Any());
-            foreach (ImageInfo image in multiArchImages)
+
+            DockerHelper.Login(Options.Username, Options.Password, Options.Server, Options.IsDryRun);
+            try
             {
-                StringBuilder manifestYml = new StringBuilder();
-                manifestYml.AppendLine($"image: {image.SharedTags.First().FullyQualifiedName}");
-
-                IEnumerable<string> additionalTags = image.SharedTags
-                    .Select(tag => tag.Name)
-                    .Skip(1);
-                if (additionalTags.Any())
+                IEnumerable<ImageInfo> multiArchImages = Manifest.Repos
+                    .SelectMany(repo => repo.Images)
+                    .Where(image => image.SharedTags.Any());
+                foreach (ImageInfo image in multiArchImages)
                 {
-                    manifestYml.AppendLine($"tags: [{string.Join(",", additionalTags)}]");
+                    string manifest = GenerateManifest(image);
+
+                    Console.WriteLine($"-- PUBLISHING MANIFEST:{Environment.NewLine}{manifest}");
+                    File.WriteAllText("manifest.yml", manifest);
+
+                    // ExecuteWithRetry because the manifest-tool fails periodically with communicating
+                    // with the Docker Registry.
+                    ExecuteHelper.ExecuteWithRetry("manifest-tool", "push from-spec manifest.yml", Options.IsDryRun);
                 }
-
-                manifestYml.AppendLine("manifests:");
-                foreach (PlatformInfo platform in image.Platforms)
-                {
-                    manifestYml.AppendLine($"  -");
-                    manifestYml.AppendLine($"    image: {platform.Tags.First().FullyQualifiedName}");
-                    manifestYml.AppendLine($"    platform:");
-                    manifestYml.AppendLine($"      architecture: {platform.Model.Architecture.ToString().ToLowerInvariant()}");
-                    manifestYml.AppendLine($"      os: {platform.Model.OS.ToString().ToLowerInvariant()}");
-                    if (platform.Model.Variant != null)
-                    {
-                        manifestYml.AppendLine($"      variant: {platform.Model.Variant}");
-                    }
-                }
-
-                Console.WriteLine($"-- PUBLISHING MANIFEST:{Environment.NewLine}{manifestYml}");
-                File.WriteAllText("manifest.yml", manifestYml.ToString());
-
-                // ExecuteWithRetry because the manifest-tool fails periodically with communicating
-                // with the Docker Registry.
-                ExecuteHelper.ExecuteWithRetry(
-                    "manifest-tool",
-                    $"--username {Options.Username} --password {Options.Password} push from-spec manifest.yml",
-                    Options.IsDryRun);
+            }
+            finally
+            {
+                DockerHelper.Logout(Options.Server, Options.IsDryRun);
             }
 
             return Task.CompletedTask;
+        }
+
+        private string GenerateManifest(ImageInfo image)
+        {
+            StringBuilder manifestYml = new StringBuilder();
+            manifestYml.AppendLine($"image: {image.SharedTags.First().FullyQualifiedName}");
+
+            IEnumerable<string> additionalTags = image.SharedTags
+                .Select(tag => tag.Name)
+                .Skip(1);
+            if (additionalTags.Any())
+            {
+                manifestYml.AppendLine($"tags: [{string.Join(",", additionalTags)}]");
+            }
+
+            manifestYml.AppendLine("manifests:");
+            foreach (PlatformInfo platform in image.Platforms)
+            {
+                manifestYml.AppendLine($"  -");
+                manifestYml.AppendLine($"    image: {platform.Tags.First().FullyQualifiedName}");
+                manifestYml.AppendLine($"    platform:");
+                manifestYml.AppendLine($"      architecture: {platform.Model.Architecture.ToString().ToLowerInvariant()}");
+                manifestYml.AppendLine($"      os: {platform.Model.OS.ToString().ToLowerInvariant()}");
+                if (platform.Model.Variant != null)
+                {
+                    manifestYml.AppendLine($"      variant: {platform.Model.Variant}");
+                }
+            }
+
+            return manifestYml.ToString();
         }
     }
 }

--- a/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
@@ -74,13 +74,13 @@ namespace Microsoft.DotNet.ImageBuilder
             return Version.TryParse(versionString, out Version version) ? version : null;
         }
 
-        public static void Login(string username, string password, bool isDryRun)
+        public static void Login(string username, string password, string server, bool isDryRun)
         {
             Version clientVersion = GetClientVersion();
             if (clientVersion >= new Version(17, 7))
             {
                 ProcessStartInfo startInfo = new ProcessStartInfo(
-                    "docker", $"login -u {username} --password-stdin");
+                    "docker", $"login -u {username} --password-stdin {server}");
                 startInfo.RedirectStandardInput = true;
                 ExecuteHelper.Execute(
                     startInfo,
@@ -96,13 +96,17 @@ namespace Microsoft.DotNet.ImageBuilder
             }
             else
             {
-                string loginArgsWithoutPassword = $"login -u {username} -p";
                 ExecuteHelper.Execute(
                     "docker",
-                    $"{loginArgsWithoutPassword} {password}",
+                    $"login -u {username} -p {password} {server}",
                     isDryRun,
-                    executeMessageOverride: $"{loginArgsWithoutPassword} ********");
+                    executeMessageOverride: $"login -u {username} -p ******** {server}");
             }
+        }
+
+        public static void Logout(string server, bool isDryRun)
+        {
+            ExecuteHelper.Execute("docker", $"logout {server}", isDryRun);
         }
 
         public static void PullBaseImages(ManifestInfo manifest, Options options)


### PR DESCRIPTION
This is needed in order to use ImageBuilder to push images to an Azure Container Registry.