### PR TITLE
Reference new variable groups

### DIFF
--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -58,9 +58,9 @@ jobs:
       condition: and(succeeded(), eq(variables['publishReadme'], 'true'))
   - script: >
       $(runImageBuilderCmd) publishImageInfo
-      $(dotnetBot-userName)
-      $(dotnetBot-email)
-      $(dotnet-bot-user-repo-adminrepohook-pat)
+      $(dotnetDockerBot.userName)
+      $(dotnetDockerBot.email)
+      $(BotAccount-dotnet-docker-bot-PAT)
       $(artifactsPath)/image-info.json
       --git-owner dotnet
       --git-repo versions

--- a/eng/common/templates/steps/publish-readmes.yml
+++ b/eng/common/templates/steps/publish-readmes.yml
@@ -7,9 +7,9 @@ steps:
     $(runImageBuilderCmd) publishMcrDocs
     --manifest $(manifest)
     --registry-override $(acr.server)
-    $(dotnetBot-userName)
-    $(dotnetBot-email)
-    $(dotnet-bot-user-repo-adminrepohook-pat)
+    $(dotnetDockerBot.userName)
+    $(dotnetDockerBot.email)
+    $(BotAccount-dotnet-docker-bot-PAT)
     $(publicGitRepoUri)
     ${{ parameters.dryRunArg }}
     $(imageBuilder.queueArgs)

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -12,5 +12,5 @@ variables:
 - name: imageBuilderDockerRunExtraOptions
   value: ""
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-  - group: DotNet-Docker-Common
-  - group: DotNet-Docker-Secrets
+  - group: DotNet-Docker-Common-New
+  - group: DotNet-Docker-Secrets-New

--- a/eng/pipelines/templates/steps/get-stale-images.yml
+++ b/eng/pipelines/templates/steps/get-stale-images.yml
@@ -11,9 +11,9 @@ steps:
   - script: >
       $(runImageBuilderCmd)
       getStaleImages
-      $(dotnetBot-userName)
-      $(dotnetBot-email)
-      $(dotnet-bot-user-repo-adminrepohook-pat)
+      $(dotnetDockerBot.userName)
+      $(dotnetDockerBot.email)
+      $(BotAccount-dotnet-docker-bot-PAT)
       ${{ parameters.staleImagePathsVariableName }}
       --subscriptions-path $(checkBaseImageSubscriptionsPath)
       --os-type ${{ parameters.osType }}


### PR DESCRIPTION
A new variable group has been defined that are connected to a key vault specific to .NET Docker: `DotNet-Docker-Secrets-New`.  In addition, a new bot account has been created for .NET Docker usage which resulted in new variable names so a new variable group, `DotNet-Docker-Common-New`, has been defined for that as well.

These changes update the infra to reference these new variable groups and variable names.  Once things have been validated and everything is migrated over to the new groups, we can then rename them back to the original names.

Related to #380 and #381 