### PR TITLE
Image info file support for CopyAcrImages cmd

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Azure.Management.ContainerRegistry.Fluent;
@@ -10,7 +12,9 @@ using Microsoft.Azure.Management.ContainerRegistry.Fluent.Models;
 using Microsoft.Azure.Management.Fluent;
 using Microsoft.Azure.Management.ResourceManager.Fluent;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Authentication;
+using Microsoft.DotNet.ImageBuilder.Models.Image;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
+using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
@@ -22,46 +26,95 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         public override async Task ExecuteAsync()
         {
-            Logger.WriteHeading("COPING IMAGES");
+            Logger.WriteHeading("COPYING IMAGES");
 
             string registryName = Manifest.Registry.TrimEnd(".azurecr.io");
 
-            await Task.WhenAll(Manifest.GetFilteredPlatformTags().Select(platformTag => ImportImage(platformTag, registryName)));
-        }
-
-        private async Task ImportImage(TagInfo platformTag, string registryName)
-        {
             AzureCredentials credentials = SdkContext.AzureCredentialsFactory
                 .FromServicePrincipal(Options.Username, Options.Password, Options.Tenant, AzureEnvironment.AzureGlobalCloud);
-            IAzure azure = Microsoft.Azure.Management.Fluent.Azure
+            IAzure azure = Azure.Management.Fluent.Azure
                 .Configure()
                 .Authenticate(credentials)
                 .WithSubscription(Options.Subscription);
 
-            string destTagName = platformTag.FullyQualifiedName.TrimStart($"{Manifest.Registry}/");
-            string sourceTagName = destTagName.Replace(Options.RepoPrefix, Options.SourceRepoPrefix);
-            ImportImageParametersInner importParams = new ImportImageParametersInner()
-            {
-                Mode = "Force",
-                Source = new ImportSource(
-                    sourceTagName,
-                    $"/subscriptions/{Options.Subscription}/resourceGroups/{Options.ResourceGroup}/providers" +
-                        $"/Microsoft.ContainerRegistry/registries/{registryName}"),
-                TargetTags = new string[] { destTagName }
-            };
+            IEnumerable<Task> importTasks = Manifest.FilteredRepos
+                .Select(repo =>
+                    repo.FilteredImages
+                        .SelectMany(image => image.FilteredPlatforms)
+                        .Select(platform => ImportImage(azure, repo, platform, registryName)))
+                .SelectMany(tasks => tasks);
 
-            Logger.WriteMessage($"Importing '{destTagName}' from '{sourceTagName}'");
+            await Task.WhenAll(importTasks);
+        }
 
