### PR TITLE
Add PublishMcrReadmesCommand

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrReadmesCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrReadmesCommand.cs
@@ -1,0 +1,119 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.ImageBuilder.ViewModel;
+using Microsoft.DotNet.VersionTools.Automation;
+using Microsoft.DotNet.VersionTools.Automation.GitHubApi;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Net.Http;
+using System.IO;
+
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    public class PublishMcrReadmesCommand : Command<PublishMcrReadmesOptions>
+    {
+        private const int MaxTries = 10;
+        private const int RetryMillisecondsDelay = 5000;
+
+        public PublishMcrReadmesCommand() : base()
+        {
+        }
+
+        public override async Task ExecuteAsync()
+        {
+            Logger.WriteHeading("PUBLISHING READMES TO MCR");
+
+            // Hookup a TraceListener in order to capture details from Microsoft.DotNet.VersionTools
+            Trace.Listeners.Add(new TextWriterTraceListener(Console.Out));
+
+            string productRepo = GetProductRepo();
+
+            GitHubAuth githubAuth = new GitHubAuth(Options.GitAuthToken, Options.GitUsername, Options.GitEmail);
+            using (GitHubClient client = new GitHubClient(githubAuth))
+            {
+                for (int i = 0; i < MaxTries; i++)
+                {
+                    try
+                    {
+                        GitHubProject project = new GitHubProject(Options.GitRepo, Options.GitOwner);
+                        GitHubBranch branch = new GitHubBranch(Options.GitBranch, project);
+                        GitObject[] gitObjects = await GetUpdatedReadMes(productRepo, client, branch);
+
+                        if (gitObjects.Any())
+                        {
+                            string masterRef = $"heads/{Options.GitBranch}";
+                            GitReference currentMaster = await client.GetReferenceAsync(project, masterRef);
+                            string masterSha = currentMaster.Object.Sha;
+                            GitTree tree = await client.PostTreeAsync(project, masterSha, gitObjects);
+                            string commitMessage = $"Mirroring {productRepo} readmes";
+                            GitCommit commit = await client.PostCommitAsync(
+                                project, commitMessage, tree.Sha, new[] { masterSha });
+
+                            // Only fast-forward. Don't overwrite other changes: throw exception instead.
+                            await client.PatchReferenceAsync(project, masterRef, commit.Sha, force: false);
+                        }
+
+                        break;
+                    }
+                    catch (HttpRequestException ex) when (i < (MaxTries - 1))
+                    {
+                        Logger.WriteMessage($"Encountered exception publishing readmes: {ex.Message}");
+                        Logger.WriteMessage($"Trying again in {RetryMillisecondsDelay}ms. {MaxTries - i - 1} tries left.");
+                        await Task.Delay(RetryMillisecondsDelay);
+                    }
+                }
+            }
+        }
+
+        private string GetProductRepo()
+        {
+            string firstRepoName = Manifest.AllRepos.First().Name
+                .TrimStart($"{Manifest.Registry}/");
+            return firstRepoName.Substring(0, firstRepoName.LastIndexOf('/'));
+        }
+
+        private async Task<GitObject[]> GetUpdatedReadMes(string productRepo, GitHubClient client, GitHubBranch branch)
+        {
+            List<GitObject> versionInfo = new List<GitObject>();
+
+            List<string> readmePaths = Manifest.FilteredRepos
+                .Select(repo => repo.Model.ReadmePath)
+                .ToList();
+
+            if (!string.IsNullOrEmpty(Manifest.Model.ReadmePath))
+            {
+                readmePaths.Add(Manifest.Model.ReadmePath);
+            }
+
+            foreach (string readmePath in readmePaths)
+            {
+                string currentReadMe = File.ReadAllText(readmePath);
+                string gitReadmePath = string.Join('/', Options.GitPath, productRepo, readmePath);
+                string lastReadMe = await client.GetGitHubFileContentsAsync(gitReadmePath, branch);
+
+                if (lastReadMe == currentReadMe)
+                {
+                    Logger.WriteMessage($"Readme has not changed:  {readmePath}");
+                }
+                else
+                {
+                    Logger.WriteMessage($"Readme has changed:  {readmePath}");
+                    versionInfo.Add(new GitObject
+                    {
+                        Path = gitReadmePath,
+                        Type = GitObject.TypeBlob,
+                        Mode = GitObject.ModeFile,
+                        Content = currentReadMe
+                    });
+                }
+            }
+
+            return versionInfo.ToArray();
+        }
+    }
+}

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrReadmesOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrReadmesOptions.cs
@@ -2,19 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.ImageBuilder.Model;
-using Microsoft.DotNet.ImageBuilder.ViewModel;
-using System.Collections.Generic;
 using System.CommandLine;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
