### PR TITLE
Ignore pushing images that have IsLocal as true

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/Model/Tag.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Model/Tag.cs
@@ -8,6 +8,8 @@ namespace Microsoft.DotNet.ImageBuilder.Model
     {
         public string Id { get; set; }
 
+        public bool IsLocal { get; set; }
+
         public bool IsUndocumented { get; set; }
 
         public Tag()

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             }
             else
             {
-                // Modeled Dockefile is just the directory containing the "Dockerfile"
+                // Modeled Dockerfile is just the directory containing the "Dockerfile"
                 platformInfo.DockerfilePath = Path.Combine(model.Dockerfile, "Dockerfile");
                 platformInfo.BuildContextPath = model.Dockerfile;
             }


### PR DESCRIPTION
Introduces an `IsLocal` property for a tag.  This is to enable the scenario where a local or transient image is used to build an image. Only the final image should be pushed to the registry, and the transient image should not be included in the push. In such a case, setting `IsLocal` to `true` on a tag will skip pushing the corresponding tag (image) to a Docker registry.

A related change is to set the `WorkingDirectory` property to build context path while invoking a build hook. This ensures that the hook can find all the files and directories it needs.