### PR TITLE
Ensure std err is redirected

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
@@ -203,7 +203,6 @@ namespace Microsoft.DotNet.ImageBuilder
         {
             ProcessStartInfo startInfo = new ProcessStartInfo("docker", $"{command} {additionalArgs}");
             startInfo.RedirectStandardOutput = true;
-            startInfo.RedirectStandardError = true;
             Process process = ExecuteHelper.Execute(startInfo, isDryRun, errorMessage);
             return isDryRun ? "" : process.StandardOutput.ReadToEnd().Trim();
         }

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
@@ -75,13 +75,10 @@ namespace Microsoft.DotNet.ImageBuilder
                 startInfo.RedirectStandardInput = true;
                 ExecuteHelper.ExecuteWithRetry(
                     startInfo,
-                    info =>
+                    process =>
                     {
-                        Process process = Process.Start(info);
                         process.StandardInput.WriteLine(password);
                         process.StandardInput.Close();
-                        process.WaitForExit();
-                        return process;
                     },
                     isDryRun);
             }
@@ -201,10 +198,8 @@ namespace Microsoft.DotNet.ImageBuilder
         private static string ExecuteCommand(
             string command, string errorMessage, string additionalArgs = null, bool isDryRun = false)
         {
-            ProcessStartInfo startInfo = new ProcessStartInfo("docker", $"{command} {additionalArgs}");
-            startInfo.RedirectStandardOutput = true;
-            Process process = ExecuteHelper.Execute(startInfo, isDryRun, errorMessage);
-            return isDryRun ? "" : process.StandardOutput.ReadToEnd().Trim();
+            string output = ExecuteHelper.Execute("docker", $"{command} {additionalArgs}", isDryRun, errorMessage);
+            return isDryRun ? "" : output;
         }
 
         private static string ExecuteCommandWithFormat(

--- a/src/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
@@ -68,6 +68,8 @@ namespace Microsoft.DotNet.ImageBuilder
             string errorMessage = null,
             string executeMessageOverride = null)
         {
+            info.RedirectStandardError = true;
+
             Process process = null;
 
             if (executeMessageOverride == null)

--- a/src/Microsoft.DotNet.ImageBuilder/src/GitHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/GitHelper.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -23,11 +22,11 @@ namespace Microsoft.DotNet.ImageBuilder
         public static string GetCommitSha(string filePath, bool useFullHash = false)
         {
             string format = useFullHash ? "H" : "h";
-            ProcessStartInfo startInfo = new ProcessStartInfo("git", $"log -1 --format=format:%{format} {filePath}");
-            startInfo.RedirectStandardOutput = true;
-            Process gitLogProcess = ExecuteHelper.Execute(
-                startInfo, false, $"Unable to retrieve the latest commit SHA for {filePath}");
-            return gitLogProcess.StandardOutput.ReadToEnd().Trim();
+            return ExecuteHelper.Execute(
+                "git",
+                $"log -1 --format=format:%{format} {filePath}",
+                false,
+                $"Unable to retrieve the latest commit SHA for {filePath}");
         }
 
         public static Uri GetArchiveUrl(GitRepo gitRepo)


### PR DESCRIPTION
Not all code paths that call into `ExecuteHelper.Execute` set `ProcessStartInfo.RedirectStandardError` to `true` but the method relies on it being set to construct an error message.  If `RedirectStandardError` is `false`, it will cause an error saying `System.InvalidOperationException: StandardError has not been redirected.`.

To fix this, the method will ensure that `RedirectStandardError` is set to `true` whenever it's called.