### PR TITLE
Fix stale image check to not include internal images

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
@@ -117,7 +117,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             foreach (RepoInfo repo in manifest.FilteredRepos)
             {
                 IEnumerable<PlatformInfo> platforms = repo.FilteredImages
-                    .SelectMany(image => image.FilteredPlatforms);
+                    .SelectMany(image => image.FilteredPlatforms)
+                    .Where(platform => !platform.IsInternalFromImage(platform.FinalStageFromImage));
 
                 RepoData repoData = repos
                     .FirstOrDefault(s => s.Repo == repo.Model.Name);
@@ -155,7 +156,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                             $"Checking base image '{fromImage}' from '{platform.DockerfilePath}'{Environment.NewLine}"
                             + $"\tLast build digest:    {lastDigest}{Environment.NewLine}"
                             + $"\tCurrent digest:       {currentDigest}{Environment.NewLine}"
-                            + $"\tImage is up-to-date:  {rebuildImage}{Environment.NewLine}");
+                            + $"\tImage is up-to-date:  {!rebuildImage}{Environment.NewLine}");
 
                         if (rebuildImage)
                         {

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
@@ -1095,6 +1095,90 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         }
 
         /// <summary>
+        /// Verifies that a Dockerfile with only an internal FROM should not be considered stale.
+        /// </summary>
+        [Fact]
+        public async Task GetStaleImagesCommand_InternalFromOnly()
+        {
+            const string repo1 = "test-repo";
+            const string dockerfile1Path = "dockerfile1/Dockerfile";
+            const string dockerfile2Path = "dockerfile2/Dockerfile";
+
+            RepoData[] imageInfoData = new RepoData[]
+            {
+                new RepoData
+                {
+                    Repo = repo1,
+                    Images = new SortedDictionary<string, ImageData>
+                    {
+                        {
+                            dockerfile1Path,
+                            new ImageData
+                            {
+                                BaseImages = new SortedDictionary<string, string>()
+                            }
+                        },
+                        {
+                            dockerfile2Path,
+                            new ImageData
+                            {
+                                BaseImages = new SortedDictionary<string, string>
+                                {
+                                    { "base1", "base1digest" }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            Subscription[] subscriptions = new Subscription[]
+            {
+                CreateSubscription(repo1)
+            };
+
+            Dictionary<Subscription, Manifest> subscriptionManifests =
+                new Dictionary<Subscription, Manifest>
+            {
+                {
+                    subscriptions[0],
+                    ManifestHelper.CreateManifest(
+                        ManifestHelper.CreateRepo(
+                            repo1,
+                            ManifestHelper.CreateImage(
+                                CreatePlatformWithRepoBuildArg(dockerfile1Path, $"{repo1}:tag2", new string[] { "tag1" })),
+                            ManifestHelper.CreateImage(
+                                ManifestHelper.CreatePlatform(dockerfile2Path, new string[] { "tag2" }))))
+                }
+            };
+
+            Dictionary<GitRepo, List<DockerfileInfo>> dockerfileInfos =
+                new Dictionary<GitRepo, List<DockerfileInfo>>
+            {
+                {
+                    subscriptions[0].RepoInfo,
+                    new List<DockerfileInfo>
+                    {
+                        new DockerfileInfo(dockerfile1Path, new FromImageInfo(null, null, isInternal: true)),
+                        new DockerfileInfo(dockerfile2Path, new FromImageInfo("base1", "base1digest"))
+                    }
+                }
+            };
+
+            using (TestContext context =
+                new TestContext(imageInfoData, subscriptions, subscriptionManifests, dockerfileInfos))
+            {
+                await context.ExecuteCommandAsync();
+
+                // No paths are expected
+                Dictionary<Subscription, IList<string>> expectedPathsBySubscription =
+                    new Dictionary<Subscription, IList<string>>();
+
+                context.Verify(expectedPathsBySubscription);
+            }
+        }
+
+        /// <summary>
         /// Use this method to generate a unique repo owner name for the tests. This ensures that each test
         /// uses a different name and prevents collisions when running the tests in parallel. This is because
         /// the <see cref="GetStaleImagesCommand"/> generates temp folders partially based on the name of


### PR DESCRIPTION
The `getStaleImages` command was incorrectly marking images to be rebuilt when they should not have been.  This was a regression from https://github.com/dotnet/docker-tools/pull/412 that caused it to include internal FROM images in its processing.

Fixed by updating the logic to only include external FROM images.

Also fixed a logic issue in the output logging.