### PR TITLE
Add build infra testing pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,4 +3,3 @@
 **/out
 **/.vscode
 **/.vs
-.git

--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -43,7 +43,7 @@ steps:
       targetPath: $(Build.ArtifactStagingDirectory)
 - script: >
     docker exec $(testRunner.container) pwsh
-    -File ./tests/run-tests.ps1
+    -File $(testScriptPath)
     -VersionFilter '$(dotnetVersion)'
     -OSFilter '$(osVariant)*'
     -ArchitectureFilter '$(architecture)'
@@ -56,7 +56,7 @@ steps:
     continueOnError: true
 - script: >
     docker cp
-    $(testRunner.container):/repo/tests/Microsoft.DotNet.Docker.Tests/TestResults/
+    $(testRunner.container):/repo/$(testResultsDirectory)
     $(Common.TestResultsDirectory)/.
   displayName: Copy Test Results
   condition: always()

--- a/eng/common/templates/steps/test-images-windows-client.yml
+++ b/eng/common/templates/steps/test-images-windows-client.yml
@@ -21,7 +21,7 @@ steps:
     parameters:
       targetPath: $(Build.ArtifactStagingDirectory)
 - powershell: >
-    ./tests/run-tests.ps1
+    $(testScriptPath)
     -VersionFilter '$(dotnetVersion)'
     -OSFilter '$(osVariant)'
     $(optionalTestArgs)

--- a/eng/common/templates/variables/common-paths.yml
+++ b/eng/common/templates/variables/common-paths.yml
@@ -2,3 +2,5 @@ variables:
   engCommonRelativePath: eng/common
   engCommonPath: $(Build.Repository.LocalPath)/$(engCommonRelativePath)
   engPath: $(Build.Repository.LocalPath)/eng
+  testScriptPath: ./tests/run-tests.ps1
+  testResultsDirectory: tests/Microsoft.DotNet.Docker.Tests/TestResults/

