### PR TITLE
Add support for modeled docker build args

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/Model/Platform.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Model/Platform.cs
@@ -16,6 +16,8 @@ namespace Microsoft.DotNet.ImageBuilder.Model
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         public Architecture Architecture { get; set; }
 
+        public IDictionary<string, string> BuildArgs { get; set; }
+
         [JsonProperty(Required = Required.Always)]
         public string Dockerfile { get; set; }
 

--- a/Microsoft.DotNet.ImageBuilder/src/Model/Tag.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Model/Tag.cs
@@ -6,6 +6,8 @@ namespace Microsoft.DotNet.ImageBuilder.Model
 {
     public class Tag
     {
+        public string Id { get; set; }
+
         public bool IsUndocumented { get; set; }
 
         public Tag()

--- a/Microsoft.DotNet.ImageBuilder/src/Utilities.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Utilities.cs
@@ -10,7 +10,7 @@ namespace Microsoft.DotNet.ImageBuilder
 {
     public static class Utilities
     {
-        private static string TagVariablePattern = $"\\$\\((?<{VariableGroupName}>[\\w]+)\\)";
+        private static string TagVariablePattern = $"\\$\\((?<{VariableGroupName}>[\\w:\\-.]+)\\)";
         private static string TimeStamp { get; } = DateTime.UtcNow.ToString("yyyymmddhhmmss");
         private const string VariableGroupName = "variable";
 

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
@@ -35,6 +35,21 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             return manifestInfo;
         }
 
+        private IEnumerable<TagInfo> GetAllTags()
+        {
+            IEnumerable<ImageInfo> images = Repos
+                .SelectMany(repo => repo.Images)
+                .ToArray();
+            IEnumerable<TagInfo> sharedTags = images
+                .SelectMany(image => image.SharedTags);
+            IEnumerable<TagInfo> platformTags = images
+                .SelectMany(image => image.Platforms)
+                .SelectMany(platform => platform.Tags);
+            return sharedTags
+                .Concat(platformTags)
+                .ToArray();
+        }
+
         public IEnumerable<string> GetExternalFromImages()
         {
             return ActiveImages
@@ -42,6 +57,21 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
                 .SelectMany(platform => platform.FromImages)
                 .Where(IsExternalImage)
                 .Distinct();
+        }
+
+        public string GetReferenceVariableValue(string variableName)
+        {
+            const string tagRef = "tagRef:";
+
+            string variableValue = null;
+            if (variableName.StartsWith(tagRef))
+            {
+                string tagId = variableName.Substring(tagRef.Length);
+                variableValue = GetAllTags()
+                    .Single(kvp => kvp.Model.Id == tagId).Name;
+            }
+
+            return variableValue;
         }
 
         public bool IsExternalImage(string image)

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
@@ -61,7 +61,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 
         public string GetReferenceVariableValue(string variableName)
         {
-            const string tagRef = "tagRef:";
+            const string tagRef = "TagRef:";
 
             string variableValue = null;
             if (variableName.StartsWith(tagRef))

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
@@ -5,6 +5,7 @@
 using Microsoft.DotNet.ImageBuilder.Model;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -15,6 +16,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
     {
         private static Regex FromRegex { get; } = new Regex(@"FROM\s+(?<fromImage>\S+)");
 
+        public IDictionary<string, string> BuildArgs { get; private set; }
         public string BuildContextPath { get; private set; }
         public string DockerfilePath { get; private set; }
         public IEnumerable<string> FromImages { get; private set; }
@@ -45,6 +47,15 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             platformInfo.Tags = model.Tags
                 .Select(kvp => TagInfo.Create(kvp.Key, kvp.Value, manifest, repoName, platformInfo.BuildContextPath))
                 .ToArray();
+
+            if (model.BuildArgs == null)
+            {
+                platformInfo.BuildArgs = ImmutableDictionary<string, string>.Empty;
+            }
+            else
+            {
+                platformInfo.BuildArgs = model.BuildArgs;
+            }
 
             platformInfo.InitializeFromImages();
 


### PR DESCRIPTION
This also includes variable support for referencing tags - e.g. $(tagRef:debian-8.2)

Sample Manifest Usage:

```
{
  "platforms": [
    {
      "dockerfile": "debian/8.2",
      "os": "linux",
      "tags": {
        "debian-8.2-$(DockerfileGitCommitSha)-$(TimeStamp)": {
          "id": "debian-8.2"
        }
      }
    }
  ]
},
{
  "platforms": [
    {
      "buildArgs": {
        "BASE_IMAGE":"$(tagRef:debian-8.2)"
      },
      "dockerfile": "debian/8.2/debpkg",
      "os": "linux",
      "tags": {
        "debian-8.2-debpkg-$(system:DockerfileGitCommitSha)-$(system:TimeStamp)": {}
      }
    }
  ]
},
```