### PR TITLE
Add generateBuildQueue command

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildQueueCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildQueueCommand.cs
@@ -59,6 +59,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             return Task.CompletedTask;
         }
 
+        /// <summary>
+        /// Formats a build leg name from the specified Dockerfile path. Any parts of the Dockerfile path that are in common with the
+        /// containing queue name are trimmed. The resulting leg name uses '-' characters as word separators.
+        /// </summary>
         private static string FormatLegName(string[] dockerfilePath, string[] queueNameParts)
         {
             string legName = dockerfilePath.First().Split('/')
@@ -73,25 +77,15 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             return legName;
         }
 
+        /// <summary>
+        /// Formats a queue name by joining the specified parts. The resulting queue name is camelCased.
+        /// Any '-' occurrences within the specified parts will be treated as word boundaries.
+        /// </summary>
         private static string FormatQueueName(string[] parts)
         {
-            StringBuilder queueName = new StringBuilder();
-            bool isFirstWord = true;
-
-            foreach (string part in parts)
-            {
-                string[] subparts = part.Split('-');
-                for (int i = 0; i < subparts.Length; i++)
-                {
-                    string subpart = subparts[i];
-                    subparts[i] = isFirstWord ? subpart : char.ToUpper(subpart[0]) + subpart.Substring(1);
-                    isFirstWord = false;
-                }
-
-                queueName.Append(string.Join(string.Empty, subparts));
-            }
-
-            return queueName.ToString();
+            string[] allParts = parts.SelectMany(part => part.Split('-')).ToArray();
+            return allParts.First() +
+                string.Join(string.Empty, allParts.Skip(1).Select(part => char.ToUpper(part[0]) + part.Substring(1)));
         }
 
         private IEnumerable<PlatformInfo> GetPlatformDependencies(PlatformInfo platform)

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildQueueCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildQueueCommand.cs
@@ -1,0 +1,104 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.ImageBuilder.Model;
+using Microsoft.DotNet.ImageBuilder.ViewModel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    public class GenerateBuildQueueCommand : Command<GenerateBuildQueueOptions>
+    {
+        public GenerateBuildQueueCommand() : base()
+        {
+        }
+
+        public override Task ExecuteAsync()
+        {
+            Logger.WriteHeading("GENERATING BUILD QUEUE");
+
+            var platformGroups = Manifest.Repos
+                .SelectMany(repo => repo.Images)
+                .SelectMany(image => image.Platforms)
+                .GroupBy(platform => new { platform.Model.OS, platform.Model.OsVersion, platform.Model.Architecture })
+                .OrderBy(platformGroup => platformGroup.Key.OS)
+                .ThenByDescending(platformGroup => platformGroup.Key.OsVersion)
+                .ThenBy(platformGroup => platformGroup.Key.Architecture);
+
+            foreach (var platformGrouping in platformGroups)
+            {
+                string[] queueNameParts = 
+                {
+                    "buildMatrix",
+                    platformGrouping.Key.OS == OS.Windows ? platformGrouping.Key.OsVersion : platformGrouping.Key.OS.ToString(),
+                    platformGrouping.Key.Architecture.GetDisplayName(useLongNames: true)
+                };
+                Logger.WriteMessage($"  {FormatQueueName(queueNameParts)}:");
+
+                // Emit legs and their variables
+                IEnumerable<IEnumerable<PlatformInfo>> subgraphs = platformGrouping.GetCompleteSubgraphs(GetPlatformDependencies);
+                foreach (IEnumerable<PlatformInfo> subgraph in subgraphs)
+                {
+                    string[] dockerfilePaths = subgraph
+                        .Select(platform => platform.Model.Dockerfile)
+                        .ToArray();
+                    Logger.WriteMessage($"    {FormatLegName(dockerfilePaths, queueNameParts)}:");
+
+                    string pathArgs = dockerfilePaths
+                        .Select(path => $"--path {path}")
+                        .Aggregate((working, next) => $"{working} {next}");
+                    Logger.WriteMessage($"      imageBuilderPaths: {pathArgs}");
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private static string FormatLegName(string[] dockerfilePath, string[] queueNameParts)
+        {
+            string legName = dockerfilePath.First().Split('/')
+                .Where(subPart => !queueNameParts.Any(queuePart => string.Equals(queuePart, subPart, StringComparison.OrdinalIgnoreCase)))
+                .Aggregate((working, next) => $"{working}-{next}");
+
+            if (dockerfilePath.Length > 1)
+            {
+                legName += "-graph";
+            }
+
+            return legName;
+        }
+
+        private static string FormatQueueName(string[] parts)
+        {
+            StringBuilder queueName = new StringBuilder();
+            bool isFirstWord = true;
+
+            foreach (string part in parts)
+            {
+                string[] subparts = part.Split('-');
+                for (int i = 0; i < subparts.Length; i++)
+                {
+                    string subpart = subparts[i];
+                    subparts[i] = isFirstWord ? subpart : char.ToUpper(subpart[0]) + subpart.Substring(1);
+                    isFirstWord = false;
+                }
+
+                queueName.Append(string.Join(string.Empty, subparts));
+            }
+
+            return queueName.ToString();
+        }
+
+        private IEnumerable<PlatformInfo> GetPlatformDependencies(PlatformInfo platform)
+        {
+            return platform.FromImages
+                .Where(fromImage => !Manifest.IsExternalImage(fromImage))
+                .Select(fromImage => Manifest.GetPlatformByTag(fromImage));
+        }
+    }
+}

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildQueueOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildQueueOptions.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.CommandLine;
+
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    public class GenerateBuildQueueOptions : Options
+    {
+        protected override string CommandHelp => "Generate the VSTS build queue for building the images";
+        protected override string CommandName => "generateBuildQueue";
+
+        public GenerateBuildQueueOptions() : base()
+        {
+        }
+    }
+}

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateTagsReadmeCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateTagsReadmeCommand.cs
@@ -48,23 +48,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             return Task.CompletedTask;
         }
 
