### PR TITLE
Update generateTagsReadme command to handle new windows versions

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateTagsReadmeCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateTagsReadmeCommand.cs
@@ -99,13 +99,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             switch (os)
             {
                 case OS.Windows:
-                    if (osVersion != null && (osVersion.Contains("1709") || osVersion.Contains("16299")))
+                    if (osVersion == null || osVersion.Contains("2016"))
                     {
-                        displayName = "Windows Server, version 1709";
+                        displayName = "Windows Server 2016";
                     }
                     else
                     {
-                        displayName = "Windows Server 2016";
+                        displayName = $"Windows Server, version {osVersion}";
                     }
                     break;
                 default:


### PR DESCRIPTION
Fixes #97 

This is a change that will hopefully cover the next versions of Windows Server assuming they stay with the `Windows Server, version N` naming scheme. 

Note: we are now only setting the version number in the manifests to the shortened stable release version - e.g. 1803, 1709, etc.)