### PR TITLE
Update build command to update architecture metadata if necessary

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
@@ -73,7 +73,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 leg.Variables.Add(("osType", platformGrouping.Key.OS.ToString().ToLowerInvariant()));
                 leg.Variables.Add(("osVariant", versionGrouping.Key.OsVariant));
                 leg.Variables.Add(("osVersion", platformGrouping.Key.OS == OS.Windows ? platformGrouping.Key.OsVersion : "*"));
-                leg.Variables.Add(("architecture", platformGrouping.Key.Architecture.ToString().ToLowerInvariant()));
+                leg.Variables.Add(("architecture", ModelExtensions.GetDockerName(platformGrouping.Key.Architecture)));
             }
         }
 

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestFilterOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestFilterOptions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.DotNet.ImageBuilder.ViewModel;
 using System;
 using System.Collections.Generic;
 using System.CommandLine;
@@ -17,7 +18,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         public void ParseCommandLine(ArgumentSyntax syntax)
         {
-            string architecture = DockerHelper.Architecture.ToString().ToLowerInvariant();
+            string architecture = DockerHelper.Architecture.GetDockerName();
             syntax.DefineOption(
                 "architecture",
                 ref architecture,

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestCommand.cs
@@ -64,7 +64,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 manifestYml.AppendLine($"  -");
                 manifestYml.AppendLine($"    image: {platform.Tags.First().FullyQualifiedName}");
                 manifestYml.AppendLine($"    platform:");
-                manifestYml.AppendLine($"      architecture: {platform.Model.Architecture.ToString().ToLowerInvariant()}");
+                manifestYml.AppendLine($"      architecture: {platform.Model.Architecture.GetDockerName()}");
                 manifestYml.AppendLine($"      os: {platform.Model.OS.ToString().ToLowerInvariant()}");
                 if (platform.Model.Variant != null)
                 {

--- a/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
@@ -208,8 +208,7 @@ namespace Microsoft.DotNet.ImageBuilder
         private static string ExecuteCommand(
             string command, string errorMessage, string additionalArgs = null, bool isDryRun = false)
         {
-            ProcessStartInfo startInfo = new ProcessStartInfo(
-                "docker", $"{command} {additionalArgs}");
+            ProcessStartInfo startInfo = new ProcessStartInfo("docker", $"{command} {additionalArgs}");
             startInfo.RedirectStandardOutput = true;
             Process process = ExecuteHelper.Execute(startInfo, isDryRun, errorMessage);
             return isDryRun ? "" : process.StandardOutput.ReadToEnd().Trim();

--- a/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
@@ -20,20 +20,6 @@ namespace Microsoft.DotNet.ImageBuilder
         public static Architecture Architecture => s_architecture.Value;
         public static OS OS => s_os.Value;
 
-        private static string ExecuteCommand(
-            string command, string errorMessage, string additionalArgs = null, bool isDryRun = false)
-        {
-            ProcessStartInfo startInfo = new ProcessStartInfo(
-                "docker", $"{command} {additionalArgs}");
-            startInfo.RedirectStandardOutput = true;
-            Process process = ExecuteHelper.Execute(startInfo, isDryRun, errorMessage);
-            return isDryRun ? "" : process.StandardOutput.ReadToEnd().Trim();
-        }
-
-        private static string ExecuteCommandWithFormat(
-            string command, string outputFormat, string errorMessage, string additionalArgs = null, bool isDryRun = false) =>
-            ExecuteCommand(command, errorMessage, $"{additionalArgs} -f \"{{{{ {outputFormat} }}}}\"", isDryRun);
-
         public static void ExecuteWithUser(Action action, string username, string password, string server, bool isDryRun)
         {
             bool userSpecified = username != null;
@@ -55,62 +41,10 @@ namespace Microsoft.DotNet.ImageBuilder
             }
         }
 
-        private static Architecture GetArchitecture()
-        {
-            Architecture architecture;
-
-            string infoArchitecture = ExecuteCommandWithFormat(
-                "info", ".Architecture", "Failed to detect Docker architecture");
-            switch (infoArchitecture)
-            {
-                case "x86_64":
-                    architecture = Architecture.AMD64;
-                    break;
-                case "arm":
-                case "arm_32":
-                case "armv7l":
-                    architecture = Architecture.ARM;
-                    break;
-                case "aarch64":
-                case "arm64":
-                    architecture = Architecture.ARM64;
-                    break;
-                default:
-                    throw new PlatformNotSupportedException($"Unknown Docker Architecture '{infoArchitecture}'");
-            }
-
-            return architecture;
-        }
-
         public static string GetImageDigest(string image, bool isDryRun)
         {
             return ExecuteCommandWithFormat(
                 "inspect", "index .RepoDigests 0", "Failed to retrieve image digest", image, isDryRun);
-        }
-
-        private static OS GetOS()
-        {
-            string osString = ExecuteCommandWithFormat("version", ".Server.Os", "Failed to detect Docker OS");
-            if (!Enum.TryParse(osString, true, out OS os))
-            {
-                throw new PlatformNotSupportedException("Unknown Docker OS");
-            }
-
-            return os;
-        }
-
-        private static Version GetClientVersion()
-        {
-            // Docker version string format - <major>.<minor>.<patch>-[ce,ee]
-            string versionString = ExecuteCommandWithFormat("version", ".Client.Version", "Failed to retrieve Docker version");
-
-            if (versionString.Contains('-'))
-            {
-                // Trim off the '-ce' or '-ee' suffix
-                versionString = versionString.Substring(0, versionString.IndexOf('-'));
-            }
-
-            return Version.TryParse(versionString, out Version version) ? version : null;
         }
 
         public static long GetImageSize(string image, bool isDryRun)
@@ -157,11 +91,6 @@ namespace Microsoft.DotNet.ImageBuilder
             }
         }
 
-        private static void Logout(string server, bool isDryRun)
-        {
-            ExecuteHelper.ExecuteWithRetry("docker", $"logout {server}", isDryRun);
-        }
-
         public static void PullBaseImages(ManifestInfo manifest, Options options)
         {
             Logger.WriteHeading("PULLING LATEST BASE IMAGES");
@@ -189,6 +118,57 @@ namespace Microsoft.DotNet.ImageBuilder
             return newRepo + image.Substring(image.IndexOf(':'));
         }
 
+        public static string GetImageArch(string image, bool isDryRun)
+        {
+            return ExecuteCommandWithFormat(
+                "inspect", ".Architecture", "Failed to retrieve image architecture", additionalArgs: image, isDryRun: isDryRun);
+        }
+
+        public static void SaveImage(string image, string tarFilePath, bool isDryRun)
+        {
+            DockerHelper.ExecuteCommand("save", "Failed to save image", $"-o {tarFilePath} {image}", isDryRun);
+        }
+
+        public static void LoadImage(string tarFilePath, bool isDryRun)
+        {
+            DockerHelper.ExecuteCommand("load", "Failed to load image", $"-i {tarFilePath}", isDryRun);
+        }
+
+        public static void CreateTag(string image, string tag, bool isDryRun)
+        {
+            DockerHelper.ExecuteCommand("tag", "Failed to create tag", $"{image} {tag}", isDryRun);
+        }
+
+        private static OS GetOS()
+        {
+            string osString = ExecuteCommandWithFormat("version", ".Server.Os", "Failed to detect Docker OS");
+            if (!Enum.TryParse(osString, true, out OS os))
+            {
+                throw new PlatformNotSupportedException("Unknown Docker OS");
+            }
+
+            return os;
+        }
+
+        private static Version GetClientVersion()
+        {
+            // Docker version string format - <major>.<minor>.<patch>-[ce,ee]
+            string versionString = ExecuteCommandWithFormat("version", ".Client.Version", "Failed to retrieve Docker version");
+
+            if (versionString.Contains('-'))
+            {
+                // Trim off the '-ce' or '-ee' suffix
+                versionString = versionString.Substring(0, versionString.IndexOf('-'));
+            }
+
+            return Version.TryParse(versionString, out Version version) ? version : null;
+        }
+
+        private static void Logout(string server, bool isDryRun)
+        {
+            ExecuteHelper.ExecuteWithRetry("docker", $"logout {server}", isDryRun);
+        }
+
         private static bool ResourceExists(ManagementType type, string filterArg, bool isDryRun)
         {
             string output = ExecuteCommand(
@@ -197,6 +177,47 @@ namespace Microsoft.DotNet.ImageBuilder
                 isDryRun: isDryRun);
             return output != "";
         }
+
+        private static Architecture GetArchitecture()
+        {
+            Architecture architecture;
+
+            string infoArchitecture = ExecuteCommandWithFormat(
+                "info", ".Architecture", "Failed to detect Docker architecture");
+            switch (infoArchitecture)
+            {
+                case "x86_64":
+                    architecture = Architecture.AMD64;
+                    break;
+                case "arm":
+                case "arm_32":
+                case "armv7l":
+                    architecture = Architecture.ARM;
+                    break;
+                case "aarch64":
+                case "arm64":
+                    architecture = Architecture.ARM64;
+                    break;
+                default:
+                    throw new PlatformNotSupportedException($"Unknown Docker Architecture '{infoArchitecture}'");
+            }
+
+            return architecture;
+        }
+
+        private static string ExecuteCommand(
+            string command, string errorMessage, string additionalArgs = null, bool isDryRun = false)
+        {
+            ProcessStartInfo startInfo = new ProcessStartInfo(
+                "docker", $"{command} {additionalArgs}");
+            startInfo.RedirectStandardOutput = true;
+            Process process = ExecuteHelper.Execute(startInfo, isDryRun, errorMessage);
+            return isDryRun ? "" : process.StandardOutput.ReadToEnd().Trim();
+        }
+
+        private static string ExecuteCommandWithFormat(
+            string command, string outputFormat, string errorMessage, string additionalArgs = null, bool isDryRun = false) =>
+            ExecuteCommand(command, errorMessage, $"{additionalArgs} -f \"{{{{ {outputFormat} }}}}\"", isDryRun);
 
         private enum ManagementType
         {

--- a/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
@@ -21,44 +21,6 @@ namespace Microsoft.DotNet.ImageBuilder
             Execute(new ProcessStartInfo(fileName, args), isDryRun, errorMessage, executeMessageOverride);
         }
 
-        public static string ExecuteAndGetOutput(
-            string fileName,
-            string args,
-            bool isDryRun,
-            string errorMessage = null,
-            string executeMessageOverride = null)
-        {
-            ProcessStartInfo startInfo = new ProcessStartInfo
-            {
-                FileName = fileName,
-                Arguments = args,
-                RedirectStandardOutput = true
-            };
-
-            StringBuilder stdOutput = new StringBuilder();
-
-            Execute(startInfo,
-                info =>
-                {
-                    Process process = new Process
-                    {
-                        EnableRaisingEvents = true,
-                        StartInfo = info
-                    };
-
-                    process.OutputDataReceived += new DataReceivedEventHandler((sender, e) => stdOutput.AppendLine(e.Data));
-                    process.Start();
-                    process.BeginOutputReadLine();
-                    process.WaitForExit();
-                    return process;
-                },
-                isDryRun,
-                errorMessage,
-                executeMessageOverride);
-
-            return stdOutput.ToString();
-        }
-
         public static Process Execute(
             ProcessStartInfo info,
             bool isDryRun,

--- a/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Text;
 using System.Threading;
 
 namespace Microsoft.DotNet.ImageBuilder

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestFilter.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestFilter.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             {
                 string archRegexPattern = GetFilterRegexPattern(IncludeArchitecture);
                 platforms = platforms.Where(platform =>
-                    Regex.IsMatch(platform.Architecture.ToString().ToLowerInvariant(), archRegexPattern, RegexOptions.IgnoreCase));
+                    Regex.IsMatch(platform.Architecture.GetDockerName(), archRegexPattern, RegexOptions.IgnoreCase));
             }
 
             if (IncludeOsType != null)

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/ModelExtensions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/ModelExtensions.cs
@@ -33,19 +33,9 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             return displayName;
         }
 
