### PR TITLE
Update to .NET Core 2.1

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/Dockerfile.debian
+++ b/Microsoft.DotNet.ImageBuilder/Dockerfile.debian
@@ -17,8 +17,6 @@ RUN dotnet restore Microsoft.DotNet.ImageBuilder.sln
 COPY . ./
 RUN dotnet build Microsoft.DotNet.ImageBuilder.sln
 RUN dotnet test tests/Microsoft.DotNet.ImageBuilder.Tests.csproj
-
-RUN dotnet add ./src/Microsoft.DotNet.ImageBuilder.csproj package ILLink.Tasks -v 0.1.4-preview-981901 -s https://dotnet.myget.org/F/dotnet-core/api/v3/index.json
 RUN dotnet publish ./src/Microsoft.DotNet.ImageBuilder.csproj -c Release -o out -r linux-x64 /p:ShowLinkerSizeComparison=true
 
 

--- a/Microsoft.DotNet.ImageBuilder/Dockerfile.debian
+++ b/Microsoft.DotNet.ImageBuilder/Dockerfile.debian
@@ -3,7 +3,7 @@
 #     docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v <local path to build>:/repo -w /repo image-builder <image-build args>
 
 # build Microsoft.DotNet.ImageBuilder
-FROM microsoft/dotnet:2.0-sdk AS build-env
+FROM microsoft/dotnet:2.1-sdk AS build-env
 WORKDIR image-builder
 
 # restore packages before copying entire source - provides optimizations when rebuilding
@@ -17,16 +17,19 @@ RUN dotnet restore Microsoft.DotNet.ImageBuilder.sln
 COPY . ./
 RUN dotnet build Microsoft.DotNet.ImageBuilder.sln
 RUN dotnet test tests/Microsoft.DotNet.ImageBuilder.Tests.csproj
-RUN dotnet publish ./src/Microsoft.DotNet.ImageBuilder.csproj -c Release -o out
+
+RUN dotnet add ./src/Microsoft.DotNet.ImageBuilder.csproj package ILLink.Tasks -v 0.1.4-preview-981901 -s https://dotnet.myget.org/F/dotnet-core/api/v3/index.json
+RUN dotnet publish ./src/Microsoft.DotNet.ImageBuilder.csproj -c Release -o out -r linux-x64 /p:ShowLinkerSizeComparison=true
 
 
 # build runtime image
-FROM microsoft/dotnet:2.0-runtime
+FROM microsoft/dotnet:2.1-runtime-deps
 
 # install Docker
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         apt-transport-https \
+        curl \
         gnupg \
         software-properties-common \
     && rm -rf /var/lib/apt/lists/*
@@ -53,4 +56,4 @@ RUN apt-get update \
 WORKDIR image-builder
 COPY --from=build-env /image-builder/src/out ./
 
-ENTRYPOINT ["dotnet", "/image-builder/Microsoft.DotNet.ImageBuilder.dll"]
+ENTRYPOINT ["/image-builder/Microsoft.DotNet.ImageBuilder"]

--- a/Microsoft.DotNet.ImageBuilder/Dockerfile.nanoserver
+++ b/Microsoft.DotNet.ImageBuilder/Dockerfile.nanoserver
@@ -1,5 +1,5 @@
 # build Microsoft.DotNet.ImageBuilder
-FROM microsoft/dotnet:2.0-sdk AS build-env
+FROM microsoft/dotnet:2.1-sdk AS build-env
 WORKDIR /image-builder
 
 # restore packages before copying entire source - provides optimizations when rebuilding
@@ -13,6 +13,8 @@ RUN dotnet restore Microsoft.DotNet.ImageBuilder.sln -r win7-x64
 COPY . ./
 RUN dotnet build Microsoft.DotNet.ImageBuilder.sln -r win7-x64
 RUN dotnet test tests/Microsoft.DotNet.ImageBuilder.Tests.csproj -r win7-x64
+
+RUN dotnet add ./src/Microsoft.DotNet.ImageBuilder.csproj package ILLink.Tasks -v 0.1.4-preview-981901 -s https://dotnet.myget.org/F/dotnet-core/api/v3/index.json
 RUN dotnet publish ./src/Microsoft.DotNet.ImageBuilder.csproj -c Release -o out -r win7-x64
 
 

--- a/Microsoft.DotNet.ImageBuilder/Dockerfile.nanoserver
+++ b/Microsoft.DotNet.ImageBuilder/Dockerfile.nanoserver
@@ -13,8 +13,6 @@ RUN dotnet restore Microsoft.DotNet.ImageBuilder.sln -r win7-x64
 COPY . ./
 RUN dotnet build Microsoft.DotNet.ImageBuilder.sln -r win7-x64
 RUN dotnet test tests/Microsoft.DotNet.ImageBuilder.Tests.csproj -r win7-x64
-
-RUN dotnet add ./src/Microsoft.DotNet.ImageBuilder.csproj package ILLink.Tasks -v 0.1.4-preview-981901 -s https://dotnet.myget.org/F/dotnet-core/api/v3/index.json
 RUN dotnet publish ./src/Microsoft.DotNet.ImageBuilder.csproj -c Release -o out -r win7-x64
 
 

--- a/Microsoft.DotNet.ImageBuilder/NuGet.config
+++ b/Microsoft.DotNet.ImageBuilder/NuGet.config
@@ -2,6 +2,7 @@
 <configuration>
   <packageSources>
     <add key="dotnet-buildtools" value="https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />
+    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="dotnet-corefxlab" value="https://dotnet.myget.org/F/dotnet-corefxlab/" />
   </packageSources>
 </configuration>

--- a/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
+++ b/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="ILLink.Tasks" Version="0.1.4-preview-981901" />
     <PackageReference Include="Microsoft.DotNet.VersionTools" Version="1.0.27-prerelease-01903-01" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.1"/>
     <PackageReference Include="System.CommandLine" Version="0.1.0-e170603-2"/>

--- a/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
+++ b/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <RootNamespace>Microsoft.DotNet.ImageBuilder</RootNamespace>
   </PropertyGroup>
 

--- a/Microsoft.DotNet.ImageBuilder/tests/Microsoft.DotNet.ImageBuilder.Tests.csproj
+++ b/Microsoft.DotNet.ImageBuilder/tests/Microsoft.DotNet.ImageBuilder.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
I also made use of the IL linker.  The primary purpose of this is to reduce the size of the resulting image.  With the combination of 2.1 and the IL linker, the Linux image size (extracted on disk) dropped from 520 MB to 457 MB.