### PR TITLE
Reset variable group names back to original value

### DIFF
--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -12,5 +12,5 @@ variables:
 - name: imageBuilderDockerRunExtraOptions
   value: ""
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-  - group: DotNet-Docker-Common-New
-  - group: DotNet-Docker-Secrets-New
+  - group: DotNet-Docker-Common
+  - group: DotNet-Docker-Secrets


### PR DESCRIPTION
Finishes up the work of migrating to the new Key Vault for .NET Docker by renaming the temporary variable groups back to their original names.

Fixes #380 
Fixes #381