### PR TITLE
Misc changes to support MCR

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/Dockerfile.debian
+++ b/Microsoft.DotNet.ImageBuilder/Dockerfile.debian
@@ -40,7 +40,7 @@ RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
     && rm -rf /var/lib/apt/lists/*
 
 # install manifest-tool
-RUN curl -fsSL "https://github.com/estesp/manifest-tool/releases/download/v0.9.0/manifest-tool-linux-amd64" \
+RUN curl -fsSL "https://github.com/estesp/manifest-tool/releases/download/v1.0.0-rc/manifest-tool-linux-amd64" \
         -o /usr/local/bin/manifest-tool \
     && chmod +x /usr/local/bin/manifest-tool
 

--- a/Microsoft.DotNet.ImageBuilder/src/AzureHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/AzureHelper.cs
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.ImageBuilder
 
             ExecuteHelper.Execute(
                 "docker",
-                $"run -it --rm -v {_sessionId}:/root {AzureCliImage} az {command}",
+                $"run --rm -v {_sessionId}:/root {AzureCliImage} az {command}",
                 isDryRun,
                 executeMessageOverride: $"docker run -it --rm -v {_sessionId}:/root {AzureCliImage} az {commandMessageOverride}");
         }

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
@@ -17,6 +17,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public bool IsPushEnabled { get; set; }
         public bool IsRetryEnabled { get; set; }
         public bool IsSkipPullingEnabled { get; set; }
+        public OS OsType { get; set; }
         public string OsVersion { get; set; }
         public IEnumerable<string> Paths { get; set; }
 

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
@@ -24,14 +24,14 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 IEnumerable<TagInfo> platformTags = Manifest.ActiveImages
                     .SelectMany(image => image.ActivePlatforms)
                     .SelectMany(platform => platform.Tags);
-                string fullRegistryName = $"{Options.Registry}.azurecr.io/";
+                string registryName = $"{Manifest.Registry}/";
 
                 foreach (TagInfo platformTag in platformTags)
                 {
                     string sourceImage = $"{Options.SourceRepository}:{platformTag.Name}";
-                    string destImage = platformTag.FullyQualifiedName.TrimStart(fullRegistryName);
+                    string destImage = platformTag.FullyQualifiedName.TrimStart(registryName);
                     helper.ExecuteAzCommand(
-                        $"acr import -n {Options.Registry} --source {sourceImage} -t {destImage} --force",
+                        $"acr import -n {Manifest.Registry.TrimEnd(".azurecr.io")} --source {sourceImage} -t {destImage} --force",
                         Options.IsDryRun);
                 }
             };

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
                 foreach (TagInfo platformTag in platformTags)
                 {
-                    string sourceImage = $"{Options.SourceRepository}:{platformTag.Name}";
+                    string sourceImage = platformTag.FullyQualifiedName.Replace(Options.RepoPrefix, Options.SourceRepoPrefix);
                     string destImage = platformTag.FullyQualifiedName.TrimStart(registryName);
                     helper.ExecuteAzCommand(
                         $"acr import -n {Manifest.Registry.TrimEnd(".azurecr.io")} --source {sourceImage} -t {destImage} --force",

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesOptions.cs
@@ -18,6 +18,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public Architecture Architecture { get; set; }
         public string Password { get; set; }
         public IEnumerable<string> Paths { get; set; }
+        public OS OsType { get; set; }
         public string OsVersion { get; set; }
         public string SourceRepoPrefix { get; set; }
         public string Subscription { get; set; }

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesOptions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public string Password { get; set; }
         public IEnumerable<string> Paths { get; set; }
         public string OsVersion { get; set; }
-        public string SourceRepository { get; set; }
+        public string SourceRepoPrefix { get; set; }
         public string Subscription { get; set; }
         public string Tenant { get; set; }
         public string Username { get; set; }
@@ -34,9 +34,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             DefineManifestFilterOptions(syntax, this);
 
-            string sourceRepository = null;
-            syntax.DefineParameter("source-repo", ref sourceRepository, "ACR repository to copy images from");
-            SourceRepository = sourceRepository;
+            string sourceRepoPrefix = null;
+            syntax.DefineParameter("source-repo-prefix", ref sourceRepoPrefix, "Prefix of the source ACR repository to copy images from");
+            SourceRepoPrefix = sourceRepoPrefix;
 
             string username = null;
             syntax.DefineParameter("username", ref username, "The URL or name associated with the service principal to use");

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesOptions.cs
@@ -19,7 +19,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public string Password { get; set; }
         public IEnumerable<string> Paths { get; set; }
         public string OsVersion { get; set; }
-        public string Registry { get; set; }
         public string SourceRepository { get; set; }
         public string Subscription { get; set; }
         public string Tenant { get; set; }
@@ -34,10 +33,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             base.ParseCommandLine(syntax);
 
             DefineManifestFilterOptions(syntax, this);
-
-            string registry = null;
-            syntax.DefineParameter("registry", ref registry, "ACR to operate on");
-            Registry = registry;
 
             string sourceRepository = null;
             syntax.DefineParameter("source-repo", ref sourceRepository, "ACR repository to copy images from");

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/CopyImagesOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/CopyImagesOptions.cs
@@ -20,6 +20,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public string DestinationServer { get; set; }
         public string DestinationUsername { get; set; }
         public IEnumerable<string> Paths { get; set; }
+        public OS OsType { get; set; }
         public string OsVersion { get; set; }
         public string SourcePassword { get; set; }
         public string SourceRepo { get; set; }

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/DockerRegistryCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/DockerRegistryCommand.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     {
         protected void ExecuteWithUser(Action action)
         {
-            DockerHelper.ExecuteWithUser(action, Options.Username, Options.Password, Options.Server, Options.IsDryRun);
+            DockerHelper.ExecuteWithUser(action, Options.Username, Options.Password, Manifest.Registry, Options.IsDryRun);
         }
     }
 }

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/DockerRegistryOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/DockerRegistryOptions.cs
@@ -10,7 +10,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     public abstract class DockerRegistryOptions : Options
     {
         public string Password { get; set; }
-        public string Server { get; set; }
         public string Username { get; set; }
 
         protected DockerRegistryOptions()
@@ -27,13 +26,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 ref password,
                 "Password for the Docker Registry the images are pushed to");
             Password = password;
-
-            string server = null;
-            syntax.DefineOption(
-                "server",
-                ref server,
-                "Docker Registry server the images are pushed to (default is Docker Hub)");
-            Server = server;
 
             string username = null;
             Argument<string> usernameArg = syntax.DefineOption(

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
@@ -56,7 +56,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 LegInfo leg = new LegInfo()
                     { Name = $"{GetOSDisplayName(platformGrouping)}-{GetArchitectureDisplayName(platformGrouping)}" };
                 string pathArgs = platformGrouping
-                    .Select(platform => $"--path {platform.DockerfilePath}")
+                    .Select(platform => $"--path {platform.Model.Dockerfile}")
                     .Aggregate((working, next) => $"{working} {next}");
                 leg.Variables.Add(("imageBuilderPaths", pathArgs));
                 leg.Variables.Add(("osVersion", platformGrouping.Key.OS == OS.Windows ? platformGrouping.Key.OsVersion : "*"));

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
@@ -59,6 +59,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     .Select(platform => $"--path {platform.Model.Dockerfile}")
                     .Aggregate((working, next) => $"{working} {next}");
                 leg.Variables.Add(("imageBuilderPaths", pathArgs));
+                leg.Variables.Add(("osType", platformGrouping.Key.OS.ToString.ToLowerInvariant()));
                 leg.Variables.Add(("osVersion", platformGrouping.Key.OS == OS.Windows ? platformGrouping.Key.OsVersion : "*"));
                 leg.Variables.Add(("architecture", platformGrouping.Key.Architecture.ToString().ToLowerInvariant()));
 

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixOptions.cs
@@ -15,6 +15,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         protected override string CommandName => "generateBuildMatrix";
 
         public Architecture Architecture { get; set; }
+        public OS OsType { get; set; }
         public string OsVersion { get; set; }
         public MatrixType MatrixType { get; set; }
         public IEnumerable<string> Paths { get; set; }

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/IManifestFilterOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/IManifestFilterOptions.cs
@@ -10,6 +10,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     public interface IManifestFilterOptions
     {
         Architecture Architecture { get; set; }
+        OS OsType { get; set; }
         string OsVersion { get; set; }
         IEnumerable<string> Paths { get; set; }
     }

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/Options.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/Options.cs
@@ -20,7 +20,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public bool IsDryRun { get; set; }
         public bool IsVerbose { get; set; }
         public string Manifest { get; set; }
+        public string RegistryOverride { get; set; }
         public string Repo { get; set; }
+        public string RepoPrefix { get; set; }
         public IDictionary<string, string> RepoOverrides { get; set; }
 
         public IDictionary<string, string> Variables { get; set; }
@@ -109,15 +111,23 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             syntax.DefineOption("manifest", ref manifest, "Path to json file which describes the repo");
             Manifest = manifest;
 
+            string registryOverride = null;
+            syntax.DefineOption("registry-override", ref registryOverride, "Alternative registry which overrides the manifest");
+            RegistryOverride = registryOverride;
+
             string repo = null;
             syntax.DefineOption("repo", ref repo, "Repo to operate on (Default is all)");
             Repo = repo;
 
             IReadOnlyList<string> repoOverrides = Array.Empty<string>();
-            syntax.DefineOptionList("repo-override", ref repoOverrides, "Alternative repos which override the manifest (<target repo>=<override>)");
+            syntax.DefineOptionList("repo-override", ref repoOverrides, "Alternative repos which overrides the manifest (<target repo>=<override>)");
             RepoOverrides = repoOverrides
                 .Select(pair => pair.Split(new char[] { '=' }, 2))
                 .ToDictionary(split => split[0], split => split[1]);
+
+            string repoPrefix = null;
+            syntax.DefineOption("repo-prefix", ref repoPrefix, "Prefix to add to the repo names specified in the manifest");
+            RepoPrefix = repoPrefix;
 
             IReadOnlyList<string> variables = Array.Empty<string>();
             syntax.DefineOptionList("var", ref variables, "Named variables to substitute into the manifest (<name>=<value>)");

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/Options.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/Options.cs
@@ -47,6 +47,14 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             filterOptions.Architecture = DefineArchitectureOption(syntax);
 
+            OS osType = DockerHelper.GetOS();
+            syntax.DefineOption(
+                "os-type",
+                ref osType,
+                value => (OS)Enum.Parse(typeof(OS), value, true),
+                "OS type of the Dockerfiles to build (linux/windows) (default is the Docker OS)");
+            filterOptions.OsType = osType;
+
             string osVersion = null;
             syntax.DefineOption(
                 "os-version",
@@ -73,6 +81,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             {
                 IManifestFilterOptions filterOptions = (IManifestFilterOptions)this;
                 filter.DockerArchitecture = filterOptions.Architecture;
+                filter.IncludeOsType = filterOptions.OsType;
                 filter.IncludeOsVersion = filterOptions.OsVersion;
                 filter.IncludePaths = filterOptions.Paths;
             }

--- a/Microsoft.DotNet.ImageBuilder/src/Model/Manifest.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Model/Manifest.cs
@@ -9,6 +9,8 @@ namespace Microsoft.DotNet.ImageBuilder.Model
 {
     public class Manifest
     {
+        public string Registry { get; set; }
+
         [JsonProperty(Required = Required.Always)]
         public Repo[] Repos { get; set; }
 

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/IOptionsInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/IOptionsInfo.cs
@@ -8,7 +8,9 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 {
     public interface IOptionsInfo
     {
+        string RegistryOverride { get; }
         IDictionary<string, string> RepoOverrides { get; }
+        string RepoPrefix { get; }
         IDictionary<string, string> Variables { get; }
 
         string GetOption(string name);

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestFilter.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestFilter.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
     public class ManifestFilter
     {
         public Architecture DockerArchitecture { get; set; } = DockerHelper.Architecture;
-        public OS DockerOS { get; } = DockerHelper.GetOS();
+        public OS IncludeOsType { get; set; } = DockerHelper.GetOS();
         public string IncludeRepo { get; set; }
         public string IncludeOsVersion { get; set; }
         public IEnumerable<string> IncludePaths { get; set; }
@@ -24,7 +24,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         public IEnumerable<Platform> GetActivePlatforms(Image image)
         {
             return GetPlatforms(image)
-                .Where(platform => platform.OS == DockerOS && platform.Architecture == DockerArchitecture);
+                .Where(platform => platform.OS == IncludeOsType && platform.Architecture == DockerArchitecture);
         }
 
         private string GetFilterRegexPattern(params string[] patterns)

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
@@ -27,8 +27,9 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             manifestInfo.Model = model;
             manifestInfo.ManifestFilter = manifestFilter;
             manifestInfo.VariableHelper = new VariableHelper(model, options, manifestInfo.GetTagById, manifestInfo.GetRepoById);
+            string registryName = options.RegistryOverride ?? model.Registry;
             manifestInfo.Repos = manifestFilter.GetRepos(manifestInfo.Model)
-                .Select(repo => RepoInfo.Create(repo, manifestFilter, options, manifestInfo.VariableHelper))
+                .Select(repo => RepoInfo.Create(repo, registryName, manifestFilter, options, manifestInfo.VariableHelper))
                 .ToArray();
             manifestInfo.ActiveImages = manifestInfo.Repos
                 .SelectMany(repo => repo.Images)

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
@@ -32,6 +32,13 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             manifestInfo.Repos = manifestFilter.GetRepos(manifestInfo.Model)
                 .Select(repo => RepoInfo.Create(repo, manifestInfo.Registry, manifestFilter, options, manifestInfo.VariableHelper))
                 .ToArray();
+
+            IEnumerable<string> repoNames = manifestInfo.Repos.Select(repo => repo.Name);
+            foreach (PlatformInfo platform in manifestInfo.Repos.SelectMany(repo => repo.Images).SelectMany(image => image.Platforms))
+            {
+                platform.Initialize(repoNames);
+            }
+
             manifestInfo.ActiveImages = manifestInfo.Repos
                 .SelectMany(repo => repo.Images)
                 .Where(image => image.ActivePlatforms.Any())

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
@@ -14,6 +14,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         public IEnumerable<ImageInfo> ActiveImages { get; private set; }
         private ManifestFilter ManifestFilter { get; set; }
         public Manifest Model { get; private set; }
+        public string Registry { get; private set; }
         public IEnumerable<RepoInfo> Repos { get; private set; }
         public VariableHelper VariableHelper { get; set; }
 
@@ -26,10 +27,10 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             ManifestInfo manifestInfo = new ManifestInfo();
             manifestInfo.Model = model;
             manifestInfo.ManifestFilter = manifestFilter;
+            manifestInfo.Registry = options.RegistryOverride ?? model.Registry;
             manifestInfo.VariableHelper = new VariableHelper(model, options, manifestInfo.GetTagById, manifestInfo.GetRepoById);
-            string registryName = options.RegistryOverride ?? model.Registry;
             manifestInfo.Repos = manifestFilter.GetRepos(manifestInfo.Model)
-                .Select(repo => RepoInfo.Create(repo, registryName, manifestFilter, options, manifestInfo.VariableHelper))
+                .Select(repo => RepoInfo.Create(repo, manifestInfo.Registry, manifestFilter, options, manifestInfo.VariableHelper))
                 .ToArray();
             manifestInfo.ActiveImages = manifestInfo.Repos
                 .SelectMany(repo => repo.Images)


### PR DESCRIPTION
- Add options for overriding the registry and specifying a repo prefix.
- Removed the server options since they were redundant with the new registry option.
- Add support for FROM references across repos within the manifest.
- Upgraded the manifest-tool to pick up an ACR bug fix.
- Changed the source-repo option of the ACR copy command to be source-repo-prefix.
- Added an option to specify the os-type.  This is needed in order to run the ACR copy command on linux when coping Windows images.
- Refactored the publish matrix to be more fine grained.  The Linux amd64 copy leg was taking 1/2 hr and the goal for publish is ~5 mins.
