### PR TITLE
Add support for a publish build matrix type

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/Commands/MatrixType.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/MatrixType.cs
@@ -9,6 +9,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     public enum MatrixType
     {
         Build,
-        Test
+        Test,
+        Publish,
     }
 }


### PR DESCRIPTION
The publish build matrix has a single entry for each platform type.

Sample output for microsoft/dotnet repo

```
    Linux-amd64:
      imageBuilderPaths: --path 1.0/runtime-deps/jessie/amd64/Dockerfile --path 1.0/runtime/jessie/amd64/Dockerfile --path 1.1/runtime/jessie/amd64/Dockerfile --path 1.1/sdk/jessie/amd64/Dockerfile --path 1.1/runtime-deps/stretch/amd64/Dockerfile --path 1.1/runtime/stretch/amd64/Dockerfile --path 1.1/sdk/stretch/amd64/Dockerfile --path 2.1/runtime-deps/stretch-slim/amd64/Dockerfile --path 2.1/runtime/stretch-slim/amd64/Dockerfile --path 2.1/aspnetcore-runtime/stretch-slim/amd64/Dockerfile --path 2.1/sdk/stretch/amd64/Dockerfile --path 2.1/runtime-deps/alpine3.7/amd64/Dockerfile --path 2.1/runtime/alpine3.7/amd64/Dockerfile --path 2.1/aspnetcore-runtime/alpine3.7/amd64/Dockerfile --path 2.1/sdk/alpine3.7/amd64/Dockerfile --path 2.1/runtime-deps/alpine3.8/amd64/Dockerfile --path 2.1/runtime/alpine3.8/amd64/Dockerfile --path 2.1/aspnetcore-runtime/alpine3.8/amd64/Dockerfile --path 2.1/sdk/alpine3.8/amd64/Dockerfile --path 2.1/runtime-deps/bionic/amd64/Dockerfile --path 2.1/aspnetcore-runtime/bionic/amd64/Dockerfile --path 2.1/runtime/bionic/amd64/Dockerfile --path 2.1/sdk/bionic/amd64/Dockerfile --path 2.2/runtime/stretch-slim/amd64/Dockerfile --path 2.2/aspnetcore-runtime/stretch-slim/amd64/Dockerfile --path 2.2/sdk/stretch/amd64/Dockerfile --path 2.2/runtime/alpine3.8/amd64/Dockerfile --path 2.2/aspnetcore-runtime/alpine3.8/amd64/Dockerfile --path 2.2/sdk/alpine3.8/amd64/Dockerfile --path 2.2/aspnetcore-runtime/bionic/amd64/Dockerfile --path 2.2/runtime/bionic/amd64/Dockerfile --path 2.2/sdk/bionic/amd64/Dockerfile --path 3.0/runtime-deps/stretch-slim/amd64/Dockerfile --path 3.0/runtime/stretch-slim/amd64/Dockerfile --path 3.0/aspnetcore-runtime/stretch-slim/amd64/Dockerfile --path 3.0/sdk/stretch/amd64/Dockerfile --path 3.0/runtime-deps/alpine3.8/amd64/Dockerfile --path 3.0/runtime/alpine3.8/amd64/Dockerfile --path 3.0/aspnetcore-runtime/alpine3.8/amd64/Dockerfile --path 3.0/sdk/alpine3.8/amd64/Dockerfile --path 3.0/runtime-deps/bionic/amd64/Dockerfile --path 3.0/aspnetcore-runtime/bionic/amd64/Dockerfile --path 3.0/runtime/bionic/amd64/Dockerfile --path 3.0/sdk/bionic/amd64/Dockerfile
    Linux-arm32v7:
      imageBuilderPaths: --path 2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile --path 2.1/runtime/stretch-slim/arm32v7/Dockerfile --path 2.1/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile --path 2.1/sdk/stretch/arm32v7/Dockerfile --path 2.1/runtime-deps/bionic/arm32v7/Dockerfile --path 2.1/aspnetcore-runtime/bionic/arm32v7/Dockerfile --path 2.1/runtime/bionic/arm32v7/Dockerfile --path 2.1/sdk/bionic/arm32v7/Dockerfile --path 2.2/runtime/stretch-slim/arm32v7/Dockerfile --path 2.2/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile --path 2.2/sdk/stretch/arm32v7/Dockerfile --path 2.2/aspnetcore-runtime/bionic/arm32v7/Dockerfile --path 2.2/runtime/bionic/arm32v7/Dockerfile --path 2.2/sdk/bionic/arm32v7/Dockerfile --path 3.0/runtime-deps/stretch-slim/arm32v7/Dockerfile --path 3.0/runtime/stretch-slim/arm32v7/Dockerfile --path 3.0/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile --path 3.0/sdk/stretch/arm32v7/Dockerfile --path 3.0/runtime-deps/bionic/arm32v7/Dockerfile --path 3.0/aspnetcore-runtime/bionic/arm32v7/Dockerfile --path 3.0/runtime/bionic/arm32v7/Dockerfile --path 3.0/sdk/bionic/arm32v7/Dockerfile
    Linux-arm64v8:
      imageBuilderPaths: --path 3.0/runtime-deps/stretch-slim/arm64v8/Dockerfile --path 3.0/runtime/stretch-slim/arm64v8/Dockerfile --path 3.0/aspnetcore-runtime/stretch-slim/arm64v8/Dockerfile --path 3.0/sdk/stretch/arm64v8/Dockerfile --path 3.0/runtime-deps/bionic/arm64v8/Dockerfile --path 3.0/runtime/bionic/arm64v8/Dockerfile --path 3.0/aspnetcore-runtime/bionic/arm64v8/Dockerfile --path 3.0/sdk/bionic/arm64v8/Dockerfile
    nanoserver-1709-amd64:
      imageBuilderPaths: --path 2.1/runtime/nanoserver-1709/amd64/Dockerfile --path 2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile --path 2.1/sdk/nanoserver-1709/amd64/Dockerfile --path 2.2/runtime/nanoserver-1709/amd64/Dockerfile --path 2.2/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile --path 2.2/sdk/nanoserver-1709/amd64/Dockerfile --path 3.0/runtime/nanoserver-1709/amd64/Dockerfile --path 3.0/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile --path 3.0/sdk/nanoserver-1709/amd64/Dockerfile
    nanoserver-1803-amd64:
      imageBuilderPaths: --path 2.1/runtime/nanoserver-1803/amd64/Dockerfile --path 2.1/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile --path 2.1/sdk/nanoserver-1803/amd64/Dockerfile --path 2.2/runtime/nanoserver-1803/amd64/Dockerfile --path 2.2/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile --path 2.2/sdk/nanoserver-1803/amd64/Dockerfile --path 3.0/runtime/nanoserver-1803/amd64/Dockerfile --path 3.0/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile --path 3.0/sdk/nanoserver-1803/amd64/Dockerfile
    nanoserver-1809-amd64:
      imageBuilderPaths: --path 2.1/runtime/nanoserver-1809/amd64/Dockerfile --path 2.1/aspnetcore-runtime/nanoserver-1809/amd64/Dockerfile --path 2.1/sdk/nanoserver-1809/amd64/Dockerfile --path 2.2/runtime/nanoserver-1809/amd64/Dockerfile --path 2.2/aspnetcore-runtime/nanoserver-1809/amd64/Dockerfile --path 2.2/sdk/nanoserver-1809/amd64/Dockerfile --path 3.0/runtime/nanoserver-1809/amd64/Dockerfile --path 3.0/aspnetcore-runtime/nanoserver-1809/amd64/Dockerfile --path 3.0/sdk/nanoserver-1809/amd64/Dockerfile
    nanoserver-1809-arm32:
      imageBuilderPaths: --path 2.2/runtime/nanoserver-1809/arm32/Dockerfile --path 2.2/aspnetcore-runtime/nanoserver-1809/arm32/Dockerfile --path 2.2/sdk/nanoserver-1809/arm32/Dockerfile --path 3.0/runtime/nanoserver-1809/arm32/Dockerfile --path 3.0/aspnetcore-runtime/nanoserver-1809/arm32/Dockerfile --path 3.0/sdk/nanoserver-1809/arm32/Dockerfile
    nanoserver-sac2016-amd64:
      imageBuilderPaths: --path 1.0/runtime/nanoserver-sac2016/amd64/Dockerfile --path 1.1/runtime/nanoserver-sac2016/amd64/Dockerfile --path 1.1/sdk/nanoserver-sac2016/amd64/Dockerfile --path 2.1/runtime/nanoserver-sac2016/amd64/Dockerfile --path 2.1/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile --path 2.1/sdk/nanoserver-sac2016/amd64/Dockerfile --path 2.2/runtime/nanoserver-sac2016/amd64/Dockerfile --path 2.2/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile --path 2.2/sdk/nanoserver-sac2016/amd64/Dockerfile --path 3.0/runtime/nanoserver-sac2016/amd64/Dockerfile --path 3.0/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile --path 3.0/sdk/nanoserver-sac2016/amd64/Dockerfile
```