### PR TITLE
Fix publish condition for calculating whether to do a dry run

### DIFF
--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -22,7 +22,7 @@ jobs:
     # Use dry-run option for certain publish operations if this is not a production build
   - script: |
       dryRunArg=""
-      if [ "PUBLISHREPOPREFIX" != "public/" ]; then
+      if [ "$PUBLISHREPOPREFIX" != "public/" ]; then
         dryRunArg=" --dry-run"
       fi
       echo "##vso[task.setvariable variable=dryRunArg]$dryRunArg"


### PR DESCRIPTION
The condition for determining whether to use a dry run for the publish stage is incorrectly.  It's not referencing the `PUBLISHREPOPREFIX` variable with the correct syntax.  This causes official builds to use dry runs for certain tasks, not updating the appropriate GitHub files.