### PR TITLE
Add support for generating MCR tags YAML and producing tags listing from it

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
@@ -170,8 +170,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private static string FormatMatrixName(IEnumerable<string> parts)
         {
             string[] allParts = parts.SelectMany(part => part.Split('-')).ToArray();
-            return allParts.First() +
-                string.Join(string.Empty, allParts.Skip(1).Select(part => char.ToUpper(part[0]) + part.Substring(1)));
+            return allParts.First() + string.Join(string.Empty, allParts.Skip(1).Select(part => part.FirstCharToUpper()));
         }
 
         private IEnumerable<MatrixInfo> GenerateMatrixInfo()

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateTagsReadmeOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateTagsReadmeOptions.cs
@@ -8,13 +8,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     public class GenerateTagsReadmeOptions : Options
     {
-        protected override string CommandHelp => "Generate the tags section of the readme";
+        protected override string CommandHelp => "Generates and updates the readme tag listing section";
 
-        public string ReadmePath { get; set; }
-        public bool SkipValidation { get; set; }
         public string SourceUrl { get; set; }
-        public string Template { get; set; }
-        public bool UpdateReadme { get; set; }
 
         public GenerateTagsReadmeOptions() : base()
         {
@@ -23,23 +19,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public override void ParseCommandLine(ArgumentSyntax syntax)
         {
             base.ParseCommandLine(syntax);
-
-            string readmePath = null;
-            syntax.DefineOption("readme-path", ref readmePath, "Path of the readme to update (defaults to manifest setting)");
-            ReadmePath = readmePath;
-
-            bool skipValidation = false;
-            syntax.DefineOption(
-                "skip-validation", ref skipValidation, "Skip validating all documented tags are included in the readme");
-            SkipValidation = skipValidation;
-
-            bool updateReadme = false;
-            syntax.DefineOption("update-readme", ref updateReadme, "Update the readme file");
-            UpdateReadme = updateReadme;
-
-            string template = null;
-            syntax.DefineOption("template", ref template, "Path to a custom template file");
-            Template = template;
 
             string sourceUrl = null;
             syntax.DefineParameter("source-url", ref sourceUrl, "Base URL of the Dockerfile sources");

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/McrTagsMetadataGenerator.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/McrTagsMetadataGenerator.cs
@@ -1,0 +1,211 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.DotNet.ImageBuilder.Model;
+using Microsoft.DotNet.ImageBuilder.ViewModel;
+
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    public class McrTagsMetadataGenerator
+    {
+        private List<ImageDocumentationInfo> _imageDocInfos;
+        private ManifestInfo _manifest;
+        private RepoInfo _repo;
+        private string _sourceUrl;
+
+        private McrTagsMetadataGenerator()
+        {
+        }
+
+        public static string Execute(ManifestInfo manifest, RepoInfo repo, string sourceUrl)
+        {
+            McrTagsMetadataGenerator generator = new McrTagsMetadataGenerator()
+            {
+                _manifest = manifest,
+                _repo = repo,
+                _sourceUrl = sourceUrl,
+            };
+
+            return generator.Execute();
+        }
+
+        private string Execute()
+        {
+            Logger.WriteHeading("GENERATING MCR TAGS METADATA");
+
+            _imageDocInfos = _repo.FilteredImages
+                .SelectMany(image =>
+                    image.AllPlatforms.SelectMany(platform => ImageDocumentationInfo.Create(image, platform)))
+                .Where(info => info.DocumentedTags.Any())
+                .ToList();
+
+            StringBuilder yaml = new StringBuilder();
+            yaml.AppendLine("repos:");
+
+            string template = File.ReadAllText(_repo.Model.McrTagsMetadataTemplatePath);
+            yaml.Append(_manifest.VariableHelper.SubstituteValues(template, GetVariableValue));
+
+            if (_imageDocInfos.Any())
+            {
+                string missingTags = string.Join(
+                    Environment.NewLine, _imageDocInfos.Select(info => info.FormattedDocumentedTags));
+                throw new InvalidOperationException(
+                    $"The following tags are not included in the tags metadata: {Environment.NewLine}{missingTags}");
+            }
+
+            string metadata = yaml.ToString();
+            Logger.WriteSubheading("Generated Metadata:");
+            Logger.WriteMessage(metadata);
+
+            return metadata;
+        }
+
+        public static string GetOSDisplayName(PlatformInfo platform)
+        {
+            string displayName;
+            string os = platform.Model.OsVersion;
+            Logger.WriteMessage($"os: {os}");
+            Logger.WriteMessage($"osType: {platform.Model.OS}");
+
+            if (platform.Model.OS == OS.Windows)
+            {
+                if (os.Contains("2016"))
+                {
+                    displayName = "Windows Server 2016";
+                }
+                else if (os.Contains("2019") || os.Contains("1809"))
+                {
+                    displayName = "Windows Server 2019";
+                }
+                else
+                {
+                    string version = os.Split('-')[1];
+                    displayName = $"Windows Server, version {version}";
+                }
+            }
+            else
+            {
+                if (os.Contains("jessie"))
+                {
+                    displayName = "Debian 8";
+                }
+                else if (os.Contains("stretch"))
+                {
+                    displayName = "Debian 9";
+                }
+                else if (os.Contains("buster"))
+                {
+                    displayName = "Debian 10";
+                }
+                else if (os.Contains("bionic"))
+                {
+                    displayName = "Ubuntu 18.04";
+                }
+                else if (os.Contains("disco"))
+                {
+                    displayName = "Ubuntu 19.04";
+                }
+                else if (os.Contains("alpine"))
+                {
+                    int versionIndex = os.IndexOfAny(new char[] { '1', '2', '3', '4', '5', '6', '7', '8', '9', '0' });
+                    if (versionIndex != -1)
+                    {
+                        os = os.Insert(versionIndex, " ");
+                    }
+
+                    displayName = os.FirstCharToUpper();
+                }
+                else
+                {
+                    throw new InvalidOperationException($"The OS version '{os}' is not supported.");
+                }
+            }
+
+            return displayName;
+        }
+
+        private static string GetRepoYaml(RepoInfo repo)
+        {
+            StringBuilder yaml = new StringBuilder();
+            yaml.AppendLine($"- repoName: public/{repo.Model.Name}");
+            yaml.AppendLine("  customTablePivots: true");
+            yaml.Append("  tagGroups:");
+
+            return yaml.ToString();
+        }
+
+        private string GetTagGroupYaml(ImageDocumentationInfo info)
+        {
+            StringBuilder yaml = new StringBuilder();
+            yaml.AppendLine($"  - tags: [ {info.FormattedDocumentedTags} ]");
+            yaml.AppendLine($"    architecture: {info.Platform.Model.Architecture.GetDisplayName()}");
+            yaml.AppendLine($"    os: {info.Platform.Model.OS.GetDockerName()}");
+            yaml.AppendLine($"    osVersion: {GetOSDisplayName(info.Platform)}");
+            yaml.Append($"    dockerfile: {_sourceUrl}/{info.Platform.DockerfilePath.Replace('\\', '/')}");
+
+            return yaml.ToString();
+        }
+
+        private string GetVariableValue(string variableType, string variableName)
+        {
+            string variableValue = null;
+
+            if (string.Equals(variableType, VariableHelper.McrTagsYmlRepoTypeId, StringComparison.Ordinal))
+            {
+                RepoInfo repo = _manifest.GetFilteredRepoById(variableName);
+                variableValue = GetRepoYaml(repo);
+            }
+            else if (string.Equals(variableType, VariableHelper.McrTagsYmlTagGroupTypeId, StringComparison.Ordinal))
+            {
+                ImageDocumentationInfo info = _imageDocInfos
+                    .FirstOrDefault(idi => idi.DocumentedTags.Any(tag => tag.Name == variableName));
+                if (info != null)
+                {
+                    _imageDocInfos.Remove(info);
+                    variableValue = GetTagGroupYaml(info);
+                }
+            }
+
+            return variableValue;
+        }
+
+        private class ImageDocumentationInfo
+        {
+            public IEnumerable<TagInfo> DocumentedTags { get; set; }
+            public string FormattedDocumentedTags { get; set; }
+            public PlatformInfo Platform { get; }
+
+            private ImageDocumentationInfo(ImageInfo image, PlatformInfo platform, string documentationGroup)
+            {
+                Platform = platform;
+                DocumentedTags = GetDocumentedTags(Platform.Tags, documentationGroup)
+                    .Concat(GetDocumentedTags(image.SharedTags, documentationGroup))
+                    .ToArray();
+                FormattedDocumentedTags = DocumentedTags
+                    .Select(tag => tag.Name)
+                    .Aggregate((working, next) => $"{working}, {next}");
+            }
+
+            public static IEnumerable<ImageDocumentationInfo> Create(ImageInfo image, PlatformInfo platform)
+            {
+                IEnumerable<string> documentationGroups = image.SharedTags
+                    .Concat(platform.Tags)
+                    .Select(tag => tag.Model.DocumentationGroup)
+                    .Distinct();
+                foreach (string documentationGroup in documentationGroups)
+                {
+                    yield return new ImageDocumentationInfo(image, platform, documentationGroup);
+                }
+            }
+
+            private static IEnumerable<TagInfo> GetDocumentedTags(IEnumerable<TagInfo> tagInfos, string documentationGroup) =>
+                tagInfos.Where(tag => !tag.Model.IsUndocumented && tag.Model.DocumentationGroup == documentationGroup);
+        }
+    }
+}

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/Options.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/Options.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
         }
 
-        private string GetCommandName()
+        public string GetCommandName()
         {
             string commandName = GetType().Name.TrimEnd("Options");
             return char.ToLowerInvariant(commandName[0]) + commandName.Substring(1);

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsOptions.cs
@@ -6,7 +6,7 @@ using System.CommandLine;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
-    public class PublishMcrReadmesOptions : Options
+    public class PublishMcrDocsOptions : Options
     {
         protected override string CommandHelp => "Publishes the readmes to MCR";
 
@@ -17,8 +17,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public string GitPath { get; set; }
         public string GitRepo { get; set; }
         public string GitUsername { get; set; }
+        public string SourceUrl { get; set; }
 
-        public PublishMcrReadmesOptions() : base()
+        public PublishMcrDocsOptions() : base()
         {
         }
 
@@ -74,6 +75,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 ref gitAuthToken,
                 "GitHub authentication token");
             GitAuthToken = gitAuthToken;
+
+            string sourceUrl = null;
+            syntax.DefineParameter("source-url", ref sourceUrl, "Base URL of the Dockerfile sources");
+            SourceUrl = sourceUrl;
         }
     }
 }

