### PR TITLE
Pipeline to push common updates to other repos

### DIFF
--- a/eng/pipelines/push-common-updates.yml
+++ b/eng/pipelines/push-common-updates.yml
@@ -1,0 +1,30 @@
+trigger:
+  batch: true
+  branches:
+    include:
+    - master
+  paths:
+    include:
+    - eng/common/*
+pr: none
+
+variables:
+- group: DotNet-Docker-Common
+- group: DotNet-Docker-Secrets
+- group: DotNet-Maestro
+
+jobs:
+- job: Build
+  pool: Hosted Ubuntu 1604
+  steps:
+  - script: >
+      docker build . -f ./eng/file-pusher/Dockerfile -t file-pusher
+    displayName: Build File Pusher
+  - script: >
+      docker run --rm file-pusher
+      $(filters)
+      ./eng/eng-common-file-pusher-config.json
+      $(dotnetBot-userName)
+      $(dotnetBot-email)
+      $(BotAccount-dotnet-maestro-bot-PAT)
+    displayName: Run File Pusher

--- a/eng/pipelines/push-common-updates.yml
+++ b/eng/pipelines/push-common-updates.yml
@@ -9,8 +9,6 @@ trigger:
 pr: none
 
 variables:
-- group: DotNet-Docker-Common
-- group: DotNet-Docker-Secrets
 - group: DotNet-Maestro
 
 jobs:
@@ -24,7 +22,7 @@ jobs:
       docker run --rm file-pusher
       $(filters)
       ./eng/eng-common-file-pusher-config.json
-      $(dotnetBot-userName)
-      $(dotnetBot-email)
+      dotnet-maestro-bot
+      dotnet-maestro-bot@microsoft.com
       $(BotAccount-dotnet-maestro-bot-PAT)
     displayName: Run File Pusher


### PR DESCRIPTION
This defines a build pipeline which will run the FilePusher utility that pushes any updates to the eng/common to the subscribing repos.  The build gets automatically triggered whenever a change is made within the eng/common folder.  I'm proposing that we have just one build definition that references this pipeline and, by default, it will use an empty `$(filters)` variable.  If there's ever an issue with one of the subscribing repos that requires temporarily disabling syncing, we can just modify the variable appropriately.