### PR TITLE
Delete image after its size is validated

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ImageSizeCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ImageSizeCommand.cs
@@ -41,11 +41,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         protected long GetImageSize(string tagName)
         {
             bool localImageExists = DockerService.LocalImageExists(tagName, Options.IsDryRun);
+            bool isImagePulled = false;
             try
             {
                 if (Options.IsPullEnabled)
                 {
                     DockerService.PullImage(tagName, Options.IsDryRun);
+                    isImagePulled = true;
                 }
                 else if (!localImageExists)
                 {
@@ -57,13 +59,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             finally
             {
                 // If we had to pull the image because it didn't exist locally, be sure to clean it up
-                if (!localImageExists)
+                if (isImagePulled)
                 {
-                    string imageId = DockerService.GetImageId(tagName, Options.IsDryRun);
-                    if (imageId != null)
-                    {
-                        DockerService.DeleteImage(imageId, Options.IsDryRun);
-                    }
+                    DockerService.DeleteImage(tagName, Options.IsDryRun);
                 }
             }
         }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/UpdateImageSizeBaselineCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/UpdateImageSizeBaselineCommand.cs
@@ -75,7 +75,12 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             ProcessImages(processImage);
 
             loggerService.WriteSubheading($"Updating `{Options.BaselinePath}`");
-            string formattedJson = json.ToString().NormalizeLineEndings(File.ReadAllText(Options.BaselinePath));
+            string formattedJson = json.ToString();
+            if (File.Exists(Options.BaselinePath))
+            {
+                formattedJson = formattedJson.NormalizeLineEndings(File.ReadAllText(Options.BaselinePath));
+            }
+
             loggerService.WriteMessage(formattedJson);
             File.WriteAllText(Options.BaselinePath, formattedJson);
         }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/UpdateImageSizeBaselineCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/UpdateImageSizeBaselineCommand.cs
@@ -75,7 +75,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             ProcessImages(processImage);
 
             loggerService.WriteSubheading($"Updating `{Options.BaselinePath}`");
-            string formattedJson = json.ToString();
+            string formattedJson = json.ToString().NormalizeLineEndings(File.ReadAllText(Options.BaselinePath));
             loggerService.WriteMessage(formattedJson);
             File.WriteAllText(Options.BaselinePath, formattedJson);
         }

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
@@ -118,19 +118,9 @@ namespace Microsoft.DotNet.ImageBuilder
             DockerHelper.ExecuteCommand("tag", "Failed to create tag", $"{image} {tag}", isDryRun);
         }
 
-        public static string GetImageId(string image, bool isDryRun)
+        public static void DeleteImage(string tag, bool isDryRun)
         {
-            return DockerHelper.ExecuteCommandWithFormat(
-                "images",
-                ".ID",
-                "Failed to get image ID",
-                $"--filter \"reference={image}\"",
-                isDryRun);
-        }
-
-        public static void DeleteImage(string imageId, bool isDryRun)
-        {
-            DockerHelper.ExecuteCommand("rmi", "Failed to delete image", imageId, isDryRun);
+            DockerHelper.ExecuteCommand("rmi", "Failed to delete image", tag, isDryRun);
         }
 
         private static OS GetOS()

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
@@ -118,6 +118,21 @@ namespace Microsoft.DotNet.ImageBuilder
             DockerHelper.ExecuteCommand("tag", "Failed to create tag", $"{image} {tag}", isDryRun);
         }
 
