### PR TITLE
Change Windows build pool used by image-builder pools

### DIFF
--- a/eng/pipelines/templates/jobs/build-image-builder.yml
+++ b/eng/pipelines/templates/jobs/build-image-builder.yml
@@ -17,5 +17,10 @@ jobs:
 - template: build-image-builder-image.yml
   parameters:
     name: Windows
-    pool: Hosted Windows Container
+    pool:
+      ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        name: DotNetCore-Docker-Public
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        name: DotNetCore-Docker
+      demands: VSTS_OS -equals Windows_Server_2019_Data_Center_RS5
     publishImages: ${{ parameters.publishImages }}


### PR DESCRIPTION
Currently the `Hosted Windows Container` pool contains 1803 which is now EOL.  Because of this, the .NET SDK image can no longer be pulled.

Workaround for https://github.com/dotnet/core-eng/issues/8339