### PR TITLE
Refactor PublishManifestCommand to support image filters

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestCommand.cs
@@ -24,8 +24,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             ExecuteWithUser(() =>
             {
-                IEnumerable<ImageInfo> multiArchImages = Manifest.FilteredRepos
-                    .SelectMany(repo => repo.AllImages)
+                IEnumerable<ImageInfo> multiArchImages = Manifest.GetFilteredImages()
                     .Where(image => image.SharedTags.Any());
                 Parallel.ForEach(multiArchImages, image =>
                 {

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestOptions.cs
@@ -2,14 +2,25 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.CommandLine;
+
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
-    public class PublishManifestOptions : DockerRegistryOptions
+    public class PublishManifestOptions : DockerRegistryOptions, IFilterableOptions
     {
         protected override string CommandHelp => "Creates and publishes the manifest to the Docker Registry";
 
+        public ManifestFilterOptions FilterOptions { get; } = new ManifestFilterOptions();
+
         public PublishManifestOptions() : base()
         {
+        }
+
+        public override void ParseCommandLine(ArgumentSyntax syntax)
+        {
+            base.ParseCommandLine(syntax);
+
+            FilterOptions.ParseCommandLine(syntax);
         }
     }
 }


### PR DESCRIPTION
You can now run the following command in the dotnet-docker repo

`-- publishManifest --path '3.0*'`

to publish the 3.0 related multi-arch tags.

```
MANIFEST TAGS PUBLISHED
-----------------------
mcr.microsoft.com/dotnet/core-nightly/runtime-deps:3.0.0-preview5
mcr.microsoft.com/dotnet/core-nightly/runtime-deps:3.0
mcr.microsoft.com/dotnet/core-nightly/runtime:3.0.0-preview5
mcr.microsoft.com/dotnet/core-nightly/runtime:3.0
mcr.microsoft.com/dotnet/core-nightly/aspnet:3.0.0-preview5
mcr.microsoft.com/dotnet/core-nightly/aspnet:3.0
mcr.microsoft.com/dotnet/core-nightly/sdk:3.0.100-preview5
mcr.microsoft.com/dotnet/core-nightly/sdk:3.0
```