### PR TITLE
Add support for generating a TAGS.md with the generateTagsReadme command

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateTagsReadmeCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateTagsReadmeCommand.cs
@@ -174,6 +174,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         }
                     }
                 }
+            } 
+            else if (string.Equals(variableType, VariableHelper.SystemVariableTypeId, StringComparison.Ordinal)
+                && string.Equals(variableName, VariableHelper.SourceUrlVariableName, StringComparison.Ordinal))
+            {
+                variableValue = Options.SourceUrl;
             }
 
             return variableValue;
@@ -203,7 +208,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             // Normalize the line endings to match the readme.
             tagsDocumentation = NormalizeLineEndings(tagsDocumentation, readme);
 
-            Regex regex = new Regex("^## Complete set of Tags\\s*(^(?!##).*\\s)*", RegexOptions.Multiline);
+            string headerLine = tagsDocumentation
+                .Split(new [] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+                .FirstOrDefault();
+            Regex regex = new Regex($"^{headerLine}\\s*(^(?!##).*\\s)*", RegexOptions.Multiline);
             string updatedReadme = regex.Replace(readme, tagsDocumentation);
             File.WriteAllText(readmePath, updatedReadme);
 

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateTagsReadmeOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateTagsReadmeOptions.cs
@@ -11,6 +11,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         protected override string CommandHelp => "Generate the tags section of the readme";
         protected override string CommandName => "generateTagsReadme";
 
+        public string ReadmePath { get; set; }
+        public bool SkipValidation { get; set; }
         public string SourceUrl { get; set; }
         public string Template { get; set; }
         public bool UpdateReadme { get; set; }
@@ -22,6 +24,15 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public override void ParseCommandLine(ArgumentSyntax syntax)
         {
             base.ParseCommandLine(syntax);
+
+            string readmePath = null;
+            syntax.DefineOption("readme-path", ref readmePath, "Path of the readme to update (defaults to manifest setting)");
+            ReadmePath = readmePath;
+
+            bool skipValidation = false;
+            syntax.DefineOption(
+                "skip-validation", ref skipValidation, "Skip validating all documented tags are included in the readme");
+            SkipValidation = skipValidation;
 
             bool updateReadme = false;
             syntax.DefineOption("update-readme", ref updateReadme, "Update the readme file");

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
@@ -14,6 +14,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
     {
         private const char BuiltInDelimiter = ':';
         public const string DockerfileGitCommitShaVariableName = "DockerfileGitCommitSha";
+        public const string SourceUrlVariableName = "SourceUrl";
         public const string SystemVariableTypeId = "System";
         public const string TagDocTypeId = "TagDoc";
         public const string TagDocListTypeId = "TagDocList";


### PR DESCRIPTION
These are the changes needed to support https://github.com/dotnet/dotnet-docker/pull/665

- Add support for a SourceUrl variable that can be referenced in a readme template.
- Add support to specify a custom `readme` file to update.
- Refactored the pattern to search and replace in the readme to be based on the `## Complete set of Tags` header section.
- Add an option to skips tag validation to support generating a partial tag list.