### PR TITLE
Update build matrix to support PR builds

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
@@ -169,9 +169,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 .ThenBy(platformGroup => platformGroup.Key.Architecture)
                 .ThenByDescending(platformGroup => platformGroup.Key.Variant);
 
-            string baseMatrixName = $"{Options.MatrixType.ToString().ToLowerInvariant()}Matrix";
+            string baseMatrixName = $"{Options.MatrixType.ToString().ToCamelCase()}Matrix";
 
-            if (Options.MatrixType == MatrixType.Publish)
+            if (Options.MatrixType == MatrixType.DependencyGraph)
             {
                 MatrixInfo matrix = new MatrixInfo() { Name = baseMatrixName };
                 matrices.Add(matrix);
@@ -193,23 +193,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     MatrixInfo matrix = new MatrixInfo() { Name = FormatMatrixName(matrixNameParts) };
                     matrices.Add(matrix);
 
-                    if (Options.MatrixType == MatrixType.Build)
+                    if (Options.MatrixType == MatrixType.PlatformDependencyGraph)
                     {
-                        // If we're generating the build matrix for a PR build, we want the matrix to be structured
-                        // in the same way as the test matrix where te grouping is based on the combination of .NET
-                        // version and OS/arch instead of just the OS/arch.  That's because PR builds wil run tests
-                        // in the same job as the images are built so the tests will need access to the full set of 
-                        // images (runtime/sdk, etc.).
-                        if (Options.IsPullRequestBuild)
-                        {
-                            AddVersionedOsLegs(matrix, platformGrouping);
-                        }
-                        else
-                        {
-                            AddDockerfilePathLegs(matrix, matrixNameParts, platformGrouping);
-                        }
+                        AddDockerfilePathLegs(matrix, matrixNameParts, platformGrouping);
                     }
-                    else if (Options.MatrixType == MatrixType.Test)
+                    else if (Options.MatrixType == MatrixType.PlatformVersionedOs)
                     {
                         AddVersionedOsLegs(matrix, platformGrouping);
                     }

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixOptions.cs
@@ -13,6 +13,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         public ManifestFilterOptions FilterOptions { get; } = new ManifestFilterOptions();
         public MatrixType MatrixType { get; set; }
+        public bool IsPullRequestBuild { get; set; }
 
         public GenerateBuildMatrixOptions() : base()
         {
@@ -31,6 +32,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 value => (MatrixType)Enum.Parse(typeof(MatrixType), value, true),
                 "Type of matrix to generate - build (default), test");
             MatrixType = matrixType;
+
+            bool isPullRequestBuild = false;
+            syntax.DefineOption(
+                "is-pr-build",
+                ref isPullRequestBuild,
+                "Indicates whether the build is for a pull request.");
+            IsPullRequestBuild = isPullRequestBuild;
         }
     }
 }

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixOptions.cs
@@ -13,7 +13,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         public ManifestFilterOptions FilterOptions { get; } = new ManifestFilterOptions();
         public MatrixType MatrixType { get; set; }
-        public bool IsPullRequestBuild { get; set; }
 
         public GenerateBuildMatrixOptions() : base()
         {
@@ -25,20 +24,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             FilterOptions.ParseCommandLine(syntax);
 
-            MatrixType matrixType = MatrixType.Build;
+            MatrixType matrixType = MatrixType.PlatformDependencyGraph;
             syntax.DefineOption(
                 "type",
                 ref matrixType,
                 value => (MatrixType)Enum.Parse(typeof(MatrixType), value, true),
                 "Type of matrix to generate - build (default), test");
             MatrixType = matrixType;
-
-            bool isPullRequestBuild = false;
-            syntax.DefineOption(
-                "is-pr-build",
-                ref isPullRequestBuild,
-                "Indicates whether the build is for a pull request.");
-            IsPullRequestBuild = isPullRequestBuild;
         }
     }
 }

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/MatrixType.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/MatrixType.cs
@@ -6,8 +6,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     public enum MatrixType
     {
-        Build,
-        Test,
-        Publish,
+        PlatformDependencyGraph,
+        PlatformVersionedOs,
+        DependencyGraph,
     }
 }

--- a/Microsoft.DotNet.ImageBuilder/src/StringExtensions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/StringExtensions.cs
@@ -25,5 +25,10 @@ namespace Microsoft.DotNet.ImageBuilder
 
             return source;
         }
+
+        public static string ToCamelCase(this string source)
+        {
+            return source.Substring(0, 1).ToLowerInvariant() + source.Substring(1);
+        }
     }
 }


### PR DESCRIPTION
For the PR builds, we need to be able to build and test within a single job.  But the build matrix that is currently generated is not suited for that scenario because it is grouped on OS/arch.  This splits out the building of images like runtime and sdk that have a dependency on each other.  This won't work for the PR builds because the tests will require the set of images (runtime, sdk, etc) to be available which means that the build phase must have built all of those images in that job.

To accomplish this, we need to just use the same matrix as is generated for tests but use it as a build matrix instead.  A new option is added for the generateBuildMatrix command to indicate that it is for a PR build.  If that option is set, it will return a build matrix that is shaped just like the test matrix when the build matrix is requested.  In addition to that, the test matrix also needs to include some extra metadata that was available in the build matrix: imageBuilderPaths.