### PR TITLE
Ignore pulling base images if name contains a build-arg

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.ImageBuilder.Model;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -65,7 +66,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         public TagInfo GetTagById(string id)
         {
             return GetAllTags()
-                .Single(kvp => kvp.Model.Id == id);
+                .FirstOrDefault(kvp => kvp.Model.Id == id);
         }
 
         public IEnumerable<string> GetTestCommands()

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/ModelExtensions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/ModelExtensions.cs
@@ -56,7 +56,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             ValidateUniqueElements(tagIds, "tag IDs");
         }
 
-        private static void ValidateUniqueElements(IEnumerable<string> source, string element)
+        private static void ValidateUniqueElements(IEnumerable<string> source, string elementsDescription)
         {
             if (source.Count() != source.Distinct().Count())
             {
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
                     .Where(x => x.Count() > 1)
                     .Select(x => x.Key);
                 throw new ValidationException(
-                    $"Duplicate {element} found: {Environment.NewLine}{string.Join(Environment.NewLine, duplicates)}");
+                    $"Duplicate {elementsDescription} found: {Environment.NewLine}{string.Join(Environment.NewLine, duplicates)}");
             }
         }
     }

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
@@ -74,13 +74,16 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         private void InitializeFromImages()
         {
             string dockerfile = File.ReadAllText(this.DockerfilePath);
-            IEnumerable<Match> fromMatches = FromRegex.Matches(dockerfile).Cast<Match>();
+            IEnumerable<Match> fromMatches = FromRegex.Matches(dockerfile);
+
             if (!fromMatches.Any())
             {
                 throw new InvalidOperationException($"Unable to find a FROM image in {this.DockerfilePath}.");
             }
 
-            FromImages = fromMatches.Select(match => match.Groups["fromImage"].Value).ToArray();
+            FromImages = fromMatches
+                .Select(match => match.Groups["fromImage"].Value)
+                .Where(match => !match.Contains("$")).ToArray();
         }
     }
 }

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
@@ -83,7 +83,8 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 
             FromImages = fromMatches
                 .Select(match => match.Groups["fromImage"].Value)
-                .Where(match => !match.Contains("$")).ToArray();
+                .Where(from => !from.Contains("$"))
+                .ToArray();
         }
     }
 }

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
@@ -91,7 +91,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             }
             else if (string.Equals(variableType, TagVariableTypeId, StringComparison.Ordinal))
             {
-                variableValue = GetTagById(variableName).Name;
+                variableValue = GetTagById(variableName)?.Name;
             }
 
             return variableValue;


### PR DESCRIPTION
A base image can contain a [build-arg](https://docs.docker.com/engine/reference/builder/#arg). For example -

```
ARG  CODE_VERSION=latest
FROM base:${CODE_VERSION}
```
Pulling `base:${CODE_VERSION}` would fail if the build-arg is not replaced with the corresponding value. Hence these changes enable _ImageBuilder_ to skip pulling base images that contains a build-arg.

A related change is validating the uniqueness of tag IDs.
