### PR TITLE
Add a showImageStats command that displays various image statistics

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/Commands/ShowImageStatsCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/ShowImageStatsCommand.cs
@@ -1,0 +1,109 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.DotNet.ImageBuilder.ViewModel;
+
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    public class ShowImageStatsCommand : ManifestCommand<ShowImageStatsOptions>
+    {
+        public ShowImageStatsCommand() : base()
+        {
+        }
+
+        public override Task ExecuteAsync()
+        {
+            Logger.WriteHeading("IMAGE STATISTICS");
+
+            PlatformInfo[] platforms = Manifest.GetFilteredPlatforms().ToArray();
+            LogGeneralStats(platforms);
+            LogBaseImageStats(platforms);
+
+            return Task.CompletedTask;
+        }
+
+        private string FormatBaseImageStats(
+            string baseImage,
+            object dependentImages,
+            object dependentConcreteTags,
+            object dependentSharedTags,
+            object dependentTags)
+            => $"{baseImage,-50}  {dependentImages,17}  {dependentConcreteTags,24}  {dependentSharedTags,29}  {dependentTags,20}";
+
+        private void LogBaseImageStats(PlatformInfo[] platforms)
+        {
+            IEnumerable<string> externalBaseImages = platforms
+                .SelectMany(platform => platform.ExternalFromImages)
+                .Distinct()
+                .OrderBy(name => name)
+                .Select(name => $"{name}");
+
+            Logger.WriteMessage();
+            Logger.WriteHeading(
+                FormatBaseImageStats(
+                    $"External Base Images ({externalBaseImages.Count()})",
+                    "Dependent Images",
+                    "Dependent Concrete Tags",
+                    "Dependent Multi-Platform Tags",
+                    "Total Dependent Tags"));
+
+            foreach (string baseImage in externalBaseImages)
+            {
+                PlatformInfo[] dependentPlatforms = platforms
+                    .Where(platform => platform.ExternalFromImages.Contains(baseImage))
+                    .SelectMany(platform => platform.GetDependencyGraph(platforms))
+                    .Distinct()
+                    .ToArray();
+                int dependentPlatformTagsCount = dependentPlatforms.SelectMany(platform => platform.Tags).Count();
+                int dependentSharedTagsCount = Manifest.GetFilteredImages()
+                    .Where(image => image.FilteredPlatforms.Intersect(dependentPlatforms).Any())
+                    .SelectMany(image => image.SharedTags)
+                    .Count();
+
+                Logger.WriteMessage(
+                    FormatBaseImageStats(
+                        baseImage,
+                        dependentPlatforms.Length,
+                        dependentPlatformTagsCount,
+                        dependentSharedTagsCount,
+                        dependentPlatformTagsCount + dependentSharedTagsCount));
+            }
+        }
+
+        private void LogGeneralStats(PlatformInfo[] platforms)
+        {
+            TagInfo[] platformTags = Manifest.GetFilteredPlatformTags().ToArray();
+            TagInfo[] sharedTags = Manifest.GetFilteredImages().SelectMany(image => image.SharedTags).ToArray();
+            TagInfo[] undocumentedPlatformTags = platformTags.Where(tag => tag.Model.IsUndocumented).ToArray();
+            TagInfo[] undocumentedSharedTags = sharedTags.Where(tag => tag.Model.IsUndocumented).ToArray();
+
+            Logger.WriteMessage($"Total Unique Images:  {platforms.Length}");
+            Logger.WriteMessage($"Total Concrete Tags:  {platformTags.Length}");
+
+            if (undocumentedPlatformTags.Length > 0)
+            {
+                Logger.WriteMessage($"    Total Undocumented Concrete Tags:  {undocumentedPlatformTags.Length}");
+            }
+
+            Logger.WriteMessage($"Total Multi-Platform Tags:  {sharedTags.Length}");
+
+            if (undocumentedSharedTags.Length > 0)
+            {
+                Logger.WriteMessage($"    Total Undocumented Shared Tags:  {undocumentedSharedTags.Length}");
+            }
+
+            Logger.WriteMessage($"Total Tags:  {platformTags.Length + sharedTags.Length}");
+
+            if (undocumentedPlatformTags.Length > 0 && undocumentedSharedTags.Length > 0)
+            {
+                Logger.WriteMessage($"    Total Undocumented Tags:  {undocumentedPlatformTags.Length + undocumentedSharedTags.Length}");
+            }
+        }
+
+    }
+}

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/ShowImageStatsCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/ShowImageStatsCommand.cs
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             object dependentConcreteTags,
             object dependentSharedTags,
             object dependentTags)
-            => $"{baseImage,-50}  {dependentImages,17}  {dependentConcreteTags,24}  {dependentSharedTags,29}  {dependentTags,20}";
+            => $"{baseImage,-50}  {dependentImages,17}  {dependentConcreteTags,24}  {dependentSharedTags,21}  {dependentTags,20}";
 
         private void LogBaseImageStats(PlatformInfo[] platforms)
         {
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     $"External Base Images ({externalBaseImages.Count()})",
                     "Dependent Images",
                     "Dependent Concrete Tags",
-                    "Dependent Multi-Platform Tags",
+                    "Dependent Shared Tags",
                     "Total Dependent Tags"));
 
             foreach (string baseImage in externalBaseImages)
@@ -90,7 +90,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 Logger.WriteMessage($"    Total Undocumented Concrete Tags:  {undocumentedPlatformTags.Length}");
             }
 
