### PR TITLE
Separate RebuildStaleImagesCommand into two separate commands

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
@@ -144,7 +144,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         return $" \"{leg.Name}\": {{{variables} }}";
                     })
                     .Aggregate((working, next) => $"{working},{next}");
-                Logger.WriteMessage($"##vso[task.setvariable variable={matrix.Name};isoutput=true]{{{legs} }}");
+                Logger.WriteMessage(PipelineHelper.FormatOutputVariable(matrix.Name, $"{{{legs}}}"));
             }
         }
 

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
@@ -57,11 +57,20 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         ImagePaths = (await GetPathsToRebuildAsync(s, repos)).ToArray()
                     }));
 
+                // Filter out any results that don't have any images to rebuild
+                results = results
+                    .Where(result => result.ImagePaths.Any())
+                    .ToArray();
+
                 string outputString = JsonConvert.SerializeObject(results);
 
                 this.loggerService.WriteMessage(
                     PipelineHelper.FormatOutputVariable(Options.VariableName, outputString)
                         .Replace("\"", "\\\"")); // Escape all quotes
+
+                string formattedResults = JsonConvert.SerializeObject(results, Formatting.Indented);
+                this.loggerService.WriteMessage(
+                    $"Image Paths to be Rebuilt:{Environment.NewLine}{formattedResults}");
             }
             finally
             {

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesOptions.cs
@@ -40,9 +40,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             string variableName = null;
             syntax.DefineParameter(
-                "variable",
+                "image-paths-variable",
                 ref variableName,
-                "The variable name to assign the image paths to");
+                "The Azure Pipeline variable name to assign the image paths to");
             VariableName = variableName;
         }
     }

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesOptions.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.CommandLine;
+
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    public class GetStaleImagesOptions : Options, IFilterableOptions
+    {
+        protected override string CommandHelp => "Gets paths to images whose base images are out-of-date";
+
+        public ManifestFilterOptions FilterOptions { get; } = new ManifestFilterOptions();
+
+        public string SubscriptionsPath { get; set; }
+        public string ImageInfoPath { get; set; }
+        public string VariableName { get; set; }
+
+        public override void ParseCommandLine(ArgumentSyntax syntax)
+        {
+            base.ParseCommandLine(syntax);
+
+            FilterOptions.ParseCommandLine(syntax);
+
+            const string DefaultSubscriptionsPath = "subscriptions.json";
+            string subscriptionsPath = DefaultSubscriptionsPath;
+            syntax.DefineOption(
+                "subscriptions-path",
+                ref subscriptionsPath,
+                $"Path to the subscriptions file (defaults to '{DefaultSubscriptionsPath}').");
+            SubscriptionsPath = subscriptionsPath;
+
+            const string DefaultImageInfoPath = "image-info.json";
+            string imageDataPath = DefaultImageInfoPath;
+            syntax.DefineOption(
+                "image-info-path",
+                ref imageDataPath,
+                $"Path to the file containing image info (defaults to '{DefaultImageInfoPath}').");
+            ImageInfoPath = imageDataPath;
+
+            string variableName = null;
+            syntax.DefineParameter(
+                "variable",
+                ref variableName,
+                "The variable name to assign the image paths to");
+            VariableName = variableName;
+        }
+    }
+}

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/QueueBuildCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/QueueBuildCommand.cs
@@ -1,0 +1,148 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.DotNet.ImageBuilder.Models.Subscription;
+using Microsoft.DotNet.ImageBuilder.Services;
+using Microsoft.TeamFoundation.Build.WebApi;
+using Microsoft.TeamFoundation.Core.WebApi;
+using Microsoft.VisualStudio.Services.Common;
+using Microsoft.VisualStudio.Services.WebApi;
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    [Export(typeof(ICommand))]
+    public class QueueBuildCommand : Command<QueueBuildOptions>
+    {
+        private readonly Dictionary<string, string> gitRepoIdToPathMapping = new Dictionary<string, string>();
+        private readonly IVssConnectionFactory connectionFactory;
+        private readonly ILoggerService loggerService;
+
+        [ImportingConstructor]
+        public QueueBuildCommand(
+            IVssConnectionFactory connectionFactory,
+            ILoggerService loggerService)
+        {
+            this.connectionFactory = connectionFactory;
+            this.loggerService = loggerService;
+        }
+
+        public override async Task ExecuteAsync()
+        {
+            string subscriptionsJson = File.ReadAllText(Options.SubscriptionsPath);
+            Subscription[] subscriptions = JsonConvert.DeserializeObject<Subscription[]>(subscriptionsJson);
+            Dictionary<string, string> consolidatedSubscriptionsData = GetConsolidatedSubscriptions();
+
+            try
+            {
+                if (consolidatedSubscriptionsData.Any())
+                {
+                    await Task.WhenAll(
+                        consolidatedSubscriptionsData.Select(
+                            kvp => QueueBuildForStaleImages(subscriptions.First(sub => sub.Id == kvp.Key), kvp.Value)));
+                }
+                else
+                {
+                    this.loggerService.WriteMessage($"None of the subscriptions have base images that are out-of-date. No rebuild necessary.");
+                }
+            }
+            finally
+            {
+                foreach (string repoPath in gitRepoIdToPathMapping.Values)
+                {
+                    // The path to the repo is stored inside a zip extraction folder so be sure to delete that
+                    // zip extraction folder, not just the inner repo folder.
+                    Directory.Delete(new DirectoryInfo(repoPath).Parent.FullName, true);
+                }
+            }
+        }
+
+        private Dictionary<string, string> GetConsolidatedSubscriptions()
+        {
+            // This data comes from the GetStaleImagesCommand and represents a mapping of a subscription to the Dockerfile paths
+            // of the images that need to be built. A given subscription may have images that are spread across Linux/Windows, AMD64/ARM
+            // which means that the paths collected for that subscription were spread across multiple jobs.  Each of the items in the 
+            // Enumerable here represents the data collected by one job.  We need to consolidate the paths for a given subscription since
+            // they could be spread across multiple items in the Enumerable.
+            IEnumerable<Dictionary<string, string>> allSubscriptionsData = Options.Subscriptions
+                .Select(subscriptionsData => JsonConvert.DeserializeObject<Dictionary<string, string>>(subscriptionsData))
+                .ToList();
+
+            Dictionary<string, string> consolidatedSubscriptionsData = new Dictionary<string, string>();
+            foreach (Dictionary<string, string> subscriptionData in allSubscriptionsData)
+            {
+                foreach (KeyValuePair<string, string> kvp in subscriptionData.Where(kvp => !String.IsNullOrEmpty(kvp.Value)))
+                {
+                    if (consolidatedSubscriptionsData.TryGetValue(kvp.Key, out string paths))
+                    {
+                        consolidatedSubscriptionsData[kvp.Key] = $"{paths} {kvp.Value}";
+                    }
+                    else
+                    {
+                        consolidatedSubscriptionsData.Add(kvp.Key, kvp.Value);
+                    }
+                }
+            }
+
+            return consolidatedSubscriptionsData;
+        }
+
+        private async Task QueueBuildForStaleImages(Subscription subscription, string pathsToRebuild)
+        {
+            if (String.IsNullOrEmpty(pathsToRebuild))
+            {
+                this.loggerService.WriteMessage($"All images for subscription '{subscription}' are using up-to-date base images. No rebuild necessary.");
+                return;
+            }
+
+            string parameters = "{\"" + subscription.PipelineTrigger.PathVariable + "\": \"" + pathsToRebuild + "\"}";
+
+            this.loggerService.WriteMessage($"Queueing build for subscription {subscription} with parameters {parameters}.");
+
+            if (Options.IsDryRun)
+            {
+                return;
+            }
+
+            using (IVssConnection connection = this.connectionFactory.Create(
+                new Uri($"https://dev.azure.com/{Options.BuildOrganization}"),
+                new VssBasicCredential(String.Empty, Options.BuildPersonalAccessToken)))
+            using (IProjectHttpClient projectHttpClient = connection.GetProjectHttpClient())
+            using (IBuildHttpClient client = connection.GetBuildHttpClient())
+            {
+                TeamProject project = await projectHttpClient.GetProjectAsync(Options.BuildProject);
+
+                Build build = new Build
+                {
+                    Project = new TeamProjectReference { Id = project.Id },
+                    Definition = new BuildDefinitionReference { Id = subscription.PipelineTrigger.Id },
+                    SourceBranch = subscription.RepoInfo.Branch,
+                    Parameters = parameters
+                };
+
+                if (await HasInProgressBuildAsync(client, subscription.PipelineTrigger.Id, project.Id))
+                {
+                    this.loggerService.WriteMessage(
+                        $"An in-progress build was detected on the pipeline for subscription '{subscription.ToString()}'. Queueing the build will be skipped.");
+                    return;
+                }
+
+                await client.QueueBuildAsync(build);
+            }
+        }
+
+        private async Task<bool> HasInProgressBuildAsync(IBuildHttpClient client, int pipelineId, Guid projectId)
+        {
+            IPagedList<Build> builds = await client.GetBuildsAsync(
+                projectId, definitions: new int[] { pipelineId }, statusFilter: BuildStatus.InProgress);
+            return builds.Any();
+        }
+    }
+}

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/QueueBuildOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/QueueBuildOptions.cs
@@ -2,27 +2,25 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Generic;
 using System.CommandLine;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
