### PR TITLE
Add copyImages command

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/Dockerfile.nanoserver
+++ b/Microsoft.DotNet.ImageBuilder/Dockerfile.nanoserver
@@ -7,12 +7,12 @@ COPY Microsoft.DotNet.ImageBuilder.sln ./
 COPY NuGet.config ./
 COPY src/Microsoft.DotNet.ImageBuilder.csproj ./src/
 COPY tests/Microsoft.DotNet.ImageBuilder.Tests.csproj ./tests/
-RUN dotnet restore Microsoft.DotNet.ImageBuilder.sln -r win7-x64
+RUN dotnet restore Microsoft.DotNet.ImageBuilder.sln
 
 # copy everything else and build
 COPY . ./
-RUN dotnet build Microsoft.DotNet.ImageBuilder.sln -r win7-x64
-RUN dotnet test tests/Microsoft.DotNet.ImageBuilder.Tests.csproj -r win7-x64
+RUN dotnet build Microsoft.DotNet.ImageBuilder.sln
+RUN dotnet test tests/Microsoft.DotNet.ImageBuilder.Tests.csproj
 RUN dotnet publish ./src/Microsoft.DotNet.ImageBuilder.csproj -c Release -o out -r win7-x64
 
 

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
@@ -3,12 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.ImageBuilder.Model;
-using Microsoft.DotNet.ImageBuilder.ViewModel;
 using System.CommandLine;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
-    public class BuildOptions : DockerRegistryOptions
+    public class BuildOptions : DockerRegistryOptions, IManifestFilterOptions
     {
         protected override string CommandHelp => "Builds and Tests Dockerfiles";
         protected override string CommandName => "build";
@@ -24,35 +23,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
         }
 
