### PR TITLE
Option to skip baseline integrity check for size validation

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/UpdateImageSizeBaselineCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/UpdateImageSizeBaselineCommand.cs
@@ -76,6 +76,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             loggerService.WriteSubheading($"Updating `{Options.BaselinePath}`");
             string formattedJson = json.ToString();
+            if (File.Exists(Options.BaselinePath))
+            {
+                formattedJson = formattedJson.NormalizeLineEndings(File.ReadAllText(Options.BaselinePath));
+            }
+
             loggerService.WriteMessage(formattedJson);
             File.WriteAllText(Options.BaselinePath, formattedJson);
         }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ValidateImageSizeCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ValidateImageSizeCommand.cs
@@ -43,10 +43,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             // This handler will be invoked for each image defined in the manifest
             void processImage(string repoId, string imageId, string tagName)
             {
-                // If the CheckBaselineIntegrityOnly option is enabled, we want to skip the retrieval
-                // of the image size.
                 long? currentSize = null;
-                if (!Options.CheckBaselineIntegrityOnly)
+                if (Options.Mode.HasFlag(ImageSizeValidationMode.Size))
                 {
                     currentSize = GetImageSize(tagName);
                 }
@@ -85,7 +83,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             IEnumerable<ImageSizeInfo> imagesWithNoSizeChange;
             IEnumerable<ImageSizeInfo> imagesWithAllowedSizeChange;
             IEnumerable<ImageSizeInfo> imagesWithDisallowedSizeChange;
-            if (Options.CheckBaselineIntegrityOnly)
+            if (Options.Mode == ImageSizeValidationMode.Integrity)
             {
                 imagesWithNoSizeChange =
                     imagesWithAllowedSizeChange =
@@ -107,8 +105,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 imagesWithNoSizeChange,
                 imagesWithAllowedSizeChange,
                 imagesWithDisallowedSizeChange,
-                Options.SkipBaselineIntegrityCheck ? Enumerable.Empty<ImageSizeInfo>() : imagesWithMissingBaseline,
-                Options.SkipBaselineIntegrityCheck ? Enumerable.Empty<ImageSizeInfo>() : imagesWithExtraneousBaseline);
+                Options.Mode == ImageSizeValidationMode.Size ? Enumerable.Empty<ImageSizeInfo>() : imagesWithMissingBaseline,
+                Options.Mode == ImageSizeValidationMode.Size ? Enumerable.Empty<ImageSizeInfo>() : imagesWithExtraneousBaseline);
         }
 
         private void LogResults(ImageSizeValidationResults results)

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ValidateImageSizeCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ValidateImageSizeCommand.cs
@@ -107,8 +107,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 imagesWithNoSizeChange,
                 imagesWithAllowedSizeChange,
                 imagesWithDisallowedSizeChange,
