### PR TITLE
Support non-root folder for manifest file

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -53,8 +53,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             List<RepoData> reposList = new List<RepoData>();
 
-            string baseDirectory = Path.GetDirectoryName(Options.Manifest);
-
             foreach (RepoInfo repoInfo in Manifest.FilteredRepos)
             {
                 RepoData repoData = new RepoData
@@ -70,7 +68,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     foreach (PlatformInfo platform in image.FilteredPlatforms)
                     {
                         ImageData imageData = new ImageData();
-                        images.Add(platform.DockerfilePath, imageData);
+                        images.Add(PathHelper.StripBaseDirectory(Manifest.BaseDirectory, platform.DockerfilePath), imageData);
 
                         bool createdPrivateDockerfile = UpdateDockerfileFromCommands(platform, out string dockerfilePath);
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -68,7 +68,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     foreach (PlatformInfo platform in image.FilteredPlatforms)
                     {
                         ImageData imageData = new ImageData();
-                        images.Add(PathHelper.StripBaseDirectory(Manifest.BaseDirectory, platform.DockerfilePath), imageData);
+                        images.Add(platform.DockerfilePathRelativeToManifest, imageData);
 
                         bool createdPrivateDockerfile = UpdateDockerfileFromCommands(platform, out string dockerfilePath);
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
@@ -96,8 +96,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         private IEnumerable<string> GetDestinationTagNames(RepoInfo repo, PlatformInfo platform)
         {
-            string lookupDockerfilePath = PathHelper.StripBaseDirectory(Manifest.BaseDirectory, platform.DockerfilePath);
-
             IEnumerable<string> destTagNames = null;
 
             // If an image info file was provided, use the tags defined there rather than the manifest. This is intended
@@ -109,7 +107,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 RepoData repoData = imageInfoRepos.Value.FirstOrDefault(repoData => repoData.Repo == repo.Model.Name);
                 if (repoData != null)
                 {
-                    if (repoData.Images.TryGetValue(lookupDockerfilePath, out ImageData image))
+                    if (repoData.Images.TryGetValue(platform.DockerfilePathRelativeToManifest, out ImageData image))
                     {
                         destTagNames = image.SimpleTags
                             .Select(tag => TagInfo.GetFullyQualifiedName(repo.Name, tag));

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
@@ -25,13 +25,14 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     public class CopyAcrImagesCommand : ManifestCommand<CopyAcrImagesOptions>
     {
         private Lazy<RepoData[]> imageInfoRepos;
-        private string baseDirectory;
         private readonly IAzureManagementFactory azureManagementFactory;
+        private readonly IEnvironmentService environmentService;
 
         [ImportingConstructor]
-        public CopyAcrImagesCommand(IAzureManagementFactory azureManagementFactory) : base()
+        public CopyAcrImagesCommand(IAzureManagementFactory azureManagementFactory, IEnvironmentService environmentService) : base()
         {
             this.azureManagementFactory = azureManagementFactory ?? throw new ArgumentNullException(nameof(azureManagementFactory));
+            this.environmentService = environmentService ?? throw new ArgumentNullException(nameof(environmentService));
             this.imageInfoRepos = new Lazy<RepoData[]>(() =>
             {
                 if (!String.IsNullOrEmpty(Options.ImageInfoPath))
@@ -46,8 +47,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public override async Task ExecuteAsync()
         {
             Logger.WriteHeading("COPYING IMAGES");
-
-            this.baseDirectory = Path.GetDirectoryName(Options.Manifest);
 
             string registryName = Manifest.Registry.TrimEnd(".azurecr.io");
 
@@ -97,6 +96,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         private IEnumerable<string> GetDestinationTagNames(RepoInfo repo, PlatformInfo platform)
         {
+            string lookupDockerfilePath = PathHelper.StripBaseDirectory(Manifest.BaseDirectory, platform.DockerfilePath);
+
             IEnumerable<string> destTagNames = null;
 
             // If an image info file was provided, use the tags defined there rather than the manifest. This is intended
@@ -108,7 +109,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 RepoData repoData = imageInfoRepos.Value.FirstOrDefault(repoData => repoData.Repo == repo.Model.Name);
                 if (repoData != null)
                 {
-                    if (repoData.Images.TryGetValue(platform.DockerfilePath, out ImageData image))
+                    if (repoData.Images.TryGetValue(lookupDockerfilePath, out ImageData image))
                     {
                         destTagNames = image.SimpleTags
                             .Select(tag => TagInfo.GetFullyQualifiedName(repo.Name, tag));
@@ -116,13 +117,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     else
                     {
                         Logger.WriteError($"Unable to find image info data for path '{platform.DockerfilePath}'.");
-                        Environment.Exit(1);
+                        this.environmentService.Exit(1);
                     }
                 }
                 else
                 {
                     Logger.WriteError($"Unable to find image info data for repo '{repo.Model.Name}'.");
-                    Environment.Exit(1);
+                    this.environmentService.Exit(1);
                 }
             }
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
@@ -106,11 +106,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         private string GetDotNetVersionFromPath(string dockerfilePath)
         {
-            if (Path.IsPathRooted(dockerfilePath))
-            {
-                return PathHelper.StripBaseDirectory(Manifest.BaseDirectory, dockerfilePath);
-            }
-
             return dockerfilePath.Split(s_pathSeparators)[0];
         }
 
@@ -120,7 +115,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 .GroupBy(platform => new
                 {
                     // Assumption:  Dockerfile path format <ProductVersion>/<ImageVariant>/<OsVariant>/...
-                    DotNetVersion = GetDotNetVersionFromPath(platform.DockerfilePath),
+                    DotNetVersion = GetDotNetVersionFromPath(platform.DockerfilePathRelativeToManifest),
                     OsVariant = platform.Model.OsVersion
                 });
             foreach (var versionGrouping in versionGroups)

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
@@ -108,9 +108,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             if (Path.IsPathRooted(dockerfilePath))
             {
-                string baseDirectory = Path.GetDirectoryName(this.Options.Manifest);
-                Debug.Assert(dockerfilePath.StartsWith(PathHelper.NormalizePath(baseDirectory)));
-                dockerfilePath = dockerfilePath.Substring(baseDirectory.Length + 1);
+                return PathHelper.StripBaseDirectory(Manifest.BaseDirectory, dockerfilePath);
             }
 
             return dockerfilePath.Split(s_pathSeparators)[0];

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
@@ -106,7 +106,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 Manifest = Path.Combine(repoPath, subscription.ManifestPath)
             };
 
-            string baseDirectory = Path.GetDirectoryName(manifestOptions.Manifest);
+            string baseDirectory = PathHelper.GetBaseDirectory(manifestOptions.Manifest);
 
             ManifestInfo manifest = ManifestInfo.Load(manifestOptions);
 
@@ -124,9 +124,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
                 foreach (var platform in platforms)
                 {
+                    string lookupDockerfilePath = PathHelper.StripBaseDirectory(baseDirectory, platform.DockerfilePath);
+
                     if (repoData != null &&
                         repoData.Images != null &&
-                        repoData.Images.TryGetValue(platform.DockerfilePath, out ImageData imageData))
+                        repoData.Images.TryGetValue(lookupDockerfilePath, out ImageData imageData))
                     {
                         bool hasDigestChanged = false;
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
@@ -106,8 +106,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 Manifest = Path.Combine(repoPath, subscription.ManifestPath)
             };
 
-            string baseDirectory = PathHelper.GetBaseDirectory(manifestOptions.Manifest);
-
             ManifestInfo manifest = ManifestInfo.Load(manifestOptions);
 
             List<string> pathsToRebuild = new List<string>();
@@ -124,11 +122,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
                 foreach (var platform in platforms)
                 {
-                    string lookupDockerfilePath = PathHelper.StripBaseDirectory(baseDirectory, platform.DockerfilePath);
-
                     if (repoData != null &&
                         repoData.Images != null &&
-                        repoData.Images.TryGetValue(lookupDockerfilePath, out ImageData imageData))
+                        repoData.Images.TryGetValue(platform.DockerfilePathRelativeToManifest, out ImageData imageData))
                     {
                         bool hasDigestChanged = false;
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsCommand.cs
@@ -100,7 +100,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             foreach (string readmePath in readmePaths)
             {
-                string fullPath = Path.Combine(Manifest.BaseDirectory, readmePath);
+                string fullPath = Path.IsPathRooted(readmePath) ?
+                    readmePath : Path.Combine(Manifest.Directory, readmePath);
+                
                 string updatedReadMe = File.ReadAllText(fullPath);
                 updatedReadMe = ReadmeHelper.UpdateTagsListing(updatedReadMe, McrTagsPlaceholder);
                 await AddUpdatedFile(readmes, client, branch, productRepo, fullPath, updatedReadMe);

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsCommand.cs
@@ -100,8 +100,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             foreach (string readmePath in readmePaths)
             {
-                string fullPath = Path.IsPathRooted(readmePath) ?
-                    readmePath : Path.Combine(Manifest.Directory, readmePath);
+                string fullPath = Path.Combine(Manifest.Directory, readmePath);
                 
                 string updatedReadMe = File.ReadAllText(fullPath);
                 updatedReadMe = ReadmeHelper.UpdateTagsListing(updatedReadMe, McrTagsPlaceholder);

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsCommand.cs
@@ -100,9 +100,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             foreach (string readmePath in readmePaths)
             {
-                string updatedReadMe = File.ReadAllText(readmePath);
+                string fullPath = Path.Combine(Manifest.BaseDirectory, readmePath);
+                string updatedReadMe = File.ReadAllText(fullPath);
                 updatedReadMe = ReadmeHelper.UpdateTagsListing(updatedReadMe, McrTagsPlaceholder);
-                await AddUpdatedFile(readmes, client, branch, productRepo, readmePath, updatedReadMe);
+                await AddUpdatedFile(readmes, client, branch, productRepo, fullPath, updatedReadMe);
             }
 
             return readmes.ToArray();

--- a/src/Microsoft.DotNet.ImageBuilder/src/McrTagsMetadataGenerator.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/McrTagsMetadataGenerator.cs
@@ -50,7 +50,8 @@ namespace Microsoft.DotNet.ImageBuilder
             StringBuilder yaml = new StringBuilder();
             yaml.AppendLine("repos:");
 
-            string template = File.ReadAllText(_repo.Model.McrTagsMetadataTemplatePath);
+            string template = File.ReadAllText(
+                Path.Combine(_manifest.BaseDirectory, _repo.Model.McrTagsMetadataTemplatePath));
             yaml.Append(_manifest.VariableHelper.SubstituteValues(template, GetVariableValue));
 
             if (_imageDocInfos.Any())
@@ -155,7 +156,18 @@ namespace Microsoft.DotNet.ImageBuilder
 
         private string GetTagGroupYaml(ImageDocumentationInfo info)
         {
-            string dockerfileRelativePath = info.Platform.DockerfilePath.Replace('\\', '/');
+            string dockerfileRelativePath;
+            if (Path.IsPathRooted(_manifest.BaseDirectory))
+            {
+                dockerfileRelativePath = PathHelper.StripBaseDirectory(_manifest.BaseDirectory, info.Platform.DockerfilePath);
+            }
+            else
+            {
+                dockerfileRelativePath = info.Platform.DockerfilePath;
+            }
+
+            dockerfileRelativePath = dockerfileRelativePath.Replace('\\', '/');
+
             string branchOrShaPathSegment = _sourceBranch ??
                 _gitService.GetCommitSha(dockerfileRelativePath, useFullHash: true);
             string dockerfilePath = $"{_sourceRepoUrl}/blob/{branchOrShaPathSegment}/{dockerfileRelativePath}";

--- a/src/Microsoft.DotNet.ImageBuilder/src/McrTagsMetadataGenerator.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/McrTagsMetadataGenerator.cs
@@ -50,15 +50,7 @@ namespace Microsoft.DotNet.ImageBuilder
             StringBuilder yaml = new StringBuilder();
             yaml.AppendLine("repos:");
 
-            string templatePath;
-            if (Path.IsPathRooted(_repo.Model.McrTagsMetadataTemplatePath))
-            {
-                templatePath = _repo.Model.McrTagsMetadataTemplatePath;
-            }
-            else
-            {
-                templatePath = Path.Combine(_manifest.Directory, _repo.Model.McrTagsMetadataTemplatePath);
-            }
+            string templatePath = Path.Combine(_manifest.Directory, _repo.Model.McrTagsMetadataTemplatePath);
 
             string template = File.ReadAllText(templatePath);
             yaml.Append(_manifest.VariableHelper.SubstituteValues(template, GetVariableValue));

--- a/src/Microsoft.DotNet.ImageBuilder/src/PathHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/PathHelper.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
+using System;
 using System.IO;
 
 namespace Microsoft.DotNet.ImageBuilder
@@ -18,7 +18,10 @@ namespace Microsoft.DotNet.ImageBuilder
         /// <param name="path">The path to be trimmed.</param>
         public static string TrimPath(string trimPath, string path)
         {
-            Debug.Assert(NormalizePath(path).StartsWith(NormalizePath(trimPath)));
+            if (!NormalizePath(path).StartsWith(NormalizePath(trimPath)))
+            {
+                throw new InvalidOperationException($"'{path}' must start with '{trimPath}'");
+            }
             string result = path.Substring(trimPath.Length);
             if (result.StartsWith("/") || result.StartsWith("\\"))
             {
@@ -31,6 +34,19 @@ namespace Microsoft.DotNet.ImageBuilder
         public static string GetNormalizedDirectory(string path)
         {
             return PathHelper.NormalizePath(Path.GetDirectoryName(path));
+        }
+
+        public static void ValidateFileReference(string path, string manifestDirectory)
+        {
+            if (Path.IsPathRooted(path))
+            {
+                throw new ValidationException($"Path '{path}' specified in manifest file must be a relative path.");
+            }
+
+            if (path != null && !File.Exists(Path.Combine(manifestDirectory, path)))
+            {
+                throw new FileNotFoundException("Path specified in manifest file does not exist.", path);
+            }
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/PathHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/PathHelper.cs
@@ -35,18 +35,5 @@ namespace Microsoft.DotNet.ImageBuilder
         {
             return PathHelper.NormalizePath(Path.GetDirectoryName(path));
         }
-
-        public static void ValidateFileReference(string path, string manifestDirectory)
-        {
-            if (Path.IsPathRooted(path))
-            {
-                throw new ValidationException($"Path '{path}' specified in manifest file must be a relative path.");
-            }
-
-            if (path != null && !File.Exists(Path.Combine(manifestDirectory, path)))
-            {
-                throw new FileNotFoundException("Path specified in manifest file does not exist.", path);
-            }
-        }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/PathHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/PathHelper.cs
@@ -2,10 +2,30 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+using System.IO;
+
 namespace Microsoft.DotNet.ImageBuilder
 {
     public static class PathHelper
     {
         public static string NormalizePath(string path) => path.Replace(@"\", "/");
+
+        public static string StripBaseDirectory(string baseDirectory, string path)
+        {
+            Debug.Assert(NormalizePath(path).StartsWith(NormalizePath(baseDirectory)));
+            string result = path.Substring(baseDirectory.Length);
+            if (result.StartsWith("/") || result.StartsWith("\\"))
+            {
+                result = result.Substring(1);
+            }
+
+            return result;
+        }
+
+        public static string GetBaseDirectory(string manifestPath)
+        {
+            return PathHelper.NormalizePath(Path.GetDirectoryName(manifestPath));
+        }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/PathHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/PathHelper.cs
@@ -11,10 +11,15 @@ namespace Microsoft.DotNet.ImageBuilder
     {
         public static string NormalizePath(string path) => path.Replace(@"\", "/");
 
-        public static string StripBaseDirectory(string baseDirectory, string path)
+        /// <summary>
+        /// Trims the <paramref name="trimPath"/> string from <paramref name="path"/>.
+        /// </summary>
+        /// <param name="trimPath">The path segment to remove from <paramref name="path"/>.</param>
+        /// <param name="path">The path to be trimmed.</param>
+        public static string TrimPath(string trimPath, string path)
         {
-            Debug.Assert(NormalizePath(path).StartsWith(NormalizePath(baseDirectory)));
-            string result = path.Substring(baseDirectory.Length);
+            Debug.Assert(NormalizePath(path).StartsWith(NormalizePath(trimPath)));
+            string result = path.Substring(trimPath.Length);
             if (result.StartsWith("/") || result.StartsWith("\\"))
             {
                 result = result.Substring(1);
@@ -23,9 +28,9 @@ namespace Microsoft.DotNet.ImageBuilder
             return result;
         }
 
-        public static string GetBaseDirectory(string manifestPath)
+        public static string GetNormalizedDirectory(string path)
         {
-            return PathHelper.NormalizePath(Path.GetDirectoryName(manifestPath));
+            return PathHelper.NormalizePath(Path.GetDirectoryName(path));
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         /// <summary>
         /// Gets the directory of the manifest file.
         /// </summary>
-        public string BaseDirectory { get; private set; }
+        public string Directory { get; private set; }
 
         private ManifestInfo()
         {
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             {
                 Model = model,
                 Registry = options.RegistryOverride ?? model.Registry,
-                BaseDirectory = PathHelper.GetBaseDirectory(manifestPath)
+                Directory = PathHelper.GetNormalizedDirectory(manifestPath)
             };
             manifestInfo.VariableHelper = new VariableHelper(model, options, manifestInfo.GetRepoById);
             manifestInfo.AllRepos = manifestInfo.Model.Repos
@@ -74,7 +74,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
                     manifestFilter,
                     options,
                     manifestInfo.VariableHelper,
-                    manifestInfo.BaseDirectory))
+                    manifestInfo.Directory))
                 .ToArray();
 
             IEnumerable<string> repoNames = manifestInfo.AllRepos.Select(repo => repo.Name).ToArray();

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
@@ -57,13 +57,14 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         {
             string manifestJson = File.ReadAllText(manifestPath);
             Manifest model = JsonConvert.DeserializeObject<Manifest>(manifestJson);
-            model.Validate();
+            string manifestDirectory = PathHelper.GetNormalizedDirectory(manifestPath);
+            model.Validate(manifestDirectory);
 
             ManifestInfo manifestInfo = new ManifestInfo
             {
                 Model = model,
                 Registry = options.RegistryOverride ?? model.Registry,
-                Directory = PathHelper.GetNormalizedDirectory(manifestPath)
+                Directory = manifestDirectory
             };
             manifestInfo.VariableHelper = new VariableHelper(model, options, manifestInfo.GetRepoById);
             manifestInfo.AllRepos = manifestInfo.Model.Repos

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ModelExtensions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ModelExtensions.cs
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 
         public static string GetDockerName(this OS os) => os.ToString().ToLowerInvariant();
 
-        public static void Validate(this Manifest manifest)
+        public static void Validate(this Manifest manifest, string manifestDirectory)
         {
             foreach (Repo repo in manifest.Repos)
             {
@@ -49,15 +49,29 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
                     throw new ValidationException($"Readme path '{repo.ReadmePath}' for repo {repo.Name} must be a relative path.");
                 }
 
+                EnsureFileExists(repo.ReadmePath, manifestDirectory);
+
                 if (Path.IsPathRooted(repo.McrTagsMetadataTemplatePath))
                 {
                     throw new ValidationException($"Tags template path '{repo.McrTagsMetadataTemplatePath}' for repo {repo.Name} must be a relative path.");
                 }
+
+                EnsureFileExists(repo.McrTagsMetadataTemplatePath, manifestDirectory);
             }
 
             if (Path.IsPathRooted(manifest.ReadmePath))
             {
                 throw new ValidationException($"Readme path '{manifest.ReadmePath}' must be a relative path.");
+            }
+
+            EnsureFileExists(manifest.ReadmePath, manifestDirectory);
+        }
+
+        private static void EnsureFileExists(string path, string manifestDirectory)
+        {
+            if (path != null && !File.Exists(Path.Combine(manifestDirectory, path)))
+            {
+                throw new FileNotFoundException("Path specified in manifest file does not exist.", path);
             }
         }
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ModelExtensions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ModelExtensions.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 
@@ -42,6 +43,21 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             foreach (Repo repo in manifest.Repos)
             {
                 ValidateUniqueTags(repo);
+
+                if (Path.IsPathRooted(repo.ReadmePath))
+                {
+                    throw new ValidationException($"Readme path '{repo.ReadmePath}' for repo {repo.Name} must be a relative path.");
+                }
+
+                if (Path.IsPathRooted(repo.McrTagsMetadataTemplatePath))
+                {
+                    throw new ValidationException($"Tags template path '{repo.McrTagsMetadataTemplatePath}' for repo {repo.Name} must be a relative path.");
+                }
+            }
+
+            if (Path.IsPathRooted(manifest.ReadmePath))
+            {
+                throw new ValidationException($"Readme path '{manifest.ReadmePath}' must be a relative path.");
             }
         }
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ModelExtensions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ModelExtensions.cs
@@ -43,36 +43,11 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             foreach (Repo repo in manifest.Repos)
             {
                 ValidateUniqueTags(repo);
-
-                if (Path.IsPathRooted(repo.ReadmePath))
-                {
-                    throw new ValidationException($"Readme path '{repo.ReadmePath}' for repo {repo.Name} must be a relative path.");
-                }
-
-                EnsureFileExists(repo.ReadmePath, manifestDirectory);
-
-                if (Path.IsPathRooted(repo.McrTagsMetadataTemplatePath))
-                {
-                    throw new ValidationException($"Tags template path '{repo.McrTagsMetadataTemplatePath}' for repo {repo.Name} must be a relative path.");
-                }
-
-                EnsureFileExists(repo.McrTagsMetadataTemplatePath, manifestDirectory);
+                PathHelper.ValidateFileReference(repo.ReadmePath, manifestDirectory);
+                PathHelper.ValidateFileReference(repo.McrTagsMetadataTemplatePath, manifestDirectory);
             }
 
-            if (Path.IsPathRooted(manifest.ReadmePath))
-            {
-                throw new ValidationException($"Readme path '{manifest.ReadmePath}' must be a relative path.");
-            }
-
-            EnsureFileExists(manifest.ReadmePath, manifestDirectory);
-        }
-
-        private static void EnsureFileExists(string path, string manifestDirectory)
-        {
-            if (path != null && !File.Exists(Path.Combine(manifestDirectory, path)))
-            {
-                throw new FileNotFoundException("Path specified in manifest file does not exist.", path);
-            }
+            PathHelper.ValidateFileReference(manifest.ReadmePath, manifestDirectory);
         }
 
         private static void ValidateUniqueTags(Repo repo)

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
@@ -44,11 +44,13 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 
         public static PlatformInfo Create(Platform model, string fullRepoModelName, string repoName, VariableHelper variableHelper, string baseDirectory)
         {
-            PlatformInfo platformInfo = new PlatformInfo(baseDirectory);
-            platformInfo.Model = model;
-            platformInfo.RepoName = repoName;
-            platformInfo.FullRepoModelName = fullRepoModelName;
-            platformInfo.VariableHelper = variableHelper;
+            PlatformInfo platformInfo = new PlatformInfo(baseDirectory)
+            {
+                Model = model,
+                RepoName = repoName,
+                FullRepoModelName = fullRepoModelName,
+                VariableHelper = variableHelper
+            };
 
             // Ensure that we construct a path using the base directory here to check for the file. In cases like
             // the GetStaleImagesCommand and unit tests, the base directory will be an absolute path to 
@@ -58,14 +60,14 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 
             if (File.Exists(dockerfileWithBaseDir))
             {
-                platformInfo.DockerfilePath = PathHelper.NormalizePath(model.Dockerfile);
-                platformInfo.BuildContextPath = Path.GetDirectoryName(model.Dockerfile);
+                platformInfo.DockerfilePath = PathHelper.NormalizePath(dockerfileWithBaseDir);
+                platformInfo.BuildContextPath = Path.GetDirectoryName(dockerfileWithBaseDir);
             }
             else
             {
                 // Modeled Dockerfile is just the directory containing the "Dockerfile"
-                platformInfo.DockerfilePath = PathHelper.NormalizePath(Path.Combine(model.Dockerfile, "Dockerfile"));
-                platformInfo.BuildContextPath = model.Dockerfile;
+                platformInfo.BuildContextPath = PathHelper.NormalizePath(dockerfileWithBaseDir);
+                platformInfo.DockerfilePath = PathHelper.NormalizePath(Path.Combine(platformInfo.BuildContextPath, "Dockerfile"));
             }
 
             platformInfo.Tags = model.Tags
@@ -107,7 +109,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         {
             _overriddenFromImages = new List<string>();
 
-            string dockerfile = File.ReadAllText(Path.Combine(this.baseDirectory, DockerfilePath));
+            string dockerfile = File.ReadAllText(DockerfilePath);
             IList<Match> fromMatches = FromRegex.Matches(dockerfile);
 
             if (!fromMatches.Any())

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
@@ -53,19 +53,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
                 VariableHelper = variableHelper
             };
 
-            string dockerfilePath = model.Dockerfile;
-
-            try
-            {
-                PathHelper.ValidateFileReference(dockerfilePath, baseDirectory);
-            }
-            catch (FileNotFoundException)
-            {
-                dockerfilePath = Path.Combine(model.Dockerfile, "Dockerfile");
-                PathHelper.ValidateFileReference(dockerfilePath, baseDirectory);
-            }
-
-            string dockerfileWithBaseDir = Path.Combine(baseDirectory, dockerfilePath);
+            string dockerfileWithBaseDir = Path.Combine(baseDirectory, model.ResolveDockerfilePath(baseDirectory));
 
             platformInfo.DockerfilePath = PathHelper.NormalizePath(dockerfileWithBaseDir);
             platformInfo.BuildContextPath = PathHelper.NormalizePath(Path.GetDirectoryName(dockerfileWithBaseDir));

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
@@ -27,6 +27,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         public IDictionary<string, string> BuildArgs { get; private set; }
         public string BuildContextPath { get; private set; }
         public string DockerfilePath { get; private set; }
+        public string DockerfilePathRelativeToManifest { get; private set; }
         public IEnumerable<string> ExternalFromImages { get; private set; }
         public IEnumerable<string> InternalFromImages { get; private set; }
         public Platform Model { get; private set; }
@@ -69,6 +70,8 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
                 platformInfo.BuildContextPath = PathHelper.NormalizePath(dockerfileWithBaseDir);
                 platformInfo.DockerfilePath = PathHelper.NormalizePath(Path.Combine(platformInfo.BuildContextPath, "Dockerfile"));
             }
+
+            platformInfo.DockerfilePathRelativeToManifest = PathHelper.TrimPath(baseDirectory, platformInfo.DockerfilePath);
 
             platformInfo.Tags = model.Tags
                 .Select(kvp => TagInfo.Create(kvp.Key, kvp.Value, repoName, variableHelper, platformInfo.BuildContextPath))

--- a/src/Microsoft.DotNet.ImageBuilder/tests/CopyAcrImagesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/CopyAcrImagesCommandTests.cs
@@ -39,7 +39,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 IAzure azure = CreateAzureMock(registriesOperationsMock);
                 Mock<IAzureManagementFactory> azureManagementFactoryMock = CreateAzureManagementFactoryMock(subscriptionId, azure);
 
-                CopyAcrImagesCommand command = new CopyAcrImagesCommand(azureManagementFactoryMock.Object);
+                Mock<IEnvironmentService> environmentServiceMock = new Mock<IEnvironmentService>();
+
+                CopyAcrImagesCommand command = new CopyAcrImagesCommand(
+                    azureManagementFactoryMock.Object, environmentServiceMock.Object);
                 command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
                 command.Options.Subscription = subscriptionId;
                 command.Options.ResourceGroup = "my resource group";
@@ -104,6 +107,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             It.IsAny<Dictionary<string, List<string>>>(),
                             It.IsAny<CancellationToken>()));
                 }
+
+                environmentServiceMock.Verify(o => o.Exit(It.IsAny<int>()), Times.Never);
             }
         }
 

--- a/src/Microsoft.DotNet.ImageBuilder/tests/McrTagsMetadataGeneratorTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/McrTagsMetadataGeneratorTests.cs
@@ -41,7 +41,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             string DockerfileDir = $"1.0/{RepoName}/os";
             Directory.CreateDirectory(Path.Combine(tempFolderContext.Path, DockerfileDir));
             string dockerfileRelativePath = Path.Combine(DockerfileDir, "Dockerfile");
-            File.WriteAllText(Path.Combine(tempFolderContext.Path, dockerfileRelativePath), "FROM base:tag");
+            string dockerfileFullPath = PathHelper.NormalizePath(Path.Combine(tempFolderContext.Path, dockerfileRelativePath));
+            File.WriteAllText(dockerfileFullPath, "FROM base:tag");
 
             // Create MCR tags metadata template file
             StringBuilder tagsMetadataTemplateBuilder = new StringBuilder();
@@ -74,7 +75,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             if (sourceRepoBranch == null)
             {
                 gitServiceMock
-                    .Setup(o => o.GetCommitSha($"{DockerfileDir}/Dockerfile", true))
+                    .Setup(o => o.GetCommitSha(dockerfileFullPath, true))
                     .Returns(DockerfileSha);
             }
 

--- a/src/Microsoft.DotNet.ImageBuilder/tests/McrTagsMetadataGeneratorTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/McrTagsMetadataGeneratorTests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         ManifestHelper.CreateImage(
                             ManifestHelper.CreatePlatform(dockerfileRelativePath, new string[] { TagName }))
                     },
-                    mcrTagsMetadataTemplatePath: tagsMetadataTemplatePath)
+                    mcrTagsMetadataTemplatePath: Path.GetFileName(tagsMetadataTemplatePath))
             );
             string manifestPath = Path.Combine(tempFolderContext.Path, "manifest.json");
             File.WriteAllText(manifestPath, JsonConvert.SerializeObject(manifest));


### PR DESCRIPTION
Updates ImageBuilder logic to support a manifest file being located in a different folder from the current working directory (i.e. the root of the repo in most cases).  This is needed in order to support #305 where we want to make use of a fake manifest file located in a test folder.

All file paths referenced from within the manifest file (e.g. readme files) should be relative to the location of the manifest file.  Similarly, the `--path` filter options that can be passed to various ImageBuilder commands should also be relative to the manifest file.

Fixes #370 