### PR TITLE
Refactor GenerateTagsReadmeCommand to support user defined templates

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateTagsReadmeCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateTagsReadmeCommand.cs
@@ -161,9 +161,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private static string NormalizeLineEndings(string value, string targetFormat)
         {
             string targetLineEnding = targetFormat.Contains("\r\n") ? "\r\n" : "\n";
-            if (targetLineEnding != Environment.NewLine)
+            string valueLineEnding = value.Contains("\r\n") ? "\r\n" : "\n";
+            if (valueLineEnding != targetLineEnding)
             {
-                value = value.Replace(Environment.NewLine, targetLineEnding);
+                value = value.Replace(valueLineEnding, targetLineEnding);
             }
 
             return value;

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateTagsReadmeCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateTagsReadmeCommand.cs
@@ -144,7 +144,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             string variableValue = null;
 
-            if (string.Equals(variableType, "TagDoc", StringComparison.Ordinal))
+            if (string.Equals(variableType, VariableHelper.TagDocTypeId, StringComparison.Ordinal))
             {
                 ImageDocumentationInfo info = ImageDocInfos
                     .FirstOrDefault(tli => tli.Platform.Tags.Any(tag => tag.Name == variableName));

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateTagsReadmeOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateTagsReadmeOptions.cs
@@ -12,6 +12,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         protected override string CommandName => "generateTagsReadme";
 
         public string SourceUrl { get; set; }
+        public string Template { get; set; }
         public bool UpdateReadme { get; set; }
 
         public GenerateTagsReadmeOptions() : base()
@@ -25,6 +26,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             bool updateReadme = false;
             syntax.DefineOption("update-readme", ref updateReadme, "Update the readme file");
             UpdateReadme = updateReadme;
+
+            string template = null;
+            syntax.DefineOption("template", ref template, "Path to a custom template file");
+            Template = template;
 
             string sourceUrl = null;
             syntax.DefineParameter("source-url", ref sourceUrl, "Base URL of the Dockerfile sources");

--- a/Microsoft.DotNet.ImageBuilder/src/Model/Image.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Model/Image.cs
@@ -12,8 +12,6 @@ namespace Microsoft.DotNet.ImageBuilder.Model
         [JsonProperty(Required = Required.Always)]
         public Platform[] Platforms { get; set; }
 
-        public int ReadmeOrder { get; set; }
-
         public IDictionary<string, Tag> SharedTags { get; set; }
 
         public Image()

--- a/Microsoft.DotNet.ImageBuilder/src/Model/Repo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Model/Repo.cs
@@ -16,6 +16,8 @@ namespace Microsoft.DotNet.ImageBuilder.Model
 
         public string ReadmePath { get; set; }
 
+        public string[] ReadmeTemplate { get; set; }
+
         public Repo()
         {
         }

--- a/Microsoft.DotNet.ImageBuilder/src/Model/Repo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Model/Repo.cs
@@ -16,8 +16,6 @@ namespace Microsoft.DotNet.ImageBuilder.Model
 
         public string ReadmePath { get; set; }
 
-        public string[] ReadmeTemplate { get; set; }
-
         public Repo()
         {
         }

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         private ManifestFilter ManifestFilter { get; set; }
         public Manifest Model { get; private set; }
         public IEnumerable<RepoInfo> Repos { get; private set; }
-        private VariableHelper VariableHelper { get; set; }
+        public VariableHelper VariableHelper { get; set; }
 
         private ManifestInfo()
         {

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/TagInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/TagInfo.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             string variableValue = null;
 
             if (string.Equals(variableType, VariableHelper.SystemVariableTypeId, StringComparison.Ordinal)
-                && string.Equals(variableName, "DockerfileGitCommitSha", StringComparison.Ordinal)
+                && string.Equals(variableName, VariableHelper.DockerfileGitCommitShaVariableName, StringComparison.Ordinal)
                 && BuildContextPath != null)
             {
                 variableValue = GitHelper.GetCommitSha(BuildContextPath);

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/TagInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/TagInfo.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Microsoft.DotNet.ImageBuilder.Model;
 
 namespace Microsoft.DotNet.ImageBuilder.ViewModel
@@ -27,19 +28,23 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             TagInfo tagInfo = new TagInfo();
             tagInfo.Model = model;
             tagInfo.BuildContextPath = buildContextPath;
-            tagInfo.Name = variableHelper.SubstituteValues(name, tagInfo.GetSubstituteValue);
+            tagInfo.Name = variableHelper.SubstituteValues(name, tagInfo.GetVariableValue);
             tagInfo.FullyQualifiedName = $"{repoName}:{tagInfo.Name}";
 
             return tagInfo;
         }
 
-        public string GetSubstituteValue(string variableName)
+        private string GetVariableValue(string variableType, string variableName)
         {
             string variableValue = null;
-            if (variableName == "DockerfileGitCommitSha" && BuildContextPath != null)
+
+            if (string.Equals(variableType, VariableHelper.SystemVariableTypeId, StringComparison.Ordinal)
+                && string.Equals(variableName, "DockerfileGitCommitSha", StringComparison.Ordinal)
+                && BuildContextPath != null)
             {
                 variableValue = GitHelper.GetCommitSha(BuildContextPath);
             }
+
             return variableValue;
         }
     }

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
@@ -13,8 +13,10 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
     public class VariableHelper
     {
         private const char BuiltInDelimiter = ':';
+        public const string DockerfileGitCommitShaVariableName = "DockerfileGitCommitSha";
         private const string RepoOwnerVariableName = "RepoOwner";
         public const string SystemVariableTypeId = "System";
+        public const string TagDocTypeId = "TagDoc";
         private const string TagVariableTypeId = "TagRef";
         private const string TimeStampVariableName = "TimeStamp";
         private const string VariableGroupName = "variable";

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
     {
         private const char BuiltInDelimiter = ':';
         private const string RepoOwnerVariableName = "RepoOwner";
-        private const string SystemVariableTypeId = "System";
+        public const string SystemVariableTypeId = "System";
         private const string TagVariableTypeId = "TagRef";
         private const string TimeStampVariableName = "TimeStamp";
         private const string VariableGroupName = "variable";
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             VariablesOverride = variablesOverride;
         }
 
-        public string SubstituteValues(string expression, Func<string, string> getContextBasedSystemValue = null)
+        public string SubstituteValues(string expression, Func<string, string, string> getContextBasedSystemValue = null)
         {
             foreach (Match match in Regex.Matches(expression, TagVariablePattern))
             {
@@ -66,7 +66,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             return expression;
         }
 
-        private string GetBuiltInValue(string variableName, Func<string, string> getContextBasedSystemValue)
+        private string GetBuiltInValue(string variableName, Func<string, string, string> getContextBasedSystemValue)
         {
             string variableValue = null;
 
@@ -86,12 +86,16 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
                 }
                 else if (getContextBasedSystemValue != null)
                 {
-                    variableValue = getContextBasedSystemValue(variableName);
+                    variableValue = getContextBasedSystemValue(variableType, variableName);
                 }
             }
             else if (string.Equals(variableType, TagVariableTypeId, StringComparison.Ordinal))
             {
                 variableValue = GetTagById(variableName)?.Name;
+            }
+            else if (getContextBasedSystemValue != null)
+            {
+                variableValue = getContextBasedSystemValue(variableType, variableName);
             }
 
             return variableValue;


### PR DESCRIPTION
Fixes #89 

I decided to try a readme template approach.  I'm not really in love with this but it does address the issues discussed in #89.  You can see an example [here](https://github.com/MichaelSimons/dotnet-docker/blob/issue-337/manifest.json#L520).  I had thought about using something like a T4 template but it is far more complicated and expensive to implement/maintain than I felt was needed.   I would like to keep this as simple as possible, yet allow PMs/repo owners the flexibility in changing the readme format yet still get the benefit of having a tool generate the individual tag lines.

@natemcmaster - I would like to get your feedback on this.