### PR TITLE
Refactor build and publish matrices to include platform variables

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestFilterOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestFilterOptions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 "Architecture of Dockerfiles to operate on - wildcard chars * and ? supported (default is current OS architecture)");
             Architecture = architecture;
 
-            string osType = DockerHelper.OS.ToString().ToLowerInvariant();
+            string osType = DockerHelper.OS.GetDockerName();
             syntax.DefineOption(
                 "os-type",
                 ref osType,

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestCommand.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 manifestYml.AppendLine($"    image: {platform.Tags.First().FullyQualifiedName}");
                 manifestYml.AppendLine($"    platform:");
                 manifestYml.AppendLine($"      architecture: {platform.Model.Architecture.GetDockerName()}");
-                manifestYml.AppendLine($"      os: {platform.Model.OS.ToString().ToLowerInvariant()}");
+                manifestYml.AppendLine($"      os: {platform.Model.OS.GetDockerName()}");
                 if (platform.Model.Variant != null)
                 {
                     manifestYml.AppendLine($"      variant: {platform.Model.Variant}");

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestFilter.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestFilter.cs
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             {
                 string osTypeRegexPattern = GetFilterRegexPattern(IncludeOsType);
                 platforms = platforms.Where(platform =>
-                    Regex.IsMatch(platform.OS.ToString().ToLowerInvariant(), osTypeRegexPattern, RegexOptions.IgnoreCase));
+                    Regex.IsMatch(platform.OS.GetDockerName(), osTypeRegexPattern, RegexOptions.IgnoreCase));
             }
 
             if (IncludePaths?.Any() ?? false)

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/ModelExtensions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/ModelExtensions.cs
@@ -33,10 +33,9 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             return displayName;
         }
 
-        public static string GetDockerName(this Architecture architecture)
-        {
-            return architecture.ToString().ToLowerInvariant();
-        }
+        public static string GetDockerName(this Architecture architecture) => architecture.ToString().ToLowerInvariant();
+
+        public static string GetDockerName(this OS os) => os.ToString().ToLowerInvariant();
 
         public static void Validate(this Manifest manifest)
         {


### PR DESCRIPTION
The primary issue being addressed here is to fixup the dotnet/core/samples build.  The publish matrix is invalid in that there are multiple entries with the same name.  The reason for this is that with the samples the same Dockerfiles are used/built on each platform

Current:
```
  publishMatrix:
    samples-Dockerfile-amd64:
      dotnetVersion: samples
      osType: linux
      osVariant: Dockerfile
      osVersion: *
      architecture: amd64
    samples-Dockerfile-amd64:
      dotnetVersion: samples
      osType: windows
      osVariant: Dockerfile
      osVersion: nanoserver-sac2016
      architecture: amd64
    samples-Dockerfile-amd64:
      dotnetVersion: samples
      osType: windows
      osVariant: Dockerfile
      osVersion: nanoserver-1809
      architecture: amd64
    samples-Dockerfile-amd64:
      dotnetVersion: samples
      osType: windows
      osVariant: Dockerfile
      osVersion: nanoserver-1803
      architecture: amd64
    samples-Dockerfile-amd64:
      dotnetVersion: samples
      osType: windows
      osVariant: Dockerfile
      osVersion: nanoserver-1709
      architecture: amd64
    samples-Dockerfile-arm32:
      dotnetVersion: samples
      osType: windows
      osVariant: Dockerfile
      osVersion: nanoserver-1809
      architecture: arm
    samples-Dockerfile-arm32v7:
      dotnetVersion: samples
      osType: linux
      osVariant: Dockerfile
      osVersion: *
      architecture: arm
```

Proposed:
```
  publishMatrix:
    samples-aspnetapp-linux-amd64:
      imageBuilderPaths: --path samples/aspnetapp
      osType: linux
      architecture: amd64
      osVersion: *
    samples-aspnetapp-linux-arm:
      imageBuilderPaths: --path samples/aspnetapp
      osType: linux
      architecture: arm
      osVersion: *
    samples-aspnetapp-nanoserver-1709-amd64:
      imageBuilderPaths: --path samples/aspnetapp
      osType: windows
      architecture: amd64
      osVersion: nanoserver-1709
    samples-aspnetapp-nanoserver-1803-amd64:
      imageBuilderPaths: --path samples/aspnetapp
      osType: windows
      architecture: amd64
      osVersion: nanoserver-1803
    samples-aspnetapp-nanoserver-1809-amd64:
      imageBuilderPaths: --path samples/aspnetapp
      osType: windows
      architecture: amd64
      osVersion: nanoserver-1809
    samples-aspnetapp-nanoserver-1809-arm:
      imageBuilderPaths: --path samples/aspnetapp
      osType: windows
      architecture: arm
      osVersion: nanoserver-1809
    samples-aspnetapp-nanoserver-sac2016-amd64:
      imageBuilderPaths: --path samples/aspnetapp
      osType: windows
      architecture: amd64
      osVersion: nanoserver-sac2016
    samples-dotnetapp-linux-amd64:
      imageBuilderPaths: --path samples/dotnetapp
      osType: linux
      architecture: amd64
      osVersion: *
    samples-dotnetapp-linux-arm:
      imageBuilderPaths: --path samples/dotnetapp
      osType: linux
      architecture: arm
      osVersion: *
    samples-dotnetapp-nanoserver-1709-amd64:
      imageBuilderPaths: --path samples/dotnetapp
      osType: windows
      architecture: amd64
      osVersion: nanoserver-1709
    samples-dotnetapp-nanoserver-1803-amd64:
      imageBuilderPaths: --path samples/dotnetapp
      osType: windows
      architecture: amd64
      osVersion: nanoserver-1803
    samples-dotnetapp-nanoserver-1809-amd64:
      imageBuilderPaths: --path samples/dotnetapp
      osType: windows
      architecture: amd64
      osVersion: nanoserver-1809
    samples-dotnetapp-nanoserver-1809-arm:
      imageBuilderPaths: --path samples/dotnetapp
      osType: windows
      architecture: arm
      osVersion: nanoserver-1809
    samples-dotnetapp-nanoserver-sac2016-amd64:
      imageBuilderPaths: --path samples/dotnetapp
      osType: windows
      architecture: amd64
      osVersion: nanoserver-sac2016
````

Additionally with this change, I am proposing we add the platform variables to the build matrix.  The architecture is needed for building on aarch64 machines and the osVersion will simplify the build as that is being passed as a variable today.

The associated changes to the dotnet-docker build def can be seen at https://github.com/dotnet/dotnet-docker/pull/966.