### PR TITLE
Pipeline changes to support testing partial graph

### DIFF
--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -16,6 +16,16 @@ jobs:
   timeoutInMinutes: ${{ parameters.buildJobTimeout }}
   variables:
     osVersion: ${{ parameters.osVersion }}
+    ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+      imageBuilderBuildArgs: >
+        --registry-override $(acr.server)
+        --repo-prefix $(stagingRepoPrefix)
+        --push
+        --username $(acr.userName)
+        --password $(BotAccount-dotnet-docker-acr-bot-password)
+        $(imageBuilder.queueArgs)
+    ${{ if eq(variables['System.TeamProject'], 'public') }}:
+      imageBuilderBuildArgs: $(imageBuilder.queueArgs)
   steps:
   # This script is necessary to workaround there not being a matching architecture when pulling images
   # on an aarch64 machine. By using the multi-arch tag for the images referenced in the sample
@@ -43,19 +53,9 @@ jobs:
   - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
     - script: >
         echo "##vso[task.setvariable variable=imageBuilderBuildArgs]
-        --image-info-output-path "$(imageBuilderArtifactsPath)/$(legName)-image-info.json"
-        --registry-override $(acr.server)
-        --repo-prefix $(stagingRepoPrefix)
-        --push
-        --username $(acr.userName)
-        --password $(BotAccount-dotnet-docker-acr-bot-password)
-        $(imageBuilder.queueArgs)"
-      displayName: Define imageBuilderBuildArgs Variable
-  - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-    - script: >
-        echo "##vso[task.setvariable variable=imageBuilderBuildArgs]
-        $(imageBuilder.queueArgs)"
-      displayName: Define imageBuilderBuildArgs Variable
+        --image-info-output-path $(artifactsPath)/$(legName)-image-info.json
+        $(imageBuilderBuildArgs)"
+      displayName: Set Image Builder Args
   - script: >
       $(runImageBuilderCmd) build
       --manifest $(manifest)
@@ -66,10 +66,8 @@ jobs:
       --retry
       $(imageBuilderBuildArgs)
     displayName: Build Images
-  - task: PublishPipelineArtifact@0
-    inputs:
-      artifactName: $(legName)-image-info
-      targetPath: $(Build.ArtifactStagingDirectory)/$(legName)-image-info.json
+  - publish: $(Build.ArtifactStagingDirectory)/$(legName)-image-info.json
+    artifact: $(legName)-image-info
     displayName: Publish Image Info File Artifact
   - ${{ if eq(variables['System.TeamProject'], 'public') }}:
     - template: ${{ format('../steps/test-images-{0}-client.yml', parameters.dockerClientOS) }}

--- a/eng/common/templates/jobs/post-build.yml
+++ b/eng/common/templates/jobs/post-build.yml
@@ -1,0 +1,17 @@
+jobs:
+- job: Build
+  pool: # linuxAmd64Pool
+    name: Hosted Ubuntu 1604
+  steps:
+  - template: ../steps/init-docker-linux.yml
+  - template: ../steps/download-build-artifact.yml
+    parameters:
+      targetPath: $(Build.ArtifactStagingDirectory)
+  - script: >
+      $(runImageBuilderCmd) mergeImageInfo
+      $(artifactsPath)
+      $(artifactsPath)/image-info.json
+    displayName: Merge Image Info Files
+  - publish: $(Build.ArtifactStagingDirectory)/image-info.json
+    artifact: image-info
+    displayName: Publish Image Info File Artifact

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -47,22 +47,17 @@ jobs:
       $(publicGitRepoUri)/blob/$(publicSourceBranch)
       $(imageBuilder.commonCmdArgs)
     displayName: Publish Readme
-  - task: DownloadPipelineArtifact@1
-    inputs:
-      buildType: specific
-      project: $(System.TeamProject)
-      pipline: $(System.DefinitionId)
-      buildVersionToDownload: specific
-      buildId: $(sourceBuildId)
+  - template: ../steps/download-build-artifact.yml
+    parameters:
       targetPath: $(Build.ArtifactStagingDirectory)
-    displayName: Download Pipline Artifacts
+      artifactName: image-info
     condition: and(succeeded(), eq(variables['publishRepoPrefix'], 'public/'))
   - script: >
       $(runImageBuilderCmd) publishImageInfo
       $(dotnetBot-userName)
       $(dotnetBot-email)
       $(dotnet-bot-user-repo-adminrepohook-pat)
