### PR TITLE
Fix GitHelper operation execution code

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/GitHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/GitHelper.cs
@@ -73,12 +73,12 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             return await client.PatchReferenceAsync(project, masterRef, commit.Sha, force: false);
         }
 
-        public static Task ExecuteGitOperationsWithRetryAsync(GitOptions gitOptions, Func<IGitHubClient, Task> execute,
+        public static async Task ExecuteGitOperationsWithRetryAsync(GitOptions gitOptions, Func<IGitHubClient, Task> execute,
             int maxTries = DefaultMaxTries, int retryMillisecondsDelay = DefaultRetryMillisecondsDelay)
         {
             using (GitHubClient client = GitHelper.GetClient(gitOptions))
             {
-                return ExecuteGitOperationsWithRetryAsync(() => execute(client), maxTries, retryMillisecondsDelay);
+                await ExecuteGitOperationsWithRetryAsync(() => execute(client), maxTries, retryMillisecondsDelay);
             }
         }
 


### PR DESCRIPTION
The `GitHelper.ExecuteGitOperationsWithRetryAsync` call results in usage of a `GitHubClient` instance that has been disposed.  This results in a `TaskCanceledException` for any calling code.

This is caused by returning the task without awaiting it.  This allows the `GitHubClient` instance to be disposed before the code which uses it to get a chance to execute.  Once it does execute, the instance is disposed and bad things happen.

Fixes #296