-                imagesWithMissingBaseline,
-                imagesWithExtraneousBaseline);
+                Options.SkipBaselineIntegrityCheck ? Enumerable.Empty<ImageSizeInfo>() : imagesWithMissingBaseline,
+                Options.SkipBaselineIntegrityCheck ? Enumerable.Empty<ImageSizeInfo>() : imagesWithExtraneousBaseline);
         }
 
         private void LogResults(ImageSizeValidationResults results)

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ValidateImageSizeOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ValidateImageSizeOptions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.CommandLine;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
@@ -10,9 +11,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     {
         protected override string CommandHelp => "Validates the size of the images against a baseline";
 
-        public bool CheckBaselineIntegrityOnly { get; set; }
-
-        public bool SkipBaselineIntegrityCheck { get; set; }
+        public ImageSizeValidationMode Mode { get; set; }
 
         public ValidateImageSizeOptions() : base()
         {
@@ -22,13 +21,17 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             base.DefineOptions(syntax);
 
-            bool checkBaselineIntegrityOnly = false;
-            syntax.DefineOption("baseline-integrity-only", ref checkBaselineIntegrityOnly, "Validate the integrity of the baseline by checking for missing or extraneous data");
-            CheckBaselineIntegrityOnly = checkBaselineIntegrityOnly;
-
-            bool skipBaselineIntegrityCheck = false;
-            syntax.DefineOption("skip-baseline-integrity", ref skipBaselineIntegrityCheck, "Skip validation of missing or extraneous data");
-            SkipBaselineIntegrityCheck = skipBaselineIntegrityCheck;
+            string mode = ImageSizeValidationMode.All.ToString().ToLowerInvariant();
+            syntax.DefineOption("mode", ref mode, "Mode of validation. Options: all (default), size, integrity");
+            Mode = (ImageSizeValidationMode)Enum.Parse(typeof(ImageSizeValidationMode), mode, ignoreCase: true);
         }
+    }
+
+    [Flags]
+    public enum ImageSizeValidationMode
+    {
+        All = Size | Integrity,
+        Size = 1,
+        Integrity = 2
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ValidateImageSizeOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ValidateImageSizeOptions.cs
@@ -12,6 +12,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         public bool CheckBaselineIntegrityOnly { get; set; }
 
+        public bool SkipBaselineIntegrityCheck { get; set; }
+
         public ValidateImageSizeOptions() : base()
         {
         }
@@ -23,6 +25,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             bool checkBaselineIntegrityOnly = false;
             syntax.DefineOption("baseline-integrity-only", ref checkBaselineIntegrityOnly, "Validate the integrity of the baseline by checking for missing or extraneous data");
             CheckBaselineIntegrityOnly = checkBaselineIntegrityOnly;
+
+            bool skipBaselineIntegrityCheck = false;
+            syntax.DefineOption("skip-baseline-integrity", ref skipBaselineIntegrityCheck, "Skip validation of missing or extraneous data");
+            SkipBaselineIntegrityCheck = skipBaselineIntegrityCheck;
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ReadmeHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ReadmeHelper.cs
@@ -11,24 +11,12 @@ namespace Microsoft.DotNet.ImageBuilder
     {
         private const string TagsSectionHeader = "# Full Tag Listing";
 
-        private static string NormalizeLineEndings(string value, string targetFormat)
-        {
-            string targetLineEnding = targetFormat.Contains("\r\n") ? "\r\n" : "\n";
-            string valueLineEnding = value.Contains("\r\n") ? "\r\n" : "\n";
-            if (valueLineEnding != targetLineEnding)
-            {
-                value = value.Replace(valueLineEnding, targetLineEnding);
-            }
-
-            return value;
-        }
-
         public static string UpdateTagsListing(string readme, string tagsListing)
         {
             tagsListing = $"{TagsSectionHeader}{Environment.NewLine}{Environment.NewLine}{tagsListing}{Environment.NewLine}{Environment.NewLine}";
 
             // Normalize the line endings to match the readme.
-            tagsListing = NormalizeLineEndings(tagsListing, readme);
+            tagsListing = tagsListing.NormalizeLineEndings(readme);
 
             // Regex to find the entire tags listing section including the header.
             Regex regex = new Regex($"^{TagsSectionHeader}\\s*(^(?!# ).*\\s)*", RegexOptions.Multiline);

--- a/src/Microsoft.DotNet.ImageBuilder/src/StringExtensions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/StringExtensions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
+
 namespace Microsoft.DotNet.ImageBuilder
 {
     public static class StringExtensions
@@ -31,6 +33,24 @@ namespace Microsoft.DotNet.ImageBuilder
         public static string ToCamelCase(this string source)
         {
             return source.Substring(0, 1).ToLowerInvariant() + source.Substring(1);
+        }
+
+        public static string NormalizeLineEndings(this string value, string targetFormat)
+        {
+            string targetLineEnding = targetFormat.Contains("\r\n") ? "\r\n" : "\n";
+            string valueLineEnding = value.Contains("\r\n") ? "\r\n" : "\n";
+            if (valueLineEnding != targetLineEnding)
+            {
+                value = value.Replace(valueLineEnding, targetLineEnding);
+            }
+
+            // Make sure the value ends with a blank line if the target ends with a blank line
+            if (targetFormat.Last() == '\n' && value.Last() != '\n')
+            {
+                value += targetLineEnding;
+            }
+
+            return value;
         }
     }
 }


### PR DESCRIPTION
Adds an option to the `validateImageSize` command to skip the baseline integrity check.  This is needed to support https://github.com/dotnet/dotnet-docker/issues/1588 so that a build job can validate a partial set of images and not run into issues with the baseline integrity check.