### PR TITLE
Include digest of built image in image info file

### DIFF
--- a/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -67,6 +67,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 {
                     Repo = repoInfo.Model.Name
                 };
+                reposList.Add(repoData);
 
                 SortedDictionary<string, ImageData> images = new SortedDictionary<string, ImageData>();
 
@@ -130,7 +131,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 if (images.Any())
                 {
                     repoData.Images = images;
-                    reposList.Add(repoData);
                 }
             }
 
@@ -274,6 +274,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 ExecuteWithUser(() =>
                 {
                     var imagesToPush = this.reposList
+                        .Where(repoData => repoData.Images != null)
                         .Select(repoData => new
                         {
                             Repo = repoData,

--- a/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Text.RegularExpressions;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 
 namespace Microsoft.DotNet.ImageBuilder
@@ -90,6 +91,18 @@ namespace Microsoft.DotNet.ImageBuilder
         public static void PullImage(string image, bool isDryRun)
         {
             ExecuteHelper.ExecuteWithRetry("docker", $"pull {image}", isDryRun);
+        }
+
+        public static string PushImage(string tag, bool isDryRun)
+        {
+            string pushOutput = ExecuteCommand($"push {tag}", errorMessage: null, isDryRun: isDryRun, enableRetry: true);
+
+            string tagOnly = tag.Substring(tag.LastIndexOf(":") + 1);
+
+            const string DigestMatchName = "digest";
+            Regex imageDigestRegex = new Regex($@"{tagOnly}:\sdigest:\s(?<{DigestMatchName}>sha256:([a-f]+|[0-9])+)\ssize:\s\d+");
+            Match match = imageDigestRegex.Match(pushOutput);
+            return match.Groups[DigestMatchName].Value;
         }
 
         public static string ReplaceRepo(string image, string newRepo)
@@ -185,17 +198,27 @@ namespace Microsoft.DotNet.ImageBuilder
         }
 
         private static string ExecuteCommand(
-            string command, string errorMessage, string additionalArgs = null, bool isDryRun = false)
+            string command, string errorMessage, string additionalArgs = null, bool isDryRun = false, bool enableRetry = false)
         {
             ProcessStartInfo startInfo = new ProcessStartInfo("docker", $"{command} {additionalArgs}");
             startInfo.RedirectStandardOutput = true;
-            Process process = ExecuteHelper.Execute(startInfo, isDryRun, errorMessage);
+
+            Process process;
+            if (enableRetry)
+            {
+                process = ExecuteHelper.ExecuteWithRetry(startInfo, isDryRun, errorMessage);
+            }
+            else
+            {
+                process = ExecuteHelper.Execute(startInfo, isDryRun, errorMessage);
+            }
+            
             return isDryRun ? "" : process.StandardOutput.ReadToEnd().Trim();
         }
 
         private static string ExecuteCommandWithFormat(
-            string command, string outputFormat, string errorMessage, string additionalArgs = null, bool isDryRun = false) =>
-            ExecuteCommand(command, errorMessage, $"{additionalArgs} -f \"{{{{ {outputFormat} }}}}\"", isDryRun);
+            string command, string outputFormat, string errorMessage, string additionalArgs = null, bool isDryRun = false, bool enableRetry = false) =>
+            ExecuteCommand(command, errorMessage, $"{additionalArgs} -f \"{{{{ {outputFormat} }}}}\"", isDryRun, enableRetry);
 
         private enum ManagementType
         {

--- a/Microsoft.DotNet.ImageBuilder/src/DockerService.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/DockerService.cs
@@ -25,9 +25,9 @@ namespace Microsoft.DotNet.ImageBuilder
             DockerHelper.PullImage(image, isDryRun);
         }
 
-        public void PushImage(string tag, bool isDryRun)
+        public string PushImage(string tag, bool isDryRun)
         {
-            ExecuteHelper.ExecuteWithRetry("docker", $"push {tag}", isDryRun);
+            return DockerHelper.PushImage(tag, isDryRun);
         }
 
         public void BuildImage(string dockerfilePath, string buildContextPath, IEnumerable<string> tags, IDictionary<string, string> buildArgs, bool isRetryEnabled, bool isDryRun)

--- a/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
@@ -29,15 +29,24 @@ namespace Microsoft.DotNet.ImageBuilder
             return Execute(info, ExecuteProcess, isDryRun, errorMessage, executeMessageOverride);
         }
 
