### PR TITLE
Reword tag headings to remove 'supported'

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateTagsReadmeCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateTagsReadmeCommand.cs
@@ -79,7 +79,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             {
                 string os = GetOsDisplayName(platformGroup.Key.OS, platformGroup.Key.OsVersion);
                 string arch = GetArchitectureDisplayName(platformGroup.Key.Architecture);
-                tagsDoc.AppendLine($"# Supported {os} {arch} tags");
+                tagsDoc.AppendLine($"# {os} {arch} tags");
                 tagsDoc.AppendLine();
 
                 IEnumerable<string> tagLines = platformGroup


### PR DESCRIPTION
Per discussion with @richlander, we want to remove the term supported as it gets confusing with the "preview 1" tags.