-    public class RebuildStaleImagesOptions : Options, IFilterableOptions
+    public class QueueBuildOptions : Options
     {
-        protected override string CommandHelp => "Queues builds to update any images with out-of-date base images";
-
-        public ManifestFilterOptions FilterOptions { get; } = new ManifestFilterOptions();
+        protected override string CommandHelp => "Queues builds to update images";
 
         public string SubscriptionsPath { get; set; }
-        public string ImageInfoPath { get; set; }
         public string BuildPersonalAccessToken { get; set; }
         public string BuildOrganization { get; set; }
         public string BuildProject { get; set; }
+        public IEnumerable<string> Subscriptions { get; set; }
 
         public override void ParseCommandLine(ArgumentSyntax syntax)
         {
             base.ParseCommandLine(syntax);
-
-            FilterOptions.ParseCommandLine(syntax);
 
             const string DefaultSubscriptionsPath = "subscriptions.json";
             string subscriptionsPath = DefaultSubscriptionsPath;
@@ -32,13 +30,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 $"Path to the subscriptions file (defaults to '{DefaultSubscriptionsPath}').");
             SubscriptionsPath = subscriptionsPath;
 
-            const string DefaultImageInfoPath = "image-info.json";
-            string imageDataPath = DefaultImageInfoPath;
-            syntax.DefineOption(
-                "image-info-path",
-                ref imageDataPath,
-                $"Path to the file containing image info (defaults to '{DefaultImageInfoPath}').");
-            ImageInfoPath = imageDataPath;
+            // These values come from the output variable of GetStaleImagesCommand
+            IReadOnlyList<string> subscriptions = Array.Empty<string>();
+            syntax.DefineOptionList(
+                "subscriptions",
+                ref subscriptions,
+                "Subscriptions data describing paths to be built");
+            Subscriptions = subscriptions;
 
             string buildPersonalAccessToken = null;
             syntax.DefineParameter(

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/QueueBuildOptions.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/QueueBuildOptions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public string BuildPersonalAccessToken { get; set; }
         public string BuildOrganization { get; set; }
         public string BuildProject { get; set; }
-        public IEnumerable<string> Subscriptions { get; set; }
+        public IEnumerable<string> AllSubscriptionImagePaths { get; set; }
 
         public override void ParseCommandLine(ArgumentSyntax syntax)
         {
@@ -30,13 +30,12 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 $"Path to the subscriptions file (defaults to '{DefaultSubscriptionsPath}').");
             SubscriptionsPath = subscriptionsPath;
 
-            // These values come from the output variable of GetStaleImagesCommand
-            IReadOnlyList<string> subscriptions = Array.Empty<string>();
+            IReadOnlyList<string> allSubscriptionImagePaths = Array.Empty<string>();
             syntax.DefineOptionList(
-                "subscriptions",
-                ref subscriptions,
-                "Subscriptions data describing paths to be built");
-            Subscriptions = subscriptions;
+                "image-paths",
+                ref allSubscriptionImagePaths,
+                "JSON string mapping a subscription ID to the image paths to be built (from the output variable of getStaleImages)");
+            AllSubscriptionImagePaths = allSubscriptionImagePaths;
 
             string buildPersonalAccessToken = null;
             syntax.DefineParameter(

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/SubscriptionImagePaths.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/SubscriptionImagePaths.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    public class SubscriptionImagePaths
+    {
+        public string SubscriptionId { get; set; }
+
+        public string[] ImagePaths { get; set; }
+    }
+}

--- a/Microsoft.DotNet.ImageBuilder/src/Models/Subscription/Subscription.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Models/Subscription/Subscription.cs
@@ -17,9 +17,11 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Subscription
         [JsonProperty(Required = Required.Always)]
         public PipelineTrigger PipelineTrigger { get; set; }
 
+        public string Id => $"{RepoInfo.Owner}/{RepoInfo.Name}/{RepoInfo.Branch}/{ManifestPath}";
+
         public override string ToString()
         {
-            return $"{RepoInfo.Owner}/{RepoInfo.Name}/{RepoInfo.Branch}/{ManifestPath}";
+            return Id;
         }
     }
 }

