### PR TITLE
Update ImageBuilder tags

### DIFF
--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,6 +1,6 @@
 variables:
-  imageNames.imageBuilder.linux: mcr.microsoft.com/dotnet-buildtools/image-builder:debian-20200214182704
-  imageNames.imageBuilder.windows: mcr.microsoft.com/dotnet-buildtools/image-builder:nanoserver-20200214182704
+  imageNames.imageBuilder.linux: mcr.microsoft.com/dotnet-buildtools/image-builder:debian-20200305171447
+  imageNames.imageBuilder.windows: mcr.microsoft.com/dotnet-buildtools/image-builder:nanoserver-20200305171447
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch-slim-docker-testrunner-d61254f-20190807161111
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/eng/pipelines/templates/jobs/build-image-builder.yml
+++ b/eng/pipelines/templates/jobs/build-image-builder.yml
@@ -4,7 +4,7 @@ parameters:
 jobs:
 - job: Initialize
   pool:
-    name: Hosted Windows Container
+    name: Hosted Ubuntu 1604
   steps:
   - powershell: write-host "##vso[task.setvariable variable=timestamp;isOutput=true]$(Get-Date -Format yyyyMMddHHmmss)"
     displayName: Define Timestamp Variable


### PR DESCRIPTION
Also updates the `Initialize` job in the pipeline to no longer use `Hosted Windows Container` because that pool is being [removed](https://aka.ms/removing-older-images-hosted-pools).