### PR TITLE
Disable publish trimming

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
+++ b/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <PublishTrimmed>True</PublishTrimmed>
+    <PublishTrimmed>False</PublishTrimmed>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <RootNamespace>Microsoft.DotNet.ImageBuilder</RootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
The `PublishTrimmed` option in the ImageBuilder project is causing the resulting image to be inoperable.  It causes the following exception:
```
System.TypeLoadException: Could not load type 'System.Collections.Immutable.ImmutableDictionary`2' from assembly 'System.Diagnostics.TextWriterTraceListener, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.
   at Microsoft.DotNet.ImageBuilder.ViewModel.PlatformInfo.InitializeBuildArgs()
   at Microsoft.DotNet.ImageBuilder.ViewModel.PlatformInfo.Initialize(IEnumerable`1 internalRepos, String registry)
   at Microsoft.DotNet.ImageBuilder.ViewModel.ManifestInfo.Create(String manifestPath, ManifestFilter manifestFilter, IManifestOptionsInfo options)
   at Microsoft.DotNet.ImageBuilder.ViewModel.ManifestInfo.Load(IManifestOptionsInfo options)
   at Microsoft.DotNet.ImageBuilder.Commands.ManifestCommand`1.LoadManifest()
   at Microsoft.DotNet.ImageBuilder.ImageBuilder.Main(String[] args)
```

Setting this to false to resolve the issue.