### PR TITLE
Variable refactoring

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
@@ -5,9 +5,7 @@
 using Microsoft.DotNet.ImageBuilder.Model;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
 using System;
-using System.Collections.Generic;
 using System.CommandLine;
-using System.Linq;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
@@ -22,7 +20,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public bool IsTestRunDisabled { get; set; }
         public string OsVersion { get; set; }
         public string Path { get; set; }
-        public IDictionary<string, string> TestVariables { get; set; }
 
         public BuildOptions() : base()
         {
@@ -69,12 +66,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             bool isTestRunDisabled = false;
             syntax.DefineOption("skip-test", ref isTestRunDisabled, "Skip running the tests");
             IsTestRunDisabled = isTestRunDisabled;
-
-            IReadOnlyList<string> nameValuePairs = Array.Empty<string>();
-            syntax.DefineOptionList("test-var", ref nameValuePairs, "Named variables to substitute into the test commands (name=value)");
-            TestVariables = nameValuePairs
-                .Select(pair => pair.Split(new char[] { '=' }, 2))
-                .ToDictionary(split => split[0], split => split[1]);
         }
     }
 }

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/Command.TOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/Command.TOptions.cs
@@ -40,7 +40,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             Manifest = ManifestInfo.Create(
                 manifestModel,
                 Options.GetManifestFilter(),
-                (Options as DockerRegistryOptions)?.RepoOwner);
+                (Options as DockerRegistryOptions)?.RepoOwner,
+                Options.Variables);
 
             if (Options.IsVerbose)
             {

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/Options.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/Options.cs
@@ -5,7 +5,9 @@
 using Microsoft.DotNet.ImageBuilder.Model;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
 using System;
+using System.Collections.Generic;
 using System.CommandLine;
+using System.Linq;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
@@ -18,6 +20,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public bool IsVerbose { get; set; }
         public string Manifest { get; set; }
         public string Repo { get; set; }
+        public IDictionary<string, string> Variables { get; set; }
 
         protected Options()
         {
@@ -47,6 +50,12 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             string repo = null;
             syntax.DefineOption("repo", ref repo, "Repo to operate on (Default is all)");
             Repo = repo;
+
+            IReadOnlyList<string> nameValuePairs = Array.Empty<string>();
+            syntax.DefineOptionList("var", ref nameValuePairs, "Named variables to substitute into the manifest (name=value)");
+            Variables = nameValuePairs
+                .Select(pair => pair.Split(new char[] { '=' }, 2))
+                .ToDictionary(split => split[0], split => split[1]);
 
             bool isVerbose = false;
             syntax.DefineOption("verbose", ref isVerbose, "Show details about the tasks run");

--- a/Microsoft.DotNet.ImageBuilder/src/Model/Manifest.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Model/Manifest.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.ImageBuilder.Model
         [JsonProperty(Required = Required.Always)]
         public Repo[] Repos { get; set; }
 
-        public IDictionary<string, string> TagVariables { get; set; }
+        public IDictionary<string, string> Variables { get; set; }
 
         [JsonConverter(typeof(EnumKeyDictionaryConverter<OS>))]
         public IDictionary<OS, string[]> TestCommands { get; set; }

--- a/Microsoft.DotNet.ImageBuilder/src/Utilities.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Utilities.cs
@@ -3,47 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
-using System.Text.RegularExpressions;
 
 namespace Microsoft.DotNet.ImageBuilder
 {
     public static class Utilities
     {
-        private static string TagVariablePattern = $"\\$\\((?<{VariableGroupName}>[\\w:\\-.]+)\\)";
-        private static string TimeStamp { get; } = DateTime.UtcNow.ToString("yyyymmddhhmmss");
-        private const string VariableGroupName = "variable";
-
-        public static string SubstituteVariables(
-            IDictionary<string, string> userVariables,
-            string expression,
-            Func<string, string> getContextBasedSystemValue = null)
-        {
-            foreach (Match match in Regex.Matches(expression, TagVariablePattern))
-            {
-                string variableName = match.Groups[VariableGroupName].Value;
-                string variableValue = null;
-                if (userVariables == null || !userVariables.TryGetValue(variableName, out variableValue))
-                {
-                    if (getContextBasedSystemValue != null)
-                    {
-                        variableValue = getContextBasedSystemValue(variableName);
-                    }
-                    if (variableValue == null && variableName == "TimeStamp")
-                    {
-                        variableValue = TimeStamp;
-                    }
-                    if (variableValue == null)
-                    {
-                        throw new InvalidOperationException($"A value was not found for the variable '{match.Value}'");
-                    }
-                }
-                expression = expression.Replace(match.Value, variableValue);
-            }
-
-            return expression;
-        }
-
         public static void WriteHeading(string heading)
         {
             Console.WriteLine();

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/ImageInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/ImageInfo.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         {
         }
 
-        public static ImageInfo Create(Image model, Manifest manifest, string repoName, ManifestFilter manifestFilter)
+        public static ImageInfo Create(Image model, string repoName, ManifestFilter manifestFilter, VariableHelper variableHelper)
         {
             ImageInfo imageInfo = new ImageInfo();
             imageInfo.Model = model;
@@ -31,12 +31,12 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             else
             {
                 imageInfo.SharedTags = model.SharedTags
-                    .Select(kvp => TagInfo.Create(kvp.Key, kvp.Value, manifest, repoName))
+                    .Select(kvp => TagInfo.Create(kvp.Key, kvp.Value, repoName, variableHelper))
                     .ToArray();
             }
 
             imageInfo.Platforms = manifestFilter.GetPlatforms(model)
-                .Select(platform => PlatformInfo.Create(platform, manifest, repoName))
+                .Select(platform => PlatformInfo.Create(platform, repoName, variableHelper))
                 .ToArray();
 
             IEnumerable<Platform> activePlatformModels = manifestFilter.GetActivePlatforms(model);

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/RepoInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/RepoInfo.cs
@@ -20,14 +20,14 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         {
         }
 
-        public static RepoInfo Create(Repo model, Manifest manifest, ManifestFilter manifestFilter, string repoOwner)
+        public static RepoInfo Create(Repo model, ManifestFilter manifestFilter, string repoOwner, VariableHelper variableHelper)
         {
             RepoInfo repoInfo = new RepoInfo();
             repoInfo.Model = model;
             repoInfo.Name = string.IsNullOrWhiteSpace(repoOwner) ?
                 model.Name : DockerHelper.ReplaceImageOwner(model.Name, repoOwner);
             repoInfo.Images = model.Images
-                .Select(image => ImageInfo.Create(image, manifest, repoInfo.Name, manifestFilter))
+                .Select(image => ImageInfo.Create(image, repoInfo.Name, manifestFilter, variableHelper))
                 .ToArray();
 
             return repoInfo;

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/TagInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/TagInfo.cs
@@ -20,14 +20,14 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         public static TagInfo Create(
             string name,
             Tag model,
-            Manifest manifest,
             string repoName,
+            VariableHelper variableHelper,
             string buildContextPath = null)
         {
             TagInfo tagInfo = new TagInfo();
             tagInfo.Model = model;
             tagInfo.BuildContextPath = buildContextPath;
-            tagInfo.Name = Utilities.SubstituteVariables(manifest.TagVariables, name, tagInfo.GetSubstituteValue);
+            tagInfo.Name = variableHelper.SubstituteValues(name, tagInfo.GetSubstituteValue);
             tagInfo.FullyQualifiedName = $"{repoName}:{tagInfo.Name}";
 
             return tagInfo;

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
@@ -1,0 +1,100 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.ImageBuilder.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.DotNet.ImageBuilder.ViewModel
+{
+    public class VariableHelper
+    {
+        private const char BuiltInDelimiter = ':';
+        private const string SystemVariableTypeId = "System";
+        private const string TagVariableTypeId = "TagRef";
+        private const string TimeStampVariableName = "TimeStamp";
+        private const string VariableGroupName = "variable";
+
+        private static string TagVariablePattern = $"\\$\\((?<{VariableGroupName}>[\\w:\\-.]+)\\)";
+        private static string TimeStamp { get; } = DateTime.UtcNow.ToString("yyyymmddhhmmss");
+
+        private Func<string, TagInfo> GetTagById { get; set; }
+        private Manifest Manifest { get; set; }
+        private IDictionary<string, string> OptionVariables { get; set; }
+
+        public VariableHelper(Manifest manifest, IDictionary<string, string> optionVariables, Func<string, TagInfo> getTagById)
+        {
+            GetTagById = getTagById;
+            Manifest = manifest;
+            OptionVariables = optionVariables;
+        }
+
+        public string SubstituteValues(string expression, Func<string, string> getContextBasedSystemValue = null)
+        {
+            foreach (Match match in Regex.Matches(expression, TagVariablePattern))
+            {
+                string variableValue;
+                string variableName = match.Groups[VariableGroupName].Value;
+
+                if (variableName.Contains(BuiltInDelimiter))
+                {
+                    variableValue = GetBuiltInValue(variableName, getContextBasedSystemValue);
+                }
+                else
+                {
+                    variableValue = GetUserValue(variableName);
+                }
+
+                if (variableValue == null)
+                {
+                    throw new InvalidOperationException($"A value was not found for the variable '{match.Value}'");
+                }
+
+                expression = expression.Replace(match.Value, variableValue);
+            }
+
+            return expression;
+        }
+
+        private string GetBuiltInValue(string variableName, Func<string, string> getContextBasedSystemValue)
+        {
+            string variableValue = null;
+
+            string[] variableNameParts = variableName.Split(BuiltInDelimiter, 2);
+            string variableType = variableNameParts[0];
+            variableName = variableNameParts[1];
+
+            if (string.Equals(variableType, SystemVariableTypeId, StringComparison.Ordinal))
+            {
+                if (string.Equals(variableName, TimeStampVariableName, StringComparison.Ordinal))
+                {
+                    variableValue = TimeStamp;
+                }
+                else if (getContextBasedSystemValue != null)
+                {
+                    variableValue = getContextBasedSystemValue(variableName);
+                }
+            }
+            else if (string.Equals(variableType, TagVariableTypeId, StringComparison.Ordinal))
+            {
+                variableValue = GetTagById(variableName).Name;
+            }
+
+            return variableValue;
+        }
+
+        private string GetUserValue(string variableName)
+        {
+            if (!OptionVariables.TryGetValue(variableName, out string variableValue)
+                && Manifest.Variables != null)
+            {
+                Manifest.Variables.TryGetValue(variableName, out variableValue);
+            }
+
+            return variableValue;
+        }
+    }
+}

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
@@ -88,10 +88,9 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 
         private string GetUserValue(string variableName)
         {
-            if (!OptionVariables.TryGetValue(variableName, out string variableValue)
-                && Manifest.Variables != null)
+            if (!OptionVariables.TryGetValue(variableName, out string variableValue))
             {
-                Manifest.Variables.TryGetValue(variableName, out variableValue);
+                Manifest.Variables?.TryGetValue(variableName, out variableValue);
             }
 
             return variableValue;


### PR DESCRIPTION
1. Made the `TagVariables` property in the model generally applicable to anywhere variables are used in the model.  As part of this the `TagVariables` property was renamed to `Variables`.
2. Refactored the `build` command's `test-var` option to be generally applicable to any command.  The option was renamed to `var`.
3. Added a prefix to all built in variables to make the manifest easier to read in that it is clear where the variable values come from.
4. Refactored the variable substitution logic so that it is more centrally located within one class.  This refactoring should make it easy to add additional built in variables in the future in addition to adding more places within the manifest that support referencing variables.