### PR TITLE
backporting eng\common changes from the dotnet-docker repo

### DIFF
--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -52,16 +52,10 @@ jobs:
       $(imageBuilder.pathArgs)
       $(imageBuilder.commonCmdArgs)
     displayName: Publish Manifest
-  - script: >
-      $(runImageBuilderCmd) publishMcrDocs
-      $(dotnetBot-userName)
-      $(dotnetBot-email)
-      $(dotnet-bot-user-repo-adminrepohook-pat)
-      $(publicGitRepoUri)
-      $(dryRunArg)
-      $(imageBuilder.commonCmdArgs)
-    displayName: Publish Readme
-    condition: and(succeeded(), eq(variables['publishReadme'], 'true'))
+  - template: ../steps/publish-readmes.yml
+    parameters:
+      dryRunArg: $(dryRunArg)
+      condition: and(succeeded(), eq(variables['publishReadme'], 'true'))
   - script: >
       $(runImageBuilderCmd) publishImageInfo
       $(dotnetBot-userName)

--- a/eng/common/templates/jobs/validate-image-sizes.yml
+++ b/eng/common/templates/jobs/validate-image-sizes.yml
@@ -1,0 +1,22 @@
+jobs:
+- job: LinuxPerfTests
+  pool: Hosted Ubuntu 1604
+  workspace:
+    clean: all
+  steps:
+  - template: ../steps/validate-image-sizes.yml
+    parameters:
+      dockerClientOS: linux
+- job: WindowsPerfTests
+  pool: # windows1909Amd64
+    ${{ if eq(variables['System.TeamProject'], 'public') }}:
+      name: DotNetCore-Docker-Public
+    ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+      name: DotNetCore-Docker
+    demands: VSTS_OS -equals Windows-ServerDatacenter-1909
+  workspace:
+    clean: all
+  steps:
+  - template: ../steps/validate-image-sizes.yml
+    parameters:
+      dockerClientOS: windows

--- a/eng/common/templates/steps/publish-readmes.yml
+++ b/eng/common/templates/steps/publish-readmes.yml
@@ -1,0 +1,17 @@
+parameters:
+  dryRunArg: ""
+  condition:  true
+
+steps:
+- script: >
+    $(runImageBuilderCmd) publishMcrDocs
+    --manifest $(manifest)
+    --registry-override $(acr.server)
+    $(dotnetBot-userName)
+    $(dotnetBot-email)
+    $(dotnet-bot-user-repo-adminrepohook-pat)
+    $(publicGitRepoUri)
+    ${{ parameters.dryRunArg }}
+    $(imageBuilder.queueArgs)
+  displayName: Publish Readmes
+  condition: ${{ parameters.condition }}

--- a/eng/common/templates/steps/validate-image-sizes.yml
+++ b/eng/common/templates/steps/validate-image-sizes.yml
@@ -1,0 +1,10 @@
+parameters:
+  dockerClientOS: null
+  
+steps:
+  - template: ${{ format('../steps/init-docker-{0}.yml', parameters.dockerClientOS) }}
+  - powershell: >
+      ./tests/performance/Validate-ImageSize.ps1
+      -BaselineIntegrityOnly:$${{ eq(variables['System.TeamProject'], 'public') }}
+    displayName: Run Image Size Tests
+  - template: ${{ format('../steps/cleanup-docker-{0}.yml', parameters.dockerClientOS) }}


### PR DESCRIPTION
These changes add support for the following:

1. A pipeline that just publishes the readmes.
2. A pipeline that runs the image size validation tests.