--- a/Microsoft.DotNet.ImageBuilder/src/ImageBuilder.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ImageBuilder.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.ImageBuilder
                     new GenerateBuildMatrixCommand(),
                     new GenerateTagsReadmeCommand(),
                     new PublishManifestCommand(),
-                    new PublishMcrReadmesCommand(),
+                    new PublishMcrDocsCommand(),
                     new UpdateVersionsCommand(),
                     new ValidateImageSizeCommand(),
                 };

--- a/Microsoft.DotNet.ImageBuilder/src/Model/Platform.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Model/Platform.cs
@@ -26,6 +26,7 @@ namespace Microsoft.DotNet.ImageBuilder.Model
         [JsonProperty(Required = Required.Always)]
         public OS OS { get; set; }
 
+        [JsonProperty(Required = Required.Always)]
         public string OsVersion { get; set; }
 
         [JsonProperty(Required = Required.Always)]

--- a/Microsoft.DotNet.ImageBuilder/src/Model/Repo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Model/Repo.cs
@@ -13,6 +13,8 @@ namespace Microsoft.DotNet.ImageBuilder.Model
         [JsonProperty(Required = Required.Always)]
         public Image[] Images { get; set; }
 
+        public string McrTagsMetadataTemplatePath { get; set; }
+
         [JsonProperty(Required = Required.Always)]
         public string Name { get; set; }
 

