### PR TITLE
Tweak McrTagsMetadataGenerator to dump out generated metadata before validating

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/McrTagsMetadataGenerator.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/McrTagsMetadataGenerator.cs
@@ -63,14 +63,14 @@ namespace Microsoft.DotNet.ImageBuilder
 
             string metadata = yaml.ToString();
 
+            Logger.WriteSubheading("Generated Metadata:");
+            Logger.WriteMessage(metadata);
+
             // Validate that the YAML is in a valid format
             new DeserializerBuilder()
                 .WithNamingConvention(CamelCaseNamingConvention.Instance)
                 .Build()
                 .Deserialize<Models.Mcr.McrTagsMetadata>(metadata);
-
-            Logger.WriteSubheading("Generated Metadata:");
-            Logger.WriteMessage(metadata);
 
             return metadata;
         }


### PR DESCRIPTION
The motivation for this change is that when there is a validation error, it is very helpful to see the generated yaml which is invalid.