### PR TITLE
Include simple tags when merging image info

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
@@ -2,8 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
 
 namespace Microsoft.DotNet.ImageBuilder
@@ -21,53 +24,88 @@ namespace Microsoft.DotNet.ImageBuilder
                 }
                 else
                 {
-                    MergeImages(srcRepo, targetRepo);
+                    MergeData(srcRepo, targetRepo);
                 }
             }
         }
 
-        private static void MergeImages(RepoData srcRepo, RepoData targetRepo)
+        private static void MergeData(object srcObj, object targetObj)
         {
-            if (srcRepo.Images == null)
+            if (srcObj.GetType() != targetObj.GetType())
             {
-                return;
+                throw new ArgumentException("Object types don't match.", nameof(targetObj));
             }
 
-            if (srcRepo.Images.Any() && targetRepo.Images == null)
+            foreach (PropertyInfo property in srcObj.GetType().GetProperties())
             {
-                targetRepo.Images = srcRepo.Images;
-                return;
-            }
-
-            foreach (KeyValuePair<string, ImageData> srcKvp in srcRepo.Images)
-            {
-                if (targetRepo.Images.TryGetValue(srcKvp.Key, out ImageData targetImage))
+                if (property.PropertyType == typeof(string))
                 {
-                    MergeDigests(srcKvp.Value, targetImage);
+                    property.SetValue(targetObj, property.GetValue(srcObj));
+                }
+                else if (typeof(IDictionary).IsAssignableFrom(property.PropertyType))
+                {
+                    MergeDictionaries(property, srcObj, targetObj);
+                }
+                else if (typeof(IList<string>).IsAssignableFrom(property.PropertyType))
+                {
+                    MergeLists(property, srcObj, targetObj);
                 }
                 else
                 {
-                    targetRepo.Images.Add(srcKvp.Key, srcKvp.Value);
+                    throw new NotSupportedException("Unsupported model property type:" + property.PropertyType.FullName);
                 }
             }
         }
 
-        private static void MergeDigests(ImageData srcImage, ImageData targetImage)
+        private static void MergeLists(PropertyInfo property, object srcObj, object targetObj)
         {
-            if (srcImage.BaseImages == null)
+            IList<string> srcList = (IList<string>)property.GetValue(srcObj);
+            if (srcList == null)
             {
                 return;
             }
 
-            if (srcImage.BaseImages.Any() && targetImage.BaseImages == null)
+            IList<string> targetList = (IList<string>)property.GetValue(targetObj);
+
+            if (srcList.Any() && targetList == null)
             {
-                targetImage.BaseImages = srcImage.BaseImages;
+                property.SetValue(targetObj, srcList);
                 return;
             }
 
-            foreach (KeyValuePair<string, string> srcKvp in srcImage.BaseImages)
+            targetList = targetList
+                .Union(srcList)
+                .OrderBy(element => element)
+                .ToList();
+            property.SetValue(targetObj, targetList);
+        }
+
+        private static void MergeDictionaries(PropertyInfo property, object srcObj, object targetObj)
+        {
+            IDictionary srcDict = (IDictionary)property.GetValue(srcObj);
+            if (srcDict == null)
             {
-                targetImage.BaseImages[srcKvp.Key] = srcKvp.Value;
+                return;
+            }
+
+            IDictionary targetDict = (IDictionary)property.GetValue(targetObj);
+
+            if (srcDict.Cast<object>().Any() && targetDict == null)
+            {
+                property.SetValue(targetObj, srcDict);
+                return;
+            }
+
+            foreach (dynamic kvp in srcDict)
+            {
+                if (targetDict.Contains(kvp.Key))
+                {
+                    MergeData(kvp.Value, targetDict[kvp.Key]);
+                }
+                else
+                {
+                    targetDict[kvp.Key] = kvp.Value;
+                }
             }
         }
     }

