### PR TITLE
Continuous mode option for GetBaseImageStatus cmd

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetBaseImageStatusCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetBaseImageStatusCommand.cs
@@ -23,7 +23,23 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             this.loggerService = loggerService ?? throw new ArgumentNullException(nameof(loggerService));
         }
 
-        public override Task ExecuteAsync()
+        public override async Task ExecuteAsync()
+        {
+            if (Options.ContinuousMode)
+            {
+                while (true)
+                {
+                    CheckStatus();
+                    await Task.Delay(Options.ContinuousModeDelay);
+                }
+            }
+            else
+            {
+                CheckStatus();
+            }
+        }
+
+        private void CheckStatus()
         {
             IEnumerable<string> imageTags = Manifest.GetFilteredPlatforms()
                 .Select(platform =>
@@ -70,8 +86,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 this.loggerService.WriteMessage($"Created {days}{timeDiff.Minutes} minutes ago");
                 this.loggerService.WriteMessage();
             }
-
-            return Task.CompletedTask;
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetBaseImageStatusOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetBaseImageStatusOptions.cs
@@ -2,21 +2,36 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
 
+using System;
 using System.CommandLine;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     public class GetBaseImageStatusOptions : ManifestOptions, IFilterableOptions
     {
+        protected override string CommandHelp => "Displays the status of the referenced external base images";
+
         public ManifestFilterOptions FilterOptions { get; } = new ManifestFilterOptions();
 
-        protected override string CommandHelp => "Displays the status of the referenced external base images";
+        public bool ContinuousMode { get; set; }
+
+        public TimeSpan ContinuousModeDelay { get; set; }
 
         public override void DefineOptions(ArgumentSyntax syntax)
         {
             base.DefineOptions(syntax);
 
             FilterOptions.DefineOptions(syntax);
+
+            bool continuousMode = false;
+            syntax.DefineOption("continuous", ref continuousMode, "Runs the status check continuously");
+            ContinuousMode = continuousMode;
+
+            const int ContinuousModeDelayDefault = 10;
+            int continuousModeDelay = ContinuousModeDelayDefault;
+            syntax.DefineOption("continuous-delay", ref continuousModeDelay,
+                $"Delay before running next status check (default {ContinuousModeDelayDefault} secs)");
+            ContinuousModeDelay = TimeSpan.FromSeconds(continuousModeDelay);
         }
     }
 }


### PR DESCRIPTION
Adds an option to the `getBaseImageStatus` command to allow the operation to run continuously.  This is useful so that the user can be assured that new images will be pulled down when they become available without needing to constantly pay attention and re-running the command manually.

Related to #402