### PR TITLE
Add logging to capture process execution time

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
@@ -62,7 +62,14 @@ namespace Microsoft.DotNet.ImageBuilder
             Logger.WriteSubheading($"EXECUTING: {executeMessageOverride}");
             if (!isDryRun)
             {
+                Stopwatch stopwatch = new Stopwatch();
+                stopwatch.Start();
+
                 process = executor(info);
+
+                stopwatch.Stop();
+                Logger.WriteSubheading($"EXECUTION ELAPSED TIME: {stopwatch.Elapsed}");
+
                 if (process.ExitCode != 0)
                 {
                     string exceptionMsg = errorMessage ?? $"Failed to execute {info.FileName} {info.Arguments}";


### PR DESCRIPTION
Fixes #298 

Sample output for pulling a Docker image

```
-- EXECUTING: docker pull alpine:3.9
3.9: Pulling from library/alpine
e7c96db7181b: Already exists                                                                                     
Digest: sha256:7746df395af22f04212cd25a92c1d6dbc5a06a0ca9579a229ef43008d4d1302a
Status: Downloaded newer image for alpine:3.9
docker.io/library/alpine:3.9
-- EXECUTION ELAPSED TIME: 00:00:05.7446610
```