### PR TITLE
Support providing additional test args.

### DIFF
--- a/eng/common/templates/steps/test-images-windows-client.yml
+++ b/eng/common/templates/steps/test-images-windows-client.yml
@@ -11,6 +11,9 @@ steps:
     } else {
       $optionalTestArgs="-IsLocalRun"
     }
+    if ($env:REPOTESTARGS) {
+      $optionalTestArgs += " $env:REPOTESTARGS"
+    }
     echo "##vso[task.setvariable variable=optionalTestArgs]$optionalTestArgs"
   displayName: Set Test Variables
 - powershell: Get-ChildItem -Path tests -r | Where {$_.Extension -match "trx"} | Remove-Item


### PR DESCRIPTION
* This is a port of changes made in https://github.com/microsoft/dotnet-framework-docker with the addition of the WCF and Asp.Net repos to be able to use a test argument to filter and only run applicable tests.