### PR TITLE
Add switch to confirm repo deletion

### DIFF
--- a/scripts/Invoke-AcrCleanup.ps1
+++ b/scripts/Invoke-AcrCleanup.ps1
@@ -42,7 +42,7 @@ foreach ($repoName in $filteredRepos) {
     if ($lastUpdateTime.AddDays(30) -lt (Get-Date)) {
         Write-Host "Deleting repository '$repoName'"
         if (-not $WhatIf) {
-            az acr repository delete --name $RegistryName --repository $repoName    
+            az acr repository delete --name $RegistryName --repository $repoName -y
         }
 
         $deletedRepos += $repoName


### PR DESCRIPTION
Deletion of the repository requires the `-y` flag to confirm the deletion in an automated scenario.