### PR TITLE
Update datetime format

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         private const string VariableGroupName = "variable";
 
         private static string TagVariablePattern = $"\\$\\((?<{VariableGroupName}>[\\w:\\-.]+)\\)";
-        private static string TimeStamp { get; } = DateTime.UtcNow.ToString("yyyymmddhhmmss");
+        private static string TimeStamp { get; } = DateTime.UtcNow.ToString("yyyyMMddHHmmss");
 
         private Func<string, TagInfo> GetTagById { get; set; }
         private Manifest Manifest { get; set; }


### PR DESCRIPTION
Date-time format used in `TimeStamp` is incorrect.  Correct format should include month `MM` and not `mm`, which is minute.  Also, updated to 24-hour format i.e, `HH` in place of `hh`.
