### PR TITLE
Remove subscription parameter to az login

### DIFF
--- a/eng/Invoke-AcrCleanup.ps1
+++ b/eng/Invoke-AcrCleanup.ps1
@@ -16,16 +16,13 @@ if ($suffixIndex -ge 0) {
     $RegistryName = $RegistryName.Substring(0, $suffixIndex)
 }
 
-if ($ServicePrincipalName) {
-    az login `
-        --subscription $SubscriptionId `
-        --service-principal `
-        --username $ServicePrincipalName `
-        --password $ServicePrincipalPassword `
-        --tenant $ServicePrincipalTenant
-} else {
-    az login --subscription $SubscriptionId
-}
+az login `
+    --service-principal `
+    --username $ServicePrincipalName `
+    --password $ServicePrincipalPassword `
+    --tenant $ServicePrincipalTenant
+
+az account set --subscription $SubscriptionId
 
 Write-Host "Querying registry '$RegistryName' for its repositories"
 Write-Host ""


### PR DESCRIPTION
The cleanup-acr-images pipeline recently broke because of a [change in the version](https://github.com/microsoft/azure-pipelines-image-generation/compare/ubuntu16/156.2...releases/ubuntu16/156#diff-f87405c9dd43f633a04dd078666d61afR7) of the az CLI used in the Hosted Ubuntu 16.04 pool.  The build was failing attempting to call `az login`.  This command no longer accepts a `subscription` parameter.  The fix is to remove that argument and set the subscription in a separate command.

I also removed the other condition when the `ServicePrincipalName` is not set since that's not a scenario that the pipeline uses.