### PR TITLE
Gracefully handle base images w/o a digest

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -140,7 +140,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             foreach (string fromImage in platform.ExternalFromImages)
             {
                 string digest = this.dockerService.GetImageDigest(fromImage, Options.IsDryRun);
-                baseImageDigestMappings[fromImage] = digest;
+                if (digest != null)
+                {
+                    baseImageDigestMappings[fromImage] = digest;
+                }
             }
 
             return baseImageDigestMappings;

--- a/src/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
@@ -89,6 +89,8 @@ namespace Microsoft.DotNet.ImageBuilder
                 if (process.ExitCode != 0)
                 {
                     string exceptionMsg = errorMessage ?? $"Failed to execute {info.FileName} {info.Arguments}";
+                    exceptionMsg += $"{Environment.NewLine}{Environment.NewLine}{process.StandardError.ReadToEnd().Trim()}";
+
                     throw new InvalidOperationException(exceptionMsg);
                 }
             }


### PR DESCRIPTION
Fixes `BuildCommand` to gracefully handle processing a base image that does not have a digest value.

Fixes #322 