### PR TITLE
Refactor build to use the same tag timestamp across images

### DIFF
--- a/.vsts-pipelines/dotnet-buildtools-image-builder-official.yml
+++ b/.vsts-pipelines/dotnet-buildtools-image-builder-official.yml
@@ -12,11 +12,4 @@ variables:
 jobs:
 - template: jobs/build-image-builder.yml
   parameters:
-    name: Linux
-    pool: Hosted Ubuntu 1604
-    publishImages: true
-- template: jobs/build-image-builder.yml
-  parameters:
-    name: Windows
-    pool: Hosted Windows Container
     publishImages: true

--- a/.vsts-pipelines/dotnet-buildtools-image-builder-pr.yml
+++ b/.vsts-pipelines/dotnet-buildtools-image-builder-pr.yml
@@ -6,11 +6,4 @@ trigger: none
 jobs:
 - template: jobs/build-image-builder.yml
   parameters:
-    name: Linux
-    pool: Hosted Ubuntu 1604
-    publishImages: false
-- template: jobs/build-image-builder.yml
-  parameters:
-    name: Windows
-    pool: Hosted Windows Container
     publishImages: false

--- a/.vsts-pipelines/jobs/build-image-builder-image.yml
+++ b/.vsts-pipelines/jobs/build-image-builder-image.yml
@@ -1,0 +1,29 @@
+parameters:
+  name: null
+  pool: {}
+  publishImages: false
+
+jobs:
+- job: ${{ parameters.name }}
+  pool: ${{ parameters.pool }}
+  dependsOn: Initialize
+  variables:
+    ${{ if eq(parameters.publishImages, 'true') }}:
+      buildParameters: $(commonBuildParameters) -DockerRepo $(acr.server)/public/dotnet-buildtools/image-builder -PushImages
+    ${{ if eq(parameters.publishImages, 'false') }}:
+      buildParameters: $(commonBuildParameters)
+    commonBuildParameters: -TagTimestamp $(timestamp)
+    timestamp: $[ dependencies.Initialize.outputs['GenerateTimestamp.timestamp'] ]
+  workspace:
+    clean: all
+  steps:
+    - ${{ if eq(parameters.publishImages, 'true') }}:
+      - script: docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)
+        displayName: Docker Login
+    - powershell: Microsoft.DotNet.ImageBuilder/build.ps1 $(buildParameters)
+      displayName: Build and Publish ImageBuilder
+    - ${{ if eq(parameters.publishImages, 'true') }}:
+      - script: docker logout
+        displayName: Docker Logout
+        condition: always()
+        continueOnError: true

--- a/.vsts-pipelines/jobs/build-image-builder.yml
+++ b/.vsts-pipelines/jobs/build-image-builder.yml
@@ -1,26 +1,21 @@
 parameters:
-  name: null
-  pool: {}
   publishImages: false
 
 jobs:
-- job: ${{ parameters.name }}
-  pool: ${{ parameters.pool }}
-  variables:
-    ${{ if eq(parameters.publishImages, 'true') }}:
-      buildParameters: -DockerRepo $(acr.server)/public/dotnet-buildtools/image-builder -PushImages
-    ${{ if eq(parameters.publishImages, 'false') }}:
-      buildParameters: ""
-  workspace:
-    clean: all
+- job: Initialize
+  pool:
+    name: Hosted Windows Container
   steps:
-    - ${{ if eq(parameters.publishImages, 'true') }}:
-      - script: docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)
-        displayName: Docker Login
-    - powershell: Microsoft.DotNet.ImageBuilder/build.ps1 $(buildParameters)
-      displayName: Build and Publish ImageBuilder
-    - ${{ if eq(parameters.publishImages, 'true') }}:
-      - script: docker logout
-        displayName: Docker Logout
-        condition: always()
-        continueOnError: true
+  - powershell: write-host "##vso[task.setvariable variable=timestamp;isOutput=true]$(Get-Date -Format yyyyMMddHHmmss)"
+    displayName: Define Timestamp Variable
+    name: GenerateTimestamp
+- template: build-image-builder-image.yml
+  parameters:
+    name: Linux
+    pool: Hosted Ubuntu 1604
+    publishImages: ${{ parameters.publishImages }}
+- template: build-image-builder-image.yml
+  parameters:
+    name: Windows
+    pool: Hosted Windows Container
+    publishImages: ${{ parameters.publishImages }}

--- a/Microsoft.DotNet.ImageBuilder/build.ps1
+++ b/Microsoft.DotNet.ImageBuilder/build.ps1
@@ -2,7 +2,8 @@
 param(
     [string]$DockerRepo = "mcr.microsoft.com/dotnet-buildtools/image-builder",
     [switch]$PushImages,
-    [switch]$CleanupDocker
+    [switch]$CleanupDocker,
+    [string]$TagTimestamp = (Get-Date -Format yyyyMMddHHmmss)
 )
 
 Set-StrictMode -Version Latest
@@ -39,7 +40,7 @@ try {
         $osFlavor = "debian"
     }
 
-    $stableTag = "$($DockerRepo):$osFlavor-$((Get-Date -Format yyyyMMddHHmmss).ToLower())"
+    $stableTag = "$($DockerRepo):$osFlavor-$TagTimestamp"
     $floatingTag = "image-builder"
 
     & docker build -t $stableTag -t $floatingTag -f "$($PSScriptRoot)/Dockerfile.$osFlavor" $PSScriptRoot


### PR DESCRIPTION
Currently the timestamp portion of the linux and windows images are different.  It would be nice if they aligned as it helps to consumption story.  This change defines a shared timestamp variable that the linux and windows build legs consume.  

I'm open to suggestions to simplify the pattern used here.