### PR TITLE
Refactor validateImageSize errors to work with AzDO pipelines

### DIFF
--- a/.vsts-pipelines/dotnet-buildtools-image-builder-official.yml
+++ b/.vsts-pipelines/dotnet-buildtools-image-builder-official.yml
@@ -14,9 +14,9 @@ jobs:
   parameters:
     name: Linux
     pool: Hosted Ubuntu 1604
-    pushImages: true
+    publishImages: true
 - template: jobs/build-image-builder.yml
   parameters:
     name: Windows
     pool: Hosted Windows Container
-    pushImages: true
+    publishImages: true

--- a/.vsts-pipelines/dotnet-buildtools-image-builder-pr.yml
+++ b/.vsts-pipelines/dotnet-buildtools-image-builder-pr.yml
@@ -8,9 +8,9 @@ jobs:
   parameters:
     name: Linux
     pool: Hosted Ubuntu 1604
-    pushImages: false
+    publishImages: false
 - template: jobs/build-image-builder.yml
   parameters:
     name: Windows
     pool: Hosted Windows Container
-    pushImages: false
+    publishImages: false

--- a/Microsoft.DotNet.ImageBuilder/Dockerfile.debian
+++ b/Microsoft.DotNet.ImageBuilder/Dockerfile.debian
@@ -3,7 +3,7 @@
 #     docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v <local path to build>:/repo -w /repo image-builder <image-build args>
 
 # build Microsoft.DotNet.ImageBuilder
-FROM microsoft/dotnet:2.1-sdk AS build-env
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1 AS build-env
 WORKDIR image-builder
 
 # restore packages before copying entire source - provides optimizations when rebuilding
@@ -21,7 +21,7 @@ RUN dotnet publish ./src/Microsoft.DotNet.ImageBuilder.csproj -c Release -o out 
 
 
 # build runtime image
-FROM microsoft/dotnet:2.1-runtime-deps
+FROM mcr.microsoft.com/dotnet/core/untime-deps:2.1
 
 # install Docker
 RUN apt-get update \

--- a/Microsoft.DotNet.ImageBuilder/Dockerfile.debian
+++ b/Microsoft.DotNet.ImageBuilder/Dockerfile.debian
@@ -21,7 +21,7 @@ RUN dotnet publish ./src/Microsoft.DotNet.ImageBuilder.csproj -c Release -o out 
 
 
 # build runtime image
-FROM mcr.microsoft.com/dotnet/core/untime-deps:2.1
+FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.1
 
 # install Docker
 RUN apt-get update \

--- a/Microsoft.DotNet.ImageBuilder/Dockerfile.nanoserver
+++ b/Microsoft.DotNet.ImageBuilder/Dockerfile.nanoserver
@@ -1,5 +1,5 @@
 # build Microsoft.DotNet.ImageBuilder
-FROM microsoft/dotnet:2.1-sdk AS build-env
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1 AS build-env
 WORKDIR /image-builder
 
 # restore packages before copying entire source - provides optimizations when rebuilding
@@ -17,6 +17,6 @@ RUN dotnet publish ./src/Microsoft.DotNet.ImageBuilder.csproj -c Release -o out 
 
 
 # build runtime image
-FROM microsoft/nanoserver
+FROM mcr.microsoft.com/windows/nanoserver:sac2016
 WORKDIR /image-builder
 COPY --from=build-env /image-builder/src/out ./


### PR DESCRIPTION
1. Refactor the ValidateImageSize command to not write the validation error detailed output to stdout as stdin and stdout get separated when looking at AzDO build output.  The headers were getting separated which made it very confusing to read.  Instead if there are any errors detected a failure message is written to stdout at the end of the processing.
2. Fixed an issue in the official builds that was causing the images to not get pushed.
3. Refactored the Dockerfiles to pull images from MCR.