### PR TITLE
Add support for RPI agents in validate-remote-docker pipeline

### DIFF
--- a/.vsts-pipelines/validate-remote-docker-config.yml
+++ b/.vsts-pipelines/validate-remote-docker-config.yml
@@ -32,7 +32,7 @@ jobs:
   - script: $(remoteDockerRunCmd) info
     displayName: Validate Remote Docker Daemon Reachability
   - script: |
-      if [[ "$(DOCKER_CERT_PATH)" == *"humw"* ]]; then
+      if [[ "$(DOCKER_CERT_PATH)" == *"humw"* ]] || [[ "$(DOCKER_CERT_PATH)" == *"rpiw"* ]]; then
         echo "##vso[task.setvariable variable=imageNames.pinger]$(imageNames.pinger.linux)"
         echo "##vso[task.setvariable variable=customPingArgs]"
       else

--- a/.vsts-pipelines/validate-remote-docker-config.yml
+++ b/.vsts-pipelines/validate-remote-docker-config.yml
@@ -11,6 +11,7 @@ jobs:
     demands:
     - agent.os -equals linux
     - agent.name -equals $(agentName)
+  timeoutInMinutes: 15
   workspace:
     clean: all
   variables:


### PR DESCRIPTION
I overlooked that the pr validation agent pool does not have the same machines as the official build.