--- a/eng/pipelines/dotnet-docker-tools-eng-validation.yml
+++ b/eng/pipelines/dotnet-docker-tools-eng-validation.yml
@@ -5,6 +5,7 @@ pr:
   paths:
     include:
     - eng/*
+    - test/*
 trigger:
   branches:
     include:
@@ -12,6 +13,7 @@ trigger:
   paths:
     include:
     - eng/*
+    - test/*
 
 variables:
 - template: ../common/templates/variables/common.yml

--- a/eng/pipelines/dotnet-docker-tools-pr.yml
+++ b/eng/pipelines/dotnet-docker-tools-pr.yml
@@ -1,0 +1,30 @@
+pr:
+  branches:
+    include:
+    - master
+  paths:
+    include:
+    - eng/*
+trigger:
+  branches:
+    include:
+    - master
+  paths:
+    include:
+    - eng/*
+
+variables:
+- template: ../common/templates/variables/common.yml
+- name: manifest
+  value: test/pipeline-validation/test-manifest.json
+- name: testScriptPath
+  value: ./test/pipeline-validation/run-tests.ps1
+- name: testResultsDirectory
+  value: test/pipeline-validation/TestResults/
+- name: publicGitRepoUri
+  value: https://github.com/dotnet/dotnet-docker-test
+- name: publishRepoPrefix
+  value: test/
+
+stages:
+- template: ../common/templates/stages/build-test-publish-repo.yml

--- a/test/pipeline-validation/1.0/focal/amd64/Dockerfile
+++ b/test/pipeline-validation/1.0/focal/amd64/Dockerfile
@@ -1,0 +1,1 @@
+FROM ubuntu:focal

--- a/test/pipeline-validation/1.0/focal/arm64v8/Dockerfile
+++ b/test/pipeline-validation/1.0/focal/arm64v8/Dockerfile
@@ -1,0 +1,1 @@
+FROM arm32v7/ubuntu:focal

--- a/test/pipeline-validation/1.0/nanoserver-1809/amd64/Dockerfile
+++ b/test/pipeline-validation/1.0/nanoserver-1809/amd64/Dockerfile
@@ -1,0 +1,1 @@
+FROM mcr.microsoft.com/windows/nanoserver:1809

--- a/test/pipeline-validation/1.0/nanoserver-1809/arm32v7/Dockerfile
+++ b/test/pipeline-validation/1.0/nanoserver-1809/arm32v7/Dockerfile
@@ -1,0 +1,1 @@
+FROM mcr.microsoft.com/windows/nanoserver:1809-arm32v7

--- a/test/pipeline-validation/README.placeholder.md
+++ b/test/pipeline-validation/README.placeholder.md
@@ -1,0 +1,25 @@
+# Test Readme
+
+A placeholder file for testing purposes. The image tags and URLs referenced here are not meant to be accessible. This is just test data.
+
+# Full Tag Listing
+
+## Linux amd64 Tags
+Tags | Dockerfile | OS Version
+-----------| -------------| -------------
+focal | [Dockerfile](https://github.com/dotnet/dotnet-docker-test/blob/master/test/pipeline-validation/1.0/focal/amd64/Dockerfile) | Ubuntu 20.04
+
+## Linux arm64 Tags
+Tags | Dockerfile | OS Version
+-----------| -------------| -------------
+focal-arm64 | [Dockerfile](https://github.com/dotnet/dotnet-docker-test/blob/master/test/pipeline-validation/1.0/focal/arm64v8/Dockerfile) | Ubuntu 20.04
+
+## Windows Server 2019 amd64 Tags
+Tag | Dockerfile
+---------| ---------------
+nanoserver-1809 | [Dockerfile](https://github.com/dotnet/dotnet-docker-test/blob/master/test/pipeline-validation/1.0/nanoserver-1809/amd64/Dockerfile)
+
+## Windows Server 2019 arm32 Tags
+Tag | Dockerfile
+---------| ---------------
+nanoserver-1809-arm | [Dockerfile](https://github.com/dotnet/dotnet-docker-test/blob/master/test/pipeline-validation/1.0/nanoserver-1809/arm32v7/Dockerfile)

--- a/test/pipeline-validation/run-tests.ps1
+++ b/test/pipeline-validation/run-tests.ps1
@@ -1,0 +1,23 @@
+#!/usr/bin/env pwsh
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+[cmdletbinding()]
+param(
+    [string]$VersionFilter,
+    [string]$ArchitectureFilter,
+    [string]$OSFilter,
+    [string]$Registry,
+    [string]$RepoPrefix,
+    [switch]$DisableHttpVerification,
+    [switch]$PullImages,
+    [string]$ImageInfoPath
+)
+
+# This script intentionally doesn't run any tests. It is to be used for pipeline validation.
+
+# Ensure that a TestResults folder exists to allow test pipeline to target folder for copying.
+$scriptDir = Split-Path -parent $PSCommandPath
+New-Item -ItemType Directory $scriptDir/TestResults

--- a/test/pipeline-validation/test-manifest.json
+++ b/test/pipeline-validation/test-manifest.json
@@ -1,0 +1,52 @@
+{
+  "registry": "mcr.microsoft.com",
+  "repos": [
+    {
+      "id": "test",
+      "name": "dotnet/test",
+      "readmePath": "README.placeholder.md",
+      "mcrTagsMetadataTemplatePath": "test-tags.yml",
+      "images": [
+        {
+          "platforms": [
+            {
+              "dockerfile": "1.0/focal/amd64",
+              "os": "linux",
+              "osVersion": "focal",
+              "tags": {
+                "focal": {}
+              }
+            },
+            {
+              "architecture": "arm64",
+              "dockerfile": "1.0/focal/arm64v8",
+              "os": "linux",
+              "osVersion": "focal",
+              "tags": {
+                "focal-arm64": {}
+              },
+              "variant": "v8"
+            },
+            {
+              "dockerfile": "1.0/nanoserver-1809/amd64",
+              "os": "windows",
+              "osVersion": "nanoserver-1809",
+              "tags": {
+                "nanoserver-1809": {}
+              }
+            },
+            {
+              "architecture": "arm",
+              "dockerfile": "1.0/nanoserver-1809/arm32v7",
+              "os": "windows",
+              "osVersion": "nanoserver-1809",
+              "tags": {
+                "nanoserver-1809-arm": {}
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/pipeline-validation/test-tags.yml
+++ b/test/pipeline-validation/test-tags.yml
@@ -1,0 +1,5 @@
+$(McrTagsYmlRepo:test)
+$(McrTagsYmlTagGroup:focal)
+$(McrTagsYmlTagGroup:focal-arm64)
+$(McrTagsYmlTagGroup:nanoserver-1809)
+$(McrTagsYmlTagGroup:nanoserver-1809-arm)


### PR DESCRIPTION
Defines a pipeline for testing the pipeline infrastructure.  This uses a set of fake files (manifest, Dockerfiles, etc) to run a build with.  This is intended to mainly test the pipeline YAML infrastructure but also does a run through the relevant logic of ImageBuilder that gets invoked by the tasks in the pipeline.  This is not a comprehensive test that will validate everything and should be considered to be more of a smoke test.  When pipeline changes get propagated to the other Docker repos (dotnet-docker, etc) those PRs will do the ultimate verification for those specific repos.

Examples of issues that would be caught by this pipeline before changes are propagated to other repos:
* https://github.com/dotnet/docker-tools/pull/361
* https://github.com/dotnet/docker-tools/pull/336

Fixes #305