-        private static string GetArchitectureDisplayName(Architecture architecture)
-        {
-            string displayName;
-
-            switch (architecture)
-            {
-                case Architecture.ARM:
-                    displayName = "arm32";
-                    break;
-                default:
-                    displayName = architecture.ToString().ToLowerInvariant();
-                    break;
-            }
-
-            return displayName;
-        }
-
         private string GetManifestBasedDocumentation()
         {
             StringBuilder tagsDoc = new StringBuilder($"## Complete set of Tags{Environment.NewLine}{Environment.NewLine}");
@@ -78,7 +61,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             foreach (var platformGroup in platformGroups)
             {
                 string os = GetOsDisplayName(platformGroup.Key.OS, platformGroup.Key.OsVersion);
-                string arch = GetArchitectureDisplayName(platformGroup.Key.Architecture);
+                string arch = platformGroup.Key.Architecture.GetDisplayName();
                 tagsDoc.AppendLine($"# {os} {arch} tags");
                 tagsDoc.AppendLine();
 

--- a/Microsoft.DotNet.ImageBuilder/src/GraphExtensions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/GraphExtensions.cs
@@ -1,0 +1,74 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.DotNet.ImageBuilder
+{
+    public static class GraphExtensions
+    {
+        public static IEnumerable<IEnumerable<T>> GetCompleteSubgraphs<T>(this IEnumerable<T> source, Func<T, IEnumerable<T>> getDependencies)
+        {
+            List<T[]> subgraphs = new List<T[]>();
+
+            List<Node<T>> nodes = CreateNodeList(source, getDependencies);
+            while (nodes.Any())
+            {
+                HashSet<Node<T>> subgraph = new HashSet<Node<T>>();
+                AddSubgraphNode(subgraph, nodes.First(), nodes);
+                subgraphs.Add(subgraph.Select(node => node.Item).ToArray());
+            }
+
+            return subgraphs;
+        }
+
+        private static List<Node<T>> CreateNodeList<T>(IEnumerable<T> source, Func<T, IEnumerable<T>> getDependencies)
+        {
+            Dictionary<T, Node<T>> nodes = new Dictionary<T, Node<T>>();
+
+            foreach (T item in source)
+            {
+                if (!nodes.TryGetValue(item, out Node<T> itemNode))
+                {
+                    itemNode = new Node<T>() { Item = item };
+                    nodes.Add(item, itemNode);
+                }
+
+                foreach (T parent in getDependencies(item))
+                {
+                    if (!nodes.TryGetValue(parent, out Node<T> parentNode))
+                    {
+                        parentNode = new Node<T>() { Item = parent };
+                        nodes.Add(parent, parentNode);
+                    }
+
+                    parentNode.Children.Add(itemNode);
+                    itemNode.Parents.Add(parentNode);
+                }
+            }
+
+            return nodes.Values.ToList();
+        }
+
+        private static void AddSubgraphNode<T>(HashSet<Node<T>> subgraph, Node<T> node, List<Node<T>> unvisitedNodes)
+        {
+            if (!subgraph.Contains(node))
+            {
+                unvisitedNodes.Remove(node);
+                subgraph.Add(node);
+                node.Parents.ForEach(parent => AddSubgraphNode(subgraph, parent, unvisitedNodes));
+                node.Children.ForEach(child => AddSubgraphNode(subgraph, child, unvisitedNodes));
+            }
+        }
+
+        private class Node<T>
+        {
+            public T Item;
+            public List<Node<T>> Parents { get; } = new List<Node<T>>();
+            public List<Node<T>> Children { get; } = new List<Node<T>>();
+        }
+    }
+}

--- a/Microsoft.DotNet.ImageBuilder/src/GraphExtensions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/GraphExtensions.cs
@@ -10,11 +10,11 @@ namespace Microsoft.DotNet.ImageBuilder
 {
     public static class GraphExtensions
     {
-        public static IEnumerable<IEnumerable<T>> GetCompleteSubgraphs<T>(this IEnumerable<T> source, Func<T, IEnumerable<T>> getDependencies)
+        public static IEnumerable<IEnumerable<T>> GetCompleteSubgraphs<T>(this IEnumerable<T> source, Func<T, IEnumerable<T>> getParents)
         {
             List<T[]> subgraphs = new List<T[]>();
 
-            List<Node<T>> nodes = CreateNodeList(source, getDependencies);
+            List<Node<T>> nodes = CreateNodeList(source, getParents);
             while (nodes.Any())
             {
                 HashSet<Node<T>> subgraph = new HashSet<Node<T>>();
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.ImageBuilder
             return subgraphs;
         }
 
-        private static List<Node<T>> CreateNodeList<T>(IEnumerable<T> source, Func<T, IEnumerable<T>> getDependencies)
+        private static List<Node<T>> CreateNodeList<T>(IEnumerable<T> source, Func<T, IEnumerable<T>> getParents)
         {
             Dictionary<T, Node<T>> nodes = new Dictionary<T, Node<T>>();
 
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.ImageBuilder
                     nodes.Add(item, itemNode);
                 }
 
-                foreach (T parent in getDependencies(item))
+                foreach (T parent in getParents(item))
                 {
                     if (!nodes.TryGetValue(parent, out Node<T> parentNode))
                     {

--- a/Microsoft.DotNet.ImageBuilder/src/ImageBuilder.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ImageBuilder.cs
@@ -20,6 +20,7 @@ namespace Microsoft.DotNet.ImageBuilder
                 ICommand[] commands = {
                     new BuildCommand(),
                     new CopyImagesCommand(),
+                    new GenerateBuildQueueCommand(),
                     new GenerateTagsReadmeCommand(),
                     new PublishManifestCommand(),
                     new UpdateReadmeCommand(),

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
@@ -62,6 +62,14 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
                 .Distinct();
         }
 
+        public PlatformInfo GetPlatformByTag(string fullTagName)
+        {
+            return this.Repos
+                .SelectMany(repo => repo.Images)
+                .SelectMany(image => image.Platforms)
+                .First(platform => platform.Tags.Any(tag => tag.FullyQualifiedName == fullTagName));
+        }
+
         public TagInfo GetTagById(string id)
         {
             return GetAllTags()

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
@@ -64,10 +64,17 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 
         public PlatformInfo GetPlatformByTag(string fullTagName)
         {
-            return this.Repos
+            PlatformInfo result = this.Repos
                 .SelectMany(repo => repo.Images)
                 .SelectMany(image => image.Platforms)
-                .First(platform => platform.Tags.Any(tag => tag.FullyQualifiedName == fullTagName));
+                .FirstOrDefault(platform => platform.Tags.Any(tag => tag.FullyQualifiedName == fullTagName));
+
+            if (result == null)
+            {
+                throw new InvalidOperationException($"Unable to find platform for the tag '{fullTagName}'");
+            }
+
+            return result;
         }
 
         public TagInfo GetTagById(string id)

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/ModelExtensions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/ModelExtensions.cs
@@ -11,6 +11,23 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 {
     public static class ModelExtensions
     {
+        public static string GetDisplayName(this Architecture architecture, bool useLongNames = false)
+        {
+            string displayName;
+
+            switch (architecture)
+            {
+                case Architecture.ARM:
+                    displayName = useLongNames ? "arm32v7" : "arm32";
+                    break;
+                default:
+                    displayName = architecture.ToString().ToLowerInvariant();
+                    break;
+            }
+
+            return displayName;
+        }
+
         public static void Validate(this Manifest manifest)
         {
             foreach (Repo repo in manifest.Repos)


### PR DESCRIPTION
Added a command that reads the manifest and generates the VSTS build queue variables.  The generated legs are the smallest possible dependency graphs as defined by the intra-repo Dockerfile depencencies.

Currently the output from this command can be copied and pasted into the VSTS build definitions.  Eventually I would like to invoke this command directly from the build to make everything dynamic.