### PR TITLE
Add support for TagDocList variable

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
@@ -16,11 +16,12 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         public const string DockerfileGitCommitShaVariableName = "DockerfileGitCommitSha";
         public const string SystemVariableTypeId = "System";
         public const string TagDocTypeId = "TagDoc";
+        public const string TagDocListTypeId = "TagDocList";
         private const string TagVariableTypeId = "TagRef";
         private const string TimeStampVariableName = "TimeStamp";
         private const string VariableGroupName = "variable";
 
-        private static string TagVariablePattern = $"\\$\\((?<{VariableGroupName}>[\\w:\\-.]+)\\)";
+        private static string TagVariablePattern = $"\\$\\((?<{VariableGroupName}>[\\w:\\-.|]+)\\)";
         private static string TimeStamp { get; } = DateTime.UtcNow.ToString("yyyyMMddHHmmss");
 
         private Func<string, TagInfo> GetTagById { get; set; }


### PR DESCRIPTION
Add support to the generatedTagsReadme command to specify an explicit set of tags.  This support is needed for the .NET Core 2.2 release where a common runtime-deps image is shared between 2.1 and 2.2.  With this scenario, the requirement is to list the image twice in the readme as we believe this will make it easier for users to find the images they are looking for.

```
...
- [`2.1.3-runtime-deps-bionic`, `2.1-runtime-deps-bionic` (*2.1/runtime-deps/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/amd64/Dockerfile)
...
- [`2.2.0-preview1-runtime-deps-bionic`, `2.2-runtime-deps-bionic` (*2.1/runtime-deps/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/amd64/Dockerfile)
...
```

I struggled with coming up with a meaningful variable name.  I don't want to change the existing `TagDoc` variable as it would be a breaking change.  I welcome suggestions on a better name.