--- a/Microsoft.DotNet.ImageBuilder/src/ReadmeHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ReadmeHelper.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.DotNet.ImageBuilder.Commands;
+using Microsoft.DotNet.ImageBuilder.Model;
+using Microsoft.DotNet.ImageBuilder.ViewModel;
+
+namespace Microsoft.DotNet.ImageBuilder
+{
+    public class ReadmeHelper
+    {
+        private const string TagsSectionHeader = "# Full Tag Listing";
+
+        private static string NormalizeLineEndings(string value, string targetFormat)
+        {
+            string targetLineEnding = targetFormat.Contains("\r\n") ? "\r\n" : "\n";
+            string valueLineEnding = value.Contains("\r\n") ? "\r\n" : "\n";
+            if (valueLineEnding != targetLineEnding)
+            {
+                value = value.Replace(valueLineEnding, targetLineEnding);
+            }
+
+            return value;
+        }
+
+        public static string UpdateTagsListing(string readme, string tagsListing)
+        {
+            tagsListing = $"{TagsSectionHeader}{Environment.NewLine}{Environment.NewLine}{tagsListing}{Environment.NewLine}{Environment.NewLine}";
+
+            // Normalize the line endings to match the readme.
+            tagsListing = NormalizeLineEndings(tagsListing, readme);
+
+            Regex regex = new Regex($"^{TagsSectionHeader}\\s*(^(?!# ).*\\s)*", RegexOptions.Multiline);
+            return regex.Replace(readme, tagsListing);
+        }
+    }
+}

