### PR TITLE
Refactor username/password option validation

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -14,7 +14,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
-    public class BuildCommand : Command<BuildOptions>
+    public class BuildCommand : DockerRegistryCommand<BuildOptions>
     {
         private IEnumerable<TagInfo> BuiltTags { get; set; } = Enumerable.Empty<TagInfo>();
 
@@ -138,8 +138,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             {
                 Logger.WriteHeading("PUSHING IMAGES");
 
-                DockerHelper.Login(Options.Username, Options.Password, Options.Server, Options.IsDryRun);
-                try
+                ExecuteWithUser(() =>
                 {
                     IEnumerable<string> pushTags = BuiltTags
                         .Where(tag => !tag.Model.IsLocal)
@@ -148,11 +147,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     {
                         ExecuteHelper.ExecuteWithRetry("docker", $"push {tag}", Options.IsDryRun);
                     }
-                }
-                finally
-                {
-                    DockerHelper.Logout(Options.Server, Options.IsDryRun);
-                }
+                });
             }
         }
 

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/DockerRegistryCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/DockerRegistryCommand.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    public abstract class DockerRegistryCommand<TOptions> : Command<TOptions>
+        where TOptions : DockerRegistryOptions, new()
+    {
+        protected void ExecuteWithUser(Action action)
+        {
+            bool userSpecified = Options.Username != null;
+            if (userSpecified)
+            {
+                DockerHelper.Login(Options.Username, Options.Password, Options.Server, Options.IsDryRun);
+            }
+
+            try
+            {
+                action();
+            }
+            finally
+            {
+                if (userSpecified)
+                {
+                    DockerHelper.Logout(Options.Server, Options.IsDryRun);
+                }
+            }
+        }
+    }
+}

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/DockerRegistryOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/DockerRegistryOptions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.CommandLine;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
@@ -21,12 +22,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             base.ParseCommandLine(syntax);
 
             string password = null;
-            syntax.DefineOption(
+            Argument<string> passwordArg = syntax.DefineOption(
                 "password",
                 ref password,
                 "Password for the Docker Registry the images are pushed to");
             Password = password;
-
 
             string server = null;
             syntax.DefineOption(
@@ -36,11 +36,17 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             Server = server;
 
             string username = null;
-            syntax.DefineOption(
+            Argument<string> usernameArg = syntax.DefineOption(
                 "username",
                 ref username,
                 "Username for the Docker Registry the images are pushed to");
             Username = username;
+
+            if (password != null ^ username != null)
+            {
+                Logger.WriteError($"error: `{usernameArg.Name}` and `{passwordArg.Name}` must both be specified.");
+                Environment.Exit(1);
+            }
         }
     }
 }

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/DockerRegistryOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/DockerRegistryOptions.cs
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 "Username for the Docker Registry the images are pushed to");
             Username = username;
 
-            if (password != null ^ username != null)
+            if (passwordArg.IsSpecified ^ usernameArg.IsSpecified)
             {
                 Logger.WriteError($"error: `{usernameArg.Name}` and `{passwordArg.Name}` must both be specified.");
                 Environment.Exit(1);

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestCommand.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
-    public class PublishManifestCommand : Command<PublishManifestOptions>
+    public class PublishManifestCommand : DockerRegistryCommand<PublishManifestOptions>
     {
         public PublishManifestCommand() : base()
         {
@@ -22,8 +22,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             Logger.WriteHeading("GENERATING MANIFESTS");
 
-            DockerHelper.Login(Options.Username, Options.Password, Options.Server, Options.IsDryRun);
-            try
+            ExecuteWithUser(() =>
             {
                 IEnumerable<ImageInfo> multiArchImages = Manifest.Repos
                     .SelectMany(repo => repo.Images)
@@ -41,11 +40,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 }
 
                 WriteManifestSummary(multiArchImages);
-            }
-            finally
-            {
-                DockerHelper.Logout(Options.Server, Options.IsDryRun);
-            }
+            });
 
             return Task.CompletedTask;
         }


### PR DESCRIPTION
Fixes #69

- Add validation to ensure both username and password are specified if one is specified.
- If a username and password are not specified, skip docker registry login.  This is useful when running locally.