### PR TITLE
Fix ARM-based base image checks

### DIFF
--- a/eng/pipelines/check-base-image-updates.yml
+++ b/eng/pipelines/check-base-image-updates.yml
@@ -11,10 +11,11 @@ jobs:
   - template: templates/steps/get-stale-images.yml
     parameters:
       osType: linux
+      architecture: amd64
       dockerClientOS: linux
       staleImagePathsVariableName: linux-amd-stale-image-paths
 
-- job: Get_Stale_Images_Linux_ARM
+- job: Get_Stale_Images_Linux_ARM32
   pool:
     name: DotNetCore-Docker
     demands:
@@ -25,9 +26,26 @@ jobs:
   - template: templates/steps/get-stale-images.yml
     parameters:
       osType: linux
+      architecture: arm
       dockerClientOS: linux
       useRemoteDockerServer: true
-      staleImagePathsVariableName: linux-arm-stale-image-paths
+      staleImagePathsVariableName: linux-arm32-stale-image-paths
+
+- job: Get_Stale_Images_Linux_ARM64
+  pool:
+    name: DotNetCore-Docker
+    demands:
+    - agent.os -equals linux
+    - RemoteDockerServerOS -equals linux
+    - RemoteDockerServerArch -equals aarch64
+  steps:
+  - template: templates/steps/get-stale-images.yml
+    parameters:
+      osType: linux
+      architecture: arm64
+      dockerClientOS: linux
+      useRemoteDockerServer: true
+      staleImagePathsVariableName: linux-arm64-stale-image-paths
 
 - job: Get_Stale_Images_Windows_AMD
   # Use the most recent Windows version so we can pull all image versions of Windows
@@ -38,10 +56,11 @@ jobs:
   - template: templates/steps/get-stale-images.yml
     parameters:
       osType: windows
+      architecture: amd64
       dockerClientOS: windows
       staleImagePathsVariableName: windows-amd-stale-image-paths
 
-- job: Get_Stale_Images_Windows_ARM
+- job: Get_Stale_Images_Windows_ARM32
   # Use the most recent ARM-supported Windows version so we can pull all image versions of Windows
   pool:
     name: DotNetCore-Docker
@@ -53,22 +72,25 @@ jobs:
   - template: templates/steps/get-stale-images.yml
     parameters:
       osType: windows
+      architecture: arm
       dockerClientOS: linux
       useRemoteDockerServer: true
-      staleImagePathsVariableName: windows-arm-stale-image-paths
+      staleImagePathsVariableName: windows-arm32-stale-image-paths
 
 - job: Queue_Stale_Image_Builds
   dependsOn:
   - Get_Stale_Images_Linux_AMD
-  - Get_Stale_Images_Linux_ARM
+  - Get_Stale_Images_Linux_ARM32
+  - Get_Stale_Images_Linux_ARM64
   - Get_Stale_Images_Windows_AMD
-  - Get_Stale_Images_Windows_ARM
+  - Get_Stale_Images_Windows_ARM32
   pool: Hosted Ubuntu 1604
   variables:
     imagePaths1: $[ dependencies.Get_Stale_Images_Linux_AMD.outputs['GetStaleImages.linux-amd-stale-image-paths'] ]
-    imagePaths2: $[ dependencies.Get_Stale_Images_Linux_ARM.outputs['GetStaleImages.linux-arm-stale-image-paths'] ]
-    imagePaths3: $[ dependencies.Get_Stale_Images_Windows_AMD.outputs['GetStaleImages.windows-amd-stale-image-paths'] ]
-    imagePaths4: $[ dependencies.Get_Stale_Images_Windows_ARM.outputs['GetStaleImages.windows-arm-stale-image-paths'] ]
+    imagePaths2: $[ dependencies.Get_Stale_Images_Linux_ARM32.outputs['GetStaleImages.linux-arm32-stale-image-paths'] ]
+    imagePaths3: $[ dependencies.Get_Stale_Images_Linux_ARM64.outputs['GetStaleImages.linux-arm64-stale-image-paths'] ]
+    imagePaths4: $[ dependencies.Get_Stale_Images_Windows_AMD.outputs['GetStaleImages.windows-amd-stale-image-paths'] ]
+    imagePaths5: $[ dependencies.Get_Stale_Images_Windows_ARM32.outputs['GetStaleImages.windows-arm32-stale-image-paths'] ]
   steps:
   - template: ../common/templates/steps/init-docker-linux.yml
   - script: >
@@ -82,5 +104,6 @@ jobs:
       --image-paths "$(imagePaths2)"
       --image-paths "$(imagePaths3)"
       --image-paths "$(imagePaths4)"
+      --image-paths "$(imagePaths5)"
     displayName: Queue Build for Stale Images
   - template: ../common/templates/steps/cleanup-docker-linux.yml

--- a/eng/pipelines/templates/steps/get-stale-images.yml
+++ b/eng/pipelines/templates/steps/get-stale-images.yml
@@ -1,5 +1,6 @@
 parameters:
   osType: null
+  architecture: null
   dockerClientOS: null
   useRemoteDockerServer: false
   staleImagePathsVariableName: null
@@ -16,6 +17,7 @@ steps:
       ${{ parameters.staleImagePathsVariableName }}
       --subscriptions-path $(checkBaseImageSubscriptionsPath)
       --os-type ${{ parameters.osType }}
+      --architecture ${{ parameters.architecture }}
       --git-owner dotnet
       --git-repo versions
       --git-branch master


### PR DESCRIPTION
The `check-base-image-updates` pipeline is not scanning ARM32 Linux base images.  In order to check for both ARM32 and ARM64 base images, the logic needs to explicitly set the `architecture` option when calling the `getStaleImages` command.  Otherwise, it'll end up using the default architecture of the daemon: AArch64 => ARM64.

Fixes #342 