### PR TITLE
Fix validate-remote-docker-config pipeline

### DIFF
--- a/eng/pipelines/templates/variables/common.yml
+++ b/eng/pipelines/templates/variables/common.yml
@@ -2,3 +2,7 @@ variables:
 - template: ../../../common/templates/variables/common.yml
 - name: checkBaseImageSubscriptionsPath
   value: eng/check-base-image-subscriptions.json
+- name: imageNames.pinger.linux
+  value: mcr.microsoft.com/windows/nanoserver:1809-arm32v7
+- name: imageNames.pinger.windows
+  value: arm32v7/debian:stretch


### PR DESCRIPTION
Fixes the pipeline by adding some missing variables.  This was broken by #209.

Fixes #227