--- a/Microsoft.DotNet.ImageBuilder/src/ReadmeHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ReadmeHelper.cs
@@ -14,7 +14,7 @@ using Microsoft.DotNet.ImageBuilder.ViewModel;
 
 namespace Microsoft.DotNet.ImageBuilder
 {
-    public class ReadmeHelper
+    public static class ReadmeHelper
     {
         private const string TagsSectionHeader = "# Full Tag Listing";
 
@@ -37,6 +37,7 @@ namespace Microsoft.DotNet.ImageBuilder
             // Normalize the line endings to match the readme.
             tagsListing = NormalizeLineEndings(tagsListing, readme);
 
+            // Regex to find the entire tags listing section including the header.
             Regex regex = new Regex($"^{TagsSectionHeader}\\s*(^(?!# ).*\\s)*", RegexOptions.Multiline);
             return regex.Replace(readme, tagsListing);
         }

--- a/Microsoft.DotNet.ImageBuilder/src/StringExtensions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/StringExtensions.cs
@@ -6,6 +6,8 @@ namespace Microsoft.DotNet.ImageBuilder
 {
     public static class StringExtensions
     {
+        public static string FirstCharToUpper(this string source) => char.ToUpper(source[0]) + source.Substring(1);
+
         public static string TrimEnd(this string source, string trimString)
         {
             while (source.EndsWith(trimString))

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
@@ -99,6 +99,11 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
                 .SelectMany(platform => platform.Tags);
         }
 
+        public RepoInfo GetFilteredRepoById(string id)
+        {
+            return FilteredRepos.FirstOrDefault(repo => repo.Id == id);
+        }
+
         public PlatformInfo GetPlatformByTag(string fullTagName)
         {
             PlatformInfo result = AllRepos

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
@@ -12,11 +12,10 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
     {
         private const char BuiltInDelimiter = ':';
         public const string DockerfileGitCommitShaVariableName = "DockerfileGitCommitSha";
+        public const string McrTagsYmlRepoTypeId = "McrTagsYmlRepo";
+        public const string McrTagsYmlTagGroupTypeId = "McrTagsYmlTagGroup";
         public const string RepoVariableTypeId = "Repo";
-        public const string SourceUrlVariableName = "SourceUrl";
         public const string SystemVariableTypeId = "System";
-        public const string TagDocTypeId = "TagDoc";
-        public const string TagDocListTypeId = "TagDocList";
         private const string TagVariableTypeId = "TagRef";
         private const string TimeStampVariableName = "TimeStamp";
         private const string VariableGroupName = "variable";


### PR DESCRIPTION
Related to https://github.com/dotnet/dotnet-docker/issues/990

- Refactor the GenerateTagsReadmeCommand to generate the MCR tags metadata and use the MCR tool to generate the tags table off of the MCR metadata.
- Refactor the PublishMcrReadmeCommand (renamed to PublishMcrDocsCommand) to generate the MCR tags metadata, strip out the tags listing in the readme, and publish the artifacts to McrDocs
- In support of the previous two commands, two model schema changes were introduced.  First the osVersion is now a required property.  Second the McrTagsMetadataTemplatePath was added to the Repo.

A sample of the output can be view at https://hub.docker.com/_/microsoft-dotnet-core-nightly-aspnet/.
The repo changes to consume this can be viewed at https://github.com/dotnet/dotnet-docker/compare/nightly...MichaelSimons:mcr-tags-table-nightly.

I will be logging a follow-up issue to refactor the GenerateBuildMatricCommand to make use of the osVersion.
