### PR TITLE
Support for optional test args for Linux

### DIFF
--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -18,6 +18,9 @@ steps:
     if [ "${{ eq(variables['System.TeamProject'], 'public') }}" == "False" ]; then
       optionalTestArgs="$optionalTestArgs -PullImages -Registry $(acr.server) -RepoPrefix $(stagingRepoPrefix) -ImageInfoPath $(artifactsPath)/image-info/image-info.json"
     fi
+    if [ "$REPOTESTARGS" != "" ]; then
+      optionalTestArgs="$optionalTestArgs $REPOTESTARGS"
+    fi
     echo "##vso[task.setvariable variable=optionalTestArgs]$optionalTestArgs"
   displayName: Set Test Variables
 - script: >


### PR DESCRIPTION
Provides support for a pipeline to pass in additional test arguments when calling the `run-tests.ps1` script in Linux scenarios.  This functionality already exists for Windows scenarios, so this is just providing parity.