### PR TITLE
Introduce build definition to validate remote Docker daemon config

### DIFF
--- a/.vsts-pipelines/validate-remote-docker-config.yml
+++ b/.vsts-pipelines/validate-remote-docker-config.yml
@@ -1,0 +1,45 @@
+pr: none
+trigger: none
+
+jobs:
+- job: ValidateRemoteDockerConfig
+  pool:
+    ${{ if eq(variables['System.TeamProject'], 'public') }}:
+      name: DotNetCore-Docker-Public
+    ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+      name: DotNetCore-Docker
+    demands:
+    - agent.os -equals linux
+    - agent.name -equals $(agentName)
+  workspace:
+    clean: all
+  variables:
+    remoteDockerRunCmd:
+      docker run
+      --rm
+      --entrypoint docker
+      -v /var/run/docker.sock:/var/run/docker.sock
+      -v $(DOCKER_CERT_PATH):/docker-certs
+      -e DOCKER_CERT_PATH=/docker-certs
+      -e DOCKER_TLS_VERIFY=1
+      -e DOCKER_HOST=tcp://$(DOCKER_HOST_IP):2376
+      $(imageNames.imageBuilder.linux)
+    imageNames.imageBuilder.linux: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch-docker-testrunner-63f2145-20184325094343
+  steps:
+  - script: docker pull $(imageNames.imageBuilder.linux)
+    displayName: Pull ImageBuilder
+  - script: $(remoteDockerRunCmd) info
+    displayName: Validate Remote Docker Daemon Reachability
+  - script: |
+      if [[ "$(DOCKER_CERT_PATH)" == *"humw"* ]]; then
+        echo "##vso[task.setvariable variable=imageNames.ping]mcr.microsoft.com/windows/nanoserver:1809-arm32v7"
+        echo "##vso[task.setvariable variable=customPingArgs]"
+      else
+        echo "##vso[task.setvariable variable=imageNames.ping]arm32v7/debian:stretch"
+        echo "##vso[task.setvariable variable=customPingArgs]-c 3"
+      fi
+    displayName: Define OS Variables
+  - script: $(remoteDockerRunCmd) pull $(imageNames.ping)
+    displayName: Pull Ping Image
+  - script: $(remoteDockerRunCmd) run --rm $(imageNames.ping) ping $(customPingArgs) www.github.com
+    displayName: Validate Remote Docker Daemon Container Network Access

--- a/.vsts-pipelines/validate-remote-docker-config.yml
+++ b/.vsts-pipelines/validate-remote-docker-config.yml
@@ -14,7 +14,9 @@ jobs:
   workspace:
     clean: all
   variables:
-    remoteDockerRunCmd:
+  - template: variables/docker-images.yml
+  - name: remoteDockerRunCmd
+    value:
       docker run
       --rm
       --entrypoint docker
@@ -23,23 +25,22 @@ jobs:
       -e DOCKER_CERT_PATH=/docker-certs
       -e DOCKER_TLS_VERIFY=1
       -e DOCKER_HOST=tcp://$(DOCKER_HOST_IP):2376
-      $(imageNames.imageBuilder.linux)
-    imageNames.imageBuilder.linux: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch-docker-testrunner-63f2145-20184325094343
+      $(imageNames.testRunner)
   steps:
-  - script: docker pull $(imageNames.imageBuilder.linux)
+  - script: docker pull $(imageNames.testRunner)
     displayName: Pull ImageBuilder
   - script: $(remoteDockerRunCmd) info
     displayName: Validate Remote Docker Daemon Reachability
   - script: |
       if [[ "$(DOCKER_CERT_PATH)" == *"humw"* ]]; then
-        echo "##vso[task.setvariable variable=imageNames.ping]mcr.microsoft.com/windows/nanoserver:1809-arm32v7"
+        echo "##vso[task.setvariable variable=imageNames.pinger]$(imageNames.pinger.linux)"
         echo "##vso[task.setvariable variable=customPingArgs]"
       else
-        echo "##vso[task.setvariable variable=imageNames.ping]arm32v7/debian:stretch"
+        echo "##vso[task.setvariable variable=imageNames.pinger]$(imageNames.pinger.windows)"
         echo "##vso[task.setvariable variable=customPingArgs]-c 3"
       fi
     displayName: Define OS Variables
-  - script: $(remoteDockerRunCmd) pull $(imageNames.ping)
+  - script: $(remoteDockerRunCmd) pull $(imageNames.pinger)
     displayName: Pull Ping Image
-  - script: $(remoteDockerRunCmd) run --rm $(imageNames.ping) ping $(customPingArgs) www.github.com
+  - script: $(remoteDockerRunCmd) run --rm $(imageNames.pinger) ping $(customPingArgs) www.github.com
     displayName: Validate Remote Docker Daemon Container Network Access

--- a/.vsts-pipelines/variables/docker-images.yml
+++ b/.vsts-pipelines/variables/docker-images.yml
@@ -1,0 +1,4 @@
+variables:
+  imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch-docker-testrunner-63f2145-20184325094343
+  imageNames.pinger.linux: mcr.microsoft.com/windows/nanoserver:1809-arm32v7
+  imageNames.pinger.windows: arm32v7/debian:stretch


### PR DESCRIPTION
This is a build definition that will up us and DDFUN validate the build agents that are configured to use a remote ARM docker daemon.

The build definition validates the following:
1. Remote daemon is reachable (validates the cert configuration) 
1. Remote daemon can run a container and that it has network access.

We can add more to this over time as we see fit.