### PR TITLE
Update PublishImageInfoCommand messages

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
@@ -51,14 +51,16 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     }
                 });
 
+                Uri imageInfoPathIdentifier = GitHelper.GetBlobUrl(Options.GitOptions);
+
                 if (gitRef != null)
                 {
                     Uri commitUrl = GitHelper.GetCommitUrl(Options.GitOptions, gitRef.Object.Sha);
-                    Logger.WriteMessage($"The '{Options.ImageInfoPath}' file was updated ({commitUrl}).");
+                    Logger.WriteMessage($"The '{imageInfoPathIdentifier}' file was updated ({commitUrl}).");
                 }
                 else
                 {
-                    Logger.WriteMessage($"No changes to the '{Options.ImageInfoPath}' file were needed.");
+                    Logger.WriteMessage($"No changes to the '{imageInfoPathIdentifier}' file were needed.");
                 }
             });
         }

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/RebuildStaleImagesCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/RebuildStaleImagesCommand.cs
@@ -215,8 +215,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 if (!this.gitRepoIdToPathMapping.TryGetValue(uniqueName, out repoPath))
                 {
                     string extractPath = Path.Combine(Path.GetTempPath(), uniqueName);
-                    string repoContentsUrl =
-                        $"https://www.github.com/{sub.RepoInfo.Owner}/{sub.RepoInfo.Name}/archive/{sub.RepoInfo.Branch}.zip";
+                    Uri repoContentsUrl = GitHelper.GetArchiveUrl(sub.RepoInfo);
                     string zipPath = Path.Combine(Path.GetTempPath(), $"{uniqueName}.zip");
                     File.WriteAllBytes(zipPath, await this.httpClient.GetByteArrayAsync(repoContentsUrl));
 

--- a/Microsoft.DotNet.ImageBuilder/src/GitHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/GitHelper.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Commands;
+using Microsoft.DotNet.ImageBuilder.Models.Subscription;
 using Microsoft.DotNet.VersionTools.Automation;
 using Microsoft.DotNet.VersionTools.Automation.GitHubApi;
 
@@ -26,6 +27,16 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             Process gitLogProcess = ExecuteHelper.Execute(
                 startInfo, false, $"Unable to retrieve the latest commit SHA for {filePath}");
             return gitLogProcess.StandardOutput.ReadToEnd().Trim();
+        }
+
+        public static Uri GetArchiveUrl(GitRepo gitRepo)
+        {
+            return new Uri($"https://github.com/{gitRepo.Owner}/{gitRepo.Name}/archive/{gitRepo.Branch}.zip");
+        }
+
+        public static Uri GetBlobUrl(GitOptions gitOptions)
+        {
+            return new Uri($"https://github.com/{gitOptions.Owner}/{gitOptions.Repo}/blob/{gitOptions.Branch}/{gitOptions.Path}");
         }
 
         public static Uri GetCommitUrl(GitOptions gitOptions, string sha)

--- a/Microsoft.DotNet.ImageBuilder/tests/RebuildStaleImagesCommandTests.cs
+++ b/Microsoft.DotNet.ImageBuilder/tests/RebuildStaleImagesCommandTests.cs
@@ -908,7 +908,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     string repoZipPath = GenerateRepoZipFile(subscription, manifest, repoDockerfileInfos);
 
                     responses.Add(
-                        $"https://www.github.com/{subscription.RepoInfo.Owner}/{subscription.RepoInfo.Name}/archive/{subscription.RepoInfo.Branch}.zip",
+                        $"https://github.com/{subscription.RepoInfo.Owner}/{subscription.RepoInfo.Name}/archive/{subscription.RepoInfo.Branch}.zip",
                         new HttpResponseMessage
                         {
                             StatusCode = HttpStatusCode.OK,


### PR DESCRIPTION
The PublishImageInfoCommand is writing status messages indicating that the _source_ image file was either updated or not, when in fact it should be referring to the _destination_ image file (the one in GitHub).  Fixed this and also centralized the construction of GitHub URLs into the GitHelper class.