### PR TITLE
Remove full Dockerfile path from tags readme

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateTagsReadmeCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateTagsReadmeCommand.cs
@@ -105,7 +105,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 .Select(tag => $"`{tag}`")
                 .Aggregate((working, next) => $"{working}, {next}");
             string dockerfile = info.Platform.DockerfilePath.Replace('\\', '/');
-            return $"- [{tags} (*{dockerfile}*)]({Options.SourceUrl}/{dockerfile})";
+            return $"- [{tags} (*Dockerfile*)]({Options.SourceUrl}/{dockerfile})";
         }
 
         private string GetTemplateBasedDocumentation(string templatePath)


### PR DESCRIPTION
This was done for two reasons
1. Our readmes are exceeding the 25 k limit on Docker Hub and this change helps reduce this size significantly.
1. This simplifies the tags section and reduces the number of multi-line image entries.