-      $(imageBuilderArtifactsPath)
+      $(artifactsPath)/image-info.json
       --git-owner dotnet
       --git-repo versions
       --git-branch master

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -164,10 +164,19 @@ stages:
 
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   ################################################################################
+  # Post-Build
+  ################################################################################
+  - stage: Post_Build
+    dependsOn: Build
+    condition: and(succeeded(), or(eq(variables['singlePhase'], ''), eq(variables['singlePhase'], 'build')))
+    jobs:
+    - template: ../jobs/post-build.yml
+
+  ################################################################################
   # Test Images
   ################################################################################
   - stage: Test
-    dependsOn: Build
+    dependsOn: Post_Build
     condition: "
       and(
         not(contains(variables['manifest'], 'samples')),

--- a/eng/common/templates/steps/download-build-artifact.yml
+++ b/eng/common/templates/steps/download-build-artifact.yml
@@ -1,0 +1,15 @@
+parameters:
+  targetPath: ""
+  artifactName: ""
+
+steps:
+- task: DownloadPipelineArtifact@1
+  inputs:
+    buildType: specific
+    project: $(System.TeamProject)
+    pipline: $(System.DefinitionId)
+    buildVersionToDownload: specific
+    buildId: $(sourceBuildId)
+    targetPath: ${{ parameters.targetPath }}
+    artifactName: ${{ parameters.artifactName }}
+  displayName: Download Build Artifact(s)

--- a/eng/common/templates/steps/init-docker-linux.yml
+++ b/eng/common/templates/steps/init-docker-linux.yml
@@ -5,6 +5,9 @@ parameters:
   cleanupDocker: true
 
 steps:
+- script: echo "##vso[task.setvariable variable=artifactsPath]/artifacts"
+  displayName: Define Artifacts Path Variable
+
   ################################################################################
   # Cleanup Docker Resources
   ################################################################################
@@ -38,13 +41,11 @@ steps:
       --build-arg IMAGE=$(imageNames.imageBuilder.linux)
       -f $(engCommonPath)/Dockerfile.WithRepo .
     displayName: Build Image for Image Builder
-  - script: echo "##vso[task.setvariable variable=imageBuilderArtifactsPath]/artifacts"
-    displayName: Define Image Builder Artifacts Path Variable
   - script: >
       echo "##vso[task.setvariable variable=runImageBuilderCmd]
       docker run --rm
       -v /var/run/docker.sock:/var/run/docker.sock
-      -v $(Build.ArtifactStagingDirectory):$(imageBuilderArtifactsPath)
+      -v $(Build.ArtifactStagingDirectory):$(artifactsPath)
       -w /repo
       $(dockerArmRunArgs)
       $(imageNames.imageBuilder.withrepo)"

--- a/eng/common/templates/steps/init-docker-windows.yml
+++ b/eng/common/templates/steps/init-docker-windows.yml
@@ -2,6 +2,9 @@ parameters:
   setupImageBuilder:  true
 
 steps:
+- script: echo "##vso[task.setvariable variable=artifactsPath]$(Build.ArtifactStagingDirectory)
+  displayName: Define Artifacts Path Variable
+
   ################################################################################
   # Cleanup Docker Resources
   ################################################################################
@@ -28,5 +31,3 @@ steps:
       echo "##vso[task.setvariable variable=runImageBuilderCmd]
       $(Build.BinariesDirectory)\.Microsoft.DotNet.ImageBuilder\Microsoft.DotNet.ImageBuilder.exe
     displayName: Define runImageBuilderCmd Variable
-  - script: echo "##vso[task.setvariable variable=imageBuilderArtifactsPath]$(Build.ArtifactStagingDirectory)
-    displayName: Define Image Builder Artifacts Path Variable

--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -2,6 +2,12 @@ parameters:
   useRemoteDockerServer: false
 
 steps:
+- template: init-docker-linux.yml
+  parameters:
+    setupRemoteDockerServer: ${{ parameters.useRemoteDockerServer }}
+    setupImageBuilder: false
+    setupTestRunner: true
+    cleanupDocker: ${{ eq(variables['System.TeamProject'], 'internal') }}
 - script: |
     echo "##vso[task.setvariable variable=testRunner.container]testrunner-$(Build.BuildId)-$(System.JobId)"
 
@@ -10,21 +16,16 @@ steps:
       optionalTestArgs="-DisableHttpVerification"
     fi
     if [ "${{ eq(variables['System.TeamProject'], 'public') }}" == "False" ]; then
-      optionalTestArgs="$optionalTestArgs -Registry $(acr.server) -RepoPrefix $(stagingRepoPrefix)"
+      optionalTestArgs="$optionalTestArgs -Registry $(acr.server) -RepoPrefix $(stagingRepoPrefix) -ImageInfoPath $(artifactsPath)/image-info/image-info.json"
     else
       optionalTestArgs="$optionalTestArgs -IsLocalRun"
     fi
     echo "##vso[task.setvariable variable=optionalTestArgs]$optionalTestArgs"
   displayName: Set Test Variables
-- template: init-docker-linux.yml
-  parameters:
-    setupRemoteDockerServer: ${{ parameters.useRemoteDockerServer }}
-    setupImageBuilder: false
-    setupTestRunner: true
-    cleanupDocker: ${{ eq(variables['System.TeamProject'], 'internal') }}
 - script: >
     docker run -t -d
     -v /var/run/docker.sock:/var/run/docker.sock
+    -v $(Build.ArtifactStagingDirectory):$(artifactsPath)
     -w /repo $(dockerArmRunArgs)
     -e RUNNING_TESTS_IN_CONTAINER=true 
     --name $(testRunner.container)
@@ -36,6 +37,9 @@ steps:
       -File $(engCommonRelativePath)/Invoke-WithRetry.ps1
       "docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)"
     displayName: Docker login
+- template: ../steps/download-build-artifact.yml
+  parameters:
+    targetPath: $(Build.ArtifactStagingDirectory)
 - script: >
     docker exec $(testRunner.container) pwsh
     -File ./tests/run-tests.ps1

--- a/eng/common/templates/steps/test-images-windows-client.yml
+++ b/eng/common/templates/steps/test-images-windows-client.yml
@@ -1,20 +1,23 @@
 steps:
-- powershell: |
-    if ("${{ eq(variables['System.TeamProject'], 'public') }}" -eq "False") {
-      $optionalTestArgs="-Registry $env:ACR_SERVER -RepoPrefix $env:STAGINGREPOPREFIX"
-    } else {
-      $optionalTestArgs="-IsLocalRun"
-    }
-    echo "##vso[task.setvariable variable=optionalTestArgs]$optionalTestArgs"
-  displayName: Set Test Variables
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - template: init-docker-windows.yml
     parameters:
       setupImageBuilder: false
   - script: docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)
     displayName: Docker login