-            if (!Options.IsDryRun)
+        private async Task ImportImage(IAzure azure, RepoInfo repo, PlatformInfo platform, string registryName)
+        {
+            List<string> destTagNames = null;
+
+            // If an image info file was provided, use the tags defined there rather than the manifest. This is intended
+            // to handle scenarios where the tag's value is dynamic, such as a timestamp, and we need to know the value
+            // of the tag for the image that was actually built rather than just generating new tag values when parsing
+            // the manifest.
+            if (!String.IsNullOrEmpty(Options.ImageInfoPath))
             {
-                try
+                RepoData[] repos = JsonConvert.DeserializeObject<RepoData[]>(File.ReadAllText(Options.ImageInfoPath));
+                RepoData repoData = repos.FirstOrDefault(repoData => repoData.Repo == repo.Model.Name);
+                if (repoData != null)
                 {
-                    await azure.ContainerRegistries.Inner.ImportImageAsync(Options.ResourceGroup, registryName, importParams);
+                    if (repoData.Images.TryGetValue(platform.BuildContextPath, out ImageData image))
+                    {
+                        destTagNames = image.SimpleTags
+                        .Select(tag => TagInfo.GetFullyQualifiedName(repo.Name, tag))
+                        .ToList();
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException($"Unable to find image info data for path '{platform.BuildContextPath}'.");
+                    }
                 }
-                catch (Exception e)
+                else
                 {
-                    Logger.WriteMessage($"Importing Failure:  {destTagName}{Environment.NewLine}{e}");
-                    throw;
+                    throw new InvalidOperationException($"Unable to find image info data for repo '{repo.Model.Name}'.");
+                }
+            }
+            
+            if (destTagNames == null)
+            {
+                destTagNames = platform.Tags
+                    .Select(tag => tag.FullyQualifiedName)
+                    .ToList();
+            }
+
+            destTagNames = destTagNames
+                .Select(tag => tag.TrimStart($"{Manifest.Registry}/"))
+                .ToList();
+
+            foreach (string destTagName in destTagNames)
+            {
+                string sourceTagName = destTagName.Replace(Options.RepoPrefix, Options.SourceRepoPrefix);
+                ImportImageParametersInner importParams = new ImportImageParametersInner()
+                {
+                    Mode = "Force",
+                    Source = new ImportSource(
+                        sourceTagName,
+                        $"/subscriptions/{Options.Subscription}/resourceGroups/{Options.ResourceGroup}/providers" +
+                            $"/Microsoft.ContainerRegistry/registries/{registryName}"),
+                    TargetTags = new string[] { destTagName }
+                };
+
+                Logger.WriteMessage($"Importing '{destTagName}' from '{sourceTagName}'");
+
+                if (!Options.IsDryRun)
+                {
+                    try
+                    {
+                        await azure.ContainerRegistries.Inner.ImportImageAsync(Options.ResourceGroup, registryName, importParams);
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.WriteMessage($"Importing Failure: {destTagName}{Environment.NewLine}{e}");
+                        throw;
+                    }
                 }
             }
         }

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesOptions.cs
@@ -17,6 +17,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public string Subscription { get; set; }
         public string Tenant { get; set; }
         public string Username { get; set; }
+        public string ImageInfoPath { get; set; }
 
         public CopyAcrImagesOptions() : base()
         {
@@ -27,6 +28,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             base.ParseCommandLine(syntax);
 
             FilterOptions.ParseCommandLine(syntax);
+
+            string imageInfoPath = null;
+            syntax.DefineOption("image-info", ref imageInfoPath, "Path to image info file");
+            ImageInfoPath = imageInfoPath;
 
             string sourceRepoPrefix = null;
             syntax.DefineParameter("source-repo-prefix", ref sourceRepoPrefix, "Prefix of the source ACR repository to copy images from");

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/TagInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/TagInfo.cs
@@ -3,7 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.IO;
+using System.Linq;
+using Microsoft.DotNet.ImageBuilder.Commands;
+using Microsoft.DotNet.ImageBuilder.Models.Image;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
+using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.ImageBuilder.ViewModel
 {
@@ -25,13 +30,20 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             VariableHelper variableHelper,
             string buildContextPath = null)
         {
-            TagInfo tagInfo = new TagInfo();
-            tagInfo.Model = model;
-            tagInfo.BuildContextPath = buildContextPath;
+            TagInfo tagInfo = new TagInfo
+            {
+                Model = model,
+                BuildContextPath = buildContextPath
+            };
             tagInfo.Name = variableHelper.SubstituteValues(name, tagInfo.GetVariableValue);
-            tagInfo.FullyQualifiedName = $"{repoName}:{tagInfo.Name}";
+            tagInfo.FullyQualifiedName = GetFullyQualifiedName(repoName, tagInfo.Name);
 
             return tagInfo;
+        }
+
+        public static string GetFullyQualifiedName(string repoName, string tagName)
+        {
+            return $"{repoName}:{tagName}";
         }
 
         private string GetVariableValue(string variableType, string variableName)


### PR DESCRIPTION
Updates the CopyAcrImages command to optionally incorporate the data from the image info file.  This is necessary to handle image tags that make use of dynamically generated values, such as timestamps.  Without these changes, Image Builder would calculate a new tag value each time it is invoked.  This is obviously not good when we're trying to reference the tag of an image that was built in a separate build step.

By making use of the image info file that was generated when the image was built, we know the exact static value of the tag that needs to be referenced.  So when the CopyAcrImages command runs and finds a Platform to process, it looks up the tag value in the image info file instead of using the value that was calculated when parsing the manifest.