### PR TITLE
Fix publish condition for calculating whether to a dry run

### DIFF
--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -22,7 +22,7 @@ jobs:
     # Use dry-run option for certain publish operations if this is not a production build
   - script: |
       dryRunArg=""
-      if [ "PUBLISHREPOPREFIX" != "public/" ]; then
+      if [ "PUBLISHREPOPREFIX" == "public/" ]; then
         dryRunArg=" --dry-run"
       fi
       echo "##vso[task.setvariable variable=dryRunArg]$dryRunArg"


### PR DESCRIPTION
The logic for determining whether to use a dry run for certain tasks in the publish phase is incorrect.  The condition should be reversed so it only uses dry run in public builds.