+- powershell: |
+    if ("${{ eq(variables['System.TeamProject'], 'public') }}" -eq "False") {
+      $optionalTestArgs="-Registry $env:ACR_SERVER -RepoPrefix $env:STAGINGREPOPREFIX -ImageInfoPath $(artifactsPath)/image-info/image-info.json"
+    } else {
+      $optionalTestArgs="-IsLocalRun"
+    }
+    echo "##vso[task.setvariable variable=optionalTestArgs]$optionalTestArgs"
+  displayName: Set Test Variables
 - powershell: Get-ChildItem -Path tests -r | Where {$_.Extension -match "trx"} | Remove-Item
   displayName: Cleanup Old Test Results
+- template: ../steps/download-build-artifact.yml
+  parameters:
+    targetPath: $(Build.ArtifactStagingDirectory)
 - powershell: >
     ./tests/run-tests.ps1
     -VersionFilter $(dotnetVersion)

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,6 +1,6 @@
 variables:
-  imageNames.imageBuilder.linux: mcr.microsoft.com/dotnet-buildtools/image-builder:debian-20190620175920
-  imageNames.imageBuilder.windows: mcr.microsoft.com/dotnet-buildtools/image-builder:nanoserver-20190620175920
+  imageNames.imageBuilder.linux: mcr.microsoft.com/dotnet-buildtools/image-builder:debian-20190702171058
+  imageNames.imageBuilder.windows: mcr.microsoft.com/dotnet-buildtools/image-builder:nanoserver-20190702171058
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch-docker-testrunner-63f2145-20184325094343
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)


### PR DESCRIPTION
These changes update the build pipeline to provide support for the scenario described by #218. The goal is for the test stage to be able to run tests for an image that was built by the build but the test requires images that were not built during the build. An example of this is provided in #218.

To solve this, the image info files produced by the build are being utilized to track image tag information that can then be read by the test project to determine which images were actually produced by the build. For those images, the test code will pull them from the staging location, where they were pushed during the build stage. For any other images that the test requires, it will pull them from the public MCR location.

A new Post_Build stage has been added which calls Image Builder to consolidate all of the image info files produced by the build jobs into a single image info file that can be used by both test and publish jobs.