--- a/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
@@ -103,7 +103,15 @@ namespace Microsoft.DotNet.ImageBuilder
                     {
                         if (targetDict.Contains(kvp.Key))
                         {
-                            MergeData(kvp.Value, targetDict[kvp.Key]);
+                            object newValue = kvp.Value;
+                            if (newValue is string)
+                            {
+                                targetDict[kvp.Key] = newValue;
+                            }
+                            else
+                            {
+                                MergeData(kvp.Value, targetDict[kvp.Key]);
+                            }
                         }
                         else
                         {

--- a/Microsoft.DotNet.ImageBuilder/tests/MergeInfoFilesCommandTests.cs
+++ b/Microsoft.DotNet.ImageBuilder/tests/MergeInfoFilesCommandTests.cs
@@ -13,10 +13,10 @@ using Xunit;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
-    public class MergeInfoFilesCommandTests
+    public class MergeImageInfoFilesCommandTests
     {
         [Fact]
-        public async Task MergeInfoFilesCommand_HappyPath()
+        public async Task MergeImageInfoFilesCommand_HappyPath()
         {
             using (TempFolderContext context = TestHelper.UseTempFolder())
             {
@@ -26,23 +26,78 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     {
                         new RepoData
                         {
-                            Repo = "repo1",
+                            Repo = "repo1"
                         },
                         new RepoData
                         {
                             Repo = "repo2",
-                        }
+                            Images = new SortedDictionary<string, ImageData>
+                            {
+                                {
+                                    "image1",
+                                    new ImageData()
+                                }
+                            }
+                        },
+                        new RepoData
+                        {
+                            Repo = "repo4",
+                            Images = new SortedDictionary<string, ImageData>
+                            {
+                                {
+                                    "image2",
+                                    new ImageData {
+                                        SimpleTags =
+                                        {
+                                            "tag1"
+                                        }
+                                    }
+                                }
+                            }
+                        },
                     },
                     new RepoData[]
                     {
                         new RepoData
                         {
                             Repo = "repo2",
+                            Images = new SortedDictionary<string, ImageData>
+                            {
+                                {
+                                    "image1",
+                                    new ImageData {
+                                        BaseImages = new SortedDictionary<string, string>
+                                        {
+                                            { "base1", "base1hash" }
+                                        },
+                                        SimpleTags =
+                                        {
+                                            "tag1"
+                                        }
+                                    }
+                                }
+                            }
                         },
                         new RepoData
                         {
                             Repo = "repo3",
-                        }
+                        },
+                        new RepoData
+                        {
+                            Repo = "repo4",
+                            Images = new SortedDictionary<string, ImageData>
+                            {
+                                {
+                                    "image2",
+                                    new ImageData {
+                                        SimpleTags =
+                                        {
+                                            "tag2"
+                                        }
+                                    }
+                                }
+                            }
+                        },
                     }
                 };
 
@@ -64,16 +119,49 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 {
                     new RepoData
                     {
-                        Repo = "repo1",
+                        Repo = "repo1"
                     },
                     new RepoData
                     {
                         Repo = "repo2",
+                        Images = new SortedDictionary<string, ImageData>
+                        {
+                            {
+                                "image1",
+                                new ImageData {
+                                    BaseImages = new SortedDictionary<string, string>
+                                    {
+                                        { "base1", "base1hash" }
+                                    },
+                                    SimpleTags =
+                                    {
+                                        "tag1"
+                                    }
+                                }
+                            }
+                        }
                     },
                     new RepoData
                     {
                         Repo = "repo3",
-                    }
+                    },
+                    new RepoData
+                    {
+                        Repo = "repo4",
+                        Images = new SortedDictionary<string, ImageData>
+                        {
+                            {
+                                "image2",
+                                new ImageData {
+                                    SimpleTags =
+                                    {
+                                        "tag1",
+                                        "tag2"
+                                    }
+                                }
+                            }
+                        }
+                    },
                 };
 
                 ImageInfoHelperTests.CompareRepos(expected, actual);
@@ -81,7 +169,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         }
 
         [Fact]
-        public async Task MergeInfoFilesCommand_SourceFolderPathNotFound()
+        public async Task MergeImageInfoFilesCommand_SourceFolderPathNotFound()
         {
             MergeImageInfoCommand command = new MergeImageInfoCommand();
             command.Options.SourceImageInfoFolderPath = "foo";
@@ -91,7 +179,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         }
 
         [Fact]
-        public async Task MergeInfoFilesCommand_SourceFolderEmpty()
+        public async Task MergeImageInfoFilesCommand_SourceFolderEmpty()
         {
             using (TempFolderContext context = TestHelper.UseTempFolder())
             {


### PR DESCRIPTION
Ensures that simple tags gets merged appropriately when merging image info data.  I've generalized the algorithm to use reflection to ensure that every property is accounted for to prevent issues like this in the future.  Updates unit tests to verify the scenario.

Fixes #233