-        public override ManifestFilter GetManifestFilter()
-        {
-            ManifestFilter filterInfo = base.GetManifestFilter();
-            filterInfo.DockerArchitecture = Architecture;
-            filterInfo.IncludeOsVersion = OsVersion;
-            filterInfo.IncludePath = Path;
-
-            return filterInfo;
-        }
-
         public override void ParseCommandLine(ArgumentSyntax syntax)
         {
             base.ParseCommandLine(syntax);
 
-            Architecture = DefineArchitectureOption(syntax);
-
-            string osVersion = null;
-            syntax.DefineOption(
-                "os-version",
-                ref osVersion,
-                "OS version of the Dockerfiles to build - wildcard chars * and ? supported (default is to build all)");
-            OsVersion = osVersion;
-
-            string path = null;
-            syntax.DefineOption(
-                "path",
-                ref path,
-                "Directory path containing the Dockerfiles to build - wildcard chars * and ? supported (default is to build all)");
-            Path = path;
+            DefineManifestFilterOptions(syntax, this);
 
             bool isPushEnabled = false;
             syntax.DefineOption("push", ref isPushEnabled, "Push built images to Docker registry");

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/CopyImagesCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/CopyImagesCommand.cs
@@ -1,0 +1,60 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.DotNet.ImageBuilder.ViewModel;
+
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    public class CopyImagesCommand : Command<CopyImagesOptions>
+    {
+        public CopyImagesCommand() : base()
+        {
+        }
+
+        public override Task ExecuteAsync()
+        {
+            Logger.WriteHeading("COPING IMAGES");
+
+            IEnumerable<TagInfo> platformTags = Manifest.ActiveImages
+                    .SelectMany(image => image.ActivePlatforms)
+                    .SelectMany(platform => platform.Tags)
+                    .ToArray();
+
+            Logger.WriteHeading("PULLING SOURCE IMAGES");
+            DockerHelper.ExecuteWithUser(
+                () =>
+                {
+                    foreach (TagInfo platformTag in platformTags)
+                    {
+                        string sourceImage = $"{Options.SourceRepo}:{platformTag.Name}";
+                        ExecuteHelper.ExecuteWithRetry("docker", $"pull {sourceImage}", Options.IsDryRun);
+                        ExecuteHelper.ExecuteWithRetry("docker", $"tag {sourceImage} {platformTag.FullyQualifiedName}", Options.IsDryRun);
+                    }
+                },
+                Options.SourceUsername,
+                Options.SourcePassword,
+                Options.SourceServer,
+                Options.IsDryRun);
+
+            Logger.WriteHeading("PUSHING IMAGES TO DESTINATION");
+            DockerHelper.ExecuteWithUser(
+                () =>
+                {
+                    foreach (TagInfo platformTag in platformTags)
+                    {
+                        ExecuteHelper.ExecuteWithRetry("docker", $"push {platformTag.FullyQualifiedName}", Options.IsDryRun);
+                    }
+                },
+                Options.DestinationUsername,
+                Options.DestinationPassword,
+                Options.DestinationServer,
+                Options.IsDryRun);
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/CopyImagesOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/CopyImagesOptions.cs
@@ -1,0 +1,97 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.CommandLine;
+using Microsoft.DotNet.ImageBuilder.Model;
+using Microsoft.DotNet.ImageBuilder.ViewModel;
+
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    public class CopyImagesOptions : Options, IManifestFilterOptions
+    {
+        protected override string CommandHelp => "Copies the platform images as specified in the manifest between Docker registries";
+        protected override string CommandName => "copyImages";
+
+        public Architecture Architecture { get; set; }
+        public string DestinationPassword { get; set; }
+        public string DestinationServer { get; set; }
+        public string DestinationUsername { get; set; }
+        public string Path { get; set; }
+        public string OsVersion { get; set; }
+        public string SourcePassword { get; set; }
+        public string SourceRepo { get; set; }
+        public string SourceServer { get; set; }
+        public string SourceUsername { get; set; }
+
+        public CopyImagesOptions() : base()
+        {
+        }
+
+        public override void ParseCommandLine(ArgumentSyntax syntax)
+        {
+            base.ParseCommandLine(syntax);
+
+            DefineManifestFilterOptions(syntax, this);
+
+            string destinationPassword = null;
+            Argument<string> destinationPasswordArg = syntax.DefineOption(
+                "destination-password",
+                ref destinationPassword,
+                "Password for the Docker Registry the images are pushed to");
+            DestinationPassword = destinationPassword;
+
+            string destinationServer = null;
+            syntax.DefineOption(
+                "destination-server",
+                ref destinationServer,
+                "Docker Registry server the images are pushed to (default is Docker Hub)");
+            DestinationServer = destinationServer;
+
+            string destinationUsername = null;
+            Argument<string> destinationUsernameArg = syntax.DefineOption(
+                "destination-username",
+                ref destinationUsername,
+                "Username for the Docker Registry the images are pushed to");
+            DestinationUsername = destinationUsername;
+
+            string sourcePassword = null;
+            Argument<string> sourcePasswordArg = syntax.DefineOption(
+                "source-password",
+                ref sourcePassword,
+                "Password for the Docker Registry the images are pulled from");
+            SourcePassword = sourcePassword;
+
+            string sourceServer = null;
+            syntax.DefineOption(
+                "source-server",
+                ref sourceServer,
+                "Docker Registry server the images are pulled from (default is Docker Hub)");
+            SourceServer = sourceServer;
+
+            string sourceUsername = null;
+            Argument<string> sourceUsernameArg = syntax.DefineOption(
+                "source-username",
+                ref sourceUsername,
+                "Username for the Docker Registry the images are pulled from");
+            SourceUsername = sourceUsername;
+
+            string sourceRepo = null;
+            syntax.DefineParameter("source-repo", ref sourceRepo, "Docker repository to pull images from");
+            SourceRepo = sourceRepo;
+
+            if (destinationPasswordArg.IsSpecified ^ destinationUsernameArg.IsSpecified)
+            {
+                Logger.WriteError($"error: `{destinationUsernameArg.Name}` and `{destinationPasswordArg.Name}` must both be specified.");
+                Environment.Exit(1);
+            }
+
+            if (sourcePasswordArg.IsSpecified ^ sourceUsernameArg.IsSpecified)
+            {
+                Logger.WriteError($"error: `{sourceUsernameArg.Name}` and `{sourcePasswordArg.Name}` must both be specified.");
+                Environment.Exit(1);
+            }
+        }
+    }
+}

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/DockerRegistryCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/DockerRegistryCommand.cs
@@ -11,23 +11,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     {
         protected void ExecuteWithUser(Action action)
         {
-            bool userSpecified = Options.Username != null;
-            if (userSpecified)
-            {
-                DockerHelper.Login(Options.Username, Options.Password, Options.Server, Options.IsDryRun);
-            }
-
-            try
-            {
-                action();
-            }
-            finally
-            {
-                if (userSpecified)
-                {
-                    DockerHelper.Logout(Options.Server, Options.IsDryRun);
-                }
-            }
+            DockerHelper.ExecuteWithUser(action, Options.Username, Options.Password, Options.Server, Options.IsDryRun);
         }
     }
 }

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/IManifestFilterOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/IManifestFilterOptions.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.ImageBuilder.Model;
+
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    public interface IManifestFilterOptions
+    {
+        Architecture Architecture { get; set; }
+        string OsVersion { get; set; }
+        string Path { get; set; }
+    }
+}

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/Options.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/Options.cs
@@ -12,7 +12,7 @@ using System.Reflection;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
-    public abstract class Options: IOptionsInfo
+    public abstract class Options : IOptionsInfo
     {
         protected abstract string CommandHelp { get; }
         protected abstract string CommandName { get; }
@@ -29,12 +29,71 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
         }
 
