### PR TITLE
Issue template for new Windows release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: "Bug Report"
+about: Create a report to help us improve
+
+---
+
+## Steps to reproduce the issue
+1.
+2.
+3.
+
+## Expected behavior
+
+
+## Actual behavior
+
+
+## Additional information (e.g. issue happens only occasionally)
+
+
+## Output of `docker version`
+
+```
+(paste your output here)
+```
+
+## Output of `docker info`
+
+```
+(paste your output here)
+```

--- a/.github/ISSUE_TEMPLATE/releases/new-windows-release.md
+++ b/.github/ISSUE_TEMPLATE/releases/new-windows-release.md
@@ -4,6 +4,7 @@ Windows version: &lt;version&gt;
 
 ## Tasks
 
-1. - [ ] Contact DDFUN to schedule the provisioning of an Azure scale set for the new Windows version.
+1. - [ ] Well before the Windows release date, contact DDFUN to schedule the provisioning of an Azure scale set for the new Windows version.
       - [ ] If the new Windows version supports ARM architecture, it will also need to be installed on new or existing ARM devices.
 1. - [ ] If this is an LTS release of Windows, update [ImageBuilder](https://github.com/dotnet/docker-tools/blob/master/src/Microsoft.DotNet.ImageBuilder/src/McrTagsMetadataGenerator.cs) code to generate the correct README display name from the version specified in the manifest.
+1. - [ ] Include additional build and test jobs in the [common pipeline](https://github.com/dotnet/docker-tools/blob/master/eng/common/templates/stages/build-test-publish-repo.yml) to support the new Windows version.

--- a/.github/ISSUE_TEMPLATE/releases/new-windows-release.md
+++ b/.github/ISSUE_TEMPLATE/releases/new-windows-release.md
@@ -1,0 +1,9 @@
+# New Windows Release
+
+Windows version: &lt;version&gt;
+
+## Tasks
+
+1. - [ ] Contact DDFUN to schedule the provisioning of an Azure scale set for the new Windows version.
+      - [ ] If the new Windows version supports ARM architecture, it will also need to be installed on new or existing ARM devices.
+1. - [ ] If this is an LTS release of Windows, update [ImageBuilder](https://github.com/dotnet/docker-tools/blob/master/src/Microsoft.DotNet.ImageBuilder/src/McrTagsMetadataGenerator.cs) code to generate the correct README display name from the version specified in the manifest.

--- a/eng/pipelines/dotnet-buildtools-image-builder-pr.yml
+++ b/eng/pipelines/dotnet-buildtools-image-builder-pr.yml
@@ -1,5 +1,10 @@
 pr:
-- master
+  branches:
+    include:
+    - master
+  paths:
+    include:
+    - src/*
 
 trigger: none
 


### PR DESCRIPTION
Defines an issue template for tracking the common set of tasks (between both .NET Core and .NET Fx) that need to be done in preparation for a new version of Windows.

Also defines a default bug template.

Related to #383 