### PR TITLE
Common script to get base image status

### DIFF
--- a/eng/common/Get-BaseImageStatus.ps1
+++ b/eng/common/Get-BaseImageStatus.ps1
@@ -16,24 +16,18 @@ param(
 
     # A value indicating whether to run the script continously
     [switch]
-    $Continuous
+    $Continuous,
+
+    # Number of seconds to wait between each iteration
+    [int]
+    $ContinuousDelay = 10
 )
 
 Set-StrictMode -Version Latest
 
-function RunCommand() {
-    $imageBuilderArgs = "getBaseImageStatus --manifest $Manifest --architecture $Architecture"
-    & "$PSScriptRoot/Invoke-ImageBuilder.ps1" -ImageBuilderArgs $imageBuilderArgs
-}
-
+$imageBuilderArgs = "getBaseImageStatus --manifest $Manifest --architecture $Architecture"
 if ($Continuous) {
-    while ($true) {
-        RunCommand
+    $imageBuilderArgs += " --continuous --continuous-delay $ContinuousDelay"
+}
 
-        # Pause before continuing so the user can scan through the results
-        Start-Sleep -s 10
-    }
-}
-else {
-    RunCommand
-}
+& "$PSScriptRoot/Invoke-ImageBuilder.ps1" -ImageBuilderArgs $imageBuilderArgs

--- a/eng/common/Get-BaseImageStatus.ps1
+++ b/eng/common/Get-BaseImageStatus.ps1
@@ -1,0 +1,22 @@
+#!/usr/bin/env pwsh
+
+<#
+.SYNOPSIS
+Outputs the status of external base images referenced in the Dockerfiles.
+#>
+[cmdletbinding()]
+param(
+    # Path to the manifest file to use
+    [string]
+    $Manifest = "manifest.json",
+
+    # Architecture to filter Dockerfiles to
+    [string]
+    $Architecture = "*"
+)
+
+Set-StrictMode -Version Latest
+
+$imageBuilderArgs = "getBaseImageStatus --manifest $Manifest --architecture $Architecture"
+
+& "$PSScriptRoot/Invoke-ImageBuilder.ps1" -ImageBuilderArgs $imageBuilderArgs

--- a/eng/common/Get-BaseImageStatus.ps1
+++ b/eng/common/Get-BaseImageStatus.ps1
@@ -12,11 +12,28 @@ param(
 
     # Architecture to filter Dockerfiles to
     [string]
-    $Architecture = "*"
+    $Architecture = "*",
+
+    # A value indicating whether to run the script continously
+    [switch]
+    $Continuous
 )
 
 Set-StrictMode -Version Latest
 
-$imageBuilderArgs = "getBaseImageStatus --manifest $Manifest --architecture $Architecture"
+function RunCommand() {
+    $imageBuilderArgs = "getBaseImageStatus --manifest $Manifest --architecture $Architecture"
+    & "$PSScriptRoot/Invoke-ImageBuilder.ps1" -ImageBuilderArgs $imageBuilderArgs
+}
 
-& "$PSScriptRoot/Invoke-ImageBuilder.ps1" -ImageBuilderArgs $imageBuilderArgs
+if ($Continuous) {
+    while ($true) {
+        RunCommand
+
+        # Pause before continuing so the user can scan through the results
+        Start-Sleep -s 10
+    }
+}
+else {
+    RunCommand
+}

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,6 +1,6 @@
 variables:
-  imageNames.imageBuilder.linux: mcr.microsoft.com/dotnet-buildtools/image-builder:debian-20200211145309
-  imageNames.imageBuilder.windows: mcr.microsoft.com/dotnet-buildtools/image-builder:nanoserver-20200211145309
+  imageNames.imageBuilder.linux: mcr.microsoft.com/dotnet-buildtools/image-builder:debian-20200213164740
+  imageNames.imageBuilder.windows: mcr.microsoft.com/dotnet-buildtools/image-builder:nanoserver-20200213164740
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch-slim-docker-testrunner-d61254f-20190807161111
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,6 +1,6 @@
 variables:
-  imageNames.imageBuilder.linux: mcr.microsoft.com/dotnet-buildtools/image-builder:debian-20200204163821
-  imageNames.imageBuilder.windows: mcr.microsoft.com/dotnet-buildtools/image-builder:nanoserver-20200204163821
+  imageNames.imageBuilder.linux: mcr.microsoft.com/dotnet-buildtools/image-builder:debian-20200211145309
+  imageNames.imageBuilder.windows: mcr.microsoft.com/dotnet-buildtools/image-builder:nanoserver-20200211145309
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch-slim-docker-testrunner-d61254f-20190807161111
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)


### PR DESCRIPTION
Adds a wrapper script for the `getBaseImageStatus` command (see https://github.com/dotnet/docker-tools/pull/410) to allow callers to get the status of base images.

Fixes #402