--- a/Microsoft.DotNet.ImageBuilder/src/Models/Subscription/Subscription.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Models/Subscription/Subscription.cs
@@ -19,9 +19,6 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Subscription
 
         public string Id => $"{RepoInfo.Owner}/{RepoInfo.Name}/{RepoInfo.Branch}/{ManifestPath}";
 
-        public override string ToString()
-        {
-            return Id;
-        }
+        public override string ToString() => Id;
     }
 }

--- a/Microsoft.DotNet.ImageBuilder/src/PipelineHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/PipelineHelper.cs
@@ -6,9 +6,7 @@ namespace Microsoft.DotNet.ImageBuilder
 {
     public static class PipelineHelper
     {
-        public static string FormatOutputVariable(string variableName, string value)
-        {
-            return $"##vso[task.setvariable variable={variableName};isoutput=true]{value}";
-        }
+        public static string FormatOutputVariable(string variableName, string value) =>
+            $"##vso[task.setvariable variable={variableName};isoutput=true]{value}";
     }
 }

--- a/Microsoft.DotNet.ImageBuilder/src/PipelineHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/PipelineHelper.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.ImageBuilder
+{
+    public static class PipelineHelper
+    {
+        public static string FormatOutputVariable(string variableName, string value)
+        {
+            return $"##vso[task.setvariable variable={variableName};isoutput=true]{value}";
+        }
+    }
+}

--- a/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
+++ b/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
@@ -772,24 +772,19 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Assert.Equal(VariableName, actualVariableName);
 
                 string variableValue = message
-                    .Substring(message.LastIndexOf("]") + 1);
+                    .Substring(message.IndexOf("]") + 1);
 
-                Dictionary<string, string> pathsBySubscription = 
-                    JsonConvert.DeserializeObject<Dictionary<string, string>>(variableValue.Replace("\\\"", "\""));
+                SubscriptionImagePaths[] pathsBySubscription = 
+                    JsonConvert.DeserializeObject<SubscriptionImagePaths[]>(variableValue.Replace("\\\"", "\""));
 
-                Assert.Equal(expectedPathsBySubscription.Count, pathsBySubscription.Count);
+                Assert.Equal(expectedPathsBySubscription.Count, pathsBySubscription.Length);
 
                 foreach (KeyValuePair<Subscription, IList<string>> kvp in expectedPathsBySubscription)
                 {
-                    string actualPaths = pathsBySubscription[kvp.Key.Id];
+                    string[] actualPaths = pathsBySubscription
+                        .First(imagePaths => imagePaths.SubscriptionId == kvp.Key.Id).ImagePaths;
 
-                    IList<string> paths = actualPaths
-                        .Split(" ", StringSplitOptions.RemoveEmptyEntries)
-                        .Where(path => path != "--path")
-                        .Select(p => p.Trim().Trim('\''))
-                        .ToList();
-
-                    Assert.Equal(kvp.Value, paths);
+                    Assert.Equal(kvp.Value, actualPaths);
                 }
             }
 

