### PR TITLE
Add RepoOwner built in variable

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/Commands/Command.TOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/Command.TOptions.cs
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             Manifest = ManifestInfo.Create(
                 manifestModel,
                 Options.GetManifestFilter(),
-                (Options as DockerRegistryOptions)?.RepoOwner,
+                Options.RepoOwner,
                 Options.Variables);
 
             if (Options.IsVerbose)

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/DockerRegistryOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/DockerRegistryOptions.cs
@@ -9,7 +9,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     public abstract class DockerRegistryOptions : Options
     {
         public string Password { get; set; }
-        public string RepoOwner { get; set; }
         public string Server { get; set; }
         public string Username { get; set; }
 
@@ -28,12 +27,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 "Password for the Docker Registry the images are pushed to");
             Password = password;
 
-            string repoOwner = null;
-            syntax.DefineOption(
-                "repo-owner",
-                ref repoOwner,
-                "An alternative repo owner which overrides what is specified in the manifest");
-            RepoOwner = repoOwner;
 
             string server = null;
             syntax.DefineOption(

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/Options.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/Options.cs
@@ -20,6 +20,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public bool IsVerbose { get; set; }
         public string Manifest { get; set; }
         public string Repo { get; set; }
+        public string RepoOwner { get; set; }
+
         public IDictionary<string, string> Variables { get; set; }
 
         protected Options()
@@ -50,6 +52,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             string repo = null;
             syntax.DefineOption("repo", ref repo, "Repo to operate on (Default is all)");
             Repo = repo;
+
+            string repoOwner = null;
+            syntax.DefineOption(
+                "repo-owner",
+                ref repoOwner,
+                "An alternative repo owner which overrides what is specified in the manifest");
+            RepoOwner = repoOwner;
 
             IReadOnlyList<string> nameValuePairs = Array.Empty<string>();
             syntax.DefineOptionList("var", ref nameValuePairs, "Named variables to substitute into the manifest (name=value)");

--- a/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
@@ -74,6 +74,11 @@ namespace Microsoft.DotNet.ImageBuilder
             return Version.TryParse(versionString, out Version version) ? version : null;
         }
 
+        public static string GetImageOwner(string image)
+        {
+            return image.Substring(0, image.IndexOf('/'));
+        }
+
         public static void Login(string username, string password, string server, bool isDryRun)
         {
             Version clientVersion = GetClientVersion();

--- a/Microsoft.DotNet.ImageBuilder/src/ValidationException.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ValidationException.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.DotNet.ImageBuilder
+{
+    public class ValidationException : Exception
+    {
+        public ValidationException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             ManifestInfo manifestInfo = new ManifestInfo();
             manifestInfo.Model = model;
             manifestInfo.ManifestFilter = manifestFilter;
-            manifestInfo.VariableHelper = new VariableHelper(model, optionVariables, manifestInfo.GetTagById);
+            manifestInfo.VariableHelper = new VariableHelper(model, optionVariables, repoOwner, manifestInfo.GetTagById);
             manifestInfo.Repos = manifestFilter.GetRepos(manifestInfo.Model)
                 .Select(repo => RepoInfo.Create(repo, manifestFilter, repoOwner, manifestInfo.VariableHelper))
                 .ToArray();


### PR DESCRIPTION
This change is to support tests that need to know the repo owner in order to test the images.  Hard coding the owner within the tests is undesirable as the name would need to be updated if using the `--repo-owner` option to push to a staging docker registry.  

[These changes](https://github.com/Microsoft/dotnet-framework-docker/compare/master...MichaelSimons:RepoOwner?expand=1) show how this new functionality would be used.