### PR TITLE
Fix option/parameter ordering for commands

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
@@ -20,11 +20,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
         }
 
-        public override void ParseCommandLine(ArgumentSyntax syntax)
+        public override void DefineOptions(ArgumentSyntax syntax)
         {
-            base.ParseCommandLine(syntax);
+            base.DefineOptions(syntax);
 
-            FilterOptions.ParseCommandLine(syntax);
+            FilterOptions.DefineOptions(syntax);
 
             bool isPushEnabled = false;
             syntax.DefineOption("push", ref isPushEnabled, "Push built images to Docker registry");

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesOptions.cs
@@ -23,15 +23,20 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
         }
 
-        public override void ParseCommandLine(ArgumentSyntax syntax)
+        public override void DefineOptions(ArgumentSyntax syntax)
         {
-            base.ParseCommandLine(syntax);
+            base.DefineOptions(syntax);
 
-            FilterOptions.ParseCommandLine(syntax);
+            FilterOptions.DefineOptions(syntax);
 
             string imageInfoPath = null;
             syntax.DefineOption("image-info", ref imageInfoPath, "Path to image info file");
             ImageInfoPath = imageInfoPath;
+        }
+
+        public override void DefineParameters(ArgumentSyntax syntax)
+        {
+            base.DefineParameters(syntax);
 
             string sourceRepoPrefix = null;
             syntax.DefineParameter("source-repo-prefix", ref sourceRepoPrefix, "Prefix of the source ACR repository to copy images from");

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/DockerRegistryOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/DockerRegistryOptions.cs
@@ -16,9 +16,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
         }
 
