### PR TITLE
Command to display base image status

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetBaseImageStatusCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetBaseImageStatusCommand.cs
@@ -1,0 +1,77 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    [Export(typeof(ICommand))]
+    public class GetBaseImageStatusCommand : ManifestCommand<GetBaseImageStatusOptions>
+    {
+        private readonly IDockerService dockerService;
+        private readonly ILoggerService loggerService;
+
+        [ImportingConstructor]
+        public GetBaseImageStatusCommand(IDockerService dockerService, ILoggerService loggerService)
+        {
+            this.dockerService = dockerService ?? throw new ArgumentNullException(nameof(dockerService));
+            this.loggerService = loggerService ?? throw new ArgumentNullException(nameof(loggerService));
+        }
+
+        public override Task ExecuteAsync()
+        {
+            IEnumerable<string> imageTags = Manifest.GetFilteredPlatforms()
+                .Select(platform =>
+                {
+                    // Find the last FROM image that's an external image. This is not the same as the last
+                    // ExternalFromImage because that could be the first FROM listed in the Dockerfile which is
+                    // not what we want.
+                    string finalFromImage = platform.FromImages.Last();
+                    return platform.IsInternalFromImage(finalFromImage) ? null : finalFromImage;
+                })
+                .Where(image => image != null)
+                .Distinct()
+                .ToList();
+
+            this.loggerService.WriteHeading("PULLING LATEST BASE IMAGES");
+            foreach (string imageTag in imageTags)
+            {
+                this.dockerService.PullImage(imageTag, Options.IsDryRun);
+            }
+
+            this.loggerService.WriteHeading("QUERYING STATUS");
+            var statuses = imageTags
+                .Select(tag => new
+                {
+                    Tag = tag,
+                    DateCreated = this.dockerService.GetCreatedDate(tag, Options.IsDryRun)
+                })
+                .ToList();
+
+            this.loggerService.WriteHeading("BASE IMAGE STATUS SUMMARY");
+            foreach (var status in statuses)
+            {
+                TimeSpan timeDiff = DateTime.Now - status.DateCreated;
+
+                string days = String.Empty;
+                // Use TotalDays so that years are represented in terms of days
+                int totalDays = (int)timeDiff.TotalDays;
+                if (totalDays > 0)
+                {
+                    days = $"{totalDays} days, ";
+                }
+
+                this.loggerService.WriteSubheading(status.Tag);
+                this.loggerService.WriteMessage($"Created {days}{timeDiff.Minutes} minutes ago");
+                this.loggerService.WriteMessage();
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetBaseImageStatusCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetBaseImageStatusCommand.cs
@@ -31,8 +31,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     // Find the last FROM image that's an external image. This is not the same as the last
                     // ExternalFromImage because that could be the first FROM listed in the Dockerfile which is
                     // not what we want.
-                    string finalFromImage = platform.FromImages.Last();
-                    return platform.IsInternalFromImage(finalFromImage) ? null : finalFromImage;
+                    return platform.IsInternalFromImage(platform.FinalStageFromImage) ?
+                        null : platform.FinalStageFromImage;
                 })
                 .Where(image => image != null)
                 .Distinct()

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetBaseImageStatusOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetBaseImageStatusOptions.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+using System.CommandLine;
+
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    public class GetBaseImageStatusOptions : ManifestOptions, IFilterableOptions
+    {
+        public ManifestFilterOptions FilterOptions { get; } = new ManifestFilterOptions();
+
+        protected override string CommandHelp => "Displays the status of the referenced external base images";
+
+        public override void DefineOptions(ArgumentSyntax syntax)
+        {
+            base.DefineOptions(syntax);
+
+            FilterOptions.DefineOptions(syntax);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
@@ -128,7 +128,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         repoData.Images != null &&
                         repoData.Images.TryGetValue(platform.DockerfilePathRelativeToManifest, out ImageData imageData))
                     {
-                        string fromImage = platform.ExternalFromImages.Last();
+                        string fromImage = platform.FinalStageFromImage;
                         string currentDigest;
 
                         await this.imageDigestsSemaphore.WaitAsync();

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
@@ -118,6 +118,12 @@ namespace Microsoft.DotNet.ImageBuilder
             DockerHelper.ExecuteCommand("tag", "Failed to create tag", $"{image} {tag}", isDryRun);
         }
 
+        public static string GetCreatedDate(string image, bool isDryRun)
+        {
+            return ExecuteCommandWithFormat(
+                "inspect", ".Created", "Failed to retrieve created date", image, isDryRun);
+        }
+
         private static OS GetOS()
         {
             string osString = ExecuteCommandWithFormat("version", ".Server.Os", "Failed to detect Docker OS");

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerService.cs
@@ -59,5 +59,10 @@ namespace Microsoft.DotNet.ImageBuilder
         {
             return DockerHelper.GetImageSize(image, isDryRun);
         }
+
+        public DateTime GetCreatedDate(string image, bool isDryRun)
+        {
+            return DateTime.Parse(DockerHelper.GetCreatedDate(image, isDryRun));
+        }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/IDockerService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/IDockerService.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 
@@ -28,5 +29,7 @@ namespace Microsoft.DotNet.ImageBuilder
         bool LocalImageExists(string tag, bool isDryRun);
 
         long GetImageSize(string image, bool isDryRun);
+
+        DateTime GetCreatedDate(string image, bool isDryRun);
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         public string BuildContextPath { get; private set; }
         public string DockerfilePath { get; private set; }
         public string DockerfilePathRelativeToManifest { get; private set; }
-        public IEnumerable<string> FromImages { get; private set; }
+        public string FinalStageFromImage { get; private set; }
         public IEnumerable<string> ExternalFromImages { get; private set; }
         public IEnumerable<string> InternalFromImages { get; private set; }
         public Platform Model { get; private set; }
@@ -109,17 +109,19 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
                 throw new InvalidOperationException($"Unable to find a FROM image in {DockerfilePath}.");
             }
 
-            FromImages = fromMatches
+            IEnumerable<string> fromImages = fromMatches
                 .Select(match => match.Groups[FromImageMatchName].Value)
                 .Select(from => SubstituteOverriddenRepo(from))
                 .Select(from => SubstituteBuildArgs(from))
                 .Where(from => !IsStageReference(from, fromMatches))
                 .ToArray();
 
-            InternalFromImages = FromImages
+            FinalStageFromImage = fromImages.Last();
+
+            InternalFromImages = fromImages
                 .Where(from => IsInternalFromImage(from))
                 .ToArray();
-            ExternalFromImages = FromImages
+            ExternalFromImages = fromImages
                 .Except(InternalFromImages)
                 .ToArray();
         }


### PR DESCRIPTION
Defines an ImageBuilder command that will display the "created date" status for external base images referenced by the Dockerfiles.

Related to #402 