### PR TITLE
Upgrade ILLink.Tasks to fix HttpClient SSL bug

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/.dockerignore
+++ b/Microsoft.DotNet.ImageBuilder/.dockerignore
@@ -3,3 +3,4 @@
 **/out
 **/.vscode
 **/.vs
+Dockerfile*

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/UpdateReadmeCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/UpdateReadmeCommand.cs
@@ -36,9 +36,12 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
                 if (!Options.IsDryRun)
                 {
-                    HttpResponseMessage response = await new HttpClient().SendAsync(request);
-                    Logger.WriteSubheading($"RESPONSE:{Environment.NewLine}{response}");
-                    response.EnsureSuccessStatusCode();
+                    using (HttpClient client = new HttpClient())
+                    using (HttpResponseMessage response = await client.SendAsync(request))
+                    {
+                        Logger.WriteSubheading($"RESPONSE:{Environment.NewLine}{response}");
+                        response.EnsureSuccessStatusCode();
+                    }
                 }
             }
         }

--- a/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
+++ b/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ILLink.Tasks" Version="0.1.4-preview-981901" />
+    <PackageReference Include="ILLink.Tasks" Version="0.1.5-preview-1461378" />
     <PackageReference Include="Microsoft.DotNet.VersionTools" Version="1.0.27-prerelease-01903-01" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.1"/>
     <PackageReference Include="System.CommandLine" Version="0.1.0-e170603-2"/>


### PR DESCRIPTION
The only required change is to upgrade the ILLink.Tasks package.  The version being used was trimming some required components for this scenario.  The other changes are related cleanup I discovered while I was debugging this issue.

Fixes #101 