### PR TITLE
Consolidate Windows-based job pools in pipeline

### DIFF
--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -33,7 +33,7 @@ stages:
       name: Build_Linux_amd64
       pool: # linuxAmd64Pool
         name: Hosted Ubuntu 1604
-      matrix: dependencies.GenerateBuildMatrix.outputs['${{ format('matrix.{0}MatrixLinuxAmd64', parameters.buildMatrixType) }}']
+      matrix: dependencies.GenerateBuildMatrix.outputs['matrix.LinuxAmd64']
       dockerClientOS: linux
       buildJobTimeout: ${{ parameters.linuxAmdBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
@@ -49,7 +49,7 @@ stages:
         - agent.os -equals linux
         - RemoteDockerServerOS -equals linux
         - RemoteDockerServerArch -equals aarch64
-      matrix: dependencies.GenerateBuildMatrix.outputs['${{ format('matrix.{0}MatrixLinuxArm64v8', parameters.buildMatrixType) }}']
+      matrix: dependencies.GenerateBuildMatrix.outputs['matrix.LinuxArm64v8']
       useRemoteDockerServer: true
       dockerClientOS: linux
       buildJobTimeout: ${{ parameters.linuxArmBuildJobTimeout }}
@@ -66,10 +66,23 @@ stages:
         - agent.os -equals linux
         - RemoteDockerServerOS -equals linux
         - RemoteDockerServerArch -equals aarch64
-      matrix: dependencies.GenerateBuildMatrix.outputs['${{ format('matrix.{0}MatrixLinuxArm32v7', parameters.buildMatrixType) }}']
+      matrix: dependencies.GenerateBuildMatrix.outputs['matrix.LinuxArm32v7']
       useRemoteDockerServer: true
       dockerClientOS: linux
       buildJobTimeout: ${{ parameters.linuxArmBuildJobTimeout }}
+      customInitSteps: ${{ parameters.customBuildInitSteps }}
+  - template: ../jobs/build-images.yml
+    parameters:
+      name: Build_NanoServer1809_amd64
+      pool: # windows1809Amd64
+        ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          name: DotNetCore-Docker-Public
+        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          name: DotNetCore-Docker
+        demands: VSTS_OS -equals Windows_Server_2019_Data_Center_RS5
+      matrix: dependencies.GenerateBuildMatrix.outputs['matrix.Windows1809Amd64']
+      dockerClientOS: windows
+      buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
   - template: ../jobs/build-images.yml
     parameters:
@@ -83,7 +96,7 @@ stages:
         - agent.os -equals linux
         - RemoteDockerServerOS -equals nanoserver-1809
         - RemoteDockerServerArch -equals arm32
-      matrix: dependencies.GenerateBuildMatrix.outputs['${{ format('matrix.{0}MatrixWindows1809Arm32', parameters.buildMatrixType) }}']
+      matrix: dependencies.GenerateBuildMatrix.outputs['matrix.Windows1809Arm32']
       dockerClientOS: linux
       useRemoteDockerServer: true
       buildJobTimeout: ${{ parameters.windowsArmBuildJobTimeout }}
@@ -97,7 +110,7 @@ stages:
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: DotNetCore-Docker
         demands: VSTS_OS -equals Windows_Server_2019_Data_Center_1903
-      matrix: dependencies.GenerateBuildMatrix.outputs['${{ format('matrix.{0}MatrixWindows1903Amd64', parameters.buildMatrixType) }}']
+      matrix: dependencies.GenerateBuildMatrix.outputs['matrix.Windows1903Amd64']
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
@@ -110,7 +123,7 @@ stages:
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: DotNetCore-Docker
         demands: VSTS_OS -equals Windows-ServerDatacenter-1909
-      matrix: dependencies.GenerateBuildMatrix.outputs['${{ format('matrix.{0}MatrixWindows1909Amd64', parameters.buildMatrixType) }}']
+      matrix: dependencies.GenerateBuildMatrix.outputs['matrix.Windows1909Amd64']
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
@@ -123,7 +136,7 @@ stages:
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: DotNetCore-Docker
         demands: VSTS_OS -equals Windows_Server_2016_Data_Center_with_Containers
-      matrix: dependencies.GenerateBuildMatrix.outputs['${{ format('matrix.{0}MatrixWindowsLtsc2016Amd64', parameters.buildMatrixType) }}']
+      matrix: dependencies.GenerateBuildMatrix.outputs['matrix.WindowsLtsc2016Amd64']
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
@@ -136,7 +149,7 @@ stages:
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: DotNetCore-Docker
         demands: VSTS_OS -equals Windows_Server_2019_Data_Center_RS5
-      matrix: dependencies.GenerateBuildMatrix.outputs['${{ format('matrix.{0}MatrixWindowsLtsc2019Amd64', parameters.buildMatrixType) }}']
+      matrix: dependencies.GenerateBuildMatrix.outputs['matrix.{0}WindowsLtsc2019Amd64']
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
@@ -175,7 +188,7 @@ stages:
         name: Test_Linux_amd64
         pool: # linuxAmd64Pool
           name: Hosted Ubuntu 1604
-        matrix: dependencies.GenerateTestMatrix.outputs['${{ format('matrix.{0}MatrixLinuxAmd64', parameters.testMatrixType) }}']
+        matrix: dependencies.GenerateTestMatrix.outputs['matrix.LinuxAmd64']
         testJobTimeout: ${{ parameters.linuxAmdTestJobTimeout }}
     - template: ../jobs/test-images-linux-client.yml
       parameters:
@@ -186,7 +199,7 @@ stages:
           - agent.os -equals linux
           - RemoteDockerServerOS -equals linux
           - RemoteDockerServerArch -equals aarch64
-        matrix: dependencies.GenerateTestMatrix.outputs['${{ format('matrix.{0}MatrixLinuxArm64v8', parameters.testMatrixType) }}']
+        matrix: dependencies.GenerateTestMatrix.outputs['matrix.LinuxArm64v8']
         testJobTimeout: ${{ parameters.linuxArmTestJobTimeout }}
         useRemoteDockerServer: true
     - template: ../jobs/test-images-linux-client.yml
@@ -198,9 +211,17 @@ stages:
           - agent.os -equals linux
           - RemoteDockerServerOS -equals linux
           - RemoteDockerServerArch -equals aarch64
-        matrix: dependencies.GenerateTestMatrix.outputs['${{ format('matrix.{0}MatrixLinuxArm32v7', parameters.testMatrixType) }}']
+        matrix: dependencies.GenerateTestMatrix.outputs['matrix.LinuxArm32v7']
         testJobTimeout: ${{ parameters.linuxArmTestJobTimeout }}
         useRemoteDockerServer: true
+    - template: ../jobs/test-images-windows-client.yml
+      parameters:
+        name: Test_Windows1809_amd64
+        pool: # windows1809Amd64
+          name: DotNetCore-Docker
+          demands: VSTS_OS -equals Windows_Server_2019_Data_Center_RS5
+        matrix: dependencies.GenerateTestMatrix.outputs['matrix.Windows1809Amd64']
+        testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
     - template: ../jobs/test-images-linux-client.yml
       parameters:
         name: Test_Windows1809_arm32
@@ -210,7 +231,7 @@ stages:
           - agent.os -equals linux
           - RemoteDockerServerOS -equals nanoserver-1809
           - RemoteDockerServerArch -equals arm32
-        matrix: dependencies.GenerateTestMatrix.outputs['${{ format('matrix.{0}MatrixWindows1809Arm32', parameters.testMatrixType) }}']
+        matrix: dependencies.GenerateTestMatrix.outputs['matrix.Windows1809Arm32']
         testJobTimeout: ${{ parameters.windowsArmTestJobTimeout }}
         useRemoteDockerServer: true
     - template: ../jobs/test-images-windows-client.yml
@@ -220,7 +241,7 @@ stages:
         pool: # windows1903Amd64
           name: DotNetCore-Docker
           demands: VSTS_OS -equals Windows_Server_2019_Data_Center_1903
-        matrix: dependencies.GenerateTestMatrix.outputs['${{ format('matrix.{0}MatrixWindows1903Amd64', parameters.testMatrixType) }}']
+        matrix: dependencies.GenerateTestMatrix.outputs['matrix.Windows1903Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
     - template: ../jobs/test-images-windows-client.yml
       parameters:
@@ -229,7 +250,7 @@ stages:
         pool: # windows1909Amd64
           name: DotNetCore-Docker
           demands: VSTS_OS -equals Windows-ServerDatacenter-1909
-        matrix: dependencies.GenerateTestMatrix.outputs['${{ format('matrix.{0}MatrixWindows1909Amd64', parameters.testMatrixType) }}']
+        matrix: dependencies.GenerateTestMatrix.outputs['matrix.Windows1909Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
     - template: ../jobs/test-images-windows-client.yml
       parameters:
@@ -238,7 +259,7 @@ stages:
         pool: # windows1607Amd64Pool
           name: DotNetCore-Docker
           demands: VSTS_OS -equals Windows_Server_2016_Data_Center_with_Containers
-        matrix: dependencies.GenerateTestMatrix.outputs['${{ format('matrix.{0}MatrixWindowsLtsc2016Amd64', parameters.testMatrixType) }}']
+        matrix: dependencies.GenerateTestMatrix.outputs['matrix.WindowsLtsc2016Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
     - template: ../jobs/test-images-windows-client.yml
       parameters:
@@ -247,7 +268,7 @@ stages:
         pool: # windows1809Amd64
           name: DotNetCore-Docker
           demands: VSTS_OS -equals Windows_Server_2019_Data_Center_RS5
-        matrix: dependencies.GenerateTestMatrix.outputs['${{ format('matrix.{0}MatrixWindowsLtsc2019Amd64', parameters.testMatrixType) }}']
+        matrix: dependencies.GenerateTestMatrix.outputs['matrix.WindowsLtsc2019Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
 
   ################################################################################

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -73,21 +73,8 @@ stages:
       customInitSteps: ${{ parameters.customBuildInitSteps }}
   - template: ../jobs/build-images.yml
     parameters:
-      name: Build_NanoServer1809_amd64
-      pool: # windows1809Amd64
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: DotNetCore-Docker-Public
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: DotNetCore-Docker
-        demands: VSTS_OS -equals Windows_Server_2019_Data_Center_RS5
-      matrix: dependencies.GenerateBuildMatrix.outputs['${{ format('matrix.{0}MatrixNanoserver1809Amd64', parameters.buildMatrixType) }}']
-      dockerClientOS: windows
-      buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
-      customInitSteps: ${{ parameters.customBuildInitSteps }}
-  - template: ../jobs/build-images.yml
-    parameters:
-      name: Build_NanoServer1809_arm32
-      pool: # nanoServer1809Arm32Pool
+      name: Build_Windows1809_arm32
+      pool: # Windows1809Arm32Pool
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: DotNetCore-Docker-Public
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
@@ -96,86 +83,60 @@ stages:
         - agent.os -equals linux
         - RemoteDockerServerOS -equals nanoserver-1809
         - RemoteDockerServerArch -equals arm32
-      matrix: dependencies.GenerateBuildMatrix.outputs['${{ format('matrix.{0}MatrixNanoserver1809Arm32', parameters.buildMatrixType) }}']
+      matrix: dependencies.GenerateBuildMatrix.outputs['${{ format('matrix.{0}MatrixWindows1809Arm32', parameters.buildMatrixType) }}']
       dockerClientOS: linux
       useRemoteDockerServer: true
       buildJobTimeout: ${{ parameters.windowsArmBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
   - template: ../jobs/build-images.yml
     parameters:
-      name: Build_NanoServer1903_amd64
+      name: Build_Windows1903_amd64
       pool: # windows1903Amd64
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: DotNetCore-Docker-Public
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: DotNetCore-Docker
         demands: VSTS_OS -equals Windows_Server_2019_Data_Center_1903
-      matrix: dependencies.GenerateBuildMatrix.outputs['${{ format('matrix.{0}MatrixNanoserver1903Amd64', parameters.buildMatrixType) }}']
+      matrix: dependencies.GenerateBuildMatrix.outputs['${{ format('matrix.{0}MatrixWindows1903Amd64', parameters.buildMatrixType) }}']
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
   - template: ../jobs/build-images.yml
     parameters:
-      name: Build_NanoServer1909_amd64
+      name: Build_Windows1909_amd64
       pool: # windows1909Amd64
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: DotNetCore-Docker-Public
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: DotNetCore-Docker
         demands: VSTS_OS -equals Windows-ServerDatacenter-1909
-      matrix: dependencies.GenerateBuildMatrix.outputs['${{ format('matrix.{0}MatrixNanoserver1909Amd64', parameters.buildMatrixType) }}']
+      matrix: dependencies.GenerateBuildMatrix.outputs['${{ format('matrix.{0}MatrixWindows1909Amd64', parameters.buildMatrixType) }}']
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
   - template: ../jobs/build-images.yml
     parameters:
-      name: Build_WindowsServerCoreLtsc2016_amd64
+      name: Build_WindowsLtsc2016_amd64
       pool: # windows1607Amd64Pool
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: DotNetCore-Docker-Public
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: DotNetCore-Docker
         demands: VSTS_OS -equals Windows_Server_2016_Data_Center_with_Containers
-      matrix: dependencies.GenerateBuildMatrix.outputs['${{ format('matrix.{0}MatrixWindowsservercoreLtsc2016Amd64', parameters.buildMatrixType) }}']
+      matrix: dependencies.GenerateBuildMatrix.outputs['${{ format('matrix.{0}MatrixWindowsLtsc2016Amd64', parameters.buildMatrixType) }}']
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
   - template: ../jobs/build-images.yml
     parameters:
-      name: Build_WindowsServerCoreLtsc2019_amd64
+      name: Build_WindowsLtsc2019_amd64
       pool: # windows1809Amd64
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: DotNetCore-Docker-Public
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: DotNetCore-Docker
         demands: VSTS_OS -equals Windows_Server_2019_Data_Center_RS5
-      matrix: dependencies.GenerateBuildMatrix.outputs['${{ format('matrix.{0}MatrixWindowsservercoreLtsc2019Amd64', parameters.buildMatrixType) }}']
-      dockerClientOS: windows
-      buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
-      customInitSteps: ${{ parameters.customBuildInitSteps }}
-  - template: ../jobs/build-images.yml
-    parameters:
-      name: Build_WindowsServerCore1903_amd64
-      pool: # windows1903Amd64
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: DotNetCore-Docker-Public
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: DotNetCore-Docker
-        demands: VSTS_OS -equals Windows_Server_2019_Data_Center_1903
-      matrix: dependencies.GenerateBuildMatrix.outputs['${{ format('matrix.{0}MatrixWindowsservercore1903Amd64', parameters.buildMatrixType) }}']
-      dockerClientOS: windows
-      buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
-      customInitSteps: ${{ parameters.customBuildInitSteps }}
-  - template: ../jobs/build-images.yml
-    parameters:
-      name: Build_WindowsServerCore1909_amd64
-      pool: # windows1909Amd64
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: DotNetCore-Docker-Public
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: DotNetCore-Docker
-        demands: VSTS_OS -equals Windows-ServerDatacenter-1909
-      matrix: dependencies.GenerateBuildMatrix.outputs['${{ format('matrix.{0}MatrixWindowsservercore1909Amd64', parameters.buildMatrixType) }}']
+      matrix: dependencies.GenerateBuildMatrix.outputs['${{ format('matrix.{0}MatrixWindowsLtsc2019Amd64', parameters.buildMatrixType) }}']
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
@@ -240,79 +201,53 @@ stages:
         matrix: dependencies.GenerateTestMatrix.outputs['${{ format('matrix.{0}MatrixLinuxArm32v7', parameters.testMatrixType) }}']
         testJobTimeout: ${{ parameters.linuxArmTestJobTimeout }}
         useRemoteDockerServer: true
-    - template: ../jobs/test-images-windows-client.yml
-      parameters:
-        name: Test_NanoServer1809_amd64
-        pool: # windows1809Amd64
-          name: DotNetCore-Docker
-          demands: VSTS_OS -equals Windows_Server_2019_Data_Center_RS5
-        matrix: dependencies.GenerateTestMatrix.outputs['${{ format('matrix.{0}MatrixNanoserver1809Amd64', parameters.testMatrixType) }}']
-        testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
     - template: ../jobs/test-images-linux-client.yml
       parameters:
-        name: Test_NanoServer1809_arm32
-        pool: # nanoServer1809Arm32Pool
+        name: Test_Windows1809_arm32
+        pool: # Windows1809Arm32Pool
           name: DotNetCore-Docker
           demands:
           - agent.os -equals linux
           - RemoteDockerServerOS -equals nanoserver-1809
           - RemoteDockerServerArch -equals arm32
-        matrix: dependencies.GenerateTestMatrix.outputs['${{ format('matrix.{0}MatrixNanoserver1809Arm32', parameters.testMatrixType) }}']
+        matrix: dependencies.GenerateTestMatrix.outputs['${{ format('matrix.{0}MatrixWindows1809Arm32', parameters.testMatrixType) }}']
         testJobTimeout: ${{ parameters.windowsArmTestJobTimeout }}
         useRemoteDockerServer: true
     - template: ../jobs/test-images-windows-client.yml
       parameters:
-        name: Test_NanoServer1903_amd64
-        buildDependencies: Build_NanoServer1903_amd64
+        name: Test_Windows1903_amd64
+        buildDependencies: Build_Windows1903_amd64
         pool: # windows1903Amd64
           name: DotNetCore-Docker
           demands: VSTS_OS -equals Windows_Server_2019_Data_Center_1903
-        matrix: dependencies.GenerateTestMatrix.outputs['${{ format('matrix.{0}MatrixNanoserver1903Amd64', parameters.testMatrixType) }}']
+        matrix: dependencies.GenerateTestMatrix.outputs['${{ format('matrix.{0}MatrixWindows1903Amd64', parameters.testMatrixType) }}']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
     - template: ../jobs/test-images-windows-client.yml
       parameters:
-        name: Test_NanoServer1909_amd64
-        buildDependencies: Build_NanoServer1909_amd64
+        name: Test_Windows1909_amd64
+        buildDependencies: Build_Windows1909_amd64
         pool: # windows1909Amd64
           name: DotNetCore-Docker
           demands: VSTS_OS -equals Windows-ServerDatacenter-1909
-        matrix: dependencies.GenerateTestMatrix.outputs['${{ format('matrix.{0}MatrixNanoserver1909Amd64', parameters.testMatrixType) }}']
+        matrix: dependencies.GenerateTestMatrix.outputs['${{ format('matrix.{0}MatrixWindows1909Amd64', parameters.testMatrixType) }}']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
     - template: ../jobs/test-images-windows-client.yml
       parameters:
-        name: Test_WindowsServerCoreLtsc2016_amd64
-        buildDependencies: Build_WindowsServerCoreLtsc2016_amd64
+        name: Test_WindowsLtsc2016_amd64
+        buildDependencies: Build_WindowsLtsc2016_amd64
         pool: # windows1607Amd64Pool
           name: DotNetCore-Docker
           demands: VSTS_OS -equals Windows_Server_2016_Data_Center_with_Containers
-        matrix: dependencies.GenerateTestMatrix.outputs['${{ format('matrix.{0}MatrixWindowsservercoreLtsc2016Amd64', parameters.testMatrixType) }}']
+        matrix: dependencies.GenerateTestMatrix.outputs['${{ format('matrix.{0}MatrixWindowsLtsc2016Amd64', parameters.testMatrixType) }}']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
     - template: ../jobs/test-images-windows-client.yml
       parameters:
-        name: Test_WindowsServerCoreLtsc2019_amd64
-        buildDependencies: Build_WindowsServerCoreLtsc2019_amd64
+        name: Test_WindowsLtsc2019_amd64
+        buildDependencies: Build_WindowsLtsc2019_amd64
         pool: # windows1809Amd64
           name: DotNetCore-Docker
           demands: VSTS_OS -equals Windows_Server_2019_Data_Center_RS5
-        matrix: dependencies.GenerateTestMatrix.outputs['${{ format('matrix.{0}MatrixWindowsservercoreLtsc2019Amd64', parameters.testMatrixType) }}']
-        testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
-    - template: ../jobs/test-images-windows-client.yml
-      parameters:
-        name: Test_WindowsServerCore1903_amd64
-        buildDependencies: Build_WindowsServerCore1903_amd64
-        pool: # windows1903Amd64
-          name: DotNetCore-Docker
-          demands: VSTS_OS -equals Windows_Server_2019_Data_Center_1903
-        matrix: dependencies.GenerateTestMatrix.outputs['${{ format('matrix.{0}MatrixWindowsservercore1903Amd64', parameters.testMatrixType) }}']
-        testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
-    - template: ../jobs/test-images-windows-client.yml
-      parameters:
-        name: Test_WindowsServerCore1909_amd64
-        buildDependencies: Build_WindowsServerCore1909_amd64
-        pool: # windows1909Amd64
-          name: DotNetCore-Docker
-          demands: VSTS_OS -equals Windows-ServerDatacenter-1909
-        matrix: dependencies.GenerateTestMatrix.outputs['${{ format('matrix.{0}MatrixWindowsservercore1909Amd64', parameters.testMatrixType) }}']
+        matrix: dependencies.GenerateTestMatrix.outputs['${{ format('matrix.{0}MatrixWindowsLtsc2019Amd64', parameters.testMatrixType) }}']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
 
   ################################################################################

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -73,7 +73,7 @@ stages:
       customInitSteps: ${{ parameters.customBuildInitSteps }}
   - template: ../jobs/build-images.yml
     parameters:
-      name: Build_NanoServer1809_amd64
+      name: Build_Windows1809_amd64
       pool: # windows1809Amd64
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: DotNetCore-Docker-Public

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -140,19 +140,6 @@ stages:
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
-  - template: ../jobs/build-images.yml
-    parameters:
-      name: Build_WindowsLtsc2019_amd64
-      pool: # windows1809Amd64
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: DotNetCore-Docker-Public
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: DotNetCore-Docker
-        demands: VSTS_OS -equals Windows_Server_2019_Data_Center_RS5
-      matrix: dependencies.GenerateBuildMatrix.outputs['matrix.{0}WindowsLtsc2019Amd64']
-      dockerClientOS: windows
-      buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
-      customInitSteps: ${{ parameters.customBuildInitSteps }}
 
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   ################################################################################
@@ -260,15 +247,6 @@ stages:
           name: DotNetCore-Docker
           demands: VSTS_OS -equals Windows_Server_2016_Data_Center_with_Containers
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.WindowsLtsc2016Amd64']
-        testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
-    - template: ../jobs/test-images-windows-client.yml
-      parameters:
-        name: Test_WindowsLtsc2019_amd64
-        buildDependencies: Build_WindowsLtsc2019_amd64
-        pool: # windows1809Amd64
-          name: DotNetCore-Docker
-          demands: VSTS_OS -equals Windows_Server_2019_Data_Center_RS5
-        matrix: dependencies.GenerateTestMatrix.outputs['matrix.WindowsLtsc2019Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
 
   ################################################################################

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
@@ -241,7 +241,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             {
                 return platformId.OsVersion
                     .Replace("nanoserver", "windows")
-                    .Replace("windowsservercore", "windows");
+                    .Replace("windowsservercore", "windows")
+                    .Replace("ltsc2019", "1809");
             }
 
             return platformId.OS.GetDockerName();

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
@@ -216,8 +216,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             {
                 string[] matrixNameParts =
                 {
-                    $"{Options.MatrixType.ToString().ToCamelCase()}Matrix",
-                    platformGrouping.Key.OsVersion ?? platformGrouping.Key.OS.GetDockerName(),
+                    GetOsMatrixNamePart(platformGrouping.Key),
                     platformGrouping.Key.Architecture.GetDisplayName(platformGrouping.Key.Variant)
                 };
                 BuildMatrixInfo matrix = new BuildMatrixInfo() { Name = FormatMatrixName(matrixNameParts) };
@@ -234,6 +233,18 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             }
 
             return matrices;
+        }
+
+        private static string GetOsMatrixNamePart(PlatformId platformId)
+        {
+            if (platformId.OsVersion != null)
+            {
+                return platformId.OsVersion
+                    .Replace("nanoserver", "windows")
+                    .Replace("windowsservercore", "windows");
+            }
+
+            return platformId.OS.GetDockerName();
         }
 
         private IEnumerable<PlatformInfo> GetPlatformDependencies(PlatformInfo platform, IEnumerable<PlatformInfo> availablePlatforms) =>


### PR DESCRIPTION
There is essentially duplication in the pipeline in the build and test stages for the Windows jobs because there are sections for handling both a NanoServer-labeled matrix and ServerCore-labeled matrix.  Both of these use the same type of agent pool for their respective Windows version.  These are being consolidate with these changes.  For 1809 amd64, this will now be labeled as ltsc2019.

What this looks like from a consuming perspective is that the manifest must change from using `nanoserver` or `windowsservercore` to just `windows`.

Example (nanoserver):

* Old: `"osVersion": "nanoserver-1909"`
* New `"osVersion": "windows-1909"`

Example (servercore using 1809):

* Old: `"osVersion": "windowsservercore-1809"`
* New `"osVersion": "windows-ltsc2019"`

Fixes #278