### PR TITLE
Fix FilterOptions in ImageSizeOptions class

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ImageSizeOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ImageSizeOptions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     public abstract class ImageSizeOptions : ManifestOptions, IFilterableOptions
     {
-        public ManifestFilterOptions FilterOptions => new ManifestFilterOptions();
+        public ManifestFilterOptions FilterOptions { get; } = new ManifestFilterOptions();
 
         public int AllowedVariance { get; set; }
         public string BaselinePath { get; set; }


### PR DESCRIPTION
Commands deriving from `ImageSizeCommand` did not have their filtering options applied.  This is because the property was reinstatiating the `ManifestFilterOptions` class each time the property was accessed.