+        public static string GetImageId(string image, bool isDryRun)
+        {
+            return DockerHelper.ExecuteCommandWithFormat(
+                "images",
+                ".ID",
+                "Failed to get image ID",
+                $"--filter \"reference={image}\"",
+                isDryRun);
+        }
+
+        public static void DeleteImage(string imageId, bool isDryRun)
+        {
+            DockerHelper.ExecuteCommand("rmi", "Failed to delete image", imageId, isDryRun);
+        }
+
         private static OS GetOS()
         {
             string osString = ExecuteCommandWithFormat("version", ".Server.Os", "Failed to detect Docker OS");
@@ -195,7 +210,8 @@ namespace Microsoft.DotNet.ImageBuilder
 
         private static string ExecuteCommandWithFormat(
             string command, string outputFormat, string errorMessage, string additionalArgs = null, bool isDryRun = false) =>
-            ExecuteCommand(command, errorMessage, $"{additionalArgs} -f \"{{{{ {outputFormat} }}}}\"", isDryRun);
+            // Use the long format option name because not all commands support the short name
+            ExecuteCommand(command, errorMessage, $"{additionalArgs} --format \"{{{{ {outputFormat} }}}}\"", isDryRun);
 
         private enum ManagementType
         {

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerService.cs
@@ -59,5 +59,15 @@ namespace Microsoft.DotNet.ImageBuilder
         {
             return DockerHelper.GetImageSize(image, isDryRun);
         }
+
+        public string GetImageId(string image, bool isDryRun)
+        {
+            return DockerHelper.GetImageId(image, isDryRun);
+        }
+
+        public void DeleteImage(string imageId, bool isDryRun)
+        {
+            DockerHelper.DeleteImage(imageId, isDryRun);
+        }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerService.cs
@@ -60,14 +60,9 @@ namespace Microsoft.DotNet.ImageBuilder
             return DockerHelper.GetImageSize(image, isDryRun);
         }
 
-        public string GetImageId(string image, bool isDryRun)
+        public void DeleteImage(string tag, bool isDryRun)
         {
-            return DockerHelper.GetImageId(image, isDryRun);
-        }
-
-        public void DeleteImage(string imageId, bool isDryRun)
-        {
-            DockerHelper.DeleteImage(imageId, isDryRun);
+            DockerHelper.DeleteImage(tag, isDryRun);
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/IDockerService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/IDockerService.cs
@@ -29,8 +29,6 @@ namespace Microsoft.DotNet.ImageBuilder
 
         long GetImageSize(string image, bool isDryRun);
 
-        public string GetImageId(string image, bool isDryRun);
-
-        public void DeleteImage(string imageId, bool isDryRun);
+        public void DeleteImage(string tag, bool isDryRun);
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/IDockerService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/IDockerService.cs
@@ -28,5 +28,9 @@ namespace Microsoft.DotNet.ImageBuilder
         bool LocalImageExists(string tag, bool isDryRun);
 
         long GetImageSize(string image, bool isDryRun);
+
+        public string GetImageId(string image, bool isDryRun);
+
+        public void DeleteImage(string imageId, bool isDryRun);
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ReadmeHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ReadmeHelper.cs
@@ -11,24 +11,12 @@ namespace Microsoft.DotNet.ImageBuilder
     {
         private const string TagsSectionHeader = "# Full Tag Listing";
 
-        private static string NormalizeLineEndings(string value, string targetFormat)
-        {
-            string targetLineEnding = targetFormat.Contains("\r\n") ? "\r\n" : "\n";
-            string valueLineEnding = value.Contains("\r\n") ? "\r\n" : "\n";
-            if (valueLineEnding != targetLineEnding)
-            {
-                value = value.Replace(valueLineEnding, targetLineEnding);
-            }
-
-            return value;
-        }
-
         public static string UpdateTagsListing(string readme, string tagsListing)
         {
             tagsListing = $"{TagsSectionHeader}{Environment.NewLine}{Environment.NewLine}{tagsListing}{Environment.NewLine}{Environment.NewLine}";
 
             // Normalize the line endings to match the readme.
-            tagsListing = NormalizeLineEndings(tagsListing, readme);
+            tagsListing = tagsListing.NormalizeLineEndings(readme);
 
             // Regex to find the entire tags listing section including the header.
             Regex regex = new Regex($"^{TagsSectionHeader}\\s*(^(?!# ).*\\s)*", RegexOptions.Multiline);

--- a/src/Microsoft.DotNet.ImageBuilder/src/StringExtensions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/StringExtensions.cs
@@ -32,5 +32,17 @@ namespace Microsoft.DotNet.ImageBuilder
         {
             return source.Substring(0, 1).ToLowerInvariant() + source.Substring(1);
         }
+
+        public static string NormalizeLineEndings(this string value, string targetFormat)
+        {
+            string targetLineEnding = targetFormat.Contains("\r\n") ? "\r\n" : "\n";
+            string valueLineEnding = value.Contains("\r\n") ? "\r\n" : "\n";
+            if (valueLineEnding != targetLineEnding)
+            {
+                value = value.Replace(valueLineEnding, targetLineEnding);
+            }
+
+            return value;
+        }
     }
 }


### PR DESCRIPTION
To avoid requiring a lot of disk space to store all the images that are pulled for image size validation, these changes remove any images that are pulled after each has been validated.  