### PR TITLE
Retry docker login

### DIFF
--- a/eng/common/templates/steps/test-images-windows-client.yml
+++ b/eng/common/templates/steps/test-images-windows-client.yml
@@ -3,7 +3,9 @@ steps:
   - template: init-docker-windows.yml
     parameters:
       setupImageBuilder: false
-  - script: docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)
+  - powershell: >
+      $(engCommonPath)/Invoke-WithRetry.ps1
+      "cmd /c 'docker login -u $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server) 2>&1'"
     displayName: Docker login
 - powershell: |
     if ("${{ eq(variables['System.TeamProject'], 'public') }}" -eq "False") {

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.ImageBuilder
                 ProcessStartInfo startInfo = new ProcessStartInfo(
                     "docker", $"login -u {username} --password-stdin {server}");
                 startInfo.RedirectStandardInput = true;
-                ExecuteHelper.Execute(
+                ExecuteHelper.ExecuteWithRetry(
                     startInfo,
                     info =>
                     {
@@ -79,7 +79,7 @@ namespace Microsoft.DotNet.ImageBuilder
             }
             else
             {
-                ExecuteHelper.Execute(
+                ExecuteHelper.ExecuteWithRetry(
                     "docker",
                     $"login -u {username} -p {password} {server}",
                     isDryRun,

--- a/src/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
@@ -45,6 +45,22 @@ namespace Microsoft.DotNet.ImageBuilder
             );
         }
 
+        public static Process ExecuteWithRetry(
+            ProcessStartInfo info,
+            Func<ProcessStartInfo, Process> executor,
+            bool isDryRun,
+            string errorMessage = null,
+            string executeMessageOverride = null)
+        {
+            return Execute(
+                info,
+                startInfo => ExecuteWithRetry(startInfo, executor),
+                isDryRun,
+                errorMessage,
+                executeMessageOverride
+            );
+        }
+
         public static Process Execute(
             ProcessStartInfo info,
             Func<ProcessStartInfo, Process> executor,


### PR DESCRIPTION
Fixes two cases where we execute `docker login` with no retry logic.

Fixes #403 