-        public override void ParseCommandLine(ArgumentSyntax syntax)
+        public override void DefineOptions(ArgumentSyntax syntax)
         {
-            base.ParseCommandLine(syntax);
+            base.DefineOptions(syntax);
 
             string password = null;
             Argument<string> passwordArg = syntax.DefineOption(

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixOptions.cs
@@ -20,11 +20,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
         }
 
-        public override void ParseCommandLine(ArgumentSyntax syntax)
+        public override void DefineOptions(ArgumentSyntax syntax)
         {
-            base.ParseCommandLine(syntax);
+            base.DefineOptions(syntax);
 
-            FilterOptions.ParseCommandLine(syntax);
+            FilterOptions.DefineOptions(syntax);
 
             MatrixType matrixType = MatrixType.PlatformDependencyGraph;
             syntax.DefineOption(

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateTagsReadmeOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateTagsReadmeOptions.cs
@@ -18,13 +18,18 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
         }
 
-        public override void ParseCommandLine(ArgumentSyntax syntax)
+        public override void DefineOptions(ArgumentSyntax syntax)
         {
-            base.ParseCommandLine(syntax);
+            base.DefineOptions(syntax);
 
             string sourceRepoBranch = null;
             syntax.DefineOption("source-branch", ref sourceRepoBranch, "Repo branch of the Dockerfile sources (default is commit SHA)");
             SourceRepoBranch = sourceRepoBranch;
+        }
+
+        public override void DefineParameters(ArgumentSyntax syntax)
+        {
+            base.DefineParameters(syntax);
 
             string sourceRepoUrl = null;
             syntax.DefineParameter("source-repo", ref sourceRepoUrl, "Repo URL of the Dockerfile sources");

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesOptions.cs
@@ -17,9 +17,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public string SubscriptionsPath { get; set; }
         public string VariableName { get; set; }
 
-        public override void ParseCommandLine(ArgumentSyntax syntax)
+        public override void DefineOptions(ArgumentSyntax syntax)
         {
-            base.ParseCommandLine(syntax);
+            base.DefineOptions(syntax);
 
             const string DefaultSubscriptionsPath = "subscriptions.json";
             string subscriptionsPath = DefaultSubscriptionsPath;
@@ -29,9 +29,16 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 $"Path to the subscriptions file (defaults to '{DefaultSubscriptionsPath}').");
             SubscriptionsPath = subscriptionsPath;
 
-            FilterOptions.ParseCommandLine(syntax);
-            GitOptions.ParseCommandLine(syntax);
-            
+            FilterOptions.DefineOptions(syntax);
+            GitOptions.DefineOptions(syntax);
+        }
+
+        public override void DefineParameters(ArgumentSyntax syntax)
+        {
+            base.DefineParameters(syntax);
+
+            GitOptions.DefineParameters(syntax);
+
             string variableName = null;
             syntax.DefineParameter(
                 "image-paths-variable",

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GitOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GitOptions.cs
@@ -26,7 +26,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             this.Path = defaultPath ?? throw new ArgumentNullException(nameof(defaultPath));
         }
 
-        public void ParseCommandLine(ArgumentSyntax syntax)
+        public void DefineOptions
+            (ArgumentSyntax syntax)
         {
             string branch = Branch;
             syntax.DefineOption(
@@ -55,7 +56,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 ref repo,
                 $"GitHub repo to write to (defaults to {repo})");
             Repo = repo;
+        }
 
+        public void DefineParameters(ArgumentSyntax syntax)
+        {
             string username = null;
             syntax.DefineParameter(
                 "git-username",

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ImageSizeOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ImageSizeOptions.cs
@@ -14,11 +14,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public string BaselinePath { get; set; }
         public bool IsPullEnabled { get; set; }
 
-        public override void ParseCommandLine(ArgumentSyntax syntax)
+        public override void DefineOptions(ArgumentSyntax syntax)
         {
-            base.ParseCommandLine(syntax);
+            base.DefineOptions(syntax);
 
-            FilterOptions.ParseCommandLine(syntax);
+            FilterOptions.DefineOptions(syntax);
 
             int allowedVariance = 5;
             syntax.DefineOption("variance", ref allowedVariance, $"Allowed percent variance in size (default is `{allowedVariance}`");
@@ -27,6 +27,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             bool isPullEnabled = false;
             syntax.DefineOption("pull", ref isPullEnabled, "Pull the images vs using local images");
             IsPullEnabled = isPullEnabled;
+        }
+
+        public override void DefineParameters(ArgumentSyntax syntax)
+        {
+            base.DefineParameters(syntax);
 
             string baselinePath = null;
             syntax.DefineParameter("baseline", ref baselinePath, "Path to the baseline file");

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestFilterOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestFilterOptions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public string OsVersion { get; set; }
         public IEnumerable<string> Paths { get; set; }
 
-        public void ParseCommandLine(ArgumentSyntax syntax)
+        public void DefineOptions(ArgumentSyntax syntax)
         {
             string architecture = DockerHelper.Architecture.GetDockerName();
             syntax.DefineOption(

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestOptions.cs
@@ -42,9 +42,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             return filter;
         }
 
-        public override void ParseCommandLine(ArgumentSyntax syntax)
+        public override void DefineOptions(ArgumentSyntax syntax)
         {
-            base.ParseCommandLine(syntax);
+            base.DefineOptions(syntax);
 
             string manifest = "manifest.json";
             syntax.DefineOption("manifest", ref manifest, "Path to json file which describes the repo");

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/MergeImageInfoOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/MergeImageInfoOptions.cs
@@ -14,9 +14,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         public string DestinationImageInfoPath { get; set; }
 
-        public override void ParseCommandLine(ArgumentSyntax syntax)
+        public override void DefineParameters(ArgumentSyntax syntax)
         {
-            base.ParseCommandLine(syntax);
+            base.DefineParameters(syntax);
 
             string sourceImageInfoFolderPath = null;
             syntax.DefineParameter(

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/Options.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/Options.cs
@@ -35,11 +35,16 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             return result;
         }
 
-        public virtual void ParseCommandLine(ArgumentSyntax syntax)
+        public void ParseCommandLine(ArgumentSyntax syntax)
         {
             ArgumentCommand command = syntax.DefineCommand(GetCommandName(), this);
             command.Help = CommandHelp;
+            DefineOptions(syntax);
+            DefineParameters(syntax);
+        }
 
+        public virtual void DefineOptions(ArgumentSyntax syntax)
+        {
             bool isDryRun = false;
             syntax.DefineOption("dry-run", ref isDryRun, "Dry run of what images get built and order they would get built in");
             IsDryRun = isDryRun;
@@ -47,6 +52,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             bool isVerbose = false;
             syntax.DefineOption("verbose", ref isVerbose, "Show details about the tasks run");
             IsVerbose = isVerbose;
+        }
+
+        public virtual void DefineParameters(ArgumentSyntax syntax)
+        {
         }
 
         public string GetCommandName()

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoOptions.cs
@@ -14,11 +14,18 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         public string ImageInfoPath { get; set; }
 
-        public override void ParseCommandLine(ArgumentSyntax syntax)
+        public override void DefineOptions(ArgumentSyntax syntax)
         {
-            base.ParseCommandLine(syntax);
+            base.DefineOptions(syntax);
 
-            GitOptions.ParseCommandLine(syntax);
+            GitOptions.DefineOptions(syntax);
+        }
+
+        public override void DefineParameters(ArgumentSyntax syntax)
+        {
+            base.DefineParameters(syntax);
+
+            GitOptions.DefineParameters(syntax);
 
             string imageInfoPath = null;
             syntax.DefineParameter(

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestOptions.cs
@@ -16,11 +16,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
         }
 
-        public override void ParseCommandLine(ArgumentSyntax syntax)
+        public override void DefineOptions(ArgumentSyntax syntax)
         {
-            base.ParseCommandLine(syntax);
+            base.DefineOptions(syntax);
 
-            FilterOptions.ParseCommandLine(syntax);
+            FilterOptions.DefineOptions(syntax);
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsOptions.cs
@@ -18,11 +18,18 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
         }
 
-        public override void ParseCommandLine(ArgumentSyntax syntax)
+        public override void DefineOptions(ArgumentSyntax syntax)
         {
-            base.ParseCommandLine(syntax);
+            base.DefineOptions(syntax);
 
-            GitOptions.ParseCommandLine(syntax);
+            GitOptions.DefineOptions(syntax);
+        }
+
+        public override void DefineParameters(ArgumentSyntax syntax)
+        {
+            base.DefineParameters(syntax);
+
+            GitOptions.DefineParameters(syntax);
 
             string sourceRepoUrl = null;
             syntax.DefineParameter("source-repo", ref sourceRepoUrl, "Repo URL of the Dockerfile sources");

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/QueueBuildOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/QueueBuildOptions.cs
@@ -18,9 +18,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public string BuildProject { get; set; }
         public IEnumerable<string> AllSubscriptionImagePaths { get; set; }
 
-        public override void ParseCommandLine(ArgumentSyntax syntax)
+        public override void DefineOptions(ArgumentSyntax syntax)
         {
-            base.ParseCommandLine(syntax);
+            base.DefineOptions(syntax);
 
             const string DefaultSubscriptionsPath = "subscriptions.json";
             string subscriptionsPath = DefaultSubscriptionsPath;
@@ -36,6 +36,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 ref allSubscriptionImagePaths,
                 "JSON string mapping a subscription ID to the image paths to be built (from the output variable of getStaleImages)");
             AllSubscriptionImagePaths = allSubscriptionImagePaths;
+        }
+
+        public override void DefineParameters(ArgumentSyntax syntax)
+        {
+            base.DefineParameters(syntax);
 
             string buildPersonalAccessToken = null;
             syntax.DefineParameter(

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ShowImageStatsOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ShowImageStatsOptions.cs
@@ -16,11 +16,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
         }
 
-        public override void ParseCommandLine(ArgumentSyntax syntax)
+        public override void DefineOptions(ArgumentSyntax syntax)
         {
-            base.ParseCommandLine(syntax);
+            base.DefineOptions(syntax);
 
-            FilterOptions.ParseCommandLine(syntax);
+            FilterOptions.DefineOptions(syntax);
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/UpdateImageSizeBaselineOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/UpdateImageSizeBaselineOptions.cs
@@ -12,13 +12,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         public bool AllBaselineData { get; set; }
 
-        public override void ParseCommandLine(ArgumentSyntax syntax)
+        public override void DefineOptions(ArgumentSyntax syntax)
         {
+            base.DefineOptions(syntax);
+
             bool allBaselineData = false;
             syntax.DefineOption("all", ref allBaselineData, "Updates baseline for all images regardless of size variance");
             AllBaselineData = allBaselineData;
-
-            base.ParseCommandLine(syntax);
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ValidateImageSizeOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ValidateImageSizeOptions.cs
@@ -16,13 +16,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
         }
 
-        public override void ParseCommandLine(ArgumentSyntax syntax)
+        public override void DefineOptions(ArgumentSyntax syntax)
         {
-            bool checkBaselineIntegrityOnly = false;
-            syntax.DefineOption("baseline-integrity-only", ref checkBaselineIntegrityOnly, "Only validate whether new or old images exist compared with baseline");
-            CheckBaselineIntegrityOnly = checkBaselineIntegrityOnly;
+            base.DefineOptions(syntax);
 
-            base.ParseCommandLine(syntax);
+            bool checkBaselineIntegrityOnly = false;
+            syntax.DefineOption("baseline-integrity-only", ref checkBaselineIntegrityOnly, "Validate the integrity of the baseline by checking for missing or extraneous data");
+            CheckBaselineIntegrityOnly = checkBaselineIntegrityOnly;
         }
     }
 }


### PR DESCRIPTION
The changes from https://github.com/dotnet/docker-tools/pull/350 are broken due to defining command options before the command has been defined in the `ArgumentSyntax` object.  The problem in resolving this is that options need to be defined before parameters and the `ImageSizeOptions` base class defines both options and parameters.  So deriving classes need to call the base `ParseCommandLine` method in order to define the command but doing so prevents them from adding additional options because the base class added a parameter.

To solve this, I've update the `Options` class to split apart the defining of options and parameters into separate virtual methods.  It first defines all options, allowing all classes in the inheritance hierarchy to add their options, and then similarly follows that up with defining parameters.