-    public class UpdateVersionsOptions : Options, IManifestFilterOptions
+    public class PublishMcrReadmesOptions : Options
     {
-        protected override string CommandHelp => "Updates the version information for the dependent images";
-        protected override string CommandName => "updateVersions";
+        protected override string CommandHelp => "Publishes the readmes to MCR";
+        protected override string CommandName => "publishMcrReadmes";
 
-        public string Architecture { get; set; }
         public string GitAuthToken { get; set; }
         public string GitBranch { get; set; }
         public string GitEmail { get; set; }
@@ -22,12 +18,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public string GitPath { get; set; }
         public string GitRepo { get; set; }
         public string GitUsername { get; set; }
-        public string OsType { get; set; }
-        public string OsVersion { get; set; }
-        public IEnumerable<string> Paths { get; set; }
 
-
-        public UpdateVersionsOptions() : base()
+        public PublishMcrReadmesOptions() : base()
         {
         }
 
@@ -35,34 +27,32 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             base.ParseCommandLine(syntax);
 
-            DefineManifestFilterOptions(syntax, this);
-
             string gitBranch = "master";
             syntax.DefineOption(
                 "git-branch",
                 ref gitBranch,
-                "GitHub branch to write version info to (defaults to master)");
+                "GitHub branch to write readmes to (defaults to master)");
             GitBranch = gitBranch;
 
-            string gitOwner = "dotnet";
+            string gitOwner = "Microsoft";
             syntax.DefineOption(
                 "git-owner",
                 ref gitOwner,
-                "Owner of the GitHub repo to write version info to (defaults to dotnet)");
+                "Owner of the GitHub repo to write readmes to (defaults to Microsoft)");
             GitOwner = gitOwner;
 
-            string gitPath = "build-info/docker";
+            string gitPath = "teams";
             syntax.DefineOption(
                 "git-path",
                 ref gitPath,
-                "Path within the GitHub repo to write version info to (defaults to build-info/docker)");
+                "Path within the GitHub repo to write readmes to (defaults to teams)");
             GitPath = gitPath;
 
-            string gitRepo = "versions";
+            string gitRepo = "mcrdocs";
             syntax.DefineOption(
                 "git-repo",
                 ref gitRepo,
-                "GitHub repo to write version info to (defaults to versions)");
+                "GitHub repo to readmes to (defaults to mcrdocs)");
             GitRepo = gitRepo;
 
             string gitUsername = null;

--- a/Microsoft.DotNet.ImageBuilder/src/ImageBuilder.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ImageBuilder.cs
@@ -24,6 +24,7 @@ namespace Microsoft.DotNet.ImageBuilder
                     new GenerateBuildMatrixCommand(),
                     new GenerateTagsReadmeCommand(),
                     new PublishManifestCommand(),
+                    new PublishMcrReadmesCommand(),
                     new UpdateReadmeCommand(),
                     new UpdateVersionsCommand(),
                 };

--- a/Microsoft.DotNet.ImageBuilder/src/Model/Manifest.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Model/Manifest.cs
@@ -9,6 +9,7 @@ namespace Microsoft.DotNet.ImageBuilder.Model
 {
     public class Manifest
     {
+        public string ReadmePath { get; set; }
         public string Registry { get; set; }
 
         [JsonProperty(Required = Required.Always)]


### PR DESCRIPTION
This command is needed in order to publish the readmes that reside in the product github repos to the mcrdocs repo.  This is where MCR gets the readmes that it pushes to Docker Hub.