### PR TITLE
Add TestDependencyGraph matrix type

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
@@ -65,8 +65,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         private string[] GetCustomLegGroupingDockerfilePaths(IEnumerable<PlatformInfo> platforms)
         {
-            return GetDockerfilePaths(platforms
-                .GetCompleteSubgraphs(platform =>
+            IEnumerable<PlatformInfo> subgraphs = platforms.GetCompleteSubgraphs(platform =>
                 {
                     if (Options.CustomBuildLegGrouping != null &&
                         platform.CustomLegGroupings.TryGetValue(
@@ -76,12 +75,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         return customBuildLegGroupingInfo.DependencyImages
                             .Select(image => Manifest.GetPlatformByTag(image));
                     }
-                    else
-                    {
-                        return Enumerable.Empty<PlatformInfo>();
-                    }
+
+                    return Enumerable.Empty<PlatformInfo>();
                 })
-                .SelectMany(image => image));
+                .SelectMany(image => image);
+            return GetDockerfilePaths(subgraphs);
         }
 
         private static void AddImageBuilderPathsVariable(string[] dockerfilePaths, LegInfo leg)

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixOptions.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.CommandLine;
+using System.Linq;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
@@ -13,6 +14,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         public ManifestFilterOptions FilterOptions { get; } = new ManifestFilterOptions();
         public MatrixType MatrixType { get; set; }
+        public string CustomBuildLegGrouping { get; set; }
 
         public GenerateBuildMatrixOptions() : base()
         {
@@ -29,8 +31,15 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 "type",
                 ref matrixType,
                 value => (MatrixType)Enum.Parse(typeof(MatrixType), value, true),
-                "Type of matrix to generate - build (default), test");
+                $"Type of matrix to generate - {Enum.GetNames(typeof(MatrixType)).Aggregate((s1, s2) => $"{s1}, {s2}")}");
             MatrixType = matrixType;
+
+            string customBuildLegGrouping = null;
+            syntax.DefineOption(
+                "customBuildLegGrouping",
+                ref customBuildLegGrouping,
+                "Name of custom build leg grouping to use.");
+            CustomBuildLegGrouping = customBuildLegGrouping;
         }
     }
 }

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/MatrixType.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/MatrixType.cs
@@ -8,7 +8,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     {
         PlatformDependencyGraph,
         PlatformVersionedOs,
-        DependencyGraph,
-        TestDependencyGraph
+        DependencyGraph
     }
 }

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/MatrixType.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/MatrixType.cs
@@ -9,5 +9,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         PlatformDependencyGraph,
         PlatformVersionedOs,
         DependencyGraph,
+        TestDependencyGraph
     }
 }

--- a/Microsoft.DotNet.ImageBuilder/src/Model/CustomBuildLegGrouping.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Model/CustomBuildLegGrouping.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.DotNet.ImageBuilder.Model
+{
+    public class CustomBuildLegGrouping
+    {
+        [JsonProperty(Required = Required.Always)]
+        public string Name { get; set; }
+
+        [JsonProperty(Required = Required.Always)]
+        public string[] Dependencies { get; set; }
+    }
+}

--- a/Microsoft.DotNet.ImageBuilder/src/Model/Platform.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Model/Platform.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using Newtonsoft.Json;
@@ -29,6 +30,8 @@ namespace Microsoft.DotNet.ImageBuilder.Model
 
         [JsonProperty(Required = Required.Always)]
         public IDictionary<string, Tag> Tags { get; set; }
+
+        public string[] TestDependencies { get; set; } = Array.Empty<string>();
 
         public string Variant { get; set; }
 

--- a/Microsoft.DotNet.ImageBuilder/src/Model/Platform.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Model/Platform.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.ImageBuilder.Model
         [JsonProperty(Required = Required.Always)]
         public IDictionary<string, Tag> Tags { get; set; }
 
-        public string[] TestDependencies { get; set; } = Array.Empty<string>();
+        public CustomBuildLegGrouping[] CustomBuildLegGrouping { get; set; } = Array.Empty<CustomBuildLegGrouping>();
 
         public string Variant { get; set; }
 

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/CustomBuildLegGroupingInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/CustomBuildLegGroupingInfo.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.ImageBuilder.ViewModel
+{
+    public class CustomBuildLegGroupingInfo
+    {
+        public CustomBuildLegGroupingInfo(string name, string[] dependencyImages)
+        {
+            this.Name = name;
+            this.DependencyImages = dependencyImages;
+        }
+
+        public string Name { get; }
+
+        public string[] DependencyImages { get; }
+    }
+}

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             IEnumerable<string> repoNames = manifestInfo.AllRepos.Select(repo => repo.Name).ToArray();
             foreach (PlatformInfo platform in manifestInfo.AllRepos.SelectMany(repo => repo.AllImages).SelectMany(image => image.AllPlatforms))
             {
-                platform.Initialize(repoNames);
+                platform.Initialize(repoNames, manifestInfo.Registry);
             }
 
             IEnumerable<Repo> filteredRepoModels = manifestFilter.GetRepos(manifestInfo.Model);

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
@@ -28,12 +28,12 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         public string DockerfilePath { get; private set; }
         public IEnumerable<string> ExternalFromImages { get; private set; }
         public IEnumerable<string> InternalFromImages { get; private set; }
