### PR TITLE
Enable manifest filtering for RebuildStaleImages command

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/Commands/RebuildStaleImagesCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/RebuildStaleImagesCommand.cs
@@ -53,7 +53,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             if (!pathsToRebuild.Any())
             {
-                Logger.WriteMessage($"All images for subscription {subscription} are using up-to-date base images. No rebuild necessary.");
+                Logger.WriteMessage($"All images for subscription '{subscription}' are using up-to-date base images. No rebuild necessary.");
                 return;
             }
 

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/RebuildStaleImagesCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/RebuildStaleImagesCommand.cs
@@ -51,6 +51,12 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             IEnumerable<string> pathsToRebuild = await GetPathsToRebuildAsync(subscription, repos);
 
+            if (!pathsToRebuild.Any())
+            {
+                Logger.WriteMessage($"All images for subscription {subscription} are using up-to-date base images. No rebuild necessary.");
+                return;
+            }
+
             string formattedParameters = pathsToRebuild
                 .Select(path => $"{ManifestFilterOptions.FormattedPathOption} '{path}'")
                 .Aggregate((p1, p2) => $"{p1} {p2}");
@@ -102,7 +108,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             string repoPath = await GetGitRepoPath(subscription);
 
-            TempManifestOptions manifestOptions = new TempManifestOptions
+            TempManifestOptions manifestOptions = new TempManifestOptions(Options.FilterOptions)
             {
                 Manifest = Path.Combine(repoPath, subscription.ManifestPath)
             };
@@ -111,10 +117,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             List<string> pathsToRebuild = new List<string>();
 
-            foreach (RepoInfo repo in manifest.AllRepos)
+            foreach (RepoInfo repo in manifest.FilteredRepos)
             {
-                IEnumerable<PlatformInfo> platforms = repo.AllImages
-                    .SelectMany(image => image.AllPlatforms);
+                IEnumerable<PlatformInfo> platforms = repo.FilteredImages
+                    .SelectMany(image => image.FilteredPlatforms);
 
                 RepoData repoData = repos
                     .FirstOrDefault(s => s.Repo == repo.Model.Name);
@@ -187,8 +193,15 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             return repoPath;
         }
 
-        private class TempManifestOptions : ManifestOptions
+        private class TempManifestOptions : ManifestOptions, IFilterableOptions
         {
+            public TempManifestOptions(ManifestFilterOptions filterOptions)
+            {
+                FilterOptions = filterOptions;
+            }
+
+            public ManifestFilterOptions FilterOptions { get; }
+
             protected override string CommandHelp => throw new NotImplementedException();
         }
     }

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/RebuildStaleImagesOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/RebuildStaleImagesOptions.cs
@@ -6,9 +6,11 @@ using System.CommandLine;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
-    public class RebuildStaleImagesOptions : Options
+    public class RebuildStaleImagesOptions : Options, IFilterableOptions
     {
         protected override string CommandHelp => "Queues builds to update any images with out-of-date base images";
+
+        public ManifestFilterOptions FilterOptions { get; } = new ManifestFilterOptions();
 
         public string SubscriptionsPath { get; set; }
         public string ImageInfoPath { get; set; }
@@ -19,6 +21,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public override void ParseCommandLine(ArgumentSyntax syntax)
         {
             base.ParseCommandLine(syntax);
+
+            FilterOptions.ParseCommandLine(syntax);
 
             const string DefaultSubscriptionsPath = "subscriptions.json";
             string subscriptionsPath = DefaultSubscriptionsPath;


### PR DESCRIPTION
The RebuildStaleImages command currently enumerates all images in the manifest and attempts to pull them to get their base image digest value.  This can't be done when there is a mix of Linux and Windows images because you can't pull a Windows image from a Linux Docker host, for example.  For that reason, there needs to be filtering options for the command that are applied to the manifests that are consumed.