### PR TITLE
Replace tags when merging image info

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/Commands/MergeImageInfoCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/MergeImageInfoCommand.cs
@@ -24,6 +24,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 SearchOption.AllDirectories);
 
             List<RepoData[]> srcReposList = imageInfoFiles
+                .OrderBy(file => file) // Ensure the files are ordered for testing consistency between OS's.
                 .Select(imageDataPath => JsonConvert.DeserializeObject<RepoData[]>(File.ReadAllText(imageDataPath)))
                 .ToList();
 

--- a/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
@@ -73,10 +73,8 @@ namespace Microsoft.DotNet.ImageBuilder
             }
         }
 
-        private static void ReplaceValue(PropertyInfo property, object srcObj, object targetObj)
-        {
+        private static void ReplaceValue(PropertyInfo property, object srcObj, object targetObj) =>
             property.SetValue(targetObj, property.GetValue(srcObj));
-        }
 
         private static void MergeLists(PropertyInfo property, object srcObj, object targetObj)
         {

--- a/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
@@ -48,13 +48,34 @@ namespace Microsoft.DotNet.ImageBuilder
                 }
                 else if (typeof(IList<string>).IsAssignableFrom(property.PropertyType))
                 {
-                    MergeLists(property, srcObj, targetObj);
+                    if (srcObj is ImageData && property.Name == nameof(ImageData.SimpleTags))
+                    {
+                        // SimpleTags are not to be merged. If an image is built, all of its tags are generated. There
+                        // would never be a case where an image gets built and only a subset of the tags specified in
+                        // the manifest are applied to the image.  So that means that the source image data indicates
+                        // the current "truth" of what the image's tags are. Any of the image's tags contained in the
+                        // target should be considered obsolete and should be replaced by the source.  This accounts
+                        // for the scenario where shared tags are moved from one image to another. If we had merged
+                        // instead of replaced, then the shared tag would not have been removed from the original image
+                        // in the image info in such a scenario.
+
+                        ReplaceValue(property, srcObj, targetObj);
+                    }
+                    else
+                    {
+                        MergeLists(property, srcObj, targetObj);
+                    }
                 }
                 else
                 {
                     throw new NotSupportedException($"Unsupported model property type: '{property.PropertyType.FullName}'");
                 }
             }
+        }
+
+        private static void ReplaceValue(PropertyInfo property, object srcObj, object targetObj)
+        {
+            property.SetValue(targetObj, property.GetValue(srcObj));
         }
 
         private static void MergeLists(PropertyInfo property, object srcObj, object targetObj)

--- a/Microsoft.DotNet.ImageBuilder/tests/ImageInfoHelperTests.cs
+++ b/Microsoft.DotNet.ImageBuilder/tests/ImageInfoHelperTests.cs
@@ -173,6 +173,96 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             CompareRepos(expected, targetRepos);
         }
 
+        /// <summary>
+        /// Verifies that tags are removed from existing images in the target
+        /// if the same tag doesn't exist in the source. This handles cases where
+        /// a shared tag has been moved from one image to another.
+        /// </summary>
+        [Fact]
+        public void ImageInfoHelper_MergeRepos_RemoveTag()
+        {
+            ImageData srcImage1;
+            ImageData targetImage2;
+
+            RepoData[] repoDataSet = new RepoData[]
+            {
+                new RepoData
+                {
+                    Repo = "repo1",
+                    Images = new SortedDictionary<string, ImageData>
+                    {
+                        {
+                            "image1",
+                            srcImage1 = new ImageData
+                            {
+                                SimpleTags =
+                                {
+                                    "tag1",
+                                    "tag3"
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            List<RepoData> targetRepos = new List<RepoData>
+            {
+                new RepoData
+                {
+                    Repo = "repo1",
+                    Images = new SortedDictionary<string, ImageData>
+                    {
+                        {
+                            "image1",
+                            new ImageData
+                            {
+                                SimpleTags =
+                                {
+                                    "tag1",
+                                    "tag2",
+                                    "tag4"
+                                }
+                            }
+                        },
+                        {
+                            "image2",
+                            targetImage2 = new ImageData
+                            {
+                                SimpleTags =
+                                {
+                                    "a"
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            ImageInfoHelper.MergeRepos(repoDataSet, targetRepos);
+
+            List<RepoData> expected = new List<RepoData>
+            {
+                new RepoData
+                {
+                    Repo = "repo1",
+                    Images = new SortedDictionary<string, ImageData>
+                    {
+                        {
+                            "image1",
+                            srcImage1
+                        },
+                        {
+                            "image2",
+                            targetImage2
+                        }
+                    }
+                }
+            };
+
+            CompareRepos(expected, targetRepos);
+        }
+
         public static void CompareRepos(IList<RepoData> expected, IList<RepoData> actual)
         {
             Assert.Equal(JsonHelper.SerializeObject(expected), JsonHelper.SerializeObject(actual));

--- a/Microsoft.DotNet.ImageBuilder/tests/MergeInfoFilesCommandTests.cs
+++ b/Microsoft.DotNet.ImageBuilder/tests/MergeInfoFilesCommandTests.cs
@@ -155,7 +155,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                 new ImageData {
                                     SimpleTags =
                                     {
-                                        "tag1",
+                                        // Since SimpleTags get replaced rather than merged
                                         "tag2"
                                     }
                                 }


### PR DESCRIPTION
There's an issue with the image info merging logic that was exposed when moving a shared tag.  In this case, the shared tag `3.0-alpine` was moved from the Alpine 3.9-based images to Alpine 3.10 in the manifest.  The images were tagged appropriately but when the image info file was updated during the publish stage, the Alpine 3.9-based images in the image info continued to list `3.0-alpine` as a tag in addition to the Alpine 3.10-based images correctly listing `3.0-alpine`.  See this [commit](https://github.com/dotnet/versions/blob/31981d050666cd82e6dc472223ebf2908a916041/build-info/docker/image-info.dotnet-dotnet-docker-nightly.json#L185) for the issue.

To fix this, the merge logic is updated to always replace the `SimpleTags` list such that the source image's tag always overwrite the target's tags in the image info.