-        public IEnumerable<string> TestDependencyImages { get; private set; }
         public Platform Model { get; private set; }
         public IEnumerable<string> OverriddenFromImages { get => _overriddenFromImages; }
         private string FullRepoModelName { get; set; }
         private string RepoName { get; set; }
         public IEnumerable<TagInfo> Tags { get; private set; }
+        public IDictionary<string, CustomBuildLegGroupingInfo> CustomLegGroupings { get; private set; }
         private VariableHelper VariableHelper { get; set; }
 
         private PlatformInfo()
@@ -72,7 +72,15 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             InitializeBuildArgs();
             InitializeFromImages(internalRepos);
 
-            TestDependencyImages = this.Model.TestDependencies.Select(td => $"{registry}/{td}");
+            CustomLegGroupings = this.Model.CustomBuildLegGrouping
+                .Select(grouping =>
+                    new CustomBuildLegGroupingInfo(
+                        grouping.Name,
+                        grouping.Dependencies
+                            .Select(d => VariableHelper.SubstituteValues(d))
+                            .ToArray()))
+                .ToDictionary(info => info.Name)
+            ;
         }
 
         private void InitializeBuildArgs()

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
@@ -28,6 +28,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         public string DockerfilePath { get; private set; }
         public IEnumerable<string> ExternalFromImages { get; private set; }
         public IEnumerable<string> InternalFromImages { get; private set; }
+        public IEnumerable<string> TestDependencyImages { get; private set; }
         public Platform Model { get; private set; }
         public IEnumerable<string> OverriddenFromImages { get => _overriddenFromImages; }
         private string FullRepoModelName { get; set; }
@@ -66,10 +67,12 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             return platformInfo;
         }
 
-        public void Initialize(IEnumerable<string> internalRepos)
+        public void Initialize(IEnumerable<string> internalRepos, string registry)
         {
             InitializeBuildArgs();
             InitializeFromImages(internalRepos);
+
+            TestDependencyImages = this.Model.TestDependencies.Select(td => $"{registry}/{td}");
         }
 
         private void InitializeBuildArgs()


### PR DESCRIPTION
In order to build and test the images in a given .NET version/OS leg in a single job, we need to ensure that all of images that are needed in order to tests are included in that leg.  In the case of .NET Core 1.0, the 1.1 SDK image is required in order to run the test.  But the platformVersionedOs matrix that is output by ImageBuilder doesn't include the 1.1 SDK Dockerfile path when generating the set of Dockerfile paths for the 1.0 legs.  The manifest doesn't currently have a mechanism for describing such a dependency that is required solely for testing.

These changes update the manifest schema such that a platform can have a set of test dependencies (i.e. image tags required by the platform in order to test it).  Here's a snippet of the manifest for the 1.0 section illustrating how this new attribute is used:
```
"platforms": [
  {
    "buildArgs": {
      "REPO": "$(Repo:runtime-deps)"
    },
    "dockerfile": "1.0/runtime/jessie/amd64",
    "os": "linux",
    "tags": {
      "$(1.0-RuntimeVersion)-jessie": {},
      "1.0-jessie": {}
    },
    "testDependencies": [
      "dotnet/core-nightly/sdk:1.1-jessie"
    ]
  },
  {
    "dockerfile": "1.0/runtime/nanoserver-1809/amd64",
    "os": "windows",
    "osVersion": "nanoserver-1809",
    "tags": {
      "$(1.0-RuntimeVersion)-nanoserver-1809": {},
      "1.0-nanoserver-1809": {}
    },
    "testDependencies": [
      "dotnet/core-nightly/sdk:1.1-nanoserver-1809"
    ]
  }
]
```
This new attribute will be used when generating a newly defined matrix type of testDependencyGraph.  For example, the jessie-1.0 diagnostic output would look like this:
```
1.0-jessie:
  osType: linux
  architecture: amd64
  osVersion: *
  dotnetVersion: 1.0
  osVariant: jessie
  imageBuilderPaths: --path 1.0/runtime-deps/jessie/amd64 --path 1.0/runtime/jessie/amd64 --path 1.1/sdk/jessie/amd64
```