### PR TITLE
Refactor repo variable support

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/Model/Repo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Model/Repo.cs
@@ -8,6 +8,8 @@ namespace Microsoft.DotNet.ImageBuilder.Model
 {
     public class Repo
     {
+        public string Id { get; set; }
+
         [JsonProperty(Required = Required.Always)]
         public Image[] Images { get; set; }
 

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             ManifestInfo manifestInfo = new ManifestInfo();
             manifestInfo.Model = model;
             manifestInfo.ManifestFilter = manifestFilter;
-            manifestInfo.VariableHelper = new VariableHelper(model, options, manifestInfo.GetTagById);
+            manifestInfo.VariableHelper = new VariableHelper(model, options, manifestInfo.GetTagById, manifestInfo.GetRepoById);
             manifestInfo.Repos = manifestFilter.GetRepos(manifestInfo.Model)
                 .Select(repo => RepoInfo.Create(repo, manifestFilter, options, manifestInfo.VariableHelper))
                 .ToArray();
@@ -74,6 +74,11 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             }
 
             return result;
+        }
+
+        public RepoInfo GetRepoById(string id)
+        {
+            return Repos.FirstOrDefault(repo => repo.Id == id);
         }
 
         public TagInfo GetTagById(string id)

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/RepoInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/RepoInfo.cs
@@ -13,6 +13,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
     public class RepoInfo
     {
         public bool HasOverriddenName { get; set; }
+        public string Id { get; private set; }
         public string Name { get; private set; }
         public IEnumerable<ImageInfo> Images { get; private set; }
         public Repo Model { get; private set; }
@@ -25,6 +26,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         {
             RepoInfo repoInfo = new RepoInfo();
             repoInfo.Model = model;
+            repoInfo.Id = model.Id ?? model.Name;
             repoInfo.HasOverriddenName = options.RepoOverrides.TryGetValue(model.Name, out string nameOverride);
             repoInfo.Name = repoInfo.HasOverriddenName ? nameOverride : model.Name;
             repoInfo.Images = model.Images

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
     {
         private const char BuiltInDelimiter = ':';
         public const string DockerfileGitCommitShaVariableName = "DockerfileGitCommitSha";
-        public const string RepoVariableName = "Repo";
+        public const string RepoVariableTypeId = "Repo";
         public const string SourceUrlVariableName = "SourceUrl";
         public const string SystemVariableTypeId = "System";
         public const string TagDocTypeId = "TagDoc";
@@ -26,6 +26,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         private static string TagVariablePattern = $"\\$\\((?<{VariableGroupName}>[\\w:\\-.|]+)\\)";
         private static string TimeStamp { get; } = DateTime.UtcNow.ToString("yyyyMMddHHmmss");
 
+        private Func<string, RepoInfo> GetRepoById { get; set; }
         private Func<string, TagInfo> GetTagById { get; set; }
         private Manifest Manifest { get; set; }
         private IOptionsInfo Options { get; set; }
@@ -33,8 +34,10 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         public VariableHelper(
             Manifest manifest,
             IOptionsInfo options,
-            Func<string, TagInfo> getTagById)
+            Func<string, TagInfo> getTagById,
+            Func<string, RepoInfo> getRepoById)
         {
+            GetRepoById = getRepoById;
             GetTagById = getTagById;
             Manifest = manifest;
             Options = options;
@@ -93,6 +96,10 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             else if (string.Equals(variableType, TagVariableTypeId, StringComparison.Ordinal))
             {
                 variableValue = GetTagById(variableName)?.Name;
+            }
+            else if (string.Equals(variableType, RepoVariableTypeId, StringComparison.Ordinal))
+            {
+                variableValue = GetRepoById(variableName)?.Name;
             }
             else if (getContextBasedSystemValue != null)
             {


### PR DESCRIPTION
This adds support for referencing any repo by id.  This supports cross repo dependencies which are needed for the move to MCR where the .NET Core repos are broken apart by image type.  There will be a separate repo for both runtime-deps and runtime images.  

Sample Usage:

```
      "id" : "runtime",
      "name": "mcr.microsoft.com/dotnet/core-nightly/runtime",
      "readmePath": "README.runtime.md",
      "images": [
        {
          "sharedTags": {
            "$(1.0-RuntimeVersion)": {},
            "1.0": {}
          },
          "platforms": [
            {
              "buildArgs": {
                "REPO": "$(Repo:runtime-deps)"
              },
              "dockerfile": "1.0/runtime/jessie/amd64",
              "os": "linux",
              "tags": {
                "$(1.0-RuntimeVersion)-jessie": {},
                "1.0-jessie": {}
              }
            },
            {
              "dockerfile": "1.0/runtime/nanoserver-sac2016/amd64",
              "os": "windows",
              "osVersion": "nanoserver-sac2016",
              "tags": {
                "$(1.0-RuntimeVersion)-nanoserver-sac2016": {},
                "1.0-nanoserver-sac2016": {}
              }
            }
          ]
        },
```