### PR TITLE
GetStaleImagesCommand fix for unknown base images

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
@@ -149,7 +149,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                                 this.imageDigestsSemaphore.Release();
                             }
 
-                            string lastDigest = imageData.BaseImages?[fromImage];
+                            string lastDigest = null;
+                            imageData.BaseImages?.TryGetValue(fromImage, out lastDigest);
 
                             if (lastDigest != currentDigest)
                             {


### PR DESCRIPTION
The GetStaleImagesCommand recently started failing after the change to update the samples to 3.1 (https://github.com/dotnet/dotnet-docker/pull/1517).  When processing those changed Dockerfiles, the command was throwing a `KeyNotFoundException` when trying to lookup the base image data for `mcr.microsoft.com/dotnet/core/sdk:3.1` from the image info.  But no such data existed because a build hasn't yet run to produce the new sample images and update the image info file.  The command needs to gracefully handles this and mark such an image as needing to be rebuilt.