-        public static void ExecuteWithRetry(
+        public static Process ExecuteWithRetry(
             string fileName,
             string args,
             bool isDryRun,
             string errorMessage = null,
             string executeMessageOverride = null)
         {
-            Execute(
-                new ProcessStartInfo(fileName, args),
+            return ExecuteWithRetry(new ProcessStartInfo(fileName, args), isDryRun, errorMessage, executeMessageOverride);
+        }
+
+        public static Process ExecuteWithRetry(
+            ProcessStartInfo info,
+            bool isDryRun,
+            string errorMessage = null,
+            string executeMessageOverride = null)
+        {
+            return Execute(
+                info,
                 info => ExecuteWithRetry(info, ExecuteProcess),
                 isDryRun,
                 errorMessage,

--- a/Microsoft.DotNet.ImageBuilder/src/IDockerService.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/IDockerService.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.ImageBuilder
 
         string GetImageDigest(string image, bool isDryRun);
 
-        void PushImage(string tag, bool isDryRun);
+        string PushImage(string tag, bool isDryRun);
 
         void BuildImage(
             string dockerfilePath,

--- a/Microsoft.DotNet.ImageBuilder/src/Models/Image/ImageData.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/Models/Image/ImageData.cs
@@ -12,5 +12,6 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Image
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public SortedDictionary<string, string> BaseImages { get; set; }
         public List<string> SimpleTags { get; set; } = new List<string>();
+        public string Digest;
     }
 }

--- a/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
+++ b/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
@@ -151,5 +151,10 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         {
             return AllRepos.FirstOrDefault(repo => repo.Id == id);
         }
+
+        public RepoInfo GetRepoByModelName(string name)
+        {
+            return AllRepos.FirstOrDefault(repo => repo.Model.Name == name);
+        }
     }
 }

--- a/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
+++ b/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -17,6 +18,88 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 {
     public class BuildCommandTests
     {
+        /// <summary>
+        /// Verifies the command outputs an image info correctly for a basic scenario.
+        /// </summary>
+        [Fact]
+        public async Task BuildCommand_ImageInfoOutput_Basic()
+        {
+            const string repoName = "runtime";
+            const string digest = "sha256:c74364a9f125ca612f9a67e4a0551937b7a37c82fabb46172c4867b73edd638c";
+            const string tag = "tag";
+            const string baseImageRepo = "baserepo";
+            string baseImageTag = $"{baseImageRepo}:basetag";
+            string baseImageDigest = $"{baseImageRepo}@sha256:d21234a9f125ca612f9a67e4a0551937b7a37c82fabb46172c4867b73edd1349";
+
+            using (TempFolderContext tempFolderContext = TestHelper.UseTempFolder())
+            {
+                Mock<IDockerService> dockerServiceMock = new Mock<IDockerService>();
+                dockerServiceMock
+                    .SetupGet(o => o.Architecture)
+                    .Returns(Architecture.AMD64);
+
+                dockerServiceMock
+                    .Setup(o => o.PushImage($"{repoName}:{tag}", false))
+                    .Returns(digest);
+
+                dockerServiceMock
+                    .Setup(o => o.GetImageDigest(baseImageTag, false))
+                    .Returns(baseImageDigest);
+
+                BuildCommand command = new BuildCommand(dockerServiceMock.Object);
+                command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
+                command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "image-info.json");
+                command.Options.IsPushEnabled = true;
+
+                const string runtimeRelativeDir = "1.0/runtime/os";
+                Directory.CreateDirectory(Path.Combine(tempFolderContext.Path, runtimeRelativeDir));
+                string dockerfileRelativePath = Path.Combine(runtimeRelativeDir, "Dockerfile");
+                File.WriteAllText(Path.Combine(tempFolderContext.Path, dockerfileRelativePath), $"FROM {baseImageTag}");
+
+                Manifest manifest = ManifestHelper.CreateManifest(
+                    ManifestHelper.CreateRepo(repoName,
+                        ManifestHelper.CreateImage(
+                            ManifestHelper.CreatePlatform(dockerfileRelativePath, new string[] { tag })))
+                );
+
+                File.WriteAllText(Path.Combine(tempFolderContext.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));
+
+                command.LoadManifest();
+                await command.ExecuteAsync();
+
+                List<RepoData> repos = new List<RepoData>
+                {
+                    new RepoData
+                    {
+                        Repo = repoName,
+                        Images = new SortedDictionary<string, ImageData>
+                        {
+                            {
+                                $"{runtimeRelativeDir}/Dockerfile",
+                                new ImageData
+                                {
+                                    Digest = digest,
+                                    BaseImages = new SortedDictionary<string, string>
+                                    {
+                                        { baseImageTag, baseImageDigest }
+                                    },
+                                    SimpleTags = new List<string>
+                                    {
+                                        tag
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+
+                string expectedOutput = JsonHelper.SerializeObject(repos);
+                string actualOutput = File.ReadAllText(command.Options.ImageInfoOutputPath);
+
+                Assert.Equal(expectedOutput, actualOutput);
+            }
+        }
+
         /// <summary>
         /// Verifies the command outputs an image info correctly when the manifest references a custom named Dockerfile.
         /// </summary>


### PR DESCRIPTION
In order to support #79, we need to be tracking the digest values of the images that get published.  These changes update the Build command to include the digest value in the image info file it outputs.  

Since the digest value isn't known until the image is pushed, the ordering of the logic had to be changed.  Previously, the image info file was written immediately after the images had been built.  Now we need to wait until after the images have been pushed so that we can retrieve the digest values and update the image info model appropriately.