### PR TITLE
Standardize around 'filtered' and 'all' view model properties

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -40,9 +40,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private void BuildImages()
         {
             Logger.WriteHeading("BUILDING IMAGES");
-            foreach (ImageInfo image in Manifest.ActiveImages)
+            foreach (ImageInfo image in Manifest.GetFilteredImages())
             {
-                foreach (PlatformInfo platform in image.ActivePlatforms)
+                foreach (PlatformInfo platform in image.FilteredPlatforms)
                 {
                     bool createdPrivateDockerfile = UpdateDockerfileFromCommands(platform, out string dockerfilePath);
 
@@ -170,7 +170,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 foreach (string fromImage in platform.OverriddenFromImages)
                 {
                     string fromRepo = DockerHelper.GetRepo(fromImage);
-                    RepoInfo repo = Manifest.Repos.First(r => r.Model.Name == fromRepo);
+                    RepoInfo repo = Manifest.FilteredRepos.First(r => r.Model.Name == fromRepo);
                     string newFromImage = DockerHelper.ReplaceRepo(fromImage, repo.Name);
                     Logger.WriteMessage($"Replacing FROM `{fromImage}` with `{newFromImage}`");
                     Regex fromRegex = new Regex($@"FROM\s+{Regex.Escape(fromImage)}[^\S\r\n]*");

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
@@ -13,11 +13,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         protected override string CommandHelp => "Builds and Tests Dockerfiles";
         protected override string CommandName => "build";
 
-        public Architecture Architecture { get; set; }
+        public string Architecture { get; set; }
         public bool IsPushEnabled { get; set; }
         public bool IsRetryEnabled { get; set; }
         public bool IsSkipPullingEnabled { get; set; }
-        public OS OsType { get; set; }
+        public string OsType { get; set; }
         public string OsVersion { get; set; }
         public IEnumerable<string> Paths { get; set; }
 

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
@@ -21,12 +21,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             using (AzureHelper helper = AzureHelper.Create(Options.Username, Options.Password, Options.Tenant, Options.IsDryRun))
             {
-                IEnumerable<TagInfo> platformTags = Manifest.ActiveImages
-                    .SelectMany(image => image.ActivePlatforms)
-                    .SelectMany(platform => platform.Tags);
                 string registryName = $"{Manifest.Registry}/";
 
-                foreach (TagInfo platformTag in platformTags)
+                foreach (TagInfo platformTag in Manifest.GetFilteredPlatformTags())
                 {
                     string sourceImage = platformTag.FullyQualifiedName.Replace(Options.RepoPrefix, Options.SourceRepoPrefix);
                     string destImage = platformTag.FullyQualifiedName.TrimStart(registryName);

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesOptions.cs
@@ -15,10 +15,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         protected override string CommandHelp => "Copies the platform images as specified in the manifest between repositories of an ACR";
         protected override string CommandName => "copyAcrImages";
 
-        public Architecture Architecture { get; set; }
+        public string Architecture { get; set; }
         public string Password { get; set; }
         public IEnumerable<string> Paths { get; set; }
-        public OS OsType { get; set; }
+        public string OsType { get; set; }
         public string OsVersion { get; set; }
         public string SourceRepoPrefix { get; set; }
         public string Subscription { get; set; }

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/CopyImagesCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/CopyImagesCommand.cs
@@ -19,10 +19,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             Logger.WriteHeading("COPING IMAGES");
 
-            IEnumerable<TagInfo> platformTags = Manifest.ActiveImages
-                    .SelectMany(image => image.ActivePlatforms)
-                    .SelectMany(platform => platform.Tags)
-                    .ToArray();
+            IEnumerable<TagInfo> platformTags = Manifest.GetFilteredPlatformTags()
+                .ToArray();
 
             Logger.WriteHeading("PULLING SOURCE IMAGES");
             DockerHelper.ExecuteWithUser(

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/CopyImagesOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/CopyImagesOptions.cs
@@ -15,12 +15,12 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         protected override string CommandHelp => "Copies the platform images as specified in the manifest between Docker registries";
         protected override string CommandName => "copyImages";
 
-        public Architecture Architecture { get; set; }
+        public string Architecture { get; set; }
         public string DestinationPassword { get; set; }
         public string DestinationServer { get; set; }
         public string DestinationUsername { get; set; }
         public IEnumerable<string> Paths { get; set; }
-        public OS OsType { get; set; }
+        public string OsType { get; set; }
         public string OsVersion { get; set; }
         public string SourcePassword { get; set; }
         public string SourceRepo { get; set; }

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
@@ -131,9 +131,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             List<MatrixInfo> matrices = new List<MatrixInfo>();
 
             // The sort order used here is arbitrary and simply helps the readability of the output.
-            var platformGroups = Manifest.Repos
-                .SelectMany(repo => repo.Images)
-                .SelectMany(image => image.Platforms)
+            var platformGroups = Manifest.GetFilteredPlatforms()
                 .GroupBy(platform =>
                     new { platform.Model.OS, platform.Model.OsVersion, platform.Model.Architecture, platform.Model.Variant })
                 .OrderBy(platformGroup => platformGroup.Key.OS)

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixOptions.cs
@@ -14,8 +14,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         protected override string CommandHelp => "Generate the VSTS build matrix for building the images";
         protected override string CommandName => "generateBuildMatrix";
 
-        public Architecture Architecture { get; set; }
-        public OS OsType { get; set; }
+        public string Architecture { get; set; }
+        public string OsType { get; set; }
         public string OsVersion { get; set; }
         public MatrixType MatrixType { get; set; }
         public IEnumerable<string> Paths { get; set; }

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateTagsReadmeCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateTagsReadmeCommand.cs
@@ -25,10 +25,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public override Task ExecuteAsync()
         {
             Logger.WriteHeading("GENERATING TAGS README");
-            foreach (RepoInfo repo in Manifest.Repos)
+            foreach (RepoInfo repo in Manifest.FilteredRepos)
             {
-                ImageDocInfos = repo.Images
-                    .SelectMany(image => image.Platforms.SelectMany(platform => ImageDocumentationInfo.Create(image, platform)))
+                ImageDocInfos = repo.AllImages
+                    .SelectMany(image => image.AllPlatforms.SelectMany(platform => ImageDocumentationInfo.Create(image, platform)))
                     .Where(info => info.DocumentedTags.Any())
                     .ToList();
 

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/IManifestFilterOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/IManifestFilterOptions.cs
@@ -9,8 +9,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     public interface IManifestFilterOptions
     {
-        Architecture Architecture { get; set; }
-        OS OsType { get; set; }
+        string Architecture { get; set; }
+        string OsType { get; set; }
         string OsVersion { get; set; }
         IEnumerable<string> Paths { get; set; }
     }

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/Options.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/Options.cs
@@ -31,14 +31,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
         }
 
-        protected static Architecture DefineArchitectureOption(ArgumentSyntax syntax)
+        protected static string DefineArchitectureOption(ArgumentSyntax syntax)
         {
-            Architecture architecture = DockerHelper.Architecture;
+            string architecture = DockerHelper.Architecture.ToString().ToLowerInvariant();
             syntax.DefineOption(
                 "architecture",
                 ref architecture,
-                value => (Architecture)Enum.Parse(typeof(Architecture), value, true),
-                "Architecture of Dockerfiles to operate on (default is current OS architecture)");
+                "Architecture of Dockerfiles to operate on - wildcard chars * and ? supported (default is current OS architecture)");
 
             return architecture;
         }
@@ -47,12 +46,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             filterOptions.Architecture = DefineArchitectureOption(syntax);
 
-            OS osType = DockerHelper.GetOS();
+            string osType = DockerHelper.OS.ToString().ToLowerInvariant();
             syntax.DefineOption(
                 "os-type",
                 ref osType,
-                value => (OS)Enum.Parse(typeof(OS), value, true),
-                "OS type of the Dockerfiles to build (linux/windows) (default is the Docker OS)");
+                "OS type (linux/windows) of the Dockerfiles to build - wildcard chars * and ? supported (default is the Docker OS)");
             filterOptions.OsType = osType;
 
             string osVersion = null;
@@ -80,7 +78,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             if (this is IManifestFilterOptions)
             {
                 IManifestFilterOptions filterOptions = (IManifestFilterOptions)this;
-                filter.DockerArchitecture = filterOptions.Architecture;
+                filter.IncludeArchitecture = filterOptions.Architecture;
                 filter.IncludeOsType = filterOptions.OsType;
                 filter.IncludeOsVersion = filterOptions.OsVersion;
                 filter.IncludePaths = filterOptions.Paths;

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestCommand.cs
@@ -24,8 +24,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             ExecuteWithUser(() =>
             {
-                IEnumerable<ImageInfo> multiArchImages = Manifest.Repos
-                    .SelectMany(repo => repo.Images)
+                IEnumerable<ImageInfo> multiArchImages = Manifest.FilteredRepos
+                    .SelectMany(repo => repo.AllImages)
                     .Where(image => image.SharedTags.Any());
                 foreach (ImageInfo image in multiArchImages)
                 {
@@ -59,7 +59,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             }
 
             manifestYml.AppendLine("manifests:");
-            foreach (PlatformInfo platform in image.Platforms)
+            foreach (PlatformInfo platform in image.AllPlatforms)
             {
                 manifestYml.AppendLine($"  -");
                 manifestYml.AppendLine($"    image: {platform.Tags.First().FullyQualifiedName}");

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/UpdateReadmeCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/UpdateReadmeCommand.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public override async Task ExecuteAsync()
         {
             Logger.WriteHeading("UPDATING READMES");
-            foreach (RepoInfo repo in Manifest.Repos)
+            foreach (RepoInfo repo in Manifest.FilteredRepos)
             {
                 // Docker Hub/Cloud API is not documented thus it is subject to change.  This is the only option
                 // until a supported API exists.

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/UpdateVersionsOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/UpdateVersionsOptions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         protected override string CommandHelp => "Updates the version information for the dependent images";
         protected override string CommandName => "updateVersions";
 
-        public Architecture Architecture { get; set; }
+        public string Architecture { get; set; }
         public string GitAuthToken { get; set; }
         public string GitBranch { get; set; }
         public string GitEmail { get; set; }
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public override ManifestFilter GetManifestFilter()
         {
             ManifestFilter filterInfo = base.GetManifestFilter();
-            filterInfo.DockerArchitecture = Architecture;
+            filterInfo.IncludeArchitecture = Architecture;
 
             return filterInfo;
         }

--- a/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
@@ -15,8 +15,10 @@ namespace Microsoft.DotNet.ImageBuilder
     public static class DockerHelper
     {
         private static Lazy<Architecture> _architecture = new Lazy<Architecture>(GetArchitecture);
+        private static Lazy<OS> _os = new Lazy<OS>(GetOS);
 
         public static Architecture Architecture => _architecture.Value;
+        public static OS OS => _os.Value;
 
         private static string ExecuteCommandWithFormat(
             string command, string outputFormat, string errorMessage, string additionalArgs = null, bool isDryRun = false)
@@ -82,7 +84,7 @@ namespace Microsoft.DotNet.ImageBuilder
                 "inspect", "index .RepoDigests 0", "Failed to retrieve image digest", image, isDryRun);
         }
 
-        public static OS GetOS()
+        private static OS GetOS()
         {
             string osString = ExecuteCommandWithFormat("version", ".Server.Os", "Failed to detect Docker OS");
             if (!Enum.TryParse(osString, true, out OS os))

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/ImageInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/ImageInfo.cs
@@ -10,8 +10,16 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 {
     public class ImageInfo
     {
+        /// <summary>
+        /// All of the platforms that are defined in the manifest for this image.
+        /// </summary>
         public IEnumerable<PlatformInfo> AllPlatforms { get; set; }
+
+        /// <summary>
+        /// The subet of image platforms after applying the command line filter options.
+        /// </summary>
         public IEnumerable<PlatformInfo> FilteredPlatforms { get; private set; }
+
         public Image Model { get; private set; }
         public IEnumerable<TagInfo> SharedTags { get; private set; }
 

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/ImageInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/ImageInfo.cs
@@ -10,9 +10,9 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 {
     public class ImageInfo
     {
-        public IEnumerable<PlatformInfo> ActivePlatforms { get; private set; }
+        public IEnumerable<PlatformInfo> AllPlatforms { get; set; }
+        public IEnumerable<PlatformInfo> FilteredPlatforms { get; private set; }
         public Image Model { get; private set; }
-        public IEnumerable<PlatformInfo> Platforms { get; set; }
         public IEnumerable<TagInfo> SharedTags { get; private set; }
 
         private ImageInfo()
@@ -36,13 +36,13 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
                     .ToArray();
             }
 
-            imageInfo.Platforms = manifestFilter.GetPlatforms(model)
+            imageInfo.AllPlatforms = manifestFilter.GetPlatforms(model)
                 .Select(platform => PlatformInfo.Create(platform, repoModel, repoName, variableHelper))
                 .ToArray();
 
-            IEnumerable<Platform> activePlatformModels = manifestFilter.GetActivePlatforms(model);
-            imageInfo.ActivePlatforms = imageInfo.Platforms
-                    .Where(platform => activePlatformModels.Contains(platform.Model));
+            IEnumerable<Platform> filteredPlatformModels = manifestFilter.GetPlatforms(model);
+            imageInfo.FilteredPlatforms = imageInfo.AllPlatforms
+                .Where(platform => filteredPlatformModels.Contains(platform.Model));
 
             return imageInfo;
         }

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
@@ -11,8 +11,16 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 {
     public class ManifestInfo
     {
+        /// <summary>
+        /// All of the repos that are defined in the manifest.
+        /// </summary>
         public IEnumerable<RepoInfo> AllRepos { get; private set; }
+
+        /// <summary>
+        /// The subet of manifest repos after applying the command line filter options.
+        /// </summary>
         public IEnumerable<RepoInfo> FilteredRepos { get; private set; }
+
         private ManifestFilter ManifestFilter { get; set; }
         public Manifest Model { get; private set; }
         public string Registry { get; private set; }

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
@@ -11,11 +11,11 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 {
     public class ManifestInfo
     {
-        public IEnumerable<ImageInfo> ActiveImages { get; private set; }
+        public IEnumerable<RepoInfo> AllRepos { get; private set; }
+        public IEnumerable<RepoInfo> FilteredRepos { get; private set; }
         private ManifestFilter ManifestFilter { get; set; }
         public Manifest Model { get; private set; }
         public string Registry { get; private set; }
-        public IEnumerable<RepoInfo> Repos { get; private set; }
         public VariableHelper VariableHelper { get; set; }
 
         private ManifestInfo()
@@ -29,19 +29,19 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             manifestInfo.ManifestFilter = manifestFilter;
             manifestInfo.Registry = options.RegistryOverride ?? model.Registry;
             manifestInfo.VariableHelper = new VariableHelper(model, options, manifestInfo.GetTagById, manifestInfo.GetRepoById);
-            manifestInfo.Repos = manifestFilter.GetRepos(manifestInfo.Model)
+            manifestInfo.AllRepos = manifestInfo.Model.Repos
                 .Select(repo => RepoInfo.Create(repo, manifestInfo.Registry, manifestFilter, options, manifestInfo.VariableHelper))
                 .ToArray();
 
-            IEnumerable<string> repoNames = manifestInfo.Repos.Select(repo => repo.Name);
-            foreach (PlatformInfo platform in manifestInfo.Repos.SelectMany(repo => repo.Images).SelectMany(image => image.Platforms))
+            IEnumerable<string> repoNames = manifestInfo.AllRepos.Select(repo => repo.Name).ToArray();
+            foreach (PlatformInfo platform in manifestInfo.AllRepos.SelectMany(repo => repo.AllImages).SelectMany(image => image.AllPlatforms))
             {
                 platform.Initialize(repoNames);
             }
 
-            manifestInfo.ActiveImages = manifestInfo.Repos
-                .SelectMany(repo => repo.Images)
-                .Where(image => image.ActivePlatforms.Any())
+            IEnumerable<Repo> filteredRepoModels = manifestFilter.GetRepos(manifestInfo.Model);
+            manifestInfo.FilteredRepos = manifestInfo.AllRepos
+                .Where(repo => filteredRepoModels.Contains(repo.Model))
                 .ToArray();
 
             return manifestInfo;
@@ -49,32 +49,49 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 
         private IEnumerable<TagInfo> GetAllTags()
         {
-            IEnumerable<ImageInfo> images = Repos
-                .SelectMany(repo => repo.Images)
+            IEnumerable<ImageInfo> images = AllRepos
+                .SelectMany(repo => repo.AllImages)
                 .ToArray();
             IEnumerable<TagInfo> sharedTags = images
                 .SelectMany(image => image.SharedTags);
             IEnumerable<TagInfo> platformTags = images
-                .SelectMany(image => image.Platforms)
+                .SelectMany(image => image.AllPlatforms)
                 .SelectMany(platform => platform.Tags);
             return sharedTags
-                .Concat(platformTags)
-                .ToArray();
+                .Concat(platformTags);
         }
 
         public IEnumerable<string> GetExternalFromImages()
         {
-            return ActiveImages
-                .SelectMany(image => image.ActivePlatforms)
+            return GetFilteredImages()
+                .SelectMany(image => image.FilteredPlatforms)
                 .SelectMany(platform => platform.ExternalFromImages)
                 .Distinct();
         }
 
+        public IEnumerable<ImageInfo> GetFilteredImages()
+        {
+            return FilteredRepos
+                .SelectMany(repo => repo.FilteredImages);
+        }
+
+        public IEnumerable<PlatformInfo> GetFilteredPlatforms()
+        {
+            return GetFilteredImages()
+                .SelectMany(image => image.FilteredPlatforms);
+        }
+
+        public IEnumerable<TagInfo> GetFilteredPlatformTags()
+        {
+            return GetFilteredPlatforms()
+                .SelectMany(platform => platform.Tags);
+        }
+
         public PlatformInfo GetPlatformByTag(string fullTagName)
         {
-            PlatformInfo result = this.Repos
-                .SelectMany(repo => repo.Images)
-                .SelectMany(image => image.Platforms)
+            PlatformInfo result = this.AllRepos
+                .SelectMany(repo => repo.AllImages)
+                .SelectMany(image => image.AllPlatforms)
                 .FirstOrDefault(platform => platform.Tags.Any(tag => tag.FullyQualifiedName == fullTagName));
 
             if (result == null)
@@ -87,7 +104,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 
         public RepoInfo GetRepoById(string id)
         {
-            return Repos.FirstOrDefault(repo => repo.Id == id);
+            return AllRepos.FirstOrDefault(repo => repo.Id == id);
         }
 
         public TagInfo GetTagById(string id)

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/RepoInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/RepoInfo.cs
@@ -12,8 +12,16 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 {
     public class RepoInfo
     {
+        /// <summary>
+        /// All of the images that are defined in the manifest for this repo.
+        /// </summary>
         public IEnumerable<ImageInfo> AllImages { get; private set; }
+
+        /// <summary>
+        /// The subet of image platforms after applying the command line filter options.
+        /// </summary>
         public IEnumerable<ImageInfo> FilteredImages { get; private set; }
+
         public string Id { get; private set; }
         public string Name { get; private set; }
         public Repo Model { get; private set; }

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/RepoInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/RepoInfo.cs
@@ -12,9 +12,10 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 {
     public class RepoInfo
     {
+        public IEnumerable<ImageInfo> AllImages { get; private set; }
+        public IEnumerable<ImageInfo> FilteredImages { get; private set; }
         public string Id { get; private set; }
         public string Name { get; private set; }
-        public IEnumerable<ImageInfo> Images { get; private set; }
         public Repo Model { get; private set; }
 
         private RepoInfo()
@@ -38,8 +39,12 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
                 repoInfo.Name = registry + options.RepoPrefix + model.Name;
             }
 
-            repoInfo.Images = model.Images
+            repoInfo.AllImages = model.Images
                 .Select(image => ImageInfo.Create(image, model, repoInfo.Name, manifestFilter, variableHelper))
+                .ToArray();
+
+            repoInfo.FilteredImages = repoInfo.AllImages
+                .Where(image => image.FilteredPlatforms.Any())
                 .ToArray();
 
             return repoInfo;


### PR DESCRIPTION
The underlying problem that needed to be fixed was that when initializing the PlatformInfo instances, the InitializeBuildArgs logic needs to access the unfiltered Repo view model which didn't exist.  This lead me to realize the messiness of the view model in that it did not consistently expose the filtered and unfiltered items.  I decided to standardize around the terms 'filtered' and 'all' in order to make it unambiguous as to what the properties/members mean.