-            Logger.WriteMessage($"Total Multi-Platform Tags:  {sharedTags.Length}");
+            Logger.WriteMessage($"Total Shared Tags:  {sharedTags.Length}");
 
             if (undocumentedSharedTags.Length > 0)
             {
@@ -104,6 +104,5 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 Logger.WriteMessage($"    Total Undocumented Tags:  {undocumentedPlatformTags.Length + undocumentedSharedTags.Length}");
             }
         }
-
     }
 }

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/ShowImageStatsOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/ShowImageStatsOptions.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.CommandLine;
+
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    public class ShowImageStatsOptions : ManifestOptions, IFilterableOptions
+    {
+        protected override string CommandHelp => "Displays statistics about the number of images";
+
+        public ManifestFilterOptions FilterOptions { get; } = new ManifestFilterOptions();
+
+        public ShowImageStatsOptions() : base()
+        {
+        }
+
+        public override void ParseCommandLine(ArgumentSyntax syntax)
+        {
+            base.ParseCommandLine(syntax);
+
+            FilterOptions.ParseCommandLine(syntax);
+        }
+    }
+}

--- a/Microsoft.DotNet.ImageBuilder/src/ImageBuilder.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ImageBuilder.cs
@@ -26,6 +26,7 @@ namespace Microsoft.DotNet.ImageBuilder
                     new PublishManifestCommand(),
                     new PublishMcrDocsCommand(),
                     new RebuildStaleImagesCommand(),
+                    new ShowImageStatsCommand(),
                     new UpdateVersionsCommand(),
                     new ValidateImageSizeCommand(),
                 };

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/ViewModelExtensions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/ViewModelExtensions.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.DotNet.ImageBuilder.ViewModel
+{
+    public static class ViewModelExtensions
+    {
+        public static IEnumerable<PlatformInfo> GetDependencyGraph(
+            this PlatformInfo parent, IEnumerable<PlatformInfo> allPlatforms)
+        {
+            string[] parentTags = parent.Tags.Select(tag => tag.FullyQualifiedName).ToArray();
+            IEnumerable<PlatformInfo> dependencies = allPlatforms
+                .Where(platform => platform.InternalFromImages.Intersect(parentTags).Any());
+            return new PlatformInfo[] {parent}
+                .Concat(dependencies.SelectMany(child => child.GetDependencyGraph(allPlatforms)));
+        }
+    }
+}


### PR DESCRIPTION
I've had a variation of this command in my local fork and find it useful from time to time.  I decided to check it in to make is generally available.  It is helpful for seeing the total number of images within a repo and what the external image dependencies are.  We should add to it going forward as needed.

Sample output of running the command on https://github.com/dotnet/dotnet-docker/tree/nightly

```
IMAGE STATISTICS
----------------
Total Unique Images:  129
Total Concrete Tags:  304
    Total Undocumented Concrete Tags:  6
Total Multi-Platform Tags:  36
Total Tags:  340


External Base Images (36)                            Dependent Images   Dependent Concrete Tags  Dependent Multi-Platform Tags  Total Dependent Tags
----------------------------------------------------------------------------------------------------------------------------------------------------
alpine:3.7                                                          4                        16                              0                    16
alpine:3.8                                                          4                        16                              0                    16
alpine:3.9                                                         11                        32                              0                    32
arm32v7/buildpack-deps:bionic-scm                                   3                         6                              0                     6
arm32v7/buildpack-deps:buster-scm                                   1                         2                              2                     4
arm32v7/buildpack-deps:disco-scm                                    1                         2                              0                     2
arm32v7/buildpack-deps:stretch-scm                                  2                         4                              5                     9
arm32v7/debian:buster-slim                                          3                         6                              6                    12
arm32v7/debian:stretch-slim                                         5                        12                             15                    27
arm32v7/ubuntu:bionic                                               8                        18                              0                    18
arm32v7/ubuntu:disco                                                3                         6                              0                     6
arm64v8/alpine:3.9                                                  3                        12                              0                    12
arm64v8/buildpack-deps:bionic-scm                                   1                         2                              0                     2
arm64v8/buildpack-deps:buster-scm                                   1                         2                              2                     4
arm64v8/buildpack-deps:disco-scm                                    1                         2                              0                     2
arm64v8/debian:buster-slim                                          3                         6                              6                    12
arm64v8/ubuntu:bionic                                               3                         6                              0                     6
arm64v8/ubuntu:disco                                                3                         6                              0                     6
buildpack-deps:bionic-scm                                           3                         6                              0                     6
buildpack-deps:buster-scm                                           1                         2                              2                     4
buildpack-deps:disco-scm                                            1                         2                              0                     2
buildpack-deps:jessie-scm                                           1                         2                              2                     4
buildpack-deps:stretch-scm                                          3                         6                              5                    11
debian:buster-slim                                                  3                         6                              6                    12
debian:jessie                                                       3                         6                              6                    12
debian:stretch                                                      2                         4                              0                     4
debian:stretch-slim                                                 5                        12                             15                    27
mcr.microsoft.com/windows/nanoserver:1803                           9                        18                             21                    39
mcr.microsoft.com/windows/nanoserver:1809                          12                        24                             27                    51
mcr.microsoft.com/windows/nanoserver:1809-arm32v7                   6                        18                             15                    33
mcr.microsoft.com/windows/nanoserver:1903                           9                        18                             21                    39
mcr.microsoft.com/windows/servercore:1803                           9                        18                             21                    39
mcr.microsoft.com/windows/servercore:1809                          12                        24                             27                    51
mcr.microsoft.com/windows/servercore:1903                           9                        18                             21                    39
ubuntu:bionic                                                       8                        18                              0                    18
ubuntu:disco                                                        3                         6                              0                     6
```