### PR TITLE
Fix AllPlatforms member to not be filtered

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/ImageInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/ImageInfo.cs
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
                     .ToArray();
             }
 
-            imageInfo.AllPlatforms = manifestFilter.GetPlatforms(model)
+            imageInfo.AllPlatforms = model.Platforms
                 .Select(platform => PlatformInfo.Create(platform, fullRepoModelName, repoName, variableHelper))
                 .ToArray();
 


### PR DESCRIPTION
Fixes #182 

The ImageInfo.AllPlatforms member was incorrectly getting populated off of the filtered model.