### PR TITLE
Allow multiple pipeline stages to be explicitly defined to run

### DIFF
--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -20,7 +20,7 @@ stages:
 # Build Images
 ################################################################################
 - stage: Build
-  condition: and(succeeded(), or(eq(variables['singlePhase'], ''), eq(variables['singlePhase'], 'build')))
+  condition: and(succeeded(), contains(variables['stages'], 'build'))
   jobs:
   - template: ../jobs/generate-matrix.yml
     parameters:
@@ -186,7 +186,7 @@ stages:
   ################################################################################
   - stage: Post_Build
     dependsOn: Build
-    condition: and(succeeded(), or(eq(variables['singlePhase'], ''), eq(variables['singlePhase'], 'build')))
+    condition: and(succeeded(), contains(variables['stages'], 'build'))
     jobs:
     - template: ../jobs/post-build.yml
 
@@ -197,12 +197,12 @@ stages:
     dependsOn: Post_Build
     condition: "
       and(
-        not(contains(variables['manifest'], 'samples')),
+        contains(variables['stages'], 'test'),
         or(
           and(
             succeeded(),
-            eq(variables['singlePhase'], '')),
-          eq(variables['singlePhase'], 'test')))"
+            contains(variables['stages'], 'build')),
+          not(contains(variables['stages'], 'build'))))"
     jobs:
     - template: ../jobs/generate-matrix.yml
       parameters:
@@ -320,15 +320,20 @@ stages:
   - stage: Publish
     dependsOn: Test
     condition: "
-      or(
-        and(
-          eq(variables['singlePhase'], ''),
+      and(
+        contains(variables['stages'], 'publish'),
+        or(
           or(
-            succeeded(),
             and(
-              contains(variables['manifest'], 'samples'),
-              succeeded('Build')))),
-        eq(variables['singlePhase'], 'publish'))"
+              contains(variables['stages'], 'build'),
+              succeeded('build')),
+            and(
+              contains(variables['stages'], 'test'),
+              succeeded('test'))),
+          not(
+            or(
+              contains(variables['stages'], 'build'),
+              contains(variables['stages'], 'test')))))"
     jobs:
     - template: ../jobs/publish.yml
       parameters:

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -325,11 +325,23 @@ stages:
         or(
           or(
             and(
-              contains(variables['stages'], 'build'),
-              succeeded('build')),
-            and(
-              contains(variables['stages'], 'test'),
-              succeeded('test'))),
+              and(
+                contains(variables['stages'], 'build'),
+                succeeded('Post_Build')),
+              and(
+                contains(variables['stages'], 'test'),
+                succeeded('Test'))),
+            or(
+              and(
+                not(contains(variables['stages'], 'build')),
+                and(
+                  contains(variables['stages'], 'test'),
+                  succeeded('Test'))),
+              and(
+                not(contains(variables['stages'], 'test')),
+                and(
+                  contains(variables['stages'], 'build'),
+                  succeeded('Post_Build'))))),
           not(
             or(
               contains(variables['stages'], 'build'),


### PR DESCRIPTION
Currently there is a queue-time variable named `singlePhase` that can be used to run specific pipeline stages.  When left empty, it runs all the stages.  The problem is that there's not a way to run more than one stage other than all of them (e.g. run just the test _and_ publish phases).

These changes replace the `singleStage` variable with a new one called `stages` that can used to list which stages the pipeline should run.  By default, the pipelines will predefine this variable with all of the stages listed: "build;test;publish".  At queue time, a person can modify this to specify which stages should be run.

Fixes #295