### PR TITLE
Fix InvalidOperationException when there are no documented tags for an image

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateTagsReadmeCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateTagsReadmeCommand.cs
@@ -83,8 +83,15 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 tagsDoc.AppendLine();
                 foreach (var tuple in platformGroup)
                 {
-                    string tags = GetDocumentedTags(tuple.Platform.Tags)
-                        .Concat(GetDocumentedTags(tuple.Image.SharedTags))
+                    IEnumerable<string> documentedTags = GetDocumentedTags(tuple.Platform.Tags)
+                        .Concat(GetDocumentedTags(tuple.Image.SharedTags));
+
+                    if (!documentedTags.Any())
+                    {
+                        continue;
+                    }
+
+                    string tags = documentedTags
                         .Select(tag => $"`{tag}`")
                         .Aggregate((working, next) => $"{working}, {next}");
                     string dockerfile = tuple.Platform.DockerfilePath.Replace('\\', '/');


### PR DESCRIPTION
Fixes the following error 
```

System.InvalidOperationException: Sequence contains no elements
   at System.Linq.Enumerable.Aggregate[TSource](IEnumerable`1 source, Func`3 func)
   at Microsoft.DotNet.ImageBuilder.Commands.GenerateTagsReadmeCommand.GetTagsDocumentation(RepoInfo repo) in /image-builder/Commands/GenerateTagsReadmeCommand.cs:line 68
   at Microsoft.DotNet.ImageBuilder.Commands.GenerateTagsReadmeCommand.ExecuteAsync() in /image-builder/Commands/GenerateTagsReadmeCommand.cs:line 28
   at Microsoft.DotNet.ImageBuilder.ImageBuilder.Main(String[] args) in /image-builder/ImageBuilder.cs:line 53
```