### PR TITLE
Prevent git repo side effects when dry-run is used

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
@@ -180,7 +180,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private async Task<RepoData[]> GetImageInfoForSubscriptionAsync(Subscription subscription)
         {
             string imageDataJson;
-            using (IGitHubClient gitHubClient = this.gitHubClientFactory.GetClient(Options.GitOptions.ToGitHubAuth()))
+            using (IGitHubClient gitHubClient = this.gitHubClientFactory.GetClient(Options.GitOptions.ToGitHubAuth(), Options.IsDryRun))
             {
                 GitHubProject project = new GitHubProject(Options.GitOptions.Repo, Options.GitOptions.Owner);
                 GitHubBranch branch = new GitHubBranch(Options.GitOptions.Branch, project);

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/IGitOptionsHost.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/IGitOptionsHost.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
-    public interface IGitOptionsHost
+    public interface IGitOptionsHost : IOptions
     {
         GitOptions GitOptions { get; }
     }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/IOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/IOptions.cs
@@ -2,10 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace Microsoft.DotNet.ImageBuilder.ViewModel
+namespace Microsoft.DotNet.ImageBuilder.Commands
 {
-    public interface IOptionsInfo
+    public interface IOptions
     {
+        bool IsDryRun { get; }
         bool IsVerbose { get; }
         string GetOption(string name);
     }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/Options.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/Options.cs
@@ -10,7 +10,7 @@ using Microsoft.DotNet.ImageBuilder.ViewModel;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
-    public abstract class Options : IOptionsInfo
+    public abstract class Options : IOptions
     {
         public bool IsDryRun { get; set; }
         public bool IsVerbose { get; set; }

--- a/src/Microsoft.DotNet.ImageBuilder/src/GitHubClientFactory.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/GitHubClientFactory.cs
@@ -2,7 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+using Microsoft.DotNet.ImageBuilder.Commands;
 using Microsoft.DotNet.VersionTools.Automation;
 using Microsoft.DotNet.VersionTools.Automation.GitHubApi;
 
@@ -11,9 +14,112 @@ namespace Microsoft.DotNet.ImageBuilder
     [Export(typeof(IGitHubClientFactory))]
     internal class GitHubClientFactory : IGitHubClientFactory
     {
-        public IGitHubClient GetClient(GitHubAuth gitHubAuth)
+        public IGitHubClient GetClient(GitHubAuth gitHubAuth, bool isDryRun)
         {
-            return new GitHubClient(gitHubAuth);
+            return new GitHubClientWrapper(new GitHubClient(gitHubAuth), isDryRun);
+        }
+
+        // Wrapper class to ensure that no operations with side-effects are invoked when the dry-run option is enabled
+        private class GitHubClientWrapper : IGitHubClient
+        {
+            private readonly GitHubClient innerClient;
+            private bool isDryRun;
+
+            public GitHubClientWrapper(GitHubClient innerClient, bool isDryRun)
+            {
+                this.innerClient = innerClient;
+                this.isDryRun = isDryRun;
+            }
+
+            public GitHubAuth Auth => this.innerClient.Auth;
+
+            public void Dispose() => this.innerClient.Dispose();
+
+            public void AdjustOptionsToCapability(PullRequestOptions options) =>
+                this.innerClient.AdjustOptionsToCapability(options);
+
+            public string CreateGitRemoteUrl(GitHubProject project) =>
+                this.innerClient.CreateGitRemoteUrl(project);
+
+            public Task<GitCommit> GetCommitAsync(GitHubProject project, string sha) =>
+                this.innerClient.GetCommitAsync(project, sha);
+
+            public Task<GitHubContents> GetGitHubFileAsync(string path, GitHubProject project, string @ref) =>
+                this.innerClient.GetGitHubFileAsync(path, project, @ref);
+
+            public Task<string> GetGitHubFileContentsAsync(string path, GitHubBranch branch) =>
+                this.innerClient.GetGitHubFileContentsAsync(path, branch);
+
+            public Task<string> GetGitHubFileContentsAsync(string path, GitHubProject project, string @ref) =>
+                this.innerClient.GetGitHubFileContentsAsync(path, project, @ref);
+
+            public Task<string> GetMyAuthorIdAsync() =>
+                this.innerClient.GetMyAuthorIdAsync();
+
+            public Task<GitReference> GetReferenceAsync(GitHubProject project, string @ref) =>
+                this.innerClient.GetReferenceAsync(project, @ref);
+
+            public Task<GitHubCombinedStatus> GetStatusAsync(GitHubProject project, string @ref) =>
+                this.innerClient.GetStatusAsync(project, @ref);
+
+            public Task<GitReference> PatchReferenceAsync(GitHubProject project, string @ref, string sha, bool force)
+            {
+                this.EnsureNotDryRun();
+                return this.innerClient.PatchReferenceAsync(project, @ref, sha, force);
+            }
+
+            public Task PostCommentAsync(GitHubProject project, int issueNumber, string message)
+            {
+                this.EnsureNotDryRun();
+                return this.innerClient.PostCommentAsync(project, issueNumber, message);
+            }
+
+            public Task<GitCommit> PostCommitAsync(GitHubProject project, string message, string tree, string[] parents)
+            {
+                this.EnsureNotDryRun();
+                return this.innerClient.PostCommitAsync(project, message, tree, parents);
+            }
+
+            public Task PostGitHubPullRequestAsync(string title, string description, GitHubBranch headBranch, GitHubBranch baseBranch, bool maintainersCanModify)
+            {
+                this.EnsureNotDryRun();
+                return this.innerClient.PostGitHubPullRequestAsync(title, description, headBranch, baseBranch, maintainersCanModify);
+            }
+
+            public Task<GitReference> PostReferenceAsync(GitHubProject project, string @ref, string sha)
+            {
+                this.EnsureNotDryRun();
+                return this.innerClient.PostReferenceAsync(project, @ref, sha);
+            }
+
+            public Task<GitTree> PostTreeAsync(GitHubProject project, string baseTree, GitObject[] tree)
+            {
+                this.EnsureNotDryRun();
+                return this.innerClient.PostTreeAsync(project, baseTree, tree);
+            }
+
+            public Task PutGitHubFileAsync(string fileUrl, string commitMessage, string newFileContents)
+            {
+                this.EnsureNotDryRun();
+                return this.innerClient.PutGitHubFileAsync(fileUrl, commitMessage, newFileContents);
+            }
+
+            public Task<GitHubPullRequest> SearchPullRequestsAsync(GitHubProject project, string headPrefix, string author, string sortType = "created") =>
+                this.innerClient.SearchPullRequestsAsync(project, headPrefix, author, sortType);
+
+            public Task UpdateGitHubPullRequestAsync(GitHubProject project, int number, string title = null, string body = null, string state = null, bool? maintainersCanModify = null)
+            {
+                this.EnsureNotDryRun();
+                return this.UpdateGitHubPullRequestAsync(project, number, title, body, state, maintainersCanModify);
+            }
+
+            private void EnsureNotDryRun()
+            {
+                if (this.isDryRun)
+                {
+                    throw new NotSupportedException("This GitHub operation is not supported when the dry-run option is enabled.");
+                }
+            }
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/IGitHubClientFactory.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/IGitHubClientFactory.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.DotNet.ImageBuilder.Commands;
 using Microsoft.DotNet.VersionTools.Automation;
 using Microsoft.DotNet.VersionTools.Automation.GitHubApi;
 
@@ -9,6 +10,6 @@ namespace Microsoft.DotNet.ImageBuilder
 {
     public interface IGitHubClientFactory
     {
-        IGitHubClient GetClient(GitHubAuth gitHubAuth);
+        IGitHubClient GetClient(GitHubAuth gitHubAuth, bool isDryRun);
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/IManifestOptionsInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/IManifestOptionsInfo.cs
@@ -3,10 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using Microsoft.DotNet.ImageBuilder.Commands;
 
 namespace Microsoft.DotNet.ImageBuilder.ViewModel
 {
-    public interface IManifestOptionsInfo : IOptionsInfo
+    public interface IManifestOptionsInfo : IOptions
     {
         string Manifest { get; }
         string RegistryOverride { get; }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
@@ -1169,7 +1169,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
                 Mock<IGitHubClientFactory> gitHubClientFactoryMock = new Mock<IGitHubClientFactory>();
                 gitHubClientFactoryMock
-                    .Setup(o => o.GetClient(It.IsAny<GitHubAuth>()))
+                    .Setup(o => o.GetClient(It.IsAny<GitHubAuth>(), false))
                     .Returns(gitHubClientMock.Object);
 
                 return gitHubClientFactoryMock.Object;

--- a/src/Microsoft.DotNet.ImageBuilder/tests/PublishImageInfoCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/PublishImageInfoCommandTests.cs
@@ -97,7 +97,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
                 Mock<IGitHubClientFactory> gitHubClientFactoryMock = new Mock<IGitHubClientFactory>();
                 gitHubClientFactoryMock
-                    .Setup(o => o.GetClient(It.IsAny<GitHubAuth>()))
+                    .Setup(o => o.GetClient(It.IsAny<GitHubAuth>(), false))
                     .Returns(gitHubClientMock.Object);
 
                 PublishImageInfoCommand command = new PublishImageInfoCommand(gitHubClientFactoryMock.Object);
@@ -161,9 +161,25 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 .Setup(o => o.PostTreeAsync(It.IsAny<GitHubProject>(), It.IsAny<string>(), It.IsAny<GitObject[]>()))
                 .ReturnsAsync(new GitTree());
 
+            GitCommit commit = new GitCommit
+            {
+                Sha = "sha"
+            };
+
             gitHubClientMock
                 .Setup(o => o.PostCommitAsync(It.IsAny<GitHubProject>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string[]>()))
-                .ReturnsAsync(new GitCommit());
+                .ReturnsAsync(commit);
+
+            gitHubClientMock
+                .Setup(o => o.PatchReferenceAsync(It.IsAny<GitHubProject>(), It.IsAny<string>(), commit.Sha, false))
+                .ReturnsAsync(new GitReference
+                {
+                    Object = new GitReferenceObject
+                    {
+                        Sha = commit.Sha
+                    }
+                });
+
             return gitHubClientMock;
         }
     }


### PR DESCRIPTION
Updates the ImageBuilder commands to ensure they do not execute any git commands that have side effects when the `dry-run` option is used.  This is specifically for the `publishImageInfo` and `publishMcrDocs` commands.  These changes are necessary in order to support the fix for #371.

Each command is implemented to explicitly account for the scenario when `dry-run` is true.  But in addition to that, a safeguard is added by implementing a wrapper around `GitHubClient` that will throw if an attempt is made to execute an operation with side effects when `dry-run` is enabled.