### PR TITLE
FilePusher enhancements to support pushing to multiple branches of a repo

### DIFF
--- a/eng/file-pusher/FilePusher.cs
+++ b/eng/file-pusher/FilePusher.cs
@@ -113,7 +113,9 @@ namespace FilePusher
             GitHubProject project = new GitHubProject(gitRepo.Name, gitRepo.Owner);
             GitHubProject forkedProject = new GitHubProject(gitRepo.Name, Options.GitUser);
             GitHubBranch baseBranch = new GitHubBranch(gitRepo.Branch, project);
-            GitHubBranch headBranch = new GitHubBranch($"{gitRepo.Owner}{config.WorkingBranchSuffix}", forkedProject);
+            GitHubBranch headBranch = new GitHubBranch(
+                $"{gitRepo.Name}-{gitRepo.Branch}{config.WorkingBranchSuffix}",
+                forkedProject);
 
             IEnumerable<GitObject> changes = await GetUpdatedFiles(config.SourcePath, client, baseBranch);
 
@@ -145,7 +147,7 @@ namespace FilePusher
             if (pullRequestToUpdate == null)
             {
                 await client.PostGitHubPullRequestAsync(
-                    config.PullRequestTitle,
+                    $"[{gitRepo.Branch}] {config.PullRequestTitle}",
                     config.PullRequestDescription,
                     headBranch,
                     baseBranch,


### PR DESCRIPTION
The FilePusher utility did not support pushing changes to multiple branches of a single repo concurrently.  What would happen is the tool would create a PR for one branch and then when processing the subsequent branches, it would overwrite the previous changes.

Fixes:
1. Use a unique fork branch name per upstream branch
1. Add the branch name to the beginning of the PR title