+        protected static Architecture DefineArchitectureOption(ArgumentSyntax syntax)
+        {
+            Architecture architecture = DockerHelper.Architecture;
+            syntax.DefineOption(
+                "architecture",
+                ref architecture,
+                value => (Architecture)Enum.Parse(typeof(Architecture), value, true),
+                "Architecture of Dockerfiles to operate on (default is current OS architecture)");
+
+            return architecture;
+        }
+
+        protected static void DefineManifestFilterOptions(ArgumentSyntax syntax, IManifestFilterOptions filterOptions)
+        {
+            filterOptions.Architecture = DefineArchitectureOption(syntax);
+
+            string osVersion = null;
+            syntax.DefineOption(
+                "os-version",
+                ref osVersion,
+                "OS version of the Dockerfiles to build - wildcard chars * and ? supported (default is to build all)");
+            filterOptions.OsVersion = osVersion;
+
+            string path = null;
+            syntax.DefineOption(
+                "path",
+                ref path,
+                "Directory path containing the Dockerfiles to build - wildcard chars * and ? supported (default is to build all)");
+            filterOptions.Path = path;
+        }
+
         public virtual ManifestFilter GetManifestFilter()
         {
-            return new ManifestFilter()
+            ManifestFilter filter = new ManifestFilter()
             {
                 IncludeRepo = Repo,
             };
+
+            if (this is IManifestFilterOptions)
+            {
+                IManifestFilterOptions filterOptions = (IManifestFilterOptions)this;
+                filter.DockerArchitecture = filterOptions.Architecture;
+                filter.IncludeOsVersion = filterOptions.OsVersion;
+                filter.IncludePath = filterOptions.Path;
+            }
+
+            return filter;
+        }
+
+        public string GetOption(string name)
+        {
+            string result;
+
+            PropertyInfo propInfo = this.GetType().GetProperties()
+                .FirstOrDefault(p => string.Equals(p.Name, name, StringComparison.Ordinal));
+            if (propInfo != null)
+            {
+                result = propInfo.GetValue(this)?.ToString() ?? "";
+            }
+            else
+            {
+                result = null;
+            }
+
+            return result;
         }
 
         public virtual void ParseCommandLine(ArgumentSyntax syntax)
@@ -70,36 +129,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             bool isVerbose = false;
             syntax.DefineOption("verbose", ref isVerbose, "Show details about the tasks run");
             IsVerbose = isVerbose;
-        }
-
-        protected static Architecture DefineArchitectureOption(ArgumentSyntax syntax)
-        {
-            Architecture architecture = DockerHelper.Architecture;
-            syntax.DefineOption(
-                "architecture",
-                ref architecture,
-                value => (Architecture)Enum.Parse(typeof(Architecture), value, true),
-                "Architecture of Dockerfiles to operate on (default is current OS architecture)");
-
-            return architecture;
-        }
-
-        public string GetOption(string name)
-        {
-            string result;
-
-            PropertyInfo propInfo = this.GetType().GetProperties()
-                .FirstOrDefault(p => string.Equals(p.Name, name, StringComparison.Ordinal));
-            if (propInfo != null)
-            {
-                result = propInfo.GetValue(this)?.ToString() ?? "";
-            }
-            else
-            {
-                result = null;
-            }
-
-            return result;
         }
     }
 }

--- a/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
@@ -28,6 +28,27 @@ namespace Microsoft.DotNet.ImageBuilder
             return isDryRun ? "" : process.StandardOutput.ReadToEnd().Trim();
         }
 
+        public static void ExecuteWithUser(Action action, string username, string password, string server, bool isDryRun)
+        {
+            bool userSpecified = username != null;
+            if (userSpecified)
+            {
+                DockerHelper.Login(username, password, server, isDryRun);
+            }
+
+            try
+            {
+                action();
+            }
+            finally
+            {
+                if (userSpecified)
+                {
+                    DockerHelper.Logout(server, isDryRun);
+                }
+            }
+        }
+
         private static Architecture GetArchitecture()
         {
             Architecture architecture;
@@ -82,7 +103,7 @@ namespace Microsoft.DotNet.ImageBuilder
             return image.Substring(0, image.IndexOf('/'));
         }
 
-        public static void Login(string username, string password, string server, bool isDryRun)
+        private static void Login(string username, string password, string server, bool isDryRun)
         {
             Version clientVersion = GetClientVersion();
             if (clientVersion >= new Version(17, 7))
@@ -112,7 +133,7 @@ namespace Microsoft.DotNet.ImageBuilder
             }
         }
 
-        public static void Logout(string server, bool isDryRun)
+        private static void Logout(string server, bool isDryRun)
         {
             ExecuteHelper.Execute("docker", $"logout {server}", isDryRun);
         }

--- a/Microsoft.DotNet.ImageBuilder/src/ImageBuilder.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ImageBuilder.cs
@@ -19,6 +19,7 @@ namespace Microsoft.DotNet.ImageBuilder
             {
                 ICommand[] commands = {
                     new BuildCommand(),
+                    new CopyImagesCommand(),
                     new GenerateTagsReadmeCommand(),
                     new PublishManifestCommand(),
                     new UpdateReadmeCommand(),


### PR DESCRIPTION
This command is intended to be used to copy images from a staging repo to the public repo (e.g. Docker Hub).

The primary changes are in CopyImagesCommand.cs and CopyImagesOptions.cs.  The rest of the changes are misc refactorings to share common code with existing commands.