--- a/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
+++ b/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
@@ -205,8 +205,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         {
             const string repo1 = "test-repo";
             const string repo2 = "test-repo2";
+            const string repo3 = "test-repo3";
             const string dockerfile1Path = "dockerfile1";
             const string dockerfile2Path = "dockerfile2";
+            const string dockerfile3Path = "dockerfile3";
 
             RepoData[] imageInfoData = new RepoData[]
             {
@@ -243,6 +245,23 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             }
                         }
                     }
+                },
+                new RepoData
+                {
+                    Repo = repo3,
+                    Images = new SortedDictionary<string, ImageData>
+                    {
+                        {
+                            dockerfile3Path,
+                            new ImageData
+                            {
+                                BaseImages = new SortedDictionary<string, string>
+                                {
+                                    { "base3", "base3digest" }
+                                }
+                            }
+                        }
+                    }
                 }
             };
 
@@ -269,7 +288,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         ManifestHelper.CreateRepo(
                             repo2,
                             ManifestHelper.CreateImage(
-                                ManifestHelper.CreatePlatform(dockerfile2Path, "tag2"))))
+                                ManifestHelper.CreatePlatform(dockerfile2Path, "tag2"))),
+                        ManifestHelper.CreateRepo(
+                            repo3,
+                            ManifestHelper.CreateImage(
+                                ManifestHelper.CreatePlatform(dockerfile3Path, "tag3"))))
                 }
             };
 
@@ -287,7 +310,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     subscriptions[1].RepoInfo,
                     new List<DockerfileInfo>
                     {
-                        new DockerfileInfo(dockerfile2Path, "base2", "base2digest")
+                        new DockerfileInfo(dockerfile2Path, "base2", "base2digest"),
+                        new DockerfileInfo(dockerfile3Path, "base3", "base3digest")
                     }
                 }
             };
@@ -491,17 +515,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             {
                 await context.ExecuteCommandAsync();
 
+                // No paths are expected
                 Dictionary<Subscription, IList<string>> expectedPathsBySubscription =
-                    new Dictionary<Subscription, IList<string>>
-                {
-                    {
-                        subscriptions[0],
-                        new List<string>
-                        {
-                            // No paths are expected
-                        }
-                    }
-                };
+                    new Dictionary<Subscription, IList<string>>();
 
                 context.Verify(expectedPathsBySubscription);
             }

