### PR TITLE
Refactor logic to support overriding the repo at build/publish time

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/Dockerfile.nanoserver
+++ b/Microsoft.DotNet.ImageBuilder/Dockerfile.nanoserver
@@ -7,12 +7,12 @@ COPY Microsoft.DotNet.ImageBuilder.sln ./
 COPY NuGet.config ./
 COPY src/Microsoft.DotNet.ImageBuilder.csproj ./src/
 COPY tests/Microsoft.DotNet.ImageBuilder.Tests.csproj ./tests/
-RUN dotnet restore Microsoft.DotNet.ImageBuilder.sln -r win7-x64
+RUN dotnet restore Microsoft.DotNet.ImageBuilder.sln
 
 # copy everything else and build
 COPY . ./
-RUN dotnet build Microsoft.DotNet.ImageBuilder.sln -r win7-x64
-RUN dotnet test tests/Microsoft.DotNet.ImageBuilder.Tests.csproj -r win7-x64
+RUN dotnet build Microsoft.DotNet.ImageBuilder.sln
+RUN dotnet test tests/Microsoft.DotNet.ImageBuilder.Tests.csproj
 RUN dotnet publish ./src/Microsoft.DotNet.ImageBuilder.csproj -c Release -o out -r win7-x64
 
 

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/Options.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/Options.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public bool IsVerbose { get; set; }
         public string Manifest { get; set; }
         public string Repo { get; set; }
-        public string RepoOwner { get; set; }
+        public IDictionary<string, string> RepoOverrides { get; set; }
 
         public IDictionary<string, string> Variables { get; set; }
 
@@ -54,16 +54,15 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             syntax.DefineOption("repo", ref repo, "Repo to operate on (Default is all)");
             Repo = repo;
 
-            string repoOwner = null;
-            syntax.DefineOption(
-                "repo-owner",
-                ref repoOwner,
-                "An alternative repo owner which overrides what is specified in the manifest");
-            RepoOwner = repoOwner;
+            IReadOnlyList<string> repoOverrides = Array.Empty<string>();
+            syntax.DefineOptionList("repo-override", ref repoOverrides, "Alternative repos which override the manifest (<target repo>=<override>)");
+            RepoOverrides = repoOverrides
+                .Select(pair => pair.Split(new char[] { '=' }, 2))
+                .ToDictionary(split => split[0], split => split[1]);
 
-            IReadOnlyList<string> nameValuePairs = Array.Empty<string>();
-            syntax.DefineOptionList("var", ref nameValuePairs, "Named variables to substitute into the manifest (name=value)");
-            Variables = nameValuePairs
+            IReadOnlyList<string> variables = Array.Empty<string>();
+            syntax.DefineOptionList("var", ref variables, "Named variables to substitute into the manifest (<name>=<value>)");
+            Variables = variables
                 .Select(pair => pair.Split(new char[] { '=' }, 2))
                 .ToDictionary(split => split[0], split => split[1]);
 

--- a/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
@@ -82,6 +82,11 @@ namespace Microsoft.DotNet.ImageBuilder
             return image.Substring(0, image.IndexOf('/'));
         }
 
+        public static string GetRepo(string image)
+        {
+            return image.Substring(0, image.IndexOf(':'));
+        }
+
         public static void Login(string username, string password, string server, bool isDryRun)
         {
             Version clientVersion = GetClientVersion();
@@ -134,9 +139,9 @@ namespace Microsoft.DotNet.ImageBuilder
             }
         }
 
-        public static string ReplaceImageOwner(string image, string newOwner)
+        public static string ReplaceRepo(string image, string newRepo)
         {
-            return newOwner + image.Substring(image.IndexOf('/'));
+            return newRepo + GetRepo(image);
         }
     }
 }

--- a/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
@@ -141,7 +141,7 @@ namespace Microsoft.DotNet.ImageBuilder
 
         public static string ReplaceRepo(string image, string newRepo)
         {
-            return newRepo + GetRepo(image);
+            return newRepo + image.Substring(image.IndexOf(':'));
         }
     }
 }

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/IOptionsInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/IOptionsInfo.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 {
     public interface IOptionsInfo
     {
-        string RepoOwner { get; }
+        IDictionary<string, string> RepoOverrides { get; }
         IDictionary<string, string> Variables { get; }
 
         string GetOption(string name);

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             manifestInfo.ManifestFilter = manifestFilter;
             manifestInfo.VariableHelper = new VariableHelper(model, options, manifestInfo.GetTagById);
             manifestInfo.Repos = manifestFilter.GetRepos(manifestInfo.Model)
-                .Select(repo => RepoInfo.Create(repo, manifestFilter, options.RepoOwner, manifestInfo.VariableHelper))
+                .Select(repo => RepoInfo.Create(repo, manifestFilter, options, manifestInfo.VariableHelper))
                 .ToArray();
             manifestInfo.ActiveImages = manifestInfo.Repos
                 .SelectMany(repo => repo.Images)

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/RepoInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/RepoInfo.cs
@@ -12,6 +12,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 {
     public class RepoInfo
     {
+        public bool HasOverriddenName { get; set; }
         public string Name { get; private set; }
         public IEnumerable<ImageInfo> Images { get; private set; }
         public Repo Model { get; private set; }
@@ -20,12 +21,12 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         {
         }
 
-        public static RepoInfo Create(Repo model, ManifestFilter manifestFilter, string repoOwner, VariableHelper variableHelper)
+        public static RepoInfo Create(Repo model, ManifestFilter manifestFilter, IOptionsInfo options, VariableHelper variableHelper)
         {
             RepoInfo repoInfo = new RepoInfo();
             repoInfo.Model = model;
-            repoInfo.Name = string.IsNullOrWhiteSpace(repoOwner) ?
-                model.Name : DockerHelper.ReplaceImageOwner(model.Name, repoOwner);
+            repoInfo.HasOverriddenName = options.RepoOverrides.TryGetValue(model.Name, out string nameOverride);
+            repoInfo.Name = repoInfo.HasOverriddenName ? nameOverride : model.Name;
             repoInfo.Images = model.Images
                 .Select(image => ImageInfo.Create(image, repoInfo.Name, manifestFilter, variableHelper))
                 .ToArray();

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
@@ -14,7 +14,6 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
     {
         private const char BuiltInDelimiter = ':';
         public const string DockerfileGitCommitShaVariableName = "DockerfileGitCommitSha";
-        private const string RepoOwnerVariableName = "RepoOwner";
         public const string SystemVariableTypeId = "System";
         public const string TagDocTypeId = "TagDoc";
         private const string TagVariableTypeId = "TagRef";
@@ -78,10 +77,6 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
                 if (string.Equals(variableName, TimeStampVariableName, StringComparison.Ordinal))
                 {
                     variableValue = TimeStamp;
-                }
-                else if (string.Equals(variableName, RepoOwnerVariableName, StringComparison.Ordinal))
-                {
-                    variableValue = Options.RepoOwner ?? DockerHelper.GetImageOwner(Manifest.Repos.First().Name);
                 }
                 else if (getContextBasedSystemValue != null)
                 {


### PR DESCRIPTION
This is needed so that we can build and push the images to a staging repo prior to publishing to the public repo (e.g. Docker Hub). Previously there was support for overriding the repo owner (e.g. `microsoft` in `microsoft/dotnet`).