-        public static string GetMetadataName(this Architecture architecture)
+        public static string GetDockerName(this Architecture architecture)
         {
-            switch (architecture)
-            {
-                case Architecture.ARM:
-                    return "arm";
-                case Architecture.ARM64:
-                    return "arm64";
-                case Architecture.AMD64:
-                    return "amd64";
-                default:
-                    throw new InvalidOperationException($"Unexpected architecture value: {architecture}.");
-            }
+            return architecture.ToString().ToLowerInvariant();
         }
 
         public static void Validate(this Manifest manifest)

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/ModelExtensions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/ModelExtensions.cs
@@ -33,6 +33,21 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             return displayName;
         }
 
+        public static string GetMetadataName(this Architecture architecture)
+        {
+            switch (architecture)
+            {
+                case Architecture.ARM:
+                    return "arm";
+                case Architecture.ARM64:
+                    return "arm64";
+                case Architecture.AMD64:
+                    return "amd64";
+                default:
+                    throw new InvalidOperationException($"Unexpected architecture value: {architecture}.");
+            }
+        }
+
         public static void Validate(this Manifest manifest)
         {
             foreach (Repo repo in manifest.Repos)


### PR DESCRIPTION
Ensures the build command on ImageBuilder will produce an image whose architecture matches the expected value in case Docker decides to misrepresent it.