### PR TITLE
Build matrix fix: Don't include dependencies if not in context

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             BuildMatrixInfo matrix, IEnumerable<string> matrixNameParts, IGrouping<PlatformId, PlatformInfo> platformGrouping)
         {
             IEnumerable<IEnumerable<PlatformInfo>> subgraphs = platformGrouping.GetCompleteSubgraphs(
-                platform => GetPlatformDependencies(platform).Intersect(platformGrouping));
+                platform => GetPlatformDependencies(platform, platformGrouping));
 
             foreach (IEnumerable<PlatformInfo> subgraph in subgraphs)
             {
@@ -114,7 +114,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             foreach (var versionGrouping in versionGroups)
             {
                 IEnumerable<PlatformInfo> subgraphs = versionGrouping
-                    .GetCompleteSubgraphs(GetPlatformDependencies)
+                    .GetCompleteSubgraphs(platform => GetPlatformDependencies(platform, platformGrouping))
                     .SelectMany(subgraph => subgraph);
 
                 BuildLegInfo leg = new BuildLegInfo() { Name = $"{versionGrouping.Key.DotNetVersion}-{versionGrouping.Key.OsVariant}" };
@@ -222,8 +222,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             return matrices;
         }
 
-        private IEnumerable<PlatformInfo> GetPlatformDependencies(PlatformInfo platform) =>
-            platform.InternalFromImages.Select(fromImage => Manifest.GetPlatformByTag(fromImage));
+        private IEnumerable<PlatformInfo> GetPlatformDependencies(PlatformInfo platform, IEnumerable<PlatformInfo> availablePlatforms) =>
+            platform.InternalFromImages
+                .Select(fromImage => Manifest.GetPlatformByTag(fromImage))
+                .Intersect(availablePlatforms);
 
         private static void LogDiagnostics(IEnumerable<BuildMatrixInfo> matrices)
         {

--- a/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
@@ -35,7 +35,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private void AddDockerfilePathLegs(
             BuildMatrixInfo matrix, IEnumerable<string> matrixNameParts, IGrouping<PlatformId, PlatformInfo> platformGrouping)
         {
-            IEnumerable<IEnumerable<PlatformInfo>> subgraphs = platformGrouping.GetCompleteSubgraphs(GetPlatformDependencies);
+            IEnumerable<IEnumerable<PlatformInfo>> subgraphs = platformGrouping.GetCompleteSubgraphs(
+                platform => GetPlatformDependencies(platform).Intersect(platformGrouping));
+
             foreach (IEnumerable<PlatformInfo> subgraph in subgraphs)
             {
                 string[] dockerfilePaths = GetDockerfilePaths(subgraph)

--- a/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
+++ b/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
@@ -16,13 +16,16 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
     public class GenerateBuildMatrixCommandTests
     {
         /// <summary>
-        /// Verifies the platformVersionedOs matrix type will include platform dependencies.
+        /// Verifies the platformVersionedOs matrix type.
         /// </summary>
         /// <remarks>
         /// https://github.com/dotnet/docker-tools/issues/243
         /// </remarks>
-        [Fact]
-        public void GenerateBuildMatrixCommand_PlatformVersionedOs_IncludePlatformDependencies()
+        [Theory]
+        [InlineData(null, "--path 2.2/runtime/os --path 2.1/runtime-deps/os", "2.2")]
+        [InlineData("--path 2.2/runtime/os", "--path 2.2/runtime/os", "2.2")]
+        [InlineData("--path 2.1/runtime-deps/os", "--path 2.1/runtime-deps/os", "2.1")]
+        public void GenerateBuildMatrixCommand_PlatformVersionedOs(string filterPaths, string expectedPaths, string verificationLegName)
         {
             using (TempFolderContext tempFolderContext = TestHelper.UseTempFolder())
             using (TestHelper.SetWorkingDirectory(tempFolderContext.Path))
@@ -30,6 +33,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 GenerateBuildMatrixCommand command = new GenerateBuildMatrixCommand();
                 command.Options.Manifest = "manifest.json";
                 command.Options.MatrixType = MatrixType.PlatformVersionedOs;
+                if (filterPaths != null)
+                {
+                    command.Options.FilterOptions.Paths = filterPaths.Replace("--path ", "").Split(" ");
+                }
 
                 const string runtimeDepsRelativeDir = "2.1/runtime-deps/os";
                 DirectoryInfo runtimeDepsDir = Directory.CreateDirectory(
@@ -59,10 +66,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Assert.Single(matrixInfos);
 
                 BuildMatrixInfo matrixInfo = matrixInfos.First();
-                BuildLegInfo leg = matrixInfo.Legs.First(leg => leg.Name.StartsWith("2.2"));
+                BuildLegInfo leg = matrixInfo.Legs.First(leg => leg.Name.StartsWith(verificationLegName));
                 string imageBuilderPaths = leg.Variables.First(variable => variable.Name == "imageBuilderPaths").Value;
 
-                Assert.Equal("--path 2.2/runtime/os --path 2.1/runtime-deps/os", imageBuilderPaths);
+                Assert.Equal(expectedPaths, imageBuilderPaths);
             }
         }
 


### PR DESCRIPTION
Allows images to be built without forcing the images they depend on to be built.  For example, we sometimes want to be able to publish an update to the SDK image but do not need to update the runtime image it depends upon.  This currently isn't possible because the matrix that gets generated will automatically include the base image(s).

These changes fix this by only including the base image graph in the outputted matrix if they match the path filter that was provided as input to the generateBuildMatrix command.

Fixes #186
