### PR TITLE
Misc cleanup of Options classes

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
@@ -8,18 +8,14 @@ using System.CommandLine;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
-    public class BuildOptions : DockerRegistryOptions, IManifestFilterOptions
+    public class BuildOptions : DockerRegistryOptions, IFilterableOptions
     {
         protected override string CommandHelp => "Builds and Tests Dockerfiles";
-        protected override string CommandName => "build";
 
-        public string Architecture { get; set; }
+        public ManifestFilterOptions FilterOptions { get; } = new ManifestFilterOptions();
         public bool IsPushEnabled { get; set; }
         public bool IsRetryEnabled { get; set; }
         public bool IsSkipPullingEnabled { get; set; }
-        public string OsType { get; set; }
-        public string OsVersion { get; set; }
-        public IEnumerable<string> Paths { get; set; }
 
         public BuildOptions() : base()
         {
@@ -29,7 +25,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             base.ParseCommandLine(syntax);
 
-            DefineManifestFilterOptions(syntax, this);
+            FilterOptions.ParseCommandLine(syntax);
 
             bool isPushEnabled = false;
             syntax.DefineOption("push", ref isPushEnabled, "Push built images to Docker registry");

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesOptions.cs
@@ -10,16 +10,12 @@ using Microsoft.DotNet.ImageBuilder.ViewModel;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
-    public class CopyAcrImagesOptions : Options, IManifestFilterOptions
+    public class CopyAcrImagesOptions : Options, IFilterableOptions
     {
         protected override string CommandHelp => "Copies the platform images as specified in the manifest between repositories of an ACR";
-        protected override string CommandName => "copyAcrImages";
 
-        public string Architecture { get; set; }
+        public ManifestFilterOptions FilterOptions { get; } = new ManifestFilterOptions();
         public string Password { get; set; }
-        public IEnumerable<string> Paths { get; set; }
-        public string OsType { get; set; }
-        public string OsVersion { get; set; }
         public string SourceRepoPrefix { get; set; }
         public string Subscription { get; set; }
         public string Tenant { get; set; }
@@ -33,7 +29,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             base.ParseCommandLine(syntax);
 
-            DefineManifestFilterOptions(syntax, this);
+            FilterOptions.ParseCommandLine(syntax);
 
             string sourceRepoPrefix = null;
             syntax.DefineParameter("source-repo-prefix", ref sourceRepoPrefix, "Prefix of the source ACR repository to copy images from");

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/CopyImagesOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/CopyImagesOptions.cs
@@ -10,18 +10,14 @@ using Microsoft.DotNet.ImageBuilder.ViewModel;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
-    public class CopyImagesOptions : Options, IManifestFilterOptions
+    public class CopyImagesOptions : Options, IFilterableOptions
     {
         protected override string CommandHelp => "Copies the platform images as specified in the manifest between Docker registries";
-        protected override string CommandName => "copyImages";
 
-        public string Architecture { get; set; }
         public string DestinationPassword { get; set; }
         public string DestinationServer { get; set; }
         public string DestinationUsername { get; set; }
-        public IEnumerable<string> Paths { get; set; }
-        public string OsType { get; set; }
-        public string OsVersion { get; set; }
+        public ManifestFilterOptions FilterOptions { get; } = new ManifestFilterOptions();
         public string SourcePassword { get; set; }
         public string SourceRepo { get; set; }
         public string SourceServer { get; set; }
@@ -35,7 +31,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             base.ParseCommandLine(syntax);
 
-            DefineManifestFilterOptions(syntax, this);
+            FilterOptions.ParseCommandLine(syntax);
 
             string destinationPassword = null;
             Argument<string> destinationPasswordArg = syntax.DefineOption(

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixOptions.cs
@@ -9,16 +9,12 @@ using Microsoft.DotNet.ImageBuilder.Model;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
-    public class GenerateBuildMatrixOptions : Options, IManifestFilterOptions
+    public class GenerateBuildMatrixOptions : Options, IFilterableOptions
     {
         protected override string CommandHelp => "Generate the VSTS build matrix for building the images";
-        protected override string CommandName => "generateBuildMatrix";
 
-        public string Architecture { get; set; }
-        public string OsType { get; set; }
-        public string OsVersion { get; set; }
+        public ManifestFilterOptions FilterOptions { get; } = new ManifestFilterOptions();
         public MatrixType MatrixType { get; set; }
-        public IEnumerable<string> Paths { get; set; }
 
         public GenerateBuildMatrixOptions() : base()
         {
@@ -28,7 +24,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             base.ParseCommandLine(syntax);
 
-            DefineManifestFilterOptions(syntax, this);
+            FilterOptions.ParseCommandLine(syntax);
 
             MatrixType matrixType = MatrixType.Build;
             syntax.DefineOption(

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateTagsReadmeOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateTagsReadmeOptions.cs
@@ -9,7 +9,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     public class GenerateTagsReadmeOptions : Options
     {
         protected override string CommandHelp => "Generate the tags section of the readme";
-        protected override string CommandName => "generateTagsReadme";
 
         public string ReadmePath { get; set; }
         public bool SkipValidation { get; set; }

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/IManifestFilterOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/IManifestFilterOptions.cs
@@ -2,16 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-using Microsoft.DotNet.ImageBuilder.Model;
-
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
-    public interface IManifestFilterOptions
+    public interface IFilterableOptions
     {
-        string Architecture { get; set; }
-        string OsType { get; set; }
-        string OsVersion { get; set; }
-        IEnumerable<string> Paths { get; set; }
+        ManifestFilterOptions FilterOptions { get; }
     }
 }

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestFilterOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestFilterOptions.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.ImageBuilder.Model;
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    public class ManifestFilterOptions
+    {
+        public string Architecture { get; set; }
+        public string OsType { get; set; }
+        public string OsVersion { get; set; }
+        public IEnumerable<string> Paths { get; set; }
+
+        public void ParseCommandLine(ArgumentSyntax syntax)
+        {
+            string architecture = DockerHelper.Architecture.ToString().ToLowerInvariant();
+            syntax.DefineOption(
+                "architecture",
+                ref architecture,
+                "Architecture of Dockerfiles to operate on - wildcard chars * and ? supported (default is current OS architecture)");
+            Architecture = architecture;
+
+            string osType = DockerHelper.OS.ToString().ToLowerInvariant();
+            syntax.DefineOption(
+                "os-type",
+                ref osType,
+                "OS type (linux/windows) of the Dockerfiles to build - wildcard chars * and ? supported (default is the Docker OS)");
+            OsType = osType;
+
+            string osVersion = null;
+            syntax.DefineOption(
+                "os-version",
+                ref osVersion,
+                "OS version of the Dockerfiles to build - wildcard chars * and ? supported (default is to build all)");
+            OsVersion = osVersion;
+
+            IReadOnlyList<string> paths = Array.Empty<string>();
+            syntax.DefineOptionList(
+                "path",
+                ref paths,
+                "Directory paths containing the Dockerfiles to build - wildcard chars * and ? supported (default is to build all)");
+            Paths = paths;
+        }
+    }
+}

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestOptions.cs
@@ -7,7 +7,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     public class PublishManifestOptions : DockerRegistryOptions
     {
         protected override string CommandHelp => "Creates and publishes the manifest to the Docker Registry";
-        protected override string CommandName => "publishManifest";
 
         public PublishManifestOptions() : base()
         {

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrReadmesOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrReadmesOptions.cs
@@ -9,7 +9,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     public class PublishMcrReadmesOptions : Options
     {
         protected override string CommandHelp => "Publishes the readmes to MCR";
-        protected override string CommandName => "publishMcrReadmes";
 
         public string GitAuthToken { get; set; }
         public string GitBranch { get; set; }

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/UpdateReadmeOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/UpdateReadmeOptions.cs
@@ -7,7 +7,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     public class UpdateReadmeOptions : DockerRegistryOptions
     {
         protected override string CommandHelp => "Updates the readme on the Docker Registries";
-        protected override string CommandName => "updateReadme";
 
         public UpdateReadmeOptions() : base()
         {

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/UpdateVersionsOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/UpdateVersionsOptions.cs
@@ -9,12 +9,11 @@ using System.CommandLine;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
-    public class UpdateVersionsOptions : Options, IManifestFilterOptions
+    public class UpdateVersionsOptions : Options, IFilterableOptions
     {
         protected override string CommandHelp => "Updates the version information for the dependent images";
-        protected override string CommandName => "updateVersions";
 
-        public string Architecture { get; set; }
+        public ManifestFilterOptions FilterOptions { get; } = new ManifestFilterOptions();
         public string GitAuthToken { get; set; }
         public string GitBranch { get; set; }
         public string GitEmail { get; set; }
@@ -22,10 +21,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public string GitPath { get; set; }
         public string GitRepo { get; set; }
         public string GitUsername { get; set; }
-        public string OsType { get; set; }
-        public string OsVersion { get; set; }
-        public IEnumerable<string> Paths { get; set; }
-
 
         public UpdateVersionsOptions() : base()
         {
@@ -35,7 +30,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             base.ParseCommandLine(syntax);
 
-            DefineManifestFilterOptions(syntax, this);
+            FilterOptions.ParseCommandLine(syntax);
 
             string gitBranch = "master";
             syntax.DefineOption(


### PR DESCRIPTION
- Compute CommandName from class name instead of having it declared on each Options class.
- Encapsulate manifest options in a single composed class vs an interface implemented numerous times.