### PR TITLE
Remove common repo owner validation

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
@@ -98,11 +98,6 @@ namespace Microsoft.DotNet.ImageBuilder
             return Version.TryParse(versionString, out Version version) ? version : null;
         }
 
-        public static string GetImageOwner(string image)
-        {
-            return image.Substring(0, image.IndexOf('/'));
-        }
-
         public static string GetRepo(string image)
         {
             return image.Substring(0, image.IndexOf(':'));

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/ModelExtensions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/ModelExtensions.cs
@@ -13,23 +13,9 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
     {
         public static void Validate(this Manifest manifest)
         {
-            ValidateCommonRepoOwner(manifest);
-
             foreach (Repo repo in manifest.Repos)
             {
                 ValidateUniqueTags(repo);
-            }
-        }
-
-        private static void ValidateCommonRepoOwner(Manifest manifest)
-        {
-            IEnumerable<string> distinctRepos = manifest.Repos
-                .Select(repo => DockerHelper.GetImageOwner(repo.Name))
-                .Distinct();
-            if (distinctRepos.Count() != 1)
-            {
-                throw new ValidationException(
-                    $"All repos must have a common owner: {Environment.NewLine}{string.Join(Environment.NewLine, distinctRepos)}");
             }
         }
 


### PR DESCRIPTION
There is a new usage scenario in which there is a desire to have a manifest with multiple repo owners/no owners (e.g. ACR).  This validation logic doesn't provide significant value and therefore I decided to remove it.

Fixes #108 