--- a/Microsoft.DotNet.ImageBuilder/tests/QueueBuildCommandTests.cs
+++ b/Microsoft.DotNet.ImageBuilder/tests/QueueBuildCommandTests.cs
@@ -1,0 +1,524 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Microsoft.DotNet.ImageBuilder.Commands;
+using Microsoft.DotNet.ImageBuilder.Models.Subscription;
+using Microsoft.DotNet.ImageBuilder.Services;
+using Microsoft.TeamFoundation.Build.WebApi;
+using Microsoft.TeamFoundation.Core.WebApi;
+using Microsoft.VisualStudio.Services.Common;
+using Microsoft.VisualStudio.Services.WebApi;
+using Moq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.DotNet.ImageBuilder.Tests
+{
+    public class QueueBuildCommandTests
+    {
+        /// <summary>
+        /// Verifies that no build is queued if a build is currently in progress.
+        /// </summary>
+        [Fact]
+        public async Task QueueBuildCommand_BuildInProgress()
+        {
+            const string path1 = "path1";
+
+            Subscription[] subscriptions = new Subscription[]
+            {
+                CreateSubscription("repo1")
+            };
+
+            List<Dictionary<string, List<string>>> pathData = new List<Dictionary<string, List<string>>>
+            {
+                new Dictionary<string, List<string>>
+                {
+                    {
+                        subscriptions[0].Id,
+                        new List<string>
+                        {
+                            path1
+                        }
+                    }
+                }
+            };
+
+            using (TestContext context = new TestContext(subscriptions, pathData, hasInProgressBuild: true))
+            {
+                await context.ExecuteCommandAsync();
+
+                // Normally this state would cause a build to be queued but since
+                // a build is marked as in progress, it doesn't.
+
+                context.Verify();
+            }
+        }
+
+        /// <summary>
+        /// Verifies the correct path arguments are passed to the queued builds for two
+        /// subscriptions that have image paths.
+        /// </summary>
+        [Fact]
+        public async Task QueueBuildCommand_MultiSubscription()
+        {
+            const string path1 = "path1";
+            const string path2 = "path2";
+            const string path3 = "path3";
+
+            Subscription[] subscriptions = new Subscription[]
+            {
+                CreateSubscription("repo1"),
+                CreateSubscription("repo2")
+            };
+
+            List<Dictionary<string, List<string>>> pathData = new List<Dictionary<string, List<string>>>
+            {
+                new Dictionary<string, List<string>>
+                {
+                    {
+                        subscriptions[0].Id,
+                        new List<string>
+                        {
+                            path1
+                        }
+                    },
+                    {
+                        subscriptions[1].Id,
+                        new List<string>
+                        {
+                            path2
+                        }
+                    }
+                },
+                new Dictionary<string, List<string>>
+                {
+                    {
+                        subscriptions[1].Id,
+                        new List<string>
+                        {
+                            path3
+                        }
+                    }
+                }
+            };
+
+            using (TestContext context = new TestContext(subscriptions, pathData))
+            {
+                await context.ExecuteCommandAsync();
+
+                Dictionary<Subscription, IList<string>> expectedPathsBySubscription =
+                    new Dictionary<Subscription, IList<string>>
+                {
+                    {
+                        subscriptions[0],
+                        new List<string>
+                        {
+                            path1
+                        }
+                    },
+                    {
+                        subscriptions[1],
+                        new List<string>
+                        {
+                            path2,
+                            path3
+                        }
+                    }
+                };
+
+                context.Verify(expectedPathsBySubscription);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that no build will be queued if no paths are specified.
+        /// </summary>
+        [Fact]
+        public async Task QueueBuildCommand_NoBaseImageChange()
+        {
+            Subscription[] subscriptions = new Subscription[]
+            {
+                CreateSubscription("repo1")
+            };
+
+            List<Dictionary<string, List<string>>> pathData = new List<Dictionary<string, List<string>>>
+            {
+                new Dictionary<string, List<string>>
+                {
+                    {
+                        subscriptions[0].Id,
+                        new List<string>()
+                    }
+                },
+                new Dictionary<string, List<string>>
+                {
+                    {
+                        subscriptions[0].Id,
+                        new List<string>()
+                    }
+                }
+            };
+
+            using (TestContext context = new TestContext(subscriptions, pathData))
+            {
+                await context.ExecuteCommandAsync();
+
+                Dictionary<Subscription, IList<string>> expectedPathsBySubscription =
+                    new Dictionary<Subscription, IList<string>>
+                {
+                    {
+                        subscriptions[0],
+                        new List<string>
+                        {
+                            // No paths are expected
+                        }
+                    }
+                };
+
+                context.Verify(expectedPathsBySubscription);
+            }
+        }
+
+        /// <summary>
+        /// Verifies the correct path arguments are passed to the queued build a subscription is spread
+        /// across multiple path sets.
+        /// </summary>
+        [Fact]
+        public async Task QueueBuildCommand_Subscription_MultiSet()
+        {
+            const string path1 = "path1";
+            const string path2 = "path2";
+            const string path3 = "path3";
+
+            Subscription[] subscriptions = new Subscription[]
+            {
+                CreateSubscription("repo1")
+            };
+
+            List<Dictionary<string, List<string>>> pathData = new List<Dictionary<string, List<string>>>
+            {
+                new Dictionary<string, List<string>>
+                {
+                    {
+                        subscriptions[0].Id,
+                        new List<string>
+                        {
+                            path1,
+                            path2
+                        }
+                    }
+                },
+                new Dictionary<string, List<string>>
+                {
+                    {
+                        subscriptions[0].Id,
+                        new List<string>
+                        {
+                            path3
+                        }
+                    }
+                }
+            };
+
+            using (TestContext context = new TestContext(subscriptions, pathData))
+            {
+                await context.ExecuteCommandAsync();
+
+                Dictionary<Subscription, IList<string>> expectedPathsBySubscription =
+                    new Dictionary<Subscription, IList<string>>
+                {
+                    {
+                        subscriptions[0],
+                        new List<string>
+                        {
+                            path1,
+                            path2,
+                            path3
+                        }
+                    }
+                };
+
+                context.Verify(expectedPathsBySubscription);
+            }
+        }
+
+        /// <summary>
+        /// Use this method to generate a unique repo owner name for the tests. This ensures that each test
+        /// uses a different name and prevents collisions when running the tests in parallel. This is because
+        /// the <see cref="QueueBuildCommand"/> generates temp folders partially based on the name of
+        /// the repo owner.
+        /// </summary>
+        private static string GetRepoOwner([CallerMemberName] string testMethodName = null, string suffix = null)
+        {
+            return testMethodName + suffix;
+        }
+
+        private static Subscription CreateSubscription(
+            string repoName,
+            int index = 0,
+            [CallerMemberName] string testMethodName = null)
+        {
+            return new Subscription
+            {
+                ManifestPath = "testmanifest.json",
+                PipelineTrigger = new PipelineTrigger
+                {
+                    Id = 1,
+                    PathVariable = "--my-path"
+                },
+                RepoInfo = new GitRepo
+                {
+                    Branch = "testBranch" + index,
+                    Name = repoName,
+                    Owner = GetRepoOwner(testMethodName, index.ToString())
+                }
+            };
+        }
+
+        /// <summary>
+        /// Sets up the test state from the provided metadata, executes the test, and verifies the results.
+        /// </summary>
+        private class TestContext : IDisposable
+        {
+            private readonly bool hasInProgressBuild;
+            private readonly List<string> filesToCleanup = new List<string>();
+            private readonly List<string> foldersToCleanup = new List<string>();
+            private readonly string subscriptionsPath;
+            private readonly Mock<IBuildHttpClient> buildHttpClientMock;
+            private readonly QueueBuildCommand command;
+            private readonly IEnumerable<Dictionary<string, List<string>>> pathData;
+
+            private const string BuildOrganization = "testOrg";
+
+            /// <summary>
+            /// Initializes a new instance of <see cref="TestContext"/>.
+            /// </summary>
+            /// <param name="subscriptions">The set of subscription metadata describing the Git repos that are listening for changes to base images.</param>
+            /// <param name="hasInProgressBuild">A value indicating whether to mark a build to be in progress for all pipelines.</param>
+            public TestContext(
+                Subscription[] subscriptions,
+                IEnumerable<Dictionary<string, List<string>>> pathData,
+                bool hasInProgressBuild = false)
+            {
+                this.pathData = pathData;
+                this.hasInProgressBuild = hasInProgressBuild;
+
+                this.subscriptionsPath = this.SerializeJsonObjectToTempFile(subscriptions);
+
+                TeamProject project = new TeamProject
+                {
+                    Id = Guid.NewGuid()
+                };
+
+                Mock<IProjectHttpClient> projectHttpClientMock = CreateProjectHttpClientMock(project);
+                this.buildHttpClientMock = CreateBuildHttpClientMock(project, hasInProgressBuild);
+                Mock<IVssConnectionFactory> connectionFactoryMock = CreateVssConnectionFactoryMock(
+                    projectHttpClientMock, this.buildHttpClientMock);
+
+                this.command = this.CreateCommand(connectionFactoryMock);
+            }
+
+            public Task ExecuteCommandAsync()
+            {
+                return this.command.ExecuteAsync();
+            }
+
+            /// <summary>
+            /// Verifies the test execution to ensure the results match the expected state.
+            /// </summary>
+            /// <param name="expectedPathsBySubscription">
+            /// A mapping of subscription metadata to the list of expected path args passed to the queued build, if any.
+            /// </param>
+            public void Verify(IDictionary<Subscription, IList<string>> expectedPathsBySubscription = null)
+            {
+                if (this.hasInProgressBuild)
+                {
+                    // If a build was marked as in progress for the pipelines, then no build is expected to ever be queued.
+                    this.buildHttpClientMock.Verify(o => o.QueueBuildAsync(It.IsAny<Build>()), Times.Never);
+                }
+                else
+                {
+                    if (expectedPathsBySubscription == null)
+                    {
+                        throw new ArgumentNullException(nameof(expectedPathsBySubscription));
+                    }
+
+                    foreach (KeyValuePair<Subscription, IList<string>> kvp in expectedPathsBySubscription)
+                    {
+                        if (kvp.Value.Any())
+                        {
+                            this.buildHttpClientMock
+                                .Verify(o =>
+                                    o.QueueBuildAsync(
+                                        It.Is<Build>(build => FilterBuildToSubscription(build, kvp.Key, kvp.Value))));
+                        }
+                        else
+                        {
+                            this.buildHttpClientMock.Verify(o => o.QueueBuildAsync(It.IsAny<Build>()), Times.Never);
+                        }
+                    }
+                }
+            }
+
+            private string SerializeJsonObjectToTempFile(object jsonObject)
+            {
+                string path = Path.GetTempFileName();
+                File.WriteAllText(path, JsonConvert.SerializeObject(jsonObject));
+                this.filesToCleanup.Add(path);
+                return path;
+            }
+
+            private QueueBuildCommand CreateCommand(Mock<IVssConnectionFactory> connectionFactoryMock)
+            {
+                Mock<ILoggerService> loggerServiceMock = new Mock<ILoggerService>();
+
+                QueueBuildCommand command = new QueueBuildCommand(connectionFactoryMock.Object, loggerServiceMock.Object);
+                command.Options.BuildOrganization = BuildOrganization;
+                command.Options.BuildPersonalAccessToken = "testToken";
+                command.Options.SubscriptionsPath = this.subscriptionsPath;
+                IEnumerable<string> subscriptions = this.pathData
+                    .Select(data => JsonConvert.SerializeObject(data.ToDictionary(kvp => kvp.Key, kvp => String.Join(" ", kvp.Value.ToArray()))));
+                command.Options.Subscriptions = subscriptions;
+
+                return command;
+            }
+
+            private static Mock<IVssConnectionFactory> CreateVssConnectionFactoryMock(
+                Mock<IProjectHttpClient> projectHttpClientMock,
+                Mock<IBuildHttpClient> buildHttpClientMock)
+            {
+                Mock<IVssConnection> connectionMock = CreateVssConnectionMock(projectHttpClientMock, buildHttpClientMock);
+
+                Mock<IVssConnectionFactory> connectionFactoryMock = new Mock<IVssConnectionFactory>();
+                connectionFactoryMock
+                    .Setup(o => o.Create(
+                        It.Is<Uri>(uri => uri.ToString() == $"https://dev.azure.com/{BuildOrganization}"),
+                        It.IsAny<VssCredentials>()))
+                    .Returns(connectionMock.Object);
+                return connectionFactoryMock;
+            }
+
+            private static Mock<IVssConnection> CreateVssConnectionMock(Mock<IProjectHttpClient> projectHttpClientMock,
+                Mock<IBuildHttpClient> buildHttpClientMock)
+            {
+                Mock<IVssConnection> connectionMock = new Mock<IVssConnection>();
+                connectionMock
+                    .Setup(o => o.GetProjectHttpClient())
+                    .Returns(projectHttpClientMock.Object);
+                connectionMock
+                    .Setup(o => o.GetBuildHttpClient())
+                    .Returns(buildHttpClientMock.Object);
+                return connectionMock;
+            }
+
+            private static Mock<IProjectHttpClient> CreateProjectHttpClientMock(TeamProject project)
+            {
+                Mock<IProjectHttpClient> projectHttpClientMock = new Mock<IProjectHttpClient>();
+                projectHttpClientMock
+                    .Setup(o => o.GetProjectAsync(It.IsAny<string>()))
+                    .ReturnsAsync(project);
+                return projectHttpClientMock;
+            }
+
+            private static Mock<IBuildHttpClient> CreateBuildHttpClientMock(TeamProject project, bool hasInProgressBuild)
+            {
+                PagedList<Build> builds = new PagedList<Build>();
+                if (hasInProgressBuild)
+                {
+                    builds.Add(new Build());
+                }
+
+                Mock<IBuildHttpClient> buildHttpClientMock = new Mock<IBuildHttpClient>();
+                buildHttpClientMock
+                    .Setup(o => o.GetBuildsAsync(project.Id, It.IsAny<IEnumerable<int>>(), It.IsAny<BuildStatus>()))
+                    .ReturnsAsync((IPagedList<Build>)builds);
+
+                return buildHttpClientMock;
+            }
+
+            /// <summary>
+            /// Returns a value indicating whether the <see cref="Build"/> object contains the expected state.
+            /// </summary>
+            /// <param name="build">The <see cref="Build"/> to validate.</param>
+            /// <param name="subscription">Subscription object that contains metadata to compare against the <paramref name="build"/>.</param>
+            /// <param name="expectedPaths">The set of expected path arguments that should have been passed to the build.</param>
+            private static bool FilterBuildToSubscription(Build build, Subscription subscription, IList<string> expectedPaths)
+            {
+                return build.Definition.Id == subscription.PipelineTrigger.Id &&
+                    build.SourceBranch == subscription.RepoInfo.Branch &&
+                    FilterBuildToParameters(build.Parameters, subscription.PipelineTrigger.PathVariable, expectedPaths);
+            }
+
+            /// <summary>
+            /// Returns a value indicating whether <paramref name="buildParametersJson"/> matches the expected results.
+            /// </summary>
+            /// <param name="buildParametersJson">The raw JSON parameters value that was provided to a <see cref="Build"/>.</param>
+            /// <param name="pathVariable">Name of the path variable that the arguments are assigned to.</param>
+            /// <param name="expectedPaths">The set of expected path arguments that should have been passed to the build.</param>
+            private static bool FilterBuildToParameters(string buildParametersJson, string pathVariable, IList<string> expectedPaths)
+            {
+                JObject buildParameters = JsonConvert.DeserializeObject<JObject>(buildParametersJson);
+                string pathString = buildParameters[pathVariable].ToString();
+                IList<string> paths = pathString
+                    .Split(" ", StringSplitOptions.RemoveEmptyEntries)
+                    .Select(p => p.Trim().Trim('\''))
+                    .ToList();
+                return CompareLists(expectedPaths, paths);
+            }
+
+            /// <summary>
+            /// Returns a value indicating whether the two lists are equivalent (order does not matter).
+            /// </summary>
+            private static bool CompareLists(IList<string> expectedPaths, IList<string> paths)
+            {
+                if (paths.Count != expectedPaths.Count)
+                {
+                    return false;
+                }
+
+                paths = paths
+                    .OrderBy(p => p)
+                    .ToList();
+                expectedPaths = expectedPaths
+                    .OrderBy(p => p)
+                    .ToList();
+
+                for (int i = 0; i < paths.Count; i++)
+                {
+                    if (paths[i] != expectedPaths[i])
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            public void Dispose()
+            {
+                foreach (string file in this.filesToCleanup)
+                {
+                    File.Delete(file);
+                }
+
+                foreach (string folder in this.foldersToCleanup)
+                {
+                    Directory.Delete(folder, true);
+                }
+            }
+        }
+
+        private class PagedList<T> : List<T>, IPagedList<T>
+        {
+            public string ContinuationToken => throw new NotImplementedException();
+        }
+    }
+}

--- a/Microsoft.DotNet.ImageBuilder/tests/QueueBuildCommandTests.cs
+++ b/Microsoft.DotNet.ImageBuilder/tests/QueueBuildCommandTests.cs
@@ -37,13 +37,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 CreateSubscription("repo1")
             };
 
-            List<Dictionary<string, List<string>>> pathData = new List<Dictionary<string, List<string>>>
+            List<List<SubscriptionImagePaths>> allSubscriptionImagePaths = new List<List<SubscriptionImagePaths>>
             {
-                new Dictionary<string, List<string>>
+                new List<SubscriptionImagePaths>
                 {
+                    new SubscriptionImagePaths
                     {
-                        subscriptions[0].Id,
-                        new List<string>
+                        SubscriptionId = subscriptions[0].Id,
+                        ImagePaths = new string[]
                         {
                             path1
                         }
@@ -51,7 +52,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            using (TestContext context = new TestContext(subscriptions, pathData, hasInProgressBuild: true))
+            using (TestContext context = new TestContext(subscriptions, allSubscriptionImagePaths, hasInProgressBuild: true))
             {
                 await context.ExecuteCommandAsync();
 
@@ -79,30 +80,33 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 CreateSubscription("repo2")
             };
 
-            List<Dictionary<string, List<string>>> pathData = new List<Dictionary<string, List<string>>>
+            List<List<SubscriptionImagePaths>> allSubscriptionImagePaths = new List<List<SubscriptionImagePaths>>
             {
-                new Dictionary<string, List<string>>
+                new List<SubscriptionImagePaths>
                 {
+                    new SubscriptionImagePaths
                     {
-                        subscriptions[0].Id,
-                        new List<string>
+                        SubscriptionId = subscriptions[0].Id,
+                        ImagePaths = new string[]
                         {
                             path1
                         }
                     },
+                    new SubscriptionImagePaths
                     {
-                        subscriptions[1].Id,
-                        new List<string>
+                        SubscriptionId = subscriptions[1].Id,
+                        ImagePaths = new string[]
                         {
                             path2
                         }
                     }
                 },
-                new Dictionary<string, List<string>>
+                new List<SubscriptionImagePaths>
                 {
+                    new SubscriptionImagePaths
                     {
-                        subscriptions[1].Id,
-                        new List<string>
+                        SubscriptionId = subscriptions[1].Id,
+                        ImagePaths = new string[]
                         {
                             path3
                         }
@@ -110,7 +114,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            using (TestContext context = new TestContext(subscriptions, pathData))
+            using (TestContext context = new TestContext(subscriptions, allSubscriptionImagePaths))
             {
                 await context.ExecuteCommandAsync();
 
@@ -149,25 +153,27 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 CreateSubscription("repo1")
             };
 
-            List<Dictionary<string, List<string>>> pathData = new List<Dictionary<string, List<string>>>
+            List<List<SubscriptionImagePaths>> allSubscriptionImagePaths = new List<List<SubscriptionImagePaths>>
             {
-                new Dictionary<string, List<string>>
+                new List<SubscriptionImagePaths>
                 {
+                    new SubscriptionImagePaths
                     {
-                        subscriptions[0].Id,
-                        new List<string>()
+                        SubscriptionId = subscriptions[0].Id,
+                        ImagePaths = Array.Empty<string>()
                     }
                 },
-                new Dictionary<string, List<string>>
+                new List<SubscriptionImagePaths>
                 {
+                    new SubscriptionImagePaths
                     {
-                        subscriptions[0].Id,
-                        new List<string>()
+                        SubscriptionId = subscriptions[0].Id,
+                        ImagePaths = Array.Empty<string>()
                     }
                 }
             };
 
-            using (TestContext context = new TestContext(subscriptions, pathData))
+            using (TestContext context = new TestContext(subscriptions, allSubscriptionImagePaths))
             {
                 await context.ExecuteCommandAsync();
 
@@ -203,24 +209,26 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 CreateSubscription("repo1")
             };
 
-            List<Dictionary<string, List<string>>> pathData = new List<Dictionary<string, List<string>>>
+            List<List<SubscriptionImagePaths>> allSubscriptionImagePaths = new List<List<SubscriptionImagePaths>>
             {
-                new Dictionary<string, List<string>>
+                new List<SubscriptionImagePaths>
                 {
+                    new SubscriptionImagePaths
                     {
-                        subscriptions[0].Id,
-                        new List<string>
+                        SubscriptionId = subscriptions[0].Id,
+                        ImagePaths = new string[]
                         {
                             path1,
                             path2
                         }
                     }
                 },
-                new Dictionary<string, List<string>>
+                new List<SubscriptionImagePaths>
                 {
+                    new SubscriptionImagePaths
                     {
-                        subscriptions[0].Id,
-                        new List<string>
+                        SubscriptionId = subscriptions[0].Id,
+                        ImagePaths = new string[]
                         {
                             path3
                         }
@@ -228,7 +236,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            using (TestContext context = new TestContext(subscriptions, pathData))
+            using (TestContext context = new TestContext(subscriptions, allSubscriptionImagePaths))
             {
                 await context.ExecuteCommandAsync();
 
@@ -294,7 +302,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             private readonly string subscriptionsPath;
             private readonly Mock<IBuildHttpClient> buildHttpClientMock;
             private readonly QueueBuildCommand command;
-            private readonly IEnumerable<Dictionary<string, List<string>>> pathData;
+            private readonly IEnumerable<IEnumerable<SubscriptionImagePaths>> allSubscriptionImagePaths;
 
             private const string BuildOrganization = "testOrg";
 
@@ -302,13 +310,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             /// Initializes a new instance of <see cref="TestContext"/>.
             /// </summary>
             /// <param name="subscriptions">The set of subscription metadata describing the Git repos that are listening for changes to base images.</param>
+            /// <param name="allSubscriptionImagePaths">Multiple sets of mappings between subscriptions and their associated image paths.</param>
             /// <param name="hasInProgressBuild">A value indicating whether to mark a build to be in progress for all pipelines.</param>
             public TestContext(
                 Subscription[] subscriptions,
-                IEnumerable<Dictionary<string, List<string>>> pathData,
+                IEnumerable<IEnumerable<SubscriptionImagePaths>> allSubscriptionImagePaths,
                 bool hasInProgressBuild = false)
             {
-                this.pathData = pathData;
+                this.allSubscriptionImagePaths = allSubscriptionImagePaths;
                 this.hasInProgressBuild = hasInProgressBuild;
 
                 this.subscriptionsPath = this.SerializeJsonObjectToTempFile(subscriptions);
@@ -384,9 +393,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 command.Options.BuildOrganization = BuildOrganization;
                 command.Options.BuildPersonalAccessToken = "testToken";
                 command.Options.SubscriptionsPath = this.subscriptionsPath;
-                IEnumerable<string> subscriptions = this.pathData
-                    .Select(data => JsonConvert.SerializeObject(data.ToDictionary(kvp => kvp.Key, kvp => String.Join(" ", kvp.Value.ToArray()))));
-                command.Options.Subscriptions = subscriptions;
+                command.Options.AllSubscriptionImagePaths = this.allSubscriptionImagePaths
+                    .Select(subscriptionImagePaths => JsonConvert.SerializeObject(subscriptionImagePaths.ToArray()));
 
                 return command;
             }
@@ -470,6 +478,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 IList<string> paths = pathString
                     .Split(" ", StringSplitOptions.RemoveEmptyEntries)
                     .Select(p => p.Trim().Trim('\''))
+                    .Except(new string[] { ManifestFilterOptions.FormattedPathOption })
                     .ToList();
                 return CompareLists(expectedPaths, paths);
             }


### PR DESCRIPTION
These changes break apart the RebuildStaleImagesCommand into two separate commands: GetStaleImagesCommand and QueueBuildCommand.  This is necessary for the check-base-image-updates pipeline so that it can determine which images need to be rebuilt across both Windows and Linux as well as the different architectures before actually queuing a build.  Once all the image paths have been determined, then the final part of the build should actually queue the necessary builds.

A given job that executes GetStaleImagesCommand will be looking for changes to images across all the subscribing Git repos/branches.  And the command will produce an output variable to be consumed by the pipeline.  So there will be four such variables whose data represents the same sets of subscriptions amongst all of them.  It's up to the QueueBuildCommand variable to take those variables as input and consolidate the data according to subscription and then queuing a build for that subscription if necessary.

Related to #274