### PR TITLE
Update image info schema to have image/platform concepts

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -102,8 +102,15 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
                     foreach (PlatformInfo platform in image.FilteredPlatforms)
                     {
-                        PlatformData platformData = new PlatformData();
-                        imageData.Platforms.Add(platform.DockerfilePathRelativeToManifest, platformData);
+                        PlatformData platformData = new PlatformData
+                        {
+                            Path = platform.DockerfilePathRelativeToManifest,
+                            Architecture = platform.Model.Architecture.GetDisplayName(),
+                            OsType = platform.Model.OS.ToString(),
+                            OsVersion = platform.GetOSDisplayName()
+                        };
+
+                        imageData.Platforms.Add(platformData);
 
                         bool createdPrivateDockerfile = UpdateDockerfileFromCommands(platform, out string dockerfilePath);
 
@@ -296,7 +303,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private IEnumerable<PlatformData> GetBuiltPlatforms() => this.repoList
             .Where(repoData => repoData.Images != null)
             .SelectMany(repoData => repoData.Images)
-            .SelectMany(imageData => imageData.Platforms.Values);
+            .SelectMany(imageData => imageData.Platforms);
 
         private IEnumerable<string> GetBuiltTags() =>
             GetBuiltPlatforms().SelectMany(image => image.AllTags);

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -102,14 +102,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
                     foreach (PlatformInfo platform in image.FilteredPlatforms)
                     {
-                        PlatformData platformData = new PlatformData
-                        {
-                            Path = platform.DockerfilePathRelativeToManifest,
-                            Architecture = platform.Model.Architecture.GetDisplayName(),
-                            OsType = platform.Model.OS.ToString(),
-                            OsVersion = platform.GetOSDisplayName()
-                        };
-
+                        PlatformData platformData = PlatformData.FromPlatformInfo(platform);
                         imageData.Platforms.Add(platformData);
 
                         bool createdPrivateDockerfile = UpdateDockerfileFromCommands(platform, out string dockerfilePath);

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             PullBaseImages();
             BuildImages();
 
-            if (GetBuiltImages().Any())
+            if (GetBuiltPlatforms().Any())
             {
                 PushImages();
             }
@@ -58,7 +58,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 return;
             }
 
-            foreach (var image in GetBuiltImages())
+            foreach (var image in GetBuiltPlatforms())
             {
                 foreach (string tag in image.FullyQualifiedSimpleTags)
                 {
@@ -95,14 +95,15 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 };
                 repoList.Add(repoData);
 
-                SortedDictionary<string, ImageData> images = new SortedDictionary<string, ImageData>();
-
                 foreach (ImageInfo image in repoInfo.FilteredImages)
                 {
+                    ImageData imageData = new ImageData();
+                    repoData.Images.Add(imageData);
+
                     foreach (PlatformInfo platform in image.FilteredPlatforms)
                     {
-                        ImageData imageData = new ImageData();
-                        images.Add(platform.DockerfilePathRelativeToManifest, imageData);
+                        PlatformData platformData = new PlatformData();
+                        imageData.Platforms.Add(platform.DockerfilePathRelativeToManifest, platformData);
 
                         bool createdPrivateDockerfile = UpdateDockerfileFromCommands(platform, out string dockerfilePath);
 
@@ -145,23 +146,18 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         SortedDictionary<string, string> baseImageDigests = GetBaseImageDigests(platform);
                         if (baseImageDigests.Any())
                         {
-                            imageData.BaseImages = baseImageDigests;
+                            platformData.BaseImages = baseImageDigests;
                         }
 
-                        imageData.SimpleTags = GetPushTags(platform.Tags)
+                        platformData.SimpleTags = GetPushTags(platform.Tags)
                             .Select(tag => tag.Name)
                             .OrderBy(name => name)
                             .ToList();
-                        imageData.FullyQualifiedSimpleTags = imageData.SimpleTags
+                        platformData.FullyQualifiedSimpleTags = platformData.SimpleTags
                             .Select(tag => TagInfo.GetFullyQualifiedName(repoInfo.Name, tag))
                             .ToList();
-                        imageData.AllTags = allTags;
+                        platformData.AllTags = allTags;
                     }
-                }
-
-                if (images.Any())
-                {
-                    repoData.Images = images;
                 }
             }
         }
@@ -297,12 +293,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             }
         }
 
-        private IEnumerable<ImageData> GetBuiltImages() => this.repoList
+        private IEnumerable<PlatformData> GetBuiltPlatforms() => this.repoList
             .Where(repoData => repoData.Images != null)
-            .SelectMany(repoData => repoData.Images.Values);
+            .SelectMany(repoData => repoData.Images)
+            .SelectMany(imageData => imageData.Platforms.Values);
 
         private IEnumerable<string> GetBuiltTags() =>
-            GetBuiltImages().SelectMany(image => image.AllTags);
+            GetBuiltPlatforms().SelectMany(image => image.AllTags);
 
         private void PushImages()
         {

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
@@ -107,7 +107,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 {
                     foreach (ImageData imageData in repoData.Images)
                     {
-                        if (imageData.Platforms.TryGetValue(platform.DockerfilePathRelativeToManifest, out PlatformData platformData))
+                        PlatformData platformData = imageData.Platforms
+                            .FirstOrDefault(platformData => platformData.Path == platform.DockerfilePathRelativeToManifest);
+                        if (platformData != null)
                         {
                             destTagNames = platformData.SimpleTags
                                 .Select(tag => TagInfo.GetFullyQualifiedName(repo.Name, tag));

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Azure.Management.ContainerRegistry.Fluent;
@@ -16,7 +15,6 @@ using Microsoft.Azure.Management.ResourceManager.Fluent.Authentication;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
 using Microsoft.DotNet.ImageBuilder.Services;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
-using Newtonsoft.Json;
 using ImportSource = Microsoft.Azure.Management.ContainerRegistry.Fluent.Models.ImportSource;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
@@ -37,7 +35,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             {
                 if (!String.IsNullOrEmpty(Options.ImageInfoPath))
                 {
-                    return JsonConvert.DeserializeObject<RepoData[]>(File.ReadAllText(Options.ImageInfoPath));
+                    return ImageInfoHelper.LoadFromFile(Options.ImageInfoPath, Manifest);
                 }
 
                 return null;
@@ -107,12 +105,17 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 RepoData repoData = imageInfoRepos.Value.FirstOrDefault(repoData => repoData.Repo == repo.Model.Name);
                 if (repoData != null)
                 {
-                    if (repoData.Images.TryGetValue(platform.DockerfilePathRelativeToManifest, out ImageData image))
+                    foreach (ImageData imageData in repoData.Images)
                     {
-                        destTagNames = image.SimpleTags
-                            .Select(tag => TagInfo.GetFullyQualifiedName(repo.Name, tag));
+                        if (imageData.Platforms.TryGetValue(platform.DockerfilePathRelativeToManifest, out PlatformData platformData))
+                        {
+                            destTagNames = platformData.SimpleTags
+                                .Select(tag => TagInfo.GetFullyQualifiedName(repo.Name, tag));
+                            break;
+                        }
                     }
-                    else
+
+                    if (destTagNames == null)
                     {
                         Logger.WriteError($"Unable to find image info data for path '{platform.DockerfilePath}'.");
                         this.environmentService.Exit(1);
@@ -124,8 +127,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     this.environmentService.Exit(1);
                 }
             }
-
-            if (destTagNames == null)
+            else
             {
                 destTagNames = platform.Tags
                     .Select(tag => tag.FullyQualifiedName);

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
@@ -105,19 +105,15 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 RepoData repoData = imageInfoRepos.Value.FirstOrDefault(repoData => repoData.Repo == repo.Model.Name);
                 if (repoData != null)
                 {
-                    foreach (ImageData imageData in repoData.Images)
+                    PlatformData platformData = repoData.Images
+                        .SelectMany(image => image.Platforms)
+                        .FirstOrDefault(platformData => platformData.Dockerfile == platform.DockerfilePathRelativeToManifest);
+                    if (platformData != null)
                     {
-                        PlatformData platformData = imageData.Platforms
-                            .FirstOrDefault(platformData => platformData.Path == platform.DockerfilePathRelativeToManifest);
-                        if (platformData != null)
-                        {
-                            destTagNames = platformData.SimpleTags
-                                .Select(tag => TagInfo.GetFullyQualifiedName(repo.Name, tag));
-                            break;
-                        }
+                        destTagNames = platformData.SimpleTags
+                            .Select(tag => TagInfo.GetFullyQualifiedName(repo.Name, tag));
                     }
-
-                    if (destTagNames == null)
+                    else
                     {
                         Logger.WriteError($"Unable to find image info data for path '{platform.DockerfilePath}'.");
                         this.environmentService.Exit(1);

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
@@ -154,7 +154,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             foreach (ImageData imageData in repoData.Images)
             {
-                if (imageData.Platforms.TryGetValue(platform.DockerfilePathRelativeToManifest, out PlatformData platformData))
+                PlatformData platformData = imageData.Platforms
+                    .FirstOrDefault(platformData => platformData.Path == platform.DockerfilePathRelativeToManifest);
+                if (platformData != null)
                 {
                     foundImageInfo = true;
                     string fromImage = platform.FinalStageFromImage;

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
@@ -155,7 +155,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             foreach (ImageData imageData in repoData.Images)
             {
                 PlatformData platformData = imageData.Platforms
-                    .FirstOrDefault(platformData => platformData.Path == platform.DockerfilePathRelativeToManifest);
+                    .FirstOrDefault(platformData => platformData.Dockerfile == platform.DockerfilePathRelativeToManifest);
                 if (platformData != null)
                 {
                     foundImageInfo = true;

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/MergeImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/MergeImageInfoCommand.cs
@@ -9,12 +9,11 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
-using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     [Export(typeof(ICommand))]
-    public class MergeImageInfoCommand : Command<MergeImageInfoOptions>
+    public class MergeImageInfoCommand : ManifestCommand<MergeImageInfoOptions>
     {
         public override Task ExecuteAsync()
         {
@@ -25,7 +24,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             List<RepoData[]> srcReposList = imageInfoFiles
                 .OrderBy(file => file) // Ensure the files are ordered for testing consistency between OS's.
-                .Select(imageDataPath => JsonConvert.DeserializeObject<RepoData[]>(File.ReadAllText(imageDataPath)))
+                .Select(imageDataPath => ImageInfoHelper.LoadFromFile(imageDataPath, Manifest))
                 .ToList();
 
             if (!srcReposList.Any())

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/MergeImageInfoOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/MergeImageInfoOptions.cs
@@ -6,7 +6,7 @@ using System.CommandLine;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
-    public class MergeImageInfoOptions : Options
+    public class MergeImageInfoOptions : ManifestOptions
     {
         protected override string CommandHelp => "Merges the content of multiple image info files into one file";
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
@@ -15,7 +14,7 @@ using Newtonsoft.Json;
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     [Export(typeof(ICommand))]
-    public class PublishImageInfoCommand : Command<PublishImageInfoOptions>
+    public class PublishImageInfoCommand : ManifestCommand<PublishImageInfoOptions>
     {
         private readonly IGitHubClientFactory gitHubClientFactory;
 
@@ -27,7 +26,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         public override async Task ExecuteAsync()
         {
-            RepoData[] srcRepos = JsonConvert.DeserializeObject<RepoData[]>(File.ReadAllText(Options.ImageInfoPath));
+            RepoData[] srcRepos = ImageInfoHelper.LoadFromFile(Options.ImageInfoPath, Manifest);
 
             using (IGitHubClient gitHubClient = this.gitHubClientFactory.GetClient(Options.GitOptions.ToGitHubAuth(), Options.IsDryRun))
             {

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoOptions.cs
@@ -6,7 +6,7 @@ using System.CommandLine;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
-    public class PublishImageInfoOptions : Options, IGitOptionsHost
+    public class PublishImageInfoOptions : ManifestOptions, IGitOptionsHost
     {
         protected override string CommandHelp => "Publishes a build's merged image info.";
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/McrTagsMetadataGenerator.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/McrTagsMetadataGenerator.cs
@@ -77,74 +77,6 @@ namespace Microsoft.DotNet.ImageBuilder
             return metadata;
         }
 
-        public static string GetOSDisplayName(PlatformInfo platform)
-        {
-            string displayName;
-            string os = platform.Model.OsVersion;
-            Logger.WriteMessage($"os: {os}");
-            Logger.WriteMessage($"osType: {platform.Model.OS}");
-
-            if (platform.Model.OS == OS.Windows)
-            {
-                if (os.Contains("2016"))
-                {
-                    displayName = "Windows Server 2016";
-                }
-                else if (os.Contains("2019") || os.Contains("1809"))
-                {
-                    displayName = "Windows Server 2019";
-                }
-                else
-                {
-                    string version = os.Split('-')[1];
-                    displayName = $"Windows Server, version {version}";
-                }
-            }
-            else
-            {
-                if (os.Contains("jessie"))
-                {
-                    displayName = "Debian 8";
-                }
-                else if (os.Contains("stretch"))
-                {
-                    displayName = "Debian 9";
-                }
-                else if (os.Contains("buster"))
-                {
-                    displayName = "Debian 10";
-                }
-                else if (os.Contains("bionic"))
-                {
-                    displayName = "Ubuntu 18.04";
-                }
-                else if (os.Contains("disco"))
-                {
-                    displayName = "Ubuntu 19.04";
-                }
-                else if (os.Contains("focal"))
-                {
-                    displayName = "Ubuntu 20.04";
-                }
-                else if (os.Contains("alpine"))
-                {
-                    int versionIndex = os.IndexOfAny(new char[] { '1', '2', '3', '4', '5', '6', '7', '8', '9', '0' });
-                    if (versionIndex != -1)
-                    {
-                        os = os.Insert(versionIndex, " ");
-                    }
-
-                    displayName = os.FirstCharToUpper();
-                }
-                else
-                {
-                    throw new InvalidOperationException($"The OS version '{os}' is not supported.");
-                }
-            }
-
-            return displayName;
-        }
-
         private static string GetRepoYaml(RepoInfo repo)
         {
             StringBuilder yaml = new StringBuilder();
@@ -167,7 +99,7 @@ namespace Microsoft.DotNet.ImageBuilder
             yaml.AppendLine($"  - tags: [ {info.FormattedDocumentedTags} ]");
             yaml.AppendLine($"    architecture: {info.Platform.Model.Architecture.GetDisplayName()}");
             yaml.AppendLine($"    os: {info.Platform.Model.OS.GetDockerName()}");
-            yaml.AppendLine($"    osVersion: {GetOSDisplayName(info.Platform)}");
+            yaml.AppendLine($"    osVersion: {info.Platform.GetOSDisplayName()}");
             yaml.Append($"    dockerfile: {dockerfilePath}");
 
             return yaml.ToString();

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/ImageData.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/ImageData.cs
@@ -2,21 +2,40 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
 using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.ImageBuilder.Models.Image
 {
-    public class ImageData
+    public class ImageData : IComparable<ImageData>
     {
-        public SortedDictionary<string, PlatformData> Platforms { get; set; } =
-            new SortedDictionary<string, PlatformData>();
+        public List<PlatformData> Platforms { get; set; } = new List<PlatformData>();
 
         /// <summary>
         /// Gets or sets a reference to the corresponding image definition in the manifest.
         /// </summary>
         [JsonIgnore]
         public ImageInfo ManifestImage { get; set; }
+
+        public int CompareTo([AllowNull] ImageData other)
+        {
+            if (other is null)
+            {
+                return 1;
+            }
+
+            if (ManifestImage == other.ManifestImage)
+            {
+                return 0;
+            }
+
+            // If we're comparing two different image items, compare them by the first Platform path's to
+            // provide deterministic ordering.
+            return Platforms.FirstOrDefault()?.Path.CompareTo(other.Platforms.FirstOrDefault()?.Path) ?? 1;
+        }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/ImageData.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/ImageData.cs
@@ -3,24 +3,20 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Linq;
+using Microsoft.DotNet.ImageBuilder.ViewModel;
 using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.ImageBuilder.Models.Image
 {
     public class ImageData
     {
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public SortedDictionary<string, string> BaseImages { get; set; }
+        public SortedDictionary<string, PlatformData> Platforms { get; set; } =
+            new SortedDictionary<string, PlatformData>();
 
-        public List<string> SimpleTags { get; set; } = new List<string>();
-
+        /// <summary>
+        /// Gets or sets a reference to the corresponding image definition in the manifest.
+        /// </summary>
         [JsonIgnore]
-        public IEnumerable<string> FullyQualifiedSimpleTags { get; set; }
-
-        [JsonIgnore]
-        public IEnumerable<string> AllTags { get; set; }
-
-        public string Digest { get; set; }
+        public ImageInfo ManifestImage { get; set; }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/ImageData.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/ImageData.cs
@@ -33,9 +33,15 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Image
                 return 0;
             }
 
-            // If we're comparing two different image items, compare them by the first Platform path's to
+            // If we're comparing two different image items, compare them by the first Platform to
             // provide deterministic ordering.
-            return Platforms.FirstOrDefault()?.Path.CompareTo(other.Platforms.FirstOrDefault()?.Path) ?? 1;
+            PlatformData thisFirstPlatform = Platforms
+                .OrderBy(platform => platform)
+                .FirstOrDefault();
+            PlatformData otherFirstPlatform = other.Platforms
+                .OrderBy(platform => platform)
+                .FirstOrDefault();
+            return thisFirstPlatform?.CompareTo(otherFirstPlatform) ?? 1;
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/PlatformData.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/PlatformData.cs
@@ -2,13 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.ImageBuilder.Models.Image
 {
-    public class PlatformData
+    public class PlatformData : IComparable<PlatformData>
     {
+        public string Path { get; set; }
+
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public SortedDictionary<string, string> BaseImages { get; set; }
 
@@ -16,10 +20,28 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Image
 
         public string Digest { get; set; }
 
+        public string Architecture { get; set; }
+        
+        public string OsType { get; set; }
+        
+        public string OsVersion { get; set; }
+
         [JsonIgnore]
         public IEnumerable<string> FullyQualifiedSimpleTags { get; set; }
 
         [JsonIgnore]
         public IEnumerable<string> AllTags { get; set; }
+
+        public int CompareTo([AllowNull] PlatformData other)
+        {
+            if (other is null)
+            {
+                return 1;
+            }
+
+            return GetIdentifier().CompareTo(other.GetIdentifier());
+        }
+
+        private string GetIdentifier() => $"{Path}-{Architecture}-{OsType}-{OsVersion}";
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/PlatformData.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/PlatformData.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.ImageBuilder.Models.Image
+{
+    public class PlatformData
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public SortedDictionary<string, string> BaseImages { get; set; }
+
+        public List<string> SimpleTags { get; set; } = new List<string>();
+
+        public string Digest { get; set; }
+
+        [JsonIgnore]
+        public IEnumerable<string> FullyQualifiedSimpleTags { get; set; }
+
+        [JsonIgnore]
+        public IEnumerable<string> AllTags { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/PlatformData.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/PlatformData.cs
@@ -5,13 +5,14 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.DotNet.ImageBuilder.ViewModel;
 using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.ImageBuilder.Models.Image
 {
     public class PlatformData : IComparable<PlatformData>
     {
-        public string Path { get; set; }
+        public string Dockerfile { get; set; }
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public SortedDictionary<string, string> BaseImages { get; set; }
@@ -42,6 +43,22 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Image
             return GetIdentifier().CompareTo(other.GetIdentifier());
         }
 
-        private string GetIdentifier() => $"{Path}-{Architecture}-{OsType}-{OsVersion}";
+        public bool Equals(PlatformInfo platformInfo)
+        {
+            return GetIdentifier() == FromPlatformInfo(platformInfo).GetIdentifier();
+        }
+
+        public string GetIdentifier() => $"{Dockerfile}-{Architecture}-{OsType}-{OsVersion}";
+
+        public static PlatformData FromPlatformInfo(PlatformInfo platform)
+        {
+            return new PlatformData
+            {
+                Dockerfile = platform.DockerfilePathRelativeToManifest,
+                Architecture = platform.Model.Architecture.GetDisplayName(),
+                OsType = platform.Model.OS.ToString(),
+                OsVersion = platform.GetOSDisplayName()
+            };
+        }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/RepoData.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/RepoData.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.ImageBuilder.Models.Image
@@ -13,7 +12,6 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Image
         [JsonProperty(Required = Required.Always)]
         public string Repo { get; set; }
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public SortedDictionary<string, ImageData> Images { get; set; }
+        public List<ImageData> Images { get; set; } = new List<ImageData>();
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
@@ -131,6 +131,74 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             return this.internalRepos.Any(repo => fromImage.StartsWith($"{repo}:"));
         }
 
+        public string GetOSDisplayName()
+        {
+            string displayName;
+            string os = Model.OsVersion;
+            Logger.WriteMessage($"os: {os}");
+            Logger.WriteMessage($"osType: {Model.OS}");
+
+            if (Model.OS == OS.Windows)
+            {
+                if (os.Contains("2016"))
+                {
+                    displayName = "Windows Server 2016";
+                }
+                else if (os.Contains("2019") || os.Contains("1809"))
+                {
+                    displayName = "Windows Server 2019";
+                }
+                else
+                {
+                    string version = os.Split('-')[1];
+                    displayName = $"Windows Server, version {version}";
+                }
+            }
+            else
+            {
+                if (os.Contains("jessie"))
+                {
+                    displayName = "Debian 8";
+                }
+                else if (os.Contains("stretch"))
+                {
+                    displayName = "Debian 9";
+                }
+                else if (os.Contains("buster"))
+                {
+                    displayName = "Debian 10";
+                }
+                else if (os.Contains("bionic"))
+                {
+                    displayName = "Ubuntu 18.04";
+                }
+                else if (os.Contains("disco"))
+                {
+                    displayName = "Ubuntu 19.04";
+                }
+                else if (os.Contains("focal"))
+                {
+                    displayName = "Ubuntu 20.04";
+                }
+                else if (os.Contains("alpine"))
+                {
+                    int versionIndex = os.IndexOfAny(new char[] { '1', '2', '3', '4', '5', '6', '7', '8', '9', '0' });
+                    if (versionIndex != -1)
+                    {
+                        os = os.Insert(versionIndex, " ");
+                    }
+
+                    displayName = os.FirstCharToUpper();
+                }
+                else
+                {
+                    throw new InvalidOperationException($"The OS version '{os}' is not supported.");
+                }
+            }
+
+            return displayName;
+        }
+
         private static bool IsStageReference(string fromImage, IList<Match> fromMatches)
         {
             bool isStageReference = false;

--- a/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
@@ -86,21 +86,22 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             new ImageData
                             {
-                                Platforms = new SortedDictionary<string, PlatformData>
+                                Platforms = new List<PlatformData>
                                 {
+                                    new PlatformData
                                     {
-                                        $"{runtimeRelativeDir}/Dockerfile",
-                                        new PlatformData
+                                        Path = $"{runtimeRelativeDir}/Dockerfile",
+                                        Architecture = "amd64",
+                                        OsType = "Linux",
+                                        OsVersion = "Ubuntu 19.04",
+                                        Digest = sha,
+                                        BaseImages = new SortedDictionary<string, string>
                                         {
-                                            Digest = sha,
-                                            BaseImages = new SortedDictionary<string, string>
-                                            {
-                                                { baseImageTag, baseImageDigest }
-                                            },
-                                            SimpleTags = new List<string>
-                                            {
-                                                tag
-                                            }
+                                            { baseImageTag, baseImageDigest }
+                                        },
+                                        SimpleTags = new List<string>
+                                        {
+                                            tag
                                         }
                                     }
                                 }
@@ -219,7 +220,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 await command.ExecuteAsync();
 
                 RepoData[] repos = JsonConvert.DeserializeObject<RepoData[]>(File.ReadAllText(command.Options.ImageInfoOutputPath));
-                Assert.Equal(PathHelper.NormalizePath(dockerfileRelativePath), repos[0].Images.First().Platforms.First().Key);
+                Assert.Equal(PathHelper.NormalizePath(dockerfileRelativePath), repos[0].Images.First().Platforms.First().Path);
             }
         }
     }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                 {
                                     new PlatformData
                                     {
-                                        Path = $"{runtimeRelativeDir}/Dockerfile",
+                                        Dockerfile = $"{runtimeRelativeDir}/Dockerfile",
                                         Architecture = "amd64",
                                         OsType = "Linux",
                                         OsVersion = "Ubuntu 19.04",
@@ -220,7 +220,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 await command.ExecuteAsync();
 
                 RepoData[] repos = JsonConvert.DeserializeObject<RepoData[]>(File.ReadAllText(command.Options.ImageInfoOutputPath));
-                Assert.Equal(PathHelper.NormalizePath(dockerfileRelativePath), repos[0].Images.First().Platforms.First().Path);
+                Assert.Equal(PathHelper.NormalizePath(dockerfileRelativePath), repos[0].Images.First().Platforms.First().Dockerfile);
             }
         }
     }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
@@ -82,20 +82,26 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     new RepoData
                     {
                         Repo = repoName,
-                        Images = new SortedDictionary<string, ImageData>
+                        Images = new List<ImageData>
                         {
+                            new ImageData
                             {
-                                $"{runtimeRelativeDir}/Dockerfile",
-                                new ImageData
+                                Platforms = new SortedDictionary<string, PlatformData>
                                 {
-                                    Digest = sha,
-                                    BaseImages = new SortedDictionary<string, string>
                                     {
-                                        { baseImageTag, baseImageDigest }
-                                    },
-                                    SimpleTags = new List<string>
-                                    {
-                                        tag
+                                        $"{runtimeRelativeDir}/Dockerfile",
+                                        new PlatformData
+                                        {
+                                            Digest = sha,
+                                            BaseImages = new SortedDictionary<string, string>
+                                            {
+                                                { baseImageTag, baseImageDigest }
+                                            },
+                                            SimpleTags = new List<string>
+                                            {
+                                                tag
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -213,7 +219,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 await command.ExecuteAsync();
 
                 RepoData[] repos = JsonConvert.DeserializeObject<RepoData[]>(File.ReadAllText(command.Options.ImageInfoOutputPath));
-                Assert.Equal(PathHelper.NormalizePath(dockerfileRelativePath), repos[0].Images.First().Key);
+                Assert.Equal(PathHelper.NormalizePath(dockerfileRelativePath), repos[0].Images.First().Platforms.First().Key);
             }
         }
     }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/CopyAcrImagesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/CopyAcrImagesCommandTests.cs
@@ -70,16 +70,22 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     runtimeRepo = new RepoData
                     {
                         Repo = "runtime",
-                        Images = new SortedDictionary<string, ImageData>
+                        Images = new List<ImageData>
                         {
+                            new ImageData
                             {
-                                PathHelper.NormalizePath(dockerfileRelativePath),
-                                new ImageData
+                                Platforms = new SortedDictionary<string, PlatformData>
                                 {
-                                    SimpleTags =
                                     {
-                                        "tag1",
-                                        "tag2"
+                                        PathHelper.NormalizePath(dockerfileRelativePath),
+                                        new PlatformData
+                                        {
+                                            SimpleTags =
+                                            {
+                                                "tag1",
+                                                "tag2"
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -92,7 +98,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 command.LoadManifest();
                 await command.ExecuteAsync();
 
-                IList<string> expectedTags = runtimeRepo.Images.First().Value.SimpleTags
+                IList<string> expectedTags = runtimeRepo.Images.First().Platforms.First().Value.SimpleTags
                     .Select(tag => $"{command.Options.RepoPrefix}{runtimeRepo.Repo}:{tag}")
                     .ToList();
 

--- a/src/Microsoft.DotNet.ImageBuilder/tests/CopyAcrImagesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/CopyAcrImagesCommandTests.cs
@@ -20,6 +20,7 @@ using Microsoft.Rest.Azure;
 using Moq;
 using Newtonsoft.Json;
 using Xunit;
+using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ImageInfoHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
@@ -76,15 +77,13 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             {
                                 Platforms = new List<PlatformData>
                                 {
-                                    new PlatformData
-                                    {
-                                        Path = PathHelper.NormalizePath(dockerfileRelativePath),
-                                        SimpleTags =
+                                    CreatePlatform(
+                                        PathHelper.NormalizePath(dockerfileRelativePath),
+                                        simpleTags: new List<string>
                                         {
                                             "tag1",
                                             "tag2"
-                                        }
-                                    }
+                                        })
                                 }
                             }
                         }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/CopyAcrImagesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/CopyAcrImagesCommandTests.cs
@@ -74,17 +74,15 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             new ImageData
                             {
-                                Platforms = new SortedDictionary<string, PlatformData>
+                                Platforms = new List<PlatformData>
                                 {
+                                    new PlatformData
                                     {
-                                        PathHelper.NormalizePath(dockerfileRelativePath),
-                                        new PlatformData
+                                        Path = PathHelper.NormalizePath(dockerfileRelativePath),
+                                        SimpleTags =
                                         {
-                                            SimpleTags =
-                                            {
-                                                "tag1",
-                                                "tag2"
-                                            }
+                                            "tag1",
+                                            "tag2"
                                         }
                                     }
                                 }
@@ -98,7 +96,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 command.LoadManifest();
                 await command.ExecuteAsync();
 
-                IList<string> expectedTags = runtimeRepo.Images.First().Platforms.First().Value.SimpleTags
+                IList<string> expectedTags = runtimeRepo.Images.First().Platforms.First().SimpleTags
                     .Select(tag => $"{command.Options.RepoPrefix}{runtimeRepo.Repo}:{tag}")
                     .ToList();
 

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
@@ -25,6 +25,7 @@ using Moq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
+using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ImageInfoHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
@@ -60,22 +61,18 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             {
                                 Platforms = new List<PlatformData>
                                 {
-                                    new PlatformData
-                                    {
-                                        Path = dockerfile1Path,
-                                        BaseImages = new SortedDictionary<string, string>
+                                    CreatePlatform(
+                                        dockerfile1Path,
+                                        baseImages: new SortedDictionary<string, string>
                                         {
                                             { "base1", "base1digest-diff" }
-                                        }
-                                    },
-                                    new PlatformData
-                                    {
-                                        Path = dockerfile2Path,
-                                        BaseImages = new SortedDictionary<string, string>
+                                        }),
+                                    CreatePlatform(
+                                        dockerfile2Path,
+                                        baseImages: new SortedDictionary<string, string>
                                         {
                                             { "base2", "base2digest" }
-                                        }
-                                    }
+                                        })
                                 }
                             }
                         }
@@ -147,24 +144,20 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             {
                                 Platforms = new List<PlatformData>
                                 {
-                                    new PlatformData
-                                    {
-                                        Path = dockerfile1Path,
-                                        BaseImages = new SortedDictionary<string, string>
+                                    CreatePlatform(
+                                        dockerfile1Path,
+                                        baseImages: new SortedDictionary<string, string>
                                         {
                                             { "base1", "base1digest" },
                                             { "base2", "base2digest-diff" }
-                                        }
-                                    },
-                                    new PlatformData
-                                    {
-                                        Path = dockerfile2Path,
-                                        BaseImages = new SortedDictionary<string, string>
+                                        }),
+                                    CreatePlatform(
+                                        dockerfile2Path,
+                                        baseImages: new SortedDictionary<string, string>
                                         {
                                             { "base2", "base2digest-diff" },
                                             { "base3", "base3digest" }
-                                        }
-                                    }
+                                        })
                                 }
                             }
                         }
@@ -427,14 +420,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             {
                                 Platforms = new List<PlatformData>
                                 {
-                                    new PlatformData
-                                    {
-                                        Path = dockerfile1Path,
-                                        BaseImages = new SortedDictionary<string, string>
+                                    CreatePlatform(
+                                        dockerfile1Path,
+                                        baseImages: new SortedDictionary<string, string>
                                         {
                                             { "base1", "base1digest-diff" }
-                                        }
-                                    }
+                                        })
                                 }
                             }
                         }
@@ -448,14 +439,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             {
                                 Platforms = new List<PlatformData>
                                 {
-                                    new PlatformData
-                                    {
-                                        Path = dockerfile2Path,
-                                        BaseImages = new SortedDictionary<string, string>
+                                    CreatePlatform(
+                                        dockerfile2Path,
+                                        baseImages: new SortedDictionary<string, string>
                                         {
                                             { "base2", "base2digest-diff" }
-                                        }
-                                    }
+                                        })
                                 }
                             }
                         }
@@ -481,14 +470,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             {
                                 Platforms = new List<PlatformData>
                                 {
-                                    new PlatformData
-                                    {
-                                        Path = dockerfile1Path,
-                                        BaseImages = new SortedDictionary<string, string>
+                                    CreatePlatform(
+                                        dockerfile1Path,
+                                        baseImages: new SortedDictionary<string, string>
                                         {
                                             { "base1", "base1digest-diff" }
-                                        }
-                                    }
+                                        })
                                 }
                             }
                         }
@@ -502,14 +489,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             {
                                 Platforms = new List<PlatformData>
                                 {
-                                    new PlatformData
-                                    {
-                                        Path = dockerfile2Path,
-                                        BaseImages = new SortedDictionary<string, string>
+                                    CreatePlatform(
+                                        dockerfile2Path,
+                                        baseImages: new SortedDictionary<string, string>
                                         {
                                             { "base2", "base2digest-diff" }
-                                        }
-                                    }
+                                        })
                                 }
                             }
                         }
@@ -523,14 +508,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             {
                                 Platforms = new List<PlatformData>
                                 {
-                                    new PlatformData
-                                    {
-                                        Path = dockerfile3Path,
-                                        BaseImages = new SortedDictionary<string, string>
+                                    CreatePlatform(
+                                        dockerfile3Path,
+                                        baseImages: new SortedDictionary<string, string>
                                         {
                                             { "base3", "base3digest" }
-                                        }
-                                    }
+                                        })
                                 }
                             }
                         }
@@ -617,22 +600,18 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             {
                                 Platforms = new List<PlatformData>
                                 {
-                                    new PlatformData
-                                    {
-                                        Path = dockerfile1Path,
-                                        BaseImages = new SortedDictionary<string, string>
+                                    CreatePlatform(
+                                        dockerfile1Path,
+                                        baseImages: new SortedDictionary<string, string>
                                         {
                                             { baseImage, baseImageDigest + "-diff" }
-                                        }
-                                    },
-                                    new PlatformData
-                                    {
-                                        Path = dockerfile2Path,
-                                        BaseImages = new SortedDictionary<string, string>
+                                        }),
+                                    CreatePlatform(
+                                        dockerfile2Path,
+                                        baseImages: new SortedDictionary<string, string>
                                         {
                                             { baseImage, baseImageDigest + "-diff" }
-                                        }
-                                    }
+                                        })
                                 }
                             }
                         }
@@ -712,14 +691,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             {
                                 Platforms = new List<PlatformData>
                                 {
-                                    new PlatformData
-                                    {
-                                        Path = dockerfile1Path,
-                                        BaseImages = new SortedDictionary<string, string>
+                                    CreatePlatform(
+                                        dockerfile1Path,
+                                        baseImages: new SortedDictionary<string, string>
                                         {
                                             { baseImage, baseImageDigest }
-                                        }
-                                    }
+                                        })
                                 }
                             }
                         }
@@ -809,14 +786,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             {
                                 Platforms = new List<PlatformData>
                                 {
-                                    new PlatformData
-                                    {
-                                        Path = runtimeDepsDockerfilePath,
-                                        BaseImages = new SortedDictionary<string, string>
+                                    CreatePlatform(
+                                        runtimeDepsDockerfilePath,
+                                        baseImages: new SortedDictionary<string, string>
                                         {
                                             { baseImage, baseImageDigest + "-diff" }
-                                        }
-                                    }
+                                        })
                                 }
                             }
                         }
@@ -843,14 +818,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             {
                                 Platforms = new List<PlatformData>
                                 {
-                                    new PlatformData
-                                    {
-                                        Path = otherDockerfilePath,
-                                        BaseImages = new SortedDictionary<string, string>
+                                    CreatePlatform(
+                                        otherDockerfilePath,
+                                        baseImages: new SortedDictionary<string, string>
                                         {
                                             { otherImage, otherImageDigest }
-                                        }
-                                    }
+                                        })
                                 }
                             }
                         }
@@ -928,22 +901,18 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             {
                                 Platforms = new List<PlatformData>
                                 {
-                                    new PlatformData
-                                    {
-                                        Path = dockerfile1Path,
-                                        BaseImages = new SortedDictionary<string, string>
+                                    CreatePlatform(
+                                        dockerfile1Path,
+                                        baseImages: new SortedDictionary<string, string>
                                         {
                                             { "base1", "base1digest-diff" }
-                                        }
-                                    },
-                                    new PlatformData
-                                    {
-                                        Path = dockerfile2Path,
-                                        BaseImages = new SortedDictionary<string, string>
+                                        }),
+                                    CreatePlatform(
+                                        dockerfile2Path,
+                                        baseImages: new SortedDictionary<string, string>
                                         {
                                             { "base2", "base2digest" }
-                                        }
-                                    }
+                                        })
                                 }
                             }
                         }
@@ -1013,14 +982,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             {
                                 Platforms = new List<PlatformData>
                                 {
-                                    new PlatformData
-                                    {
-                                        Path = dockerfile1Path,
-                                        BaseImages = new SortedDictionary<string, string>
+                                    CreatePlatform(
+                                        dockerfile1Path,
+                                        baseImages: new SortedDictionary<string, string>
                                         {
                                             { "base1", "base1digest" }
-                                        }
-                                    }
+                                        })
                                 }
                             }
                         }
@@ -1091,19 +1058,13 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             {
                                 Platforms = new List<PlatformData>
                                 {
-                                    new PlatformData
-                                    {
-                                        Path = dockerfile1Path,
-                                        BaseImages = new SortedDictionary<string, string>()
-                                    },
-                                    new PlatformData
-                                    {
-                                        Path = dockerfile2Path,
-                                        BaseImages = new SortedDictionary<string, string>
+                                    CreatePlatform(dockerfile1Path),
+                                    CreatePlatform(
+                                        dockerfile2Path,
+                                        baseImages: new SortedDictionary<string, string>
                                         {
                                             { "base1", "base1digest" }
-                                        }
-                                    }
+                                        })
                                 }
                             }
                         }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
@@ -41,61 +41,57 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             const string dockerfile1Path = "dockerfile1/Dockerfile";
             const string dockerfile2Path = "dockerfile2/Dockerfile";
 
-            RepoData[] imageInfoData = new RepoData[]
+            SubscriptionInfo[] subscriptionInfos = new SubscriptionInfo[]
             {
-                new RepoData
-                {
-                    Repo = repo1,
-                    Images = new SortedDictionary<string, ImageData>
-                    {
-                        {
-                            dockerfile1Path,
-                            new ImageData
-                            {
-                                BaseImages = new SortedDictionary<string, string>
-                                {
-                                    { "base1", "base1digest-diff" }
-                                }
-                            }
-                        },
-                        {
-                            dockerfile2Path,
-                            new ImageData
-                            {
-                                BaseImages = new SortedDictionary<string, string>
-                                {
-                                    { "base2", "base2digest" }
-                                }
-                            }
-                        }
-                    }
-                }
-            };
-
-            Subscription[] subscriptions = new Subscription[]
-            {
-                CreateSubscription(repo1)
-            };
-
-            Dictionary<Subscription, Manifest> subscriptionManifests =
-                new Dictionary<Subscription, Manifest>
-            {
-                {
-                    subscriptions[0],
+                new SubscriptionInfo(
+                    CreateSubscription(repo1),
                     ManifestHelper.CreateManifest(
                         ManifestHelper.CreateRepo(
                             repo1,
                             ManifestHelper.CreateImage(
                                 ManifestHelper.CreatePlatform(dockerfile1Path, new string[] { "tag1" }),
-                                ManifestHelper.CreatePlatform(dockerfile2Path, new string[] { "tag2" }))))
-                }
+                                ManifestHelper.CreatePlatform(dockerfile2Path, new string[] { "tag2" })))),
+                    new RepoData
+                    {
+                        Repo = repo1,
+                        Images = new List<ImageData>
+                        {
+                            new ImageData
+                            {
+                                Platforms = new SortedDictionary<string, PlatformData>
+                                {
+                                    {
+                                        dockerfile1Path,
+                                        new PlatformData
+                                        {
+                                            BaseImages = new SortedDictionary<string, string>
+                                            {
+                                                { "base1", "base1digest-diff" }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        dockerfile2Path,
+                                        new PlatformData
+                                        {
+                                            BaseImages = new SortedDictionary<string, string>
+                                            {
+                                                { "base2", "base2digest" }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                )
             };
 
             Dictionary<GitRepo, List<DockerfileInfo>> dockerfileInfos =
                 new Dictionary<GitRepo, List<DockerfileInfo>>
             {
                 {
-                    subscriptions[0].RepoInfo,
+                    subscriptionInfos[0].Subscription.RepoInfo,
                     new List<DockerfileInfo>
                     {
                         new DockerfileInfo(dockerfile1Path, new FromImageInfo("base1", "base1digest")),
@@ -104,8 +100,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            using (TestContext context =
-                new TestContext(imageInfoData, subscriptions, subscriptionManifests, dockerfileInfos))
+            using (TestContext context = new TestContext(subscriptionInfos, dockerfileInfos))
             {
                 await context.ExecuteCommandAsync();
 
@@ -114,7 +109,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     new Dictionary<Subscription, IList<string>>
                 {
                     {
-                        subscriptions[0],
+                        subscriptionInfos[0].Subscription,
                         new List<string>
                         {
                             dockerfile1Path
@@ -137,63 +132,59 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             const string dockerfile1Path = "dockerfile1/Dockerfile";
             const string dockerfile2Path = "dockerfile2/Dockerfile";
 
-            RepoData[] imageInfoData = new RepoData[]
+            SubscriptionInfo[] subscriptionInfos = new SubscriptionInfo[]
             {
-                new RepoData
-                {
-                    Repo = repo1,
-                    Images = new SortedDictionary<string, ImageData>
-                    {
-                        {
-                            dockerfile1Path,
-                            new ImageData
-                            {
-                                BaseImages = new SortedDictionary<string, string>
-                                {
-                                    { "base1", "base1digest" },
-                                    { "base2", "base2digest-diff" }
-                                }
-                            }
-                        },
-                        {
-                            dockerfile2Path,
-                            new ImageData
-                            {
-                                BaseImages = new SortedDictionary<string, string>
-                                {
-                                    { "base2", "base2digest-diff" },
-                                    { "base3", "base3digest" }
-                                }
-                            }
-                        }
-                    }
-                }
-            };
-
-            Subscription[] subscriptions = new Subscription[]
-            {
-                CreateSubscription(repo1)
-            };
-
-            Dictionary<Subscription, Manifest> subscriptionManifests =
-                new Dictionary<Subscription, Manifest>
-            {
-                {
-                    subscriptions[0],
+                new SubscriptionInfo(
+                    CreateSubscription(repo1),
                     ManifestHelper.CreateManifest(
                         ManifestHelper.CreateRepo(
                             repo1,
                             ManifestHelper.CreateImage(
                                 ManifestHelper.CreatePlatform(dockerfile1Path, new string[] { "tag1" }),
-                                ManifestHelper.CreatePlatform(dockerfile2Path, new string[] { "tag2" }))))
-                }
+                                ManifestHelper.CreatePlatform(dockerfile2Path, new string[] { "tag2" })))),
+                    new RepoData
+                    {
+                        Repo = repo1,
+                        Images = new List<ImageData>
+                        {
+                            new ImageData
+                            {
+                                Platforms = new SortedDictionary<string, PlatformData>
+                                {
+                                    {
+                                        dockerfile1Path,
+                                        new PlatformData
+                                        {
+                                            BaseImages = new SortedDictionary<string, string>
+                                            {
+                                                { "base1", "base1digest" },
+                                                { "base2", "base2digest-diff" }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        dockerfile2Path,
+                                        new PlatformData
+                                        {
+                                            BaseImages = new SortedDictionary<string, string>
+                                            {
+                                                { "base2", "base2digest-diff" },
+                                                { "base3", "base3digest" }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                )
             };
 
             Dictionary<GitRepo, List<DockerfileInfo>> dockerfileInfos =
                 new Dictionary<GitRepo, List<DockerfileInfo>>
             {
                 {
-                    subscriptions[0].RepoInfo,
+                    subscriptionInfos[0].Subscription.RepoInfo,
                     new List<DockerfileInfo>
                     {
                         new DockerfileInfo(
@@ -209,7 +200,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             };
 
             using (TestContext context =
-                new TestContext(imageInfoData, subscriptions, subscriptionManifests, dockerfileInfos))
+                new TestContext(subscriptionInfos, dockerfileInfos))
             {
                 await context.ExecuteCommandAsync();
 
@@ -218,7 +209,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     new Dictionary<Subscription, IList<string>>
                 {
                     {
-                        subscriptions[0],
+                        subscriptionInfos[0].Subscription,
                         new List<string>
                         {
                             dockerfile1Path
@@ -241,20 +232,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             const string dockerfile2Path = "dockerfile2";
             const string dockerfile3Path = "dockerfile3";
 
-            RepoData[] imageInfoData = new RepoData[]
+            SubscriptionInfo[] subscriptionInfos = new SubscriptionInfo[]
             {
-            };
-
-            Subscription[] subscriptions = new Subscription[]
-            {
-                CreateSubscription(repo1, osType: "windows")
-            };
-
-            Dictionary<Subscription, Manifest> subscriptionManifests =
-                new Dictionary<Subscription, Manifest>
-            {
-                {
-                    subscriptions[0],
+                new SubscriptionInfo(
+                    CreateSubscription(repo1, osType: "windows"),
                     ManifestHelper.CreateManifest(
                         ManifestHelper.CreateRepo(
                             repo1,
@@ -262,14 +243,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                 ManifestHelper.CreatePlatform(dockerfile1Path, new string[] { "tag1" }, OS.Windows),
                                 ManifestHelper.CreatePlatform(dockerfile2Path, new string[] { "tag2" }, OS.Linux),
                                 ManifestHelper.CreatePlatform(dockerfile3Path, new string[] { "tag3" }, OS.Windows))))
-                }
+                )
             };
 
             Dictionary<GitRepo, List<DockerfileInfo>> dockerfileInfos =
                 new Dictionary<GitRepo, List<DockerfileInfo>>
             {
                 {
-                    subscriptions[0].RepoInfo,
+                    subscriptionInfos[0].Subscription.RepoInfo,
                     new List<DockerfileInfo>
                     {
                         new DockerfileInfo(dockerfile1Path, new FromImageInfo("base1", "base1digest")),
@@ -284,7 +265,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             const string commandOsType = "windows";
 
             using (TestContext context =
-                new TestContext(imageInfoData, subscriptions, subscriptionManifests, dockerfileInfos, commandOsType))
+                new TestContext(subscriptionInfos, dockerfileInfos, commandOsType))
             {
                 await context.ExecuteCommandAsync();
 
@@ -292,7 +273,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     new Dictionary<Subscription, IList<string>>
                 {
                     {
-                        subscriptions[0],
+                        subscriptionInfos[0].Subscription,
                         new List<string>
                         {
                             dockerfile1Path,
@@ -316,20 +297,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             const string dockerfile2Path = "dockerfile2";
             const string dockerfile3Path = "dockerfile3";
 
-            RepoData[] imageInfoData = new RepoData[]
+            SubscriptionInfo[] subscriptionInfos = new SubscriptionInfo[]
             {
-            };
-
-            Subscription[] subscriptions = new Subscription[]
-            {
-                CreateSubscription(repo1, osType: "windows")
-            };
-
-            Dictionary<Subscription, Manifest> subscriptionManifests =
-                new Dictionary<Subscription, Manifest>
-            {
-                {
-                    subscriptions[0],
+                new SubscriptionInfo(
+                    CreateSubscription(repo1, osType: "windows"),
                     ManifestHelper.CreateManifest(
                         ManifestHelper.CreateRepo(
                             repo1,
@@ -337,14 +308,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                 ManifestHelper.CreatePlatform(dockerfile1Path, new string[] { "tag1" }, OS.Windows),
                                 ManifestHelper.CreatePlatform(dockerfile2Path, new string[] { "tag2" }, OS.Linux),
                                 ManifestHelper.CreatePlatform(dockerfile3Path, new string[] { "tag3" }, OS.Windows))))
-                }
+                )
             };
 
             Dictionary<GitRepo, List<DockerfileInfo>> dockerfileInfos =
                 new Dictionary<GitRepo, List<DockerfileInfo>>
             {
                 {
-                    subscriptions[0].RepoInfo,
+                    subscriptionInfos[0].Subscription.RepoInfo,
                     new List<DockerfileInfo>
                     {
                         new DockerfileInfo(dockerfile1Path, new FromImageInfo("base1", "base1digest")),
@@ -359,7 +330,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             const string commandOsType = "linux";
 
             using (TestContext context =
-                new TestContext(imageInfoData, subscriptions, subscriptionManifests, dockerfileInfos, commandOsType))
+                new TestContext(subscriptionInfos, dockerfileInfos, commandOsType))
             {
                 await context.ExecuteCommandAsync();
 
@@ -383,34 +354,24 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             const string dockerfile1Path = "dockerfile1/Dockerfile";
             const string dockerfile2Path = "dockerfile2/Dockerfile";
 
-            RepoData[] imageInfoData = new RepoData[]
+            SubscriptionInfo[] subscriptionInfos = new SubscriptionInfo[]
             {
-            };
-
-            Subscription[] subscriptions = new Subscription[]
-            {
-                CreateSubscription(repo1)
-            };
-
-            Dictionary<Subscription, Manifest> subscriptionManifests =
-                new Dictionary<Subscription, Manifest>
-            {
-                {
-                    subscriptions[0],
+                new SubscriptionInfo(
+                    CreateSubscription(repo1),
                     ManifestHelper.CreateManifest(
                         ManifestHelper.CreateRepo(
                             repo1,
                             ManifestHelper.CreateImage(
                                 ManifestHelper.CreatePlatform(dockerfile1Path, new string[] { "tag1" }),
                                 ManifestHelper.CreatePlatform(dockerfile2Path, new string[] { "tag2" }))))
-                }
+                )
             };
 
             Dictionary<GitRepo, List<DockerfileInfo>> dockerfileInfos =
                 new Dictionary<GitRepo, List<DockerfileInfo>>
             {
                 {
-                    subscriptions[0].RepoInfo,
+                    subscriptionInfos[0].Subscription.RepoInfo,
                     new List<DockerfileInfo>
                     {
                         new DockerfileInfo(dockerfile1Path, new FromImageInfo("base1", "base1digest")),
@@ -420,7 +381,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             };
 
             using (TestContext context =
-                new TestContext(imageInfoData, subscriptions, subscriptionManifests, dockerfileInfos))
+                new TestContext(subscriptionInfos, dockerfileInfos))
             {
                 await context.ExecuteCommandAsync();
 
@@ -429,7 +390,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     new Dictionary<Subscription, IList<string>>
                 {
                     {
-                        subscriptions[0],
+                        subscriptionInfos[0].Subscription,
                         new List<string>
                         {
                             dockerfile1Path,
@@ -456,80 +417,64 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             const string dockerfile2Path = "dockerfile2/Dockerfile";
             const string dockerfile3Path = "dockerfile3/Dockerfile";
 
-            RepoData[] imageInfoData = new RepoData[]
+            SubscriptionInfo[] subscriptionInfos = new SubscriptionInfo[]
             {
-                new RepoData
-                {
-                    Repo = repo1,
-                    Images = new SortedDictionary<string, ImageData>
-                    {
-                        {
-                            dockerfile1Path,
-                            new ImageData
-                            {
-                                BaseImages = new SortedDictionary<string, string>
-                                {
-                                    { "base1", "base1digest-diff" }
-                                }
-                            }
-                        }
-                    }
-                },
-                new RepoData
-                {
-                    Repo = repo2,
-                    Images = new SortedDictionary<string, ImageData>
-                    {
-                        {
-                            dockerfile2Path,
-                            new ImageData
-                            {
-                                BaseImages = new SortedDictionary<string, string>
-                                {
-                                    { "base2", "base2digest-diff" }
-                                }
-                            }
-                        }
-                    }
-                },
-                new RepoData
-                {
-                    Repo = repo3,
-                    Images = new SortedDictionary<string, ImageData>
-                    {
-                        {
-                            dockerfile3Path,
-                            new ImageData
-                            {
-                                BaseImages = new SortedDictionary<string, string>
-                                {
-                                    { "base3", "base3digest" }
-                                }
-                            }
-                        }
-                    }
-                }
-            };
-
-            Subscription[] subscriptions = new Subscription[]
-            {
-                CreateSubscription(repo1, 1),
-                CreateSubscription(repo2, 2)
-            };
-
-            Dictionary<Subscription, Manifest> subscriptionManifests =
-                new Dictionary<Subscription, Manifest>
-            {
-                {
-                    subscriptions[0],
+                new SubscriptionInfo(
+                    CreateSubscription(repo1, 1),
                     ManifestHelper.CreateManifest(
                         ManifestHelper.CreateRepo(
                             repo1,
                             ManifestHelper.CreateImage(
-                                ManifestHelper.CreatePlatform(dockerfile1Path, new string[] { "tag1" }))))
-                },
-                {
-                    subscriptions[1],
+                                ManifestHelper.CreatePlatform(dockerfile1Path, new string[] { "tag1" })))),
+                    new RepoData
+                    {
+                        Repo = repo1,
+                        Images = new List<ImageData>
+                        {
+                            new ImageData
+                            {
+                                Platforms = new SortedDictionary<string, PlatformData>
+                                {
+                                    {
+                                        dockerfile1Path,
+                                        new PlatformData
+                                        {
+                                            BaseImages = new SortedDictionary<string, string>
+                                            {
+                                                { "base1", "base1digest-diff" }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    new RepoData
+                    {
+                        Repo = repo2,
+                        Images = new List<ImageData>
+                        {
+                            new ImageData
+                            {
+                                Platforms = new SortedDictionary<string, PlatformData>
+                                {
+                                    {
+                                        dockerfile2Path,
+                                        new PlatformData
+                                        {
+                                            BaseImages = new SortedDictionary<string, string>
+                                            {
+                                                { "base2", "base2digest-diff" }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }                    
+                ),
+                new SubscriptionInfo(
+                    CreateSubscription(repo2, 2),
                     ManifestHelper.CreateManifest(
                         ManifestHelper.CreateRepo(
                             repo2,
@@ -538,22 +483,91 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         ManifestHelper.CreateRepo(
                             repo3,
                             ManifestHelper.CreateImage(
-                                ManifestHelper.CreatePlatform(dockerfile3Path, new string[] { "tag3" }))))
-                }
+                                ManifestHelper.CreatePlatform(dockerfile3Path, new string[] { "tag3" })))),
+                    new RepoData
+                    {
+                        Repo = repo1,
+                        Images = new List<ImageData>
+                        {
+                            new ImageData
+                            {
+                                Platforms = new SortedDictionary<string, PlatformData>
+                                {
+                                    {
+                                        dockerfile1Path,
+                                        new PlatformData
+                                        {
+                                            BaseImages = new SortedDictionary<string, string>
+                                            {
+                                                { "base1", "base1digest-diff" }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    new RepoData
+                    {
+                        Repo = repo2,
+                        Images = new List<ImageData>
+                        {
+                            new ImageData
+                            {
+                                Platforms = new SortedDictionary<string, PlatformData>
+                                {
+                                    {
+                                        dockerfile2Path,
+                                        new PlatformData
+                                        {
+                                            BaseImages = new SortedDictionary<string, string>
+                                            {
+                                                { "base2", "base2digest-diff" }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    new RepoData
+                    {
+                        Repo = repo3,
+                        Images = new List<ImageData>
+                        {
+                            new ImageData
+                            {
+                                Platforms = new SortedDictionary<string, PlatformData>
+                                {
+                                    {
+                                        dockerfile3Path,
+                                        new PlatformData
+                                        {
+                                            BaseImages = new SortedDictionary<string, string>
+                                            {
+                                                { "base3", "base3digest" }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                )
             };
 
             Dictionary<GitRepo, List<DockerfileInfo>> dockerfileInfos =
                 new Dictionary<GitRepo, List<DockerfileInfo>>
             {
                 {
-                    subscriptions[0].RepoInfo,
+                    subscriptionInfos[0].Subscription.RepoInfo,
                     new List<DockerfileInfo>
                     {
                         new DockerfileInfo(dockerfile1Path, new FromImageInfo("base1", "base1digest"))
                     }
                 },
                 {
-                    subscriptions[1].RepoInfo,
+                    subscriptionInfos[1].Subscription.RepoInfo,
                     new List<DockerfileInfo>
                     {
                         new DockerfileInfo(dockerfile2Path, new FromImageInfo("base2", "base2digest")),
@@ -563,7 +577,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             };
 
             using (TestContext context =
-                new TestContext(imageInfoData, subscriptions, subscriptionManifests, dockerfileInfos))
+                new TestContext(subscriptionInfos, dockerfileInfos))
             {
                 await context.ExecuteCommandAsync();
 
@@ -571,14 +585,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     new Dictionary<Subscription, IList<string>>
                 {
                     {
-                        subscriptions[0],
+                        subscriptionInfos[0].Subscription,
                         new List<string>
                         {
                             dockerfile1Path
                         }
                     },
                     {
-                        subscriptions[1],
+                        subscriptionInfos[1].Subscription,
                         new List<string>
                         {
                             dockerfile2Path
@@ -602,61 +616,58 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             const string baseImage = "base1";
             const string baseImageDigest = "base1digest";
 
-            RepoData[] imageInfoData = new RepoData[]
+            SubscriptionInfo[] subscriptionInfos = new SubscriptionInfo[]
             {
-                new RepoData
-                {
-                    Repo = repo1,
-                    Images = new SortedDictionary<string, ImageData>
-                    {
-                        {
-                            dockerfile1Path,
-                            new ImageData
-                            {
-                                BaseImages = new SortedDictionary<string, string>
-                                {
-                                    { baseImage, baseImageDigest + "-diff" }
-                                }
-                            }
-                        },
-                        {
-                            dockerfile2Path,
-                            new ImageData
-                            {
-                                BaseImages = new SortedDictionary<string, string>
-                                {
-                                    { baseImage, baseImageDigest + "-diff" }
-                                }
-                            }
-                        }
-                    }
-                }
-            };
-
-            Subscription[] subscriptions = new Subscription[]
-            {
-                CreateSubscription(repo1)
-            };
-
-            Dictionary<Subscription, Manifest> subscriptionManifests =
-                new Dictionary<Subscription, Manifest>
-            {
-                {
-                    subscriptions[0],
+                new SubscriptionInfo(
+                    CreateSubscription(repo1),
                     ManifestHelper.CreateManifest(
                         ManifestHelper.CreateRepo(
                             repo1,
                             ManifestHelper.CreateImage(
                                 ManifestHelper.CreatePlatform(dockerfile1Path, new string[] { "tag1" }),
-                                ManifestHelper.CreatePlatform(dockerfile2Path, new string[] { "tag2" }))))
-                }
+                                ManifestHelper.CreatePlatform(dockerfile2Path, new string[] { "tag2" })))),
+                    new RepoData
+                    {
+                        Repo = repo1,
+                        Images = new List<ImageData>
+                        {
+                            new ImageData
+                            {
+                                Platforms = new SortedDictionary<string, PlatformData>
+                                {
+                                    {
+                                        dockerfile1Path,
+                                        new PlatformData
+                                        {
+                                            BaseImages = new SortedDictionary<string, string>
+                                            {
+                                                { baseImage, baseImageDigest + "-diff" }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        dockerfile2Path,
+                                        new PlatformData
+                                        {
+                                            BaseImages = new SortedDictionary<string, string>
+                                            {
+                                                { baseImage, baseImageDigest + "-diff" }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                )
             };
+
 
             Dictionary<GitRepo, List<DockerfileInfo>> dockerfileInfos =
                 new Dictionary<GitRepo, List<DockerfileInfo>>
             {
                 {
-                    subscriptions[0].RepoInfo,
+                    subscriptionInfos[0].Subscription.RepoInfo,
                     new List<DockerfileInfo>
                     {
                         new DockerfileInfo(dockerfile1Path, new FromImageInfo(baseImage, baseImageDigest)),
@@ -666,7 +677,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             };
 
             using (TestContext context =
-                new TestContext(imageInfoData, subscriptions, subscriptionManifests, dockerfileInfos))
+                new TestContext(subscriptionInfos, dockerfileInfos))
             {
                 await context.ExecuteCommandAsync();
 
@@ -675,7 +686,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     new Dictionary<Subscription, IList<string>>
                 {
                     {
-                        subscriptions[0],
+                        subscriptionInfos[0].Subscription,
                         new List<string>
                         {
                             dockerfile1Path,
@@ -705,50 +716,46 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             const string baseImage = "base1";
             const string baseImageDigest = "base1digest";
 
-            RepoData[] imageInfoData = new RepoData[]
+            SubscriptionInfo[] subscriptionInfos = new SubscriptionInfo[]
             {
-                new RepoData
-                {
-                    Repo = repo1,
-                    Images = new SortedDictionary<string, ImageData>
-                    {
-                        {
-                            dockerfile1Path,
-                            new ImageData
-                            {
-                                BaseImages = new SortedDictionary<string, string>
-                                {
-                                    { baseImage, baseImageDigest }
-                                }
-                            }
-                        }
-                    }
-                }
-            };
-
-            Subscription[] subscriptions = new Subscription[]
-            {
-                CreateSubscription(repo1)
-            };
-
-            Dictionary<Subscription, Manifest> subscriptionManifests =
-                new Dictionary<Subscription, Manifest>
-            {
-                {
-                    subscriptions[0],
+                new SubscriptionInfo(
+                    CreateSubscription(repo1),
                     ManifestHelper.CreateManifest(
                         ManifestHelper.CreateRepo(
                             repo1,
                             ManifestHelper.CreateImage(
-                                ManifestHelper.CreatePlatform(dockerfile1Path, new string[] { "tag1" }))))
-                }
+                                ManifestHelper.CreatePlatform(dockerfile1Path, new string[] { "tag1" })))),
+                    new RepoData
+                    {
+                        Repo = repo1,
+                        Images = new List<ImageData>
+                        {
+                            new ImageData
+                            {
+                                Platforms = new SortedDictionary<string, PlatformData>
+                                {
+                                    {
+                                        dockerfile1Path,
+                                        new PlatformData
+                                        {
+                                            BaseImages = new SortedDictionary<string, string>
+                                            {
+                                                { baseImage, baseImageDigest }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                )
             };
 
             Dictionary<GitRepo, List<DockerfileInfo>> dockerfileInfos =
                 new Dictionary<GitRepo, List<DockerfileInfo>>
             {
                 {
-                    subscriptions[0].RepoInfo,
+                    subscriptionInfos[0].Subscription.RepoInfo,
                     new List<DockerfileInfo>
                     {
                         new DockerfileInfo(dockerfile1Path, new FromImageInfo(baseImage, baseImageDigest))
@@ -757,7 +764,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             };
 
             using (TestContext context =
-                new TestContext(imageInfoData, subscriptions, subscriptionManifests, dockerfileInfos))
+                new TestContext(subscriptionInfos, dockerfileInfos))
             {
                 await context.ExecuteCommandAsync();
 
@@ -792,67 +799,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             const string otherImage = "other";
             const string otherImageDigest = "otherDigest";
 
-            RepoData[] imageInfoData = new RepoData[]
+            SubscriptionInfo[] subscriptionInfos = new SubscriptionInfo[]
             {
-                new RepoData
-                {
-                    Repo = runtimeDepsRepo,
-                    Images = new SortedDictionary<string, ImageData>
-                    {
-                        {
-                            runtimeDepsDockerfilePath,
-                            new ImageData
-                            {
-                                BaseImages = new SortedDictionary<string, string>
-                                {
-                                    { baseImage, baseImageDigest + "-diff" }
-                                }
-                            }
-                        }
-                    }
-                },
-                new RepoData
-                {
-                    Repo = runtimeRepo
-                },
-                new RepoData
-                {
-                    Repo = sdkRepo
-                },
-                new RepoData
-                {
-                    Repo = aspnetRepo
-                },
-                // Include an image that has not been changed and should not be included in the expected paths.
-                new RepoData
-                {
-                    Repo = otherRepo,
-                    Images = new SortedDictionary<string, ImageData>
-                    {
-                        {
-                            otherDockerfilePath,
-                            new ImageData
-                            {
-                                BaseImages = new SortedDictionary<string, string>
-                                {
-                                    { otherImage, otherImageDigest }
-                                }
-                            }
-                        }
-                    }
-                }
-            };
-
-            Subscription[] subscriptions = new Subscription[]
-            {
-                CreateSubscription("repo1")
-            };
-
-            Dictionary<Subscription, Manifest> subscriptionManifests =
-                new Dictionary<Subscription, Manifest>
-            {
-                {
-                    subscriptions[0],
+                new SubscriptionInfo(
+                    CreateSubscription("repo1"),
                     ManifestHelper.CreateManifest(
                         ManifestHelper.CreateRepo(
                             runtimeDepsRepo,
@@ -873,15 +823,74 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         ManifestHelper.CreateRepo(
                             otherRepo,
                             ManifestHelper.CreateImage(
-                                ManifestHelper.CreatePlatform(otherDockerfilePath, new string[] { "tag1" }))))
-                }
+                                ManifestHelper.CreatePlatform(otherDockerfilePath, new string[] { "tag1" })))),
+                    new RepoData
+                    {
+                        Repo = runtimeDepsRepo,
+                        Images = new List<ImageData>
+                        {
+                            new ImageData
+                            {
+                                Platforms = new SortedDictionary<string, PlatformData>
+                                {
+                                    {
+                                        runtimeDepsDockerfilePath,
+                                        new PlatformData
+                                        {
+                                            BaseImages = new SortedDictionary<string, string>
+                                            {
+                                                { baseImage, baseImageDigest + "-diff" }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    new RepoData
+                    {
+                        Repo = runtimeRepo
+                    },
+                    new RepoData
+                    {
+                        Repo = sdkRepo
+                    },
+                    new RepoData
+                    {
+                        Repo = aspnetRepo
+                    },
+                    // Include an image that has not been changed and should not be included in the expected paths.
+                    new RepoData
+                    {
+                        Repo = otherRepo,
+                        Images = new List<ImageData>
+                        {
+                            new ImageData
+                            {
+                                Platforms = new SortedDictionary<string, PlatformData>
+                                {
+                                    {
+                                        otherDockerfilePath,
+                                        new PlatformData
+                                        {
+                                            BaseImages = new SortedDictionary<string, string>
+                                            {
+                                                { otherImage, otherImageDigest }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                )
             };
 
             Dictionary<GitRepo, List<DockerfileInfo>> dockerfileInfos =
                 new Dictionary<GitRepo, List<DockerfileInfo>>
             {
                 {
-                    subscriptions[0].RepoInfo,
+                    subscriptionInfos[0].Subscription.RepoInfo,
                     new List<DockerfileInfo>
                     {
                         new DockerfileInfo(runtimeDepsDockerfilePath, new FromImageInfo(baseImage, baseImageDigest)),
@@ -894,7 +903,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             };
 
             using (TestContext context =
-                new TestContext(imageInfoData, subscriptions, subscriptionManifests, dockerfileInfos))
+                new TestContext(subscriptionInfos, dockerfileInfos))
             {
                 await context.ExecuteCommandAsync();
 
@@ -902,7 +911,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     new Dictionary<Subscription, IList<string>>
                 {
                     {
-                        subscriptions[0],
+                        subscriptionInfos[0].Subscription,
                         new List<string>
                         {
                             runtimeDepsDockerfilePath,
@@ -928,61 +937,57 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             const string dockerfile1Path = "path/to/Dockerfile.custom";
             const string dockerfile2Path = "path/to/Dockerfile";
 
-            RepoData[] imageInfoData = new RepoData[]
+            SubscriptionInfo[] subscriptionInfos = new SubscriptionInfo[]
             {
-                new RepoData
-                {
-                    Repo = repo1,
-                    Images = new SortedDictionary<string, ImageData>
-                    {
-                        {
-                            dockerfile1Path,
-                            new ImageData
-                            {
-                                BaseImages = new SortedDictionary<string, string>
-                                {
-                                    { "base1", "base1digest-diff" }
-                                }
-                            }
-                        },
-                        {
-                            dockerfile2Path,
-                            new ImageData
-                            {
-                                BaseImages = new SortedDictionary<string, string>
-                                {
-                                    { "base2", "base2digest" }
-                                }
-                            }
-                        }
-                    }
-                }
-            };
-
-            Subscription[] subscriptions = new Subscription[]
-            {
-                CreateSubscription(repo1)
-            };
-
-            Dictionary<Subscription, Manifest> subscriptionManifests =
-                new Dictionary<Subscription, Manifest>
-            {
-                {
-                    subscriptions[0],
+                new SubscriptionInfo(
+                    CreateSubscription(repo1),
                     ManifestHelper.CreateManifest(
                         ManifestHelper.CreateRepo(
                             repo1,
                             ManifestHelper.CreateImage(
                                 ManifestHelper.CreatePlatform(dockerfile1Path, new string[] { "tag1" }),
-                                ManifestHelper.CreatePlatform(dockerfile2Path, new string[] { "tag2" }))))
-                }
+                                ManifestHelper.CreatePlatform(dockerfile2Path, new string[] { "tag2" })))),
+                    new RepoData
+                    {
+                        Repo = repo1,
+                        Images = new List<ImageData>
+                        {
+                            new ImageData
+                            {
+                                Platforms = new SortedDictionary<string, PlatformData>
+                                {
+                                    {
+                                        dockerfile1Path,
+                                        new PlatformData
+                                        {
+                                            BaseImages = new SortedDictionary<string, string>
+                                            {
+                                                { "base1", "base1digest-diff" }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        dockerfile2Path,
+                                        new PlatformData
+                                        {
+                                            BaseImages = new SortedDictionary<string, string>
+                                            {
+                                                { "base2", "base2digest" }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                )
             };
 
             Dictionary<GitRepo, List<DockerfileInfo>> dockerfileInfos =
                 new Dictionary<GitRepo, List<DockerfileInfo>>
             {
                 {
-                    subscriptions[0].RepoInfo,
+                    subscriptionInfos[0].Subscription.RepoInfo,
                     new List<DockerfileInfo>
                     {
                         new DockerfileInfo(dockerfile1Path, new FromImageInfo("base1", "base1digest")),
@@ -992,7 +997,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             };
 
             using (TestContext context =
-                new TestContext(imageInfoData, subscriptions, subscriptionManifests, dockerfileInfos))
+                new TestContext(subscriptionInfos, dockerfileInfos))
             {
                 await context.ExecuteCommandAsync();
 
@@ -1001,7 +1006,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     new Dictionary<Subscription, IList<string>>
                 {
                     {
-                        subscriptions[0],
+                        subscriptionInfos[0].Subscription,
                         new List<string>
                         {
                             dockerfile1Path
@@ -1022,50 +1027,46 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             const string repo1 = "test-repo";
             const string dockerfile1Path = "dockerfile1/Dockerfile";
 
-            RepoData[] imageInfoData = new RepoData[]
+            SubscriptionInfo[] subscriptionInfos = new SubscriptionInfo[]
             {
-                new RepoData
-                {
-                    Repo = repo1,
-                    Images = new SortedDictionary<string, ImageData>
-                    {
-                        {
-                            dockerfile1Path,
-                            new ImageData
-                            {
-                                BaseImages = new SortedDictionary<string, string>
-                                {
-                                    { "base1", "base1digest" }
-                                }
-                            }
-                        }
-                    }
-                }
-            };
-
-            Subscription[] subscriptions = new Subscription[]
-            {
-                CreateSubscription(repo1)
-            };
-
-            Dictionary<Subscription, Manifest> subscriptionManifests =
-                new Dictionary<Subscription, Manifest>
-            {
-                {
-                    subscriptions[0],
+                new SubscriptionInfo(
+                    CreateSubscription(repo1),
                     ManifestHelper.CreateManifest(
                         ManifestHelper.CreateRepo(
                             repo1,
                             ManifestHelper.CreateImage(
-                                ManifestHelper.CreatePlatform(dockerfile1Path, new string[] { "tag1" }))))
-                }
+                                ManifestHelper.CreatePlatform(dockerfile1Path, new string[] { "tag1" })))),
+                    new RepoData
+                    {
+                        Repo = repo1,
+                        Images = new List<ImageData>
+                        {
+                            new ImageData
+                            {
+                                Platforms = new SortedDictionary<string, PlatformData>
+                                {
+                                    {
+                                        dockerfile1Path,
+                                        new PlatformData
+                                        {
+                                            BaseImages = new SortedDictionary<string, string>
+                                            {
+                                                { "base1", "base1digest" }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                )
             };
 
             Dictionary<GitRepo, List<DockerfileInfo>> dockerfileInfos =
                 new Dictionary<GitRepo, List<DockerfileInfo>>
             {
                 {
-                    subscriptions[0].RepoInfo,
+                    subscriptionInfos[0].Subscription.RepoInfo,
                     new List<DockerfileInfo>
                     {
                         new DockerfileInfo(dockerfile1Path, new FromImageInfo("base2", "base2digest")),
@@ -1074,7 +1075,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             };
 
             using (TestContext context =
-                new TestContext(imageInfoData, subscriptions, subscriptionManifests, dockerfileInfos))
+                new TestContext(subscriptionInfos, dockerfileInfos))
             {
                 await context.ExecuteCommandAsync();
 
@@ -1082,7 +1083,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     new Dictionary<Subscription, IList<string>>
                 {
                     {
-                        subscriptions[0],
+                        subscriptionInfos[0].Subscription,
                         new List<string>
                         {
                             dockerfile1Path
@@ -1104,59 +1105,55 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             const string dockerfile1Path = "dockerfile1/Dockerfile";
             const string dockerfile2Path = "dockerfile2/Dockerfile";
 
-            RepoData[] imageInfoData = new RepoData[]
+            SubscriptionInfo[] subscriptionInfos = new SubscriptionInfo[]
             {
-                new RepoData
-                {
-                    Repo = repo1,
-                    Images = new SortedDictionary<string, ImageData>
-                    {
-                        {
-                            dockerfile1Path,
-                            new ImageData
-                            {
-                                BaseImages = new SortedDictionary<string, string>()
-                            }
-                        },
-                        {
-                            dockerfile2Path,
-                            new ImageData
-                            {
-                                BaseImages = new SortedDictionary<string, string>
-                                {
-                                    { "base1", "base1digest" }
-                                }
-                            }
-                        }
-                    }
-                }
-            };
-
-            Subscription[] subscriptions = new Subscription[]
-            {
-                CreateSubscription(repo1)
-            };
-
-            Dictionary<Subscription, Manifest> subscriptionManifests =
-                new Dictionary<Subscription, Manifest>
-            {
-                {
-                    subscriptions[0],
+                new SubscriptionInfo(
+                    CreateSubscription(repo1),
                     ManifestHelper.CreateManifest(
                         ManifestHelper.CreateRepo(
                             repo1,
                             ManifestHelper.CreateImage(
                                 CreatePlatformWithRepoBuildArg(dockerfile1Path, $"{repo1}:tag2", new string[] { "tag1" })),
                             ManifestHelper.CreateImage(
-                                ManifestHelper.CreatePlatform(dockerfile2Path, new string[] { "tag2" }))))
-                }
+                                ManifestHelper.CreatePlatform(dockerfile2Path, new string[] { "tag2" })))),
+                    new RepoData
+                    {
+                        Repo = repo1,
+                        Images = new List<ImageData>
+                        {
+                            new ImageData
+                            {
+                                Platforms = new SortedDictionary<string, PlatformData>
+                                {
+                                    {
+                                        dockerfile1Path,
+                                        new PlatformData
+                                        {
+                                            BaseImages = new SortedDictionary<string, string>()
+                                        }
+                                    },
+                                    {
+                                        dockerfile2Path,
+                                        new PlatformData
+                                        {
+                                            BaseImages = new SortedDictionary<string, string>
+                                            {
+                                                { "base1", "base1digest" }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                )
             };
 
             Dictionary<GitRepo, List<DockerfileInfo>> dockerfileInfos =
                 new Dictionary<GitRepo, List<DockerfileInfo>>
             {
                 {
-                    subscriptions[0].RepoInfo,
+                    subscriptionInfos[0].Subscription.RepoInfo,
                     new List<DockerfileInfo>
                     {
                         new DockerfileInfo(dockerfile1Path, new FromImageInfo(null, null, isInternal: true)),
@@ -1166,7 +1163,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             };
 
             using (TestContext context =
-                new TestContext(imageInfoData, subscriptions, subscriptionManifests, dockerfileInfos))
+                new TestContext(subscriptionInfos, dockerfileInfos))
             {
                 await context.ExecuteCommandAsync();
 
@@ -1249,20 +1246,17 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             /// <summary>
             /// Initializes a new instance of <see cref="TestContext"/>.
             /// </summary>
-            /// <param name="imageInfoData">The set of image info data for all Git repos.</param>
-            /// <param name="subscriptions">The set of subscription metadata describing the Git repos that are listening for changes to base images.</param>
-            /// <param name="subscriptionManifests">A mapping of subscriptions to their associated manifests.</param>
+            /// <param name="subscriptionInfos">Mapping of data to subscriptions.</param>
             /// <param name="dockerfileInfos">A mapping of Git repos to their associated set of Dockerfiles.</param>
             /// <param name="osType">The OS type to filter the command with.</param>
             public TestContext(
-                RepoData[] imageInfoData,
-                Subscription[] subscriptions,
-                IDictionary<Subscription, Manifest> subscriptionManifests,
+                SubscriptionInfo[] subscriptionInfos,
                 Dictionary<GitRepo, List<DockerfileInfo>> dockerfileInfos,
                 string osType = "*")
             {
                 this.osType = osType;
-                this.subscriptionsPath = this.SerializeJsonObjectToTempFile(subscriptions);
+                this.subscriptionsPath = this.SerializeJsonObjectToTempFile(
+                    subscriptionInfos.Select(tuple => tuple.Subscription).ToArray());
 
                 // Cache image digests lookup
                 foreach (FromImageInfo fromImage in 
@@ -1279,10 +1273,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     Id = Guid.NewGuid()
                 };
 
-                this.httpClientFactory = CreateHttpClientFactory(subscriptions, subscriptionManifests, dockerfileInfos);
-
-                string imageInfoContents = JsonConvert.SerializeObject(imageInfoData);
-                this.gitHubClientFactory = CreateGitHubClientFactory(imageInfoContents);
+                this.httpClientFactory = CreateHttpClientFactory(subscriptionInfos, dockerfileInfos);
+                this.gitHubClientFactory = CreateGitHubClientFactory(subscriptionInfos);
 
                 this.DockerServiceMock = this.CreateDockerServiceMock();
                 this.command = this.CreateCommand();
@@ -1349,12 +1341,17 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 return command;
             }
 
-            private IGitHubClientFactory CreateGitHubClientFactory(string imageInfoContents)
+            private IGitHubClientFactory CreateGitHubClientFactory(SubscriptionInfo[] subscriptionInfos)
             {
                 Mock<IGitHubClient> gitHubClientMock = new Mock<IGitHubClient>();
-                gitHubClientMock
-                    .Setup(o => o.GetGitHubFileContentsAsync(It.IsAny<string>(), It.Is<GitHubBranch>(branch => IsMatchingBranch(branch))))
-                    .ReturnsAsync(imageInfoContents);
+
+                foreach (SubscriptionInfo subscriptionInfo in subscriptionInfos)
+                {
+                    string imageInfoContents = JsonConvert.SerializeObject(subscriptionInfo.ImageInfo);
+                    gitHubClientMock
+                        .Setup(o => o.GetGitHubFileContentsAsync(It.IsAny<string>(), It.Is<GitHubBranch>(branch => IsMatchingBranch(branch))))
+                        .ReturnsAsync(imageInfoContents);
+                }
 
                 Mock<IGitHubClientFactory> gitHubClientFactoryMock = new Mock<IGitHubClientFactory>();
                 gitHubClientFactoryMock
@@ -1375,30 +1372,26 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             /// Returns an <see cref="IHttpClientFactory"/> that creates an <see cref="HttpClient"/> which 
             /// bypasses the network and return back pre-built responses for GitHub repo zip files.
             /// </summary>
-            /// <param name="subscriptions">The set of subscriptions referring to GitHub repos that should have file responses.</param>
-            /// <param name="subscriptionManifests">A mapping of subscriptions to their associated manifests.</param>
+            /// <param name="subscriptionInfos">Mapping of data to subscriptions.</param>
             /// <param name="dockerfileInfos">A mapping of Git repos to their associated set of Dockerfiles.</param>
             private IHttpClientFactory CreateHttpClientFactory(
-                Subscription[] subscriptions,
-                IDictionary<Subscription, Manifest> subscriptionManifests,
+                SubscriptionInfo[] subscriptionInfos,
                 Dictionary<GitRepo, List<DockerfileInfo>> dockerfileInfos)
             {
                 Dictionary<string, HttpResponseMessage> responses = new Dictionary<string, HttpResponseMessage>();
-                foreach (Subscription subscription in subscriptions)
+                foreach (SubscriptionInfo subscriptionInfo in subscriptionInfos)
                 {
-                    if (subscriptionManifests.TryGetValue(subscription, out Manifest manifest))
-                    {
-                        List<DockerfileInfo> repoDockerfileInfos = dockerfileInfos[subscription.RepoInfo];
-                        string repoZipPath = GenerateRepoZipFile(subscription, manifest, repoDockerfileInfos);
+                    Subscription subscription = subscriptionInfo.Subscription;
+                    List<DockerfileInfo> repoDockerfileInfos = dockerfileInfos[subscription.RepoInfo];
+                    string repoZipPath = GenerateRepoZipFile(subscription, subscriptionInfo.Manifest, repoDockerfileInfos);
 
-                        responses.Add(
-                            $"https://github.com/{subscription.RepoInfo.Owner}/{subscription.RepoInfo.Name}/archive/{subscription.RepoInfo.Branch}.zip",
-                            new HttpResponseMessage
-                            {
-                                StatusCode = HttpStatusCode.OK,
-                                Content = new ByteArrayContent(File.ReadAllBytes(repoZipPath))
-                            });
-                    }
+                    responses.Add(
+                        $"https://github.com/{subscription.RepoInfo.Owner}/{subscription.RepoInfo.Name}/archive/{subscription.RepoInfo.Branch}.zip",
+                        new HttpResponseMessage
+                        {
+                            StatusCode = HttpStatusCode.OK,
+                            Content = new ByteArrayContent(File.ReadAllBytes(repoZipPath))
+                        });
                 }
 
                 HttpClient client = new HttpClient(new TestHttpMessageHandler(responses));
@@ -1557,6 +1550,20 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         private class PagedList<T> : List<T>, IPagedList<T>
         {
             public string ContinuationToken => throw new NotImplementedException();
+        }
+
+        private class SubscriptionInfo
+        {
+            public SubscriptionInfo(Subscription subscription, Manifest manifest, params RepoData[] imageInfo)
+            {
+                Subscription = subscription;
+                Manifest = manifest;
+                ImageInfo = imageInfo;
+            }
+
+            public Subscription Subscription { get; }
+            public Manifest Manifest { get; }
+            public RepoData[] ImageInfo { get; }
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
@@ -58,26 +58,22 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             new ImageData
                             {
-                                Platforms = new SortedDictionary<string, PlatformData>
+                                Platforms = new List<PlatformData>
                                 {
+                                    new PlatformData
                                     {
-                                        dockerfile1Path,
-                                        new PlatformData
+                                        Path = dockerfile1Path,
+                                        BaseImages = new SortedDictionary<string, string>
                                         {
-                                            BaseImages = new SortedDictionary<string, string>
-                                            {
-                                                { "base1", "base1digest-diff" }
-                                            }
+                                            { "base1", "base1digest-diff" }
                                         }
                                     },
+                                    new PlatformData
                                     {
-                                        dockerfile2Path,
-                                        new PlatformData
+                                        Path = dockerfile2Path,
+                                        BaseImages = new SortedDictionary<string, string>
                                         {
-                                            BaseImages = new SortedDictionary<string, string>
-                                            {
-                                                { "base2", "base2digest" }
-                                            }
+                                            { "base2", "base2digest" }
                                         }
                                     }
                                 }
@@ -149,28 +145,24 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             new ImageData
                             {
-                                Platforms = new SortedDictionary<string, PlatformData>
+                                Platforms = new List<PlatformData>
                                 {
+                                    new PlatformData
                                     {
-                                        dockerfile1Path,
-                                        new PlatformData
+                                        Path = dockerfile1Path,
+                                        BaseImages = new SortedDictionary<string, string>
                                         {
-                                            BaseImages = new SortedDictionary<string, string>
-                                            {
-                                                { "base1", "base1digest" },
-                                                { "base2", "base2digest-diff" }
-                                            }
+                                            { "base1", "base1digest" },
+                                            { "base2", "base2digest-diff" }
                                         }
                                     },
+                                    new PlatformData
                                     {
-                                        dockerfile2Path,
-                                        new PlatformData
+                                        Path = dockerfile2Path,
+                                        BaseImages = new SortedDictionary<string, string>
                                         {
-                                            BaseImages = new SortedDictionary<string, string>
-                                            {
-                                                { "base2", "base2digest-diff" },
-                                                { "base3", "base3digest" }
-                                            }
+                                            { "base2", "base2digest-diff" },
+                                            { "base3", "base3digest" }
                                         }
                                     }
                                 }
@@ -433,16 +425,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             new ImageData
                             {
-                                Platforms = new SortedDictionary<string, PlatformData>
+                                Platforms = new List<PlatformData>
                                 {
+                                    new PlatformData
                                     {
-                                        dockerfile1Path,
-                                        new PlatformData
+                                        Path = dockerfile1Path,
+                                        BaseImages = new SortedDictionary<string, string>
                                         {
-                                            BaseImages = new SortedDictionary<string, string>
-                                            {
-                                                { "base1", "base1digest-diff" }
-                                            }
+                                            { "base1", "base1digest-diff" }
                                         }
                                     }
                                 }
@@ -456,16 +446,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             new ImageData
                             {
-                                Platforms = new SortedDictionary<string, PlatformData>
+                                Platforms = new List<PlatformData>
                                 {
+                                    new PlatformData
                                     {
-                                        dockerfile2Path,
-                                        new PlatformData
+                                        Path = dockerfile2Path,
+                                        BaseImages = new SortedDictionary<string, string>
                                         {
-                                            BaseImages = new SortedDictionary<string, string>
-                                            {
-                                                { "base2", "base2digest-diff" }
-                                            }
+                                            { "base2", "base2digest-diff" }
                                         }
                                     }
                                 }
@@ -491,16 +479,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             new ImageData
                             {
-                                Platforms = new SortedDictionary<string, PlatformData>
+                                Platforms = new List<PlatformData>
                                 {
+                                    new PlatformData
                                     {
-                                        dockerfile1Path,
-                                        new PlatformData
+                                        Path = dockerfile1Path,
+                                        BaseImages = new SortedDictionary<string, string>
                                         {
-                                            BaseImages = new SortedDictionary<string, string>
-                                            {
-                                                { "base1", "base1digest-diff" }
-                                            }
+                                            { "base1", "base1digest-diff" }
                                         }
                                     }
                                 }
@@ -514,16 +500,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             new ImageData
                             {
-                                Platforms = new SortedDictionary<string, PlatformData>
+                                Platforms = new List<PlatformData>
                                 {
+                                    new PlatformData
                                     {
-                                        dockerfile2Path,
-                                        new PlatformData
+                                        Path = dockerfile2Path,
+                                        BaseImages = new SortedDictionary<string, string>
                                         {
-                                            BaseImages = new SortedDictionary<string, string>
-                                            {
-                                                { "base2", "base2digest-diff" }
-                                            }
+                                            { "base2", "base2digest-diff" }
                                         }
                                     }
                                 }
@@ -537,16 +521,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             new ImageData
                             {
-                                Platforms = new SortedDictionary<string, PlatformData>
+                                Platforms = new List<PlatformData>
                                 {
+                                    new PlatformData
                                     {
-                                        dockerfile3Path,
-                                        new PlatformData
+                                        Path = dockerfile3Path,
+                                        BaseImages = new SortedDictionary<string, string>
                                         {
-                                            BaseImages = new SortedDictionary<string, string>
-                                            {
-                                                { "base3", "base3digest" }
-                                            }
+                                            { "base3", "base3digest" }
                                         }
                                     }
                                 }
@@ -633,26 +615,22 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             new ImageData
                             {
-                                Platforms = new SortedDictionary<string, PlatformData>
+                                Platforms = new List<PlatformData>
                                 {
+                                    new PlatformData
                                     {
-                                        dockerfile1Path,
-                                        new PlatformData
+                                        Path = dockerfile1Path,
+                                        BaseImages = new SortedDictionary<string, string>
                                         {
-                                            BaseImages = new SortedDictionary<string, string>
-                                            {
-                                                { baseImage, baseImageDigest + "-diff" }
-                                            }
+                                            { baseImage, baseImageDigest + "-diff" }
                                         }
                                     },
+                                    new PlatformData
                                     {
-                                        dockerfile2Path,
-                                        new PlatformData
+                                        Path = dockerfile2Path,
+                                        BaseImages = new SortedDictionary<string, string>
                                         {
-                                            BaseImages = new SortedDictionary<string, string>
-                                            {
-                                                { baseImage, baseImageDigest + "-diff" }
-                                            }
+                                            { baseImage, baseImageDigest + "-diff" }
                                         }
                                     }
                                 }
@@ -732,16 +710,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             new ImageData
                             {
-                                Platforms = new SortedDictionary<string, PlatformData>
+                                Platforms = new List<PlatformData>
                                 {
+                                    new PlatformData
                                     {
-                                        dockerfile1Path,
-                                        new PlatformData
+                                        Path = dockerfile1Path,
+                                        BaseImages = new SortedDictionary<string, string>
                                         {
-                                            BaseImages = new SortedDictionary<string, string>
-                                            {
-                                                { baseImage, baseImageDigest }
-                                            }
+                                            { baseImage, baseImageDigest }
                                         }
                                     }
                                 }
@@ -831,16 +807,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             new ImageData
                             {
-                                Platforms = new SortedDictionary<string, PlatformData>
+                                Platforms = new List<PlatformData>
                                 {
+                                    new PlatformData
                                     {
-                                        runtimeDepsDockerfilePath,
-                                        new PlatformData
+                                        Path = runtimeDepsDockerfilePath,
+                                        BaseImages = new SortedDictionary<string, string>
                                         {
-                                            BaseImages = new SortedDictionary<string, string>
-                                            {
-                                                { baseImage, baseImageDigest + "-diff" }
-                                            }
+                                            { baseImage, baseImageDigest + "-diff" }
                                         }
                                     }
                                 }
@@ -867,16 +841,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             new ImageData
                             {
-                                Platforms = new SortedDictionary<string, PlatformData>
+                                Platforms = new List<PlatformData>
                                 {
+                                    new PlatformData
                                     {
-                                        otherDockerfilePath,
-                                        new PlatformData
+                                        Path = otherDockerfilePath,
+                                        BaseImages = new SortedDictionary<string, string>
                                         {
-                                            BaseImages = new SortedDictionary<string, string>
-                                            {
-                                                { otherImage, otherImageDigest }
-                                            }
+                                            { otherImage, otherImageDigest }
                                         }
                                     }
                                 }
@@ -954,26 +926,22 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             new ImageData
                             {
-                                Platforms = new SortedDictionary<string, PlatformData>
+                                Platforms = new List<PlatformData>
                                 {
+                                    new PlatformData
                                     {
-                                        dockerfile1Path,
-                                        new PlatformData
+                                        Path = dockerfile1Path,
+                                        BaseImages = new SortedDictionary<string, string>
                                         {
-                                            BaseImages = new SortedDictionary<string, string>
-                                            {
-                                                { "base1", "base1digest-diff" }
-                                            }
+                                            { "base1", "base1digest-diff" }
                                         }
                                     },
+                                    new PlatformData
                                     {
-                                        dockerfile2Path,
-                                        new PlatformData
+                                        Path = dockerfile2Path,
+                                        BaseImages = new SortedDictionary<string, string>
                                         {
-                                            BaseImages = new SortedDictionary<string, string>
-                                            {
-                                                { "base2", "base2digest" }
-                                            }
+                                            { "base2", "base2digest" }
                                         }
                                     }
                                 }
@@ -1043,16 +1011,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             new ImageData
                             {
-                                Platforms = new SortedDictionary<string, PlatformData>
+                                Platforms = new List<PlatformData>
                                 {
+                                    new PlatformData
                                     {
-                                        dockerfile1Path,
-                                        new PlatformData
+                                        Path = dockerfile1Path,
+                                        BaseImages = new SortedDictionary<string, string>
                                         {
-                                            BaseImages = new SortedDictionary<string, string>
-                                            {
-                                                { "base1", "base1digest" }
-                                            }
+                                            { "base1", "base1digest" }
                                         }
                                     }
                                 }
@@ -1123,23 +1089,19 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             new ImageData
                             {
-                                Platforms = new SortedDictionary<string, PlatformData>
+                                Platforms = new List<PlatformData>
                                 {
+                                    new PlatformData
                                     {
-                                        dockerfile1Path,
-                                        new PlatformData
-                                        {
-                                            BaseImages = new SortedDictionary<string, string>()
-                                        }
+                                        Path = dockerfile1Path,
+                                        BaseImages = new SortedDictionary<string, string>()
                                     },
+                                    new PlatformData
                                     {
-                                        dockerfile2Path,
-                                        new PlatformData
+                                        Path = dockerfile2Path,
+                                        BaseImages = new SortedDictionary<string, string>
                                         {
-                                            BaseImages = new SortedDictionary<string, string>
-                                            {
-                                                { "base1", "base1digest" }
-                                            }
+                                            { "base1", "base1digest" }
                                         }
                                     }
                                 }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ImageInfoHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ImageInfoHelper.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Microsoft.DotNet.ImageBuilder.Models.Image;
+
+namespace Microsoft.DotNet.ImageBuilder.Tests.Helpers
+{
+    public static class ImageInfoHelper
+    {
+        public static PlatformData CreatePlatform(
+            string dockerfile, string digest = null, string architecture = "amd64", string osType = "Linux", string osVersion = "Ubuntu 19.04",
+            List<string> simpleTags = null, SortedDictionary<string, string> baseImages = null)
+        {
+            return new PlatformData
+            {
+                Dockerfile = dockerfile,
+                Digest = digest,
+                Architecture = architecture,
+                OsType = osType,
+                OsVersion = osVersion,
+                SimpleTags = simpleTags,
+                BaseImages = baseImages
+            };
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ManifestHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ManifestHelper.cs
@@ -45,7 +45,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests.Helpers
             };
         }
 
-        public static Platform CreatePlatform(string dockerfilePath, string[] tags, OS os = OS.Linux, string osVersion = "disco")
+        public static Platform CreatePlatform(
+            string dockerfilePath, string[] tags, OS os = OS.Linux, string osVersion = "disco", Architecture architecture = Architecture.AMD64)
         {
             return new Platform
             {
@@ -53,7 +54,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests.Helpers
                 OsVersion = osVersion,
                 OS = os,
                 Tags = tags.ToDictionary(tag => tag, tag => new Tag()),
-                Architecture = Architecture.AMD64
+                Architecture = architecture
             };
         }
     }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/ImageInfoHelperTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/ImageInfoHelperTests.cs
@@ -23,14 +23,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     {
                         new ImageData
                         {
-                            Platforms = new SortedDictionary<string, PlatformData>
+                            Platforms = new List<PlatformData>
                             {
+                                new PlatformData
                                 {
-                                    "image1",
-                                    new PlatformData
-                                    {
-                                        Digest = "digest"
-                                    }
+                                    Path = "image1",
+                                    Digest = "digest"
                                 }
                             }
                         }
@@ -47,11 +45,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     {
                         new ImageData
                         {
-                            Platforms = new SortedDictionary<string, PlatformData>
+                            Platforms = new List<PlatformData>
                             {
+                                new PlatformData
                                 {
-                                    "image1",
-                                    new PlatformData()
+                                    Path = "image1"
                                 }
                             }
                         }
@@ -79,11 +77,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     {
                         new ImageData
                         {
-                            Platforms = new SortedDictionary<string, PlatformData>
+                            Platforms = new List<PlatformData>
                             {
+                                new PlatformData
                                 {
-                                    "image1",
-                                    new PlatformData()
+                                    Path = "image1"
                                 }
                             }
                         }
@@ -114,22 +112,23 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     {
                         new ImageData
                         {
-                            Platforms = new SortedDictionary<string, PlatformData>
+                            Platforms = new List<PlatformData>
                             {
                                 {
-                                    "image1",
                                     repo2Image1 = new PlatformData
                                     {
+                                        Path = "image1",
                                         BaseImages = new SortedDictionary<string, string>
                                         {
                                             { "base1", "base1digest-NEW" }
                                         }
                                     }
-                                }
-                                ,
+                                },
                                 {
-                                    "image3",
-                                    repo2Image3 = new PlatformData()
+                                    repo2Image3  = new PlatformData
+                                    {
+                                        Path = "image3"
+                                    }
                                 }
                             }
                         }
@@ -142,11 +141,13 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     {
                         new ImageData
                         {
-                            Platforms = new SortedDictionary<string, PlatformData>
+                            Platforms = new List<PlatformData>
                             {
                                 {
-                                    "image1",
-                                    repo3Image1 = new PlatformData()
+                                    repo3Image1 = new PlatformData
+                                    {
+                                        Path = "image1"
+                                    }
                                 }
                             }
                         }
@@ -171,22 +172,20 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     {
                         new ImageData
                         {
-                            Platforms = new SortedDictionary<string, PlatformData>
+                            Platforms = new List<PlatformData>
                             {
+                                new PlatformData
                                 {
-                                    "image1",
-                                    new PlatformData
+                                    Path = "image1",
+                                    BaseImages = new SortedDictionary<string, string>
                                     {
-                                        BaseImages = new SortedDictionary<string, string>
-                                        {
-                                            { "base1", "base1digest" }
-                                        }
+                                        { "base1", "base1digest" }
                                     }
                                 },
                                 {
-                                    "image2",
                                     repo2Image2 = new PlatformData
                                     {
+                                        Path = "image2",
                                         BaseImages = new SortedDictionary<string, string>
                                         {
                                             { "base2", "base2digest" }
@@ -218,20 +217,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     {
                         new ImageData
                         {
-                            Platforms = new SortedDictionary<string, PlatformData>
+                            Platforms = new List<PlatformData>
                             {
-                                {
-                                    "image1",
-                                    repo2Image1
-                                },
-                                {
-                                    "image2",
-                                    repo2Image2
-                                },
-                                {
-                                    "image3",
-                                    repo2Image3
-                                }
+                                repo2Image1,
+                                repo2Image2,
+                                repo2Image3
                             }
                         }
                     }
@@ -243,12 +233,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     {
                         new ImageData
                         {
-                            Platforms = new SortedDictionary<string, PlatformData>
+                            Platforms = new List<PlatformData>
                             {
-                                {
-                                    "image1",
-                                    repo3Image1
-                                }
+                                repo3Image1
                             }
                         }
                     }
@@ -280,12 +267,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     {
                         new ImageData
                         {
-                            Platforms = new SortedDictionary<string, PlatformData>
+                            Platforms = new List<PlatformData>
                             {
                                 {
-                                    "image1",
                                     srcImage1 = new PlatformData
                                     {
+                                        Path = "image1",
                                         SimpleTags =
                                         {
                                             "tag1",
@@ -308,24 +295,22 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     {
                         new ImageData
                         {
-                            Platforms = new SortedDictionary<string, PlatformData>
+                            Platforms = new List<PlatformData>
                             {
+                                new PlatformData
                                 {
-                                    "image1",
-                                    new PlatformData
+                                    Path = "image1",
+                                    SimpleTags =
                                     {
-                                        SimpleTags =
-                                        {
-                                            "tag1",
-                                            "tag2",
-                                            "tag4"
-                                        }
+                                        "tag1",
+                                        "tag2",
+                                        "tag4"
                                     }
                                 },
                                 {
-                                    "image2",
                                     targetImage2 = new PlatformData
                                     {
+                                        Path = "image2",
                                         SimpleTags =
                                         {
                                             "a"
@@ -349,25 +334,20 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     {
                         new ImageData
                         {
-                            Platforms = new SortedDictionary<string, PlatformData>
+                            Platforms = new List<PlatformData>
                             {
+                                new PlatformData
                                 {
-                                    "image1",
-                                    new PlatformData
+                                    Path = "image1",
+                                    SimpleTags =
                                     {
-                                        SimpleTags =
-                                        {
-                                            "tag1",
-                                            "tag2",
-                                            "tag3",
-                                            "tag4"
-                                        }
+                                        "tag1",
+                                        "tag2",
+                                        "tag3",
+                                        "tag4"
                                     }
                                 },
-                                {
-                                    "image2",
-                                    targetImage2
-                                }
+                                targetImage2
                             }
                         }
                     }
@@ -397,12 +377,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     {
                         new ImageData
                         {
-                            Platforms = new SortedDictionary<string, PlatformData>
+                            Platforms = new List<PlatformData>
                             {
                                 {
-                                    "image1",
                                     srcImage1 = new PlatformData
                                     {
+                                        Path = "image1",
                                         SimpleTags =
                                         {
                                             "tag1",
@@ -425,12 +405,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     {
                         new ImageData
                         {
-                            Platforms = new SortedDictionary<string, PlatformData>
+                            Platforms = new List<PlatformData>
                             {
                                 {
-                                    "image1",
                                     new PlatformData
                                     {
+                                        Path = "image1",
                                         SimpleTags =
                                         {
                                             "tag1",
@@ -440,9 +420,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     }
                                 },
                                 {
-                                    "image2",
                                     targetImage2 = new PlatformData
                                     {
+                                        Path = "image2",
                                         SimpleTags =
                                         {
                                             "a"
@@ -471,16 +451,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     {
                         new ImageData
                         {
-                            Platforms = new SortedDictionary<string, PlatformData>
+                            Platforms = new List<PlatformData>
                             {
-                                {
-                                    "image1",
-                                    srcImage1
-                                },
-                                {
-                                    "image2",
-                                    targetImage2
-                                }
+                                srcImage1,
+                                targetImage2
                             }
                         }
                     }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/ImageInfoHelperTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/ImageInfoHelperTests.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
+using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 using Xunit;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
@@ -18,13 +19,19 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 new RepoData
                 {
                     Repo = "repo",
-                    Images = new SortedDictionary<string, ImageData>
+                    Images = new List<ImageData>
                     {
+                        new ImageData
                         {
-                            "image1",
-                            new ImageData
+                            Platforms = new SortedDictionary<string, PlatformData>
                             {
-                                Digest = "digest"
+                                {
+                                    "image1",
+                                    new PlatformData
+                                    {
+                                        Digest = "digest"
+                                    }
+                                }
                             }
                         }
                     }
@@ -36,11 +43,17 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 new RepoData
                 {
                     Repo = "repo",
-                    Images = new SortedDictionary<string, ImageData>
+                    Images = new List<ImageData>
                     {
+                        new ImageData
                         {
-                            "image1",
-                            new ImageData()
+                            Platforms = new SortedDictionary<string, PlatformData>
+                            {
+                                {
+                                    "image1",
+                                    new PlatformData()
+                                }
+                            }
                         }
                     }
                 }
@@ -62,11 +75,17 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 new RepoData
                 {
                     Repo = "repo2",
-                    Images = new SortedDictionary<string, ImageData>
+                    Images = new List<ImageData>
                     {
+                        new ImageData
                         {
-                            "image1",
-                            new ImageData()
+                            Platforms = new SortedDictionary<string, PlatformData>
+                            {
+                                {
+                                    "image1",
+                                    new PlatformData()
+                                }
+                            }
                         }
                     }
                 }
@@ -81,43 +100,55 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         [Fact]
         public void ImageInfoHelper_MergeRepos_ExistingTarget()
         {
-            ImageData repo2Image1;
-            ImageData repo2Image2;
-            ImageData repo2Image3;
-            ImageData repo3Image1;
+            PlatformData repo2Image1;
+            PlatformData repo2Image2;
+            PlatformData repo2Image3;
+            PlatformData repo3Image1;
 
             RepoData[] repoDataSet = new RepoData[]
             {
                 new RepoData
                 {
                     Repo = "repo2",
-                    Images = new SortedDictionary<string, ImageData>
+                    Images = new List<ImageData>
                     {
+                        new ImageData
                         {
-                            "image1",
-                            repo2Image1 = new ImageData
+                            Platforms = new SortedDictionary<string, PlatformData>
                             {
-                                BaseImages = new SortedDictionary<string, string>
                                 {
-                                    { "base1", "base1digest-NEW" }
+                                    "image1",
+                                    repo2Image1 = new PlatformData
+                                    {
+                                        BaseImages = new SortedDictionary<string, string>
+                                        {
+                                            { "base1", "base1digest-NEW" }
+                                        }
+                                    }
+                                }
+                                ,
+                                {
+                                    "image3",
+                                    repo2Image3 = new PlatformData()
                                 }
                             }
-                        }
-                        ,
-                        {
-                            "image3",
-                            repo2Image3 = new ImageData()
                         }
                     }
                 },
                 new RepoData
                 {
                     Repo = "repo3",
-                    Images = new SortedDictionary<string, ImageData>
+                    Images = new List<ImageData>
                     {
+                        new ImageData
                         {
-                            "image1",
-                            repo3Image1 = new ImageData()
+                            Platforms = new SortedDictionary<string, PlatformData>
+                            {
+                                {
+                                    "image1",
+                                    repo3Image1 = new PlatformData()
+                                }
+                            }
                         }
                     }
                 },
@@ -136,25 +167,31 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 new RepoData
                 {
                     Repo = "repo2",
-                    Images = new SortedDictionary<string, ImageData>
+                    Images = new List<ImageData>
                     {
+                        new ImageData
                         {
-                            "image1",
-                            new ImageData
+                            Platforms = new SortedDictionary<string, PlatformData>
                             {
-                                BaseImages = new SortedDictionary<string, string>
                                 {
-                                    { "base1", "base1digest" }
-                                }
-                            }
-                        },
-                        {
-                            "image2",
-                            repo2Image2 = new ImageData
-                            {
-                                BaseImages = new SortedDictionary<string, string>
+                                    "image1",
+                                    new PlatformData
+                                    {
+                                        BaseImages = new SortedDictionary<string, string>
+                                        {
+                                            { "base1", "base1digest" }
+                                        }
+                                    }
+                                },
                                 {
-                                    { "base2", "base2digest" }
+                                    "image2",
+                                    repo2Image2 = new PlatformData
+                                    {
+                                        BaseImages = new SortedDictionary<string, string>
+                                        {
+                                            { "base2", "base2digest" }
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -177,30 +214,42 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 new RepoData
                 {
                     Repo = "repo2",
-                    Images = new SortedDictionary<string, ImageData>
+                    Images = new List<ImageData>
                     {
+                        new ImageData
                         {
-                            "image1",
-                            repo2Image1
-                        },
-                        {
-                            "image2",
-                            repo2Image2
-                        },
-                        {
-                            "image3",
-                            repo2Image3
+                            Platforms = new SortedDictionary<string, PlatformData>
+                            {
+                                {
+                                    "image1",
+                                    repo2Image1
+                                },
+                                {
+                                    "image2",
+                                    repo2Image2
+                                },
+                                {
+                                    "image3",
+                                    repo2Image3
+                                }
+                            }
                         }
                     }
                 },
                 new RepoData
                 {
                     Repo = "repo3",
-                    Images = new SortedDictionary<string, ImageData>
+                    Images = new List<ImageData>
                     {
+                        new ImageData
                         {
-                            "image1",
-                            repo3Image1
+                            Platforms = new SortedDictionary<string, PlatformData>
+                            {
+                                {
+                                    "image1",
+                                    repo3Image1
+                                }
+                            }
                         }
                     }
                 },
@@ -219,24 +268,30 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         [Fact]
         public void ImageInfoHelper_MergeRepos_MergeTags()
         {
-            ImageData srcImage1;
-            ImageData targetImage2;
+            PlatformData srcImage1;
+            PlatformData targetImage2;
 
             RepoData[] repoDataSet = new RepoData[]
             {
                 new RepoData
                 {
                     Repo = "repo1",
-                    Images = new SortedDictionary<string, ImageData>
+                    Images = new List<ImageData>
                     {
+                        new ImageData
                         {
-                            "image1",
-                            srcImage1 = new ImageData
+                            Platforms = new SortedDictionary<string, PlatformData>
                             {
-                                SimpleTags =
                                 {
-                                    "tag1",
-                                    "tag3"
+                                    "image1",
+                                    srcImage1 = new PlatformData
+                                    {
+                                        SimpleTags =
+                                        {
+                                            "tag1",
+                                            "tag3"
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -249,27 +304,33 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 new RepoData
                 {
                     Repo = "repo1",
-                    Images = new SortedDictionary<string, ImageData>
+                    Images = new List<ImageData>
                     {
+                        new ImageData
                         {
-                            "image1",
-                            new ImageData
+                            Platforms = new SortedDictionary<string, PlatformData>
                             {
-                                SimpleTags =
                                 {
-                                    "tag1",
-                                    "tag2",
-                                    "tag4"
-                                }
-                            }
-                        },
-                        {
-                            "image2",
-                            targetImage2 = new ImageData
-                            {
-                                SimpleTags =
+                                    "image1",
+                                    new PlatformData
+                                    {
+                                        SimpleTags =
+                                        {
+                                            "tag1",
+                                            "tag2",
+                                            "tag4"
+                                        }
+                                    }
+                                },
                                 {
-                                    "a"
+                                    "image2",
+                                    targetImage2 = new PlatformData
+                                    {
+                                        SimpleTags =
+                                        {
+                                            "a"
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -284,24 +345,30 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 new RepoData
                 {
                     Repo = "repo1",
-                    Images = new SortedDictionary<string, ImageData>
+                    Images = new List<ImageData>
                     {
+                        new ImageData
                         {
-                            "image1",
-                            new ImageData
+                            Platforms = new SortedDictionary<string, PlatformData>
                             {
-                                SimpleTags =
                                 {
-                                    "tag1",
-                                    "tag2",
-                                    "tag3",
-                                    "tag4"
+                                    "image1",
+                                    new PlatformData
+                                    {
+                                        SimpleTags =
+                                        {
+                                            "tag1",
+                                            "tag2",
+                                            "tag3",
+                                            "tag4"
+                                        }
+                                    }
+                                },
+                                {
+                                    "image2",
+                                    targetImage2
                                 }
                             }
-                        },
-                        {
-                            "image2",
-                            targetImage2
                         }
                     }
                 }
@@ -318,24 +385,30 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         [Fact]
         public void ImageInfoHelper_MergeRepos_RemoveTag()
         {
-            ImageData srcImage1;
-            ImageData targetImage2;
+            PlatformData srcImage1;
+            PlatformData targetImage2;
 
             RepoData[] repoDataSet = new RepoData[]
             {
                 new RepoData
                 {
                     Repo = "repo1",
-                    Images = new SortedDictionary<string, ImageData>
+                    Images = new List<ImageData>
                     {
+                        new ImageData
                         {
-                            "image1",
-                            srcImage1 = new ImageData
+                            Platforms = new SortedDictionary<string, PlatformData>
                             {
-                                SimpleTags =
                                 {
-                                    "tag1",
-                                    "tag3"
+                                    "image1",
+                                    srcImage1 = new PlatformData
+                                    {
+                                        SimpleTags =
+                                        {
+                                            "tag1",
+                                            "tag3"
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -348,27 +421,33 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 new RepoData
                 {
                     Repo = "repo1",
-                    Images = new SortedDictionary<string, ImageData>
+                    Images = new List<ImageData>
                     {
+                        new ImageData
                         {
-                            "image1",
-                            new ImageData
+                            Platforms = new SortedDictionary<string, PlatformData>
                             {
-                                SimpleTags =
                                 {
-                                    "tag1",
-                                    "tag2",
-                                    "tag4"
-                                }
-                            }
-                        },
-                        {
-                            "image2",
-                            targetImage2 = new ImageData
-                            {
-                                SimpleTags =
+                                    "image1",
+                                    new PlatformData
+                                    {
+                                        SimpleTags =
+                                        {
+                                            "tag1",
+                                            "tag2",
+                                            "tag4"
+                                        }
+                                    }
+                                },
                                 {
-                                    "a"
+                                    "image2",
+                                    targetImage2 = new PlatformData
+                                    {
+                                        SimpleTags =
+                                        {
+                                            "a"
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -388,15 +467,21 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 new RepoData
                 {
                     Repo = "repo1",
-                    Images = new SortedDictionary<string, ImageData>
+                    Images = new List<ImageData>
                     {
+                        new ImageData
                         {
-                            "image1",
-                            srcImage1
-                        },
-                        {
-                            "image2",
-                            targetImage2
+                            Platforms = new SortedDictionary<string, PlatformData>
+                            {
+                                {
+                                    "image1",
+                                    srcImage1
+                                },
+                                {
+                                    "image2",
+                                    targetImage2
+                                }
+                            }
                         }
                     }
                 }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/ImageInfoHelperTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/ImageInfoHelperTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             {
                                 new PlatformData
                                 {
-                                    Path = "image1",
+                                    Dockerfile = "image1",
                                     Digest = "digest"
                                 }
                             }
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             {
                                 new PlatformData
                                 {
-                                    Path = "image1"
+                                    Dockerfile = "image1"
                                 }
                             }
                         }
@@ -81,7 +81,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             {
                                 new PlatformData
                                 {
-                                    Path = "image1"
+                                    Dockerfile = "image1"
                                 }
                             }
                         }
@@ -117,7 +117,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                 {
                                     repo2Image1 = new PlatformData
                                     {
-                                        Path = "image1",
+                                        Dockerfile = "image1",
                                         BaseImages = new SortedDictionary<string, string>
                                         {
                                             { "base1", "base1digest-NEW" }
@@ -127,7 +127,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                 {
                                     repo2Image3  = new PlatformData
                                     {
-                                        Path = "image3"
+                                        Dockerfile = "image3"
                                     }
                                 }
                             }
@@ -146,7 +146,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                 {
                                     repo3Image1 = new PlatformData
                                     {
-                                        Path = "image1"
+                                        Dockerfile = "image1"
                                     }
                                 }
                             }
@@ -176,7 +176,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             {
                                 new PlatformData
                                 {
-                                    Path = "image1",
+                                    Dockerfile = "image1",
                                     BaseImages = new SortedDictionary<string, string>
                                     {
                                         { "base1", "base1digest" }
@@ -185,7 +185,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                 {
                                     repo2Image2 = new PlatformData
                                     {
-                                        Path = "image2",
+                                        Dockerfile = "image2",
                                         BaseImages = new SortedDictionary<string, string>
                                         {
                                             { "base2", "base2digest" }
@@ -272,7 +272,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                 {
                                     srcImage1 = new PlatformData
                                     {
-                                        Path = "image1",
+                                        Dockerfile = "image1",
                                         SimpleTags =
                                         {
                                             "tag1",
@@ -299,7 +299,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             {
                                 new PlatformData
                                 {
-                                    Path = "image1",
+                                    Dockerfile = "image1",
                                     SimpleTags =
                                     {
                                         "tag1",
@@ -310,7 +310,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                 {
                                     targetImage2 = new PlatformData
                                     {
-                                        Path = "image2",
+                                        Dockerfile = "image2",
                                         SimpleTags =
                                         {
                                             "a"
@@ -338,7 +338,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             {
                                 new PlatformData
                                 {
-                                    Path = "image1",
+                                    Dockerfile = "image1",
                                     SimpleTags =
                                     {
                                         "tag1",
@@ -382,7 +382,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                 {
                                     srcImage1 = new PlatformData
                                     {
-                                        Path = "image1",
+                                        Dockerfile = "image1",
                                         SimpleTags =
                                         {
                                             "tag1",
@@ -410,7 +410,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                 {
                                     new PlatformData
                                     {
-                                        Path = "image1",
+                                        Dockerfile = "image1",
                                         SimpleTags =
                                         {
                                             "tag1",
@@ -422,7 +422,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                 {
                                     targetImage2 = new PlatformData
                                     {
-                                        Path = "image2",
+                                        Dockerfile = "image2",
                                         SimpleTags =
                                         {
                                             "a"

--- a/src/Microsoft.DotNet.ImageBuilder/tests/MergeImageInfoFilesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/MergeImageInfoFilesCommandTests.cs
@@ -43,27 +43,25 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             {
                                 new ImageData
                                 {
-                                    Platforms = new SortedDictionary<string, PlatformData>
+                                    Platforms = new List<PlatformData>
                                     {
+                                        new PlatformData
                                         {
-                                            repo2Image1Dockerfile,
-                                            new PlatformData
+                                            Path = repo2Image1Dockerfile,
+                                            SimpleTags =
                                             {
-                                                SimpleTags =
-                                                {
-                                                    "tag3"
-                                                }
+                                                "tag3"
                                             }
                                         }
                                     }
                                 },
                                 new ImageData
                                 {
-                                    Platforms = new SortedDictionary<string, PlatformData>
+                                    Platforms = new List<PlatformData>
                                     {
+                                        new PlatformData
                                         {
-                                            repo2Image2Dockerfile,
-                                            new PlatformData()
+                                            Path = repo2Image2Dockerfile
                                         }
                                     }
                                 }
@@ -76,16 +74,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             {
                                 new ImageData
                                 {
-                                    Platforms = new SortedDictionary<string, PlatformData>
+                                    Platforms = new List<PlatformData>
                                     {
+                                        new PlatformData
                                         {
-                                            repo4Image2Dockerfile,
-                                            new PlatformData
+                                            Path = repo4Image2Dockerfile,
+                                            SimpleTags =
                                             {
-                                                SimpleTags =
-                                                {
-                                                    "tag1"
-                                                }
+                                                "tag1"
                                             }
                                         }
                                     }
@@ -102,36 +98,32 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             {
                                 new ImageData
                                 {
-                                    Platforms = new SortedDictionary<string, PlatformData>
+                                    Platforms = new List<PlatformData>
                                     {
+                                        new PlatformData
                                         {
-                                            repo2Image1Dockerfile,
-                                            new PlatformData
+                                            Path = repo2Image1Dockerfile,
+                                            BaseImages = new SortedDictionary<string, string>
                                             {
-                                                BaseImages = new SortedDictionary<string, string>
-                                                {
-                                                    { "base1", "base1hash" }
-                                                },
-                                                SimpleTags =
-                                                {
-                                                    "tag1"
-                                                }
+                                                { "base1", "base1hash" }
+                                            },
+                                            SimpleTags =
+                                            {
+                                                "tag1"
                                             }
                                         }
                                     }
                                 },
                                 new ImageData
                                 {
-                                    Platforms = new SortedDictionary<string, PlatformData>
+                                    Platforms = new List<PlatformData>
                                     {
+                                        new PlatformData
                                         {
-                                            repo2Image2Dockerfile,
-                                            new PlatformData
+                                            Path = repo2Image2Dockerfile,
+                                            SimpleTags =
                                             {
-                                                SimpleTags =
-                                                {
-                                                    "tag2"
-                                                }
+                                                "tag2"
                                             }
                                         }
                                     }
@@ -149,32 +141,28 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             {
                                 new ImageData
                                 {
-                                    Platforms = new SortedDictionary<string, PlatformData>
+                                    Platforms = new List<PlatformData>
                                     {
+                                        new PlatformData
                                         {
-                                            repo4Image2Dockerfile,
-                                            new PlatformData
+                                            Path = repo4Image2Dockerfile,
+                                            SimpleTags =
                                             {
-                                                SimpleTags =
-                                                {
-                                                    "tag2"
-                                                }
+                                                "tag2"
                                             }
                                         }
                                     }
                                 },
                                 new ImageData
                                 {
-                                    Platforms = new SortedDictionary<string, PlatformData>
+                                    Platforms = new List<PlatformData>
                                     {
+                                        new PlatformData
                                         {
-                                            repo4Image3Dockerfile,
-                                            new PlatformData
+                                            Path = repo4Image3Dockerfile,
+                                            SimpleTags =
                                             {
-                                                SimpleTags =
-                                                {
-                                                    "tag1"
-                                                }
+                                                "tag1"
                                             }
                                         }
                                     }
@@ -229,35 +217,33 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             new ImageData
                             {
-                                Platforms = new SortedDictionary<string, PlatformData>
+                                Platforms = new List<PlatformData>
                                 {
+                                    new PlatformData
                                     {
-                                        repo2Image1Dockerfile,
-                                        new PlatformData {
-                                            BaseImages = new SortedDictionary<string, string>
-                                            {
-                                                { "base1", "base1hash" }
-                                            },
-                                            SimpleTags =
-                                            {
-                                                "tag1",
-                                                "tag3"
-                                            }
+                                        Path = repo2Image1Dockerfile,
+                                        BaseImages = new SortedDictionary<string, string>
+                                        {
+                                            { "base1", "base1hash" }
+                                        },
+                                        SimpleTags =
+                                        {
+                                            "tag1",
+                                            "tag3"
                                         }
                                     }
                                 }
                             },
                             new ImageData
                             {
-                                Platforms = new SortedDictionary<string, PlatformData>
+                                Platforms = new List<PlatformData>
                                 {
+                                    new PlatformData
                                     {
-                                        repo2Image2Dockerfile,
-                                        new PlatformData {
-                                            SimpleTags =
-                                            {
-                                                "tag2"
-                                            }
+                                        Path = repo2Image2Dockerfile,
+                                        SimpleTags =
+                                        {
+                                            "tag2"
                                         }
                                     }
                                 }
@@ -275,27 +261,130 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             new ImageData
                             {
-                                Platforms = new SortedDictionary<string, PlatformData>
+                                Platforms = new List<PlatformData>
                                 {
+                                    new PlatformData
                                     {
-                                        repo4Image2Dockerfile,
-                                        new PlatformData {
-                                            SimpleTags =
-                                            {
-                                                "tag1",
-                                                "tag2"
-                                            }
+                                        Path = repo4Image2Dockerfile,
+                                        SimpleTags =
+                                        {
+                                            "tag1",
+                                            "tag2"
                                         }
                                     }
                                 }
                             },
                             new ImageData
                             {
-                                Platforms = new SortedDictionary<string, PlatformData>
+                                Platforms = new List<PlatformData>
                                 {
+                                    new PlatformData
                                     {
-                                        repo4Image3Dockerfile,
-                                        new PlatformData {
+                                        Path = repo4Image3Dockerfile,
+                                        SimpleTags =
+                                        {
+                                            "tag1"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                };
+
+                ImageInfoHelperTests.CompareRepos(expected, actual);
+            }
+        }
+
+        [Fact]
+        public async Task MergeImageInfoFilesCommand_DuplicateDockerfilePaths()
+        {
+            using (TempFolderContext context = TestHelper.UseTempFolder())
+            {
+                string dockerfile1 = CreateDockerfile("1.0/repo1/os1", context);
+                string dockerfile2 = CreateDockerfile("1.0/repo1/os2", context);
+
+                List<RepoData[]> repoDataSets = new List<RepoData[]>
+                {
+                    new RepoData[]
+                    {
+                        new RepoData
+                        {
+                            Repo = "repo1",
+                            Images = new List<ImageData>
+                            {
+                                new ImageData
+                                {
+                                    Platforms = new List<PlatformData>
+                                    {
+                                        new PlatformData
+                                        {
+                                            Architecture = "arm",
+                                            Digest = "digest1",
+                                            Path = dockerfile1,
+                                            SimpleTags =
+                                            {
+                                                "tag1",
+                                                "tag2"
+                                            }
+                                        },
+                                        new PlatformData
+                                        {
+                                            Architecture = "arm64",
+                                            Digest = "digest2",
+                                            Path = dockerfile1,
+                                            SimpleTags =
+                                            {
+                                                "tag2"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    new RepoData[]
+                    {
+                        new RepoData
+                        {
+                            Repo = "repo1",
+                            Images = new List<ImageData>
+                            {
+                                new ImageData
+                                {
+                                    Platforms = new List<PlatformData>
+                                    {
+                                        new PlatformData
+                                        {
+                                            Architecture = "arm64",
+                                            Digest = "digest2-new",
+                                            Path = dockerfile1,
+                                            SimpleTags =
+                                            {
+                                                "tag3",
+                                                "tag2"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    new RepoData[]
+                    {
+                        new RepoData
+                        {
+                            Repo = "repo1",
+                            Images = new List<ImageData>
+                            {
+                                new ImageData
+                                {
+                                    Platforms = new List<PlatformData>
+                                    {
+                                        new PlatformData
+                                        {
+                                            Digest = "digest3",
+                                            Path = dockerfile2,
                                             SimpleTags =
                                             {
                                                 "tag1"
@@ -305,7 +394,89 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                 }
                             }
                         }
-                    },
+                    }
+                };
+
+                MergeImageInfoCommand command = new MergeImageInfoCommand();
+                command.Options.SourceImageInfoFolderPath = Path.Combine(context.Path, "image-infos");
+                command.Options.DestinationImageInfoPath = Path.Combine(context.Path, "output.json");
+                command.Options.Manifest = Path.Combine(context.Path, "manifest.json");
+
+                Directory.CreateDirectory(command.Options.SourceImageInfoFolderPath);
+                for (int i = 0; i < repoDataSets.Count; i++)
+                {
+                    string file = Path.Combine(command.Options.SourceImageInfoFolderPath, $"{i}.json");
+                    File.WriteAllText(file, JsonHelper.SerializeObject(repoDataSets[i]));
+                }
+
+                Manifest manifest = CreateManifest(
+                    CreateRepo("repo1",
+                        CreateImage(
+                            CreatePlatform(dockerfile1, new string[0]),
+                            CreatePlatform(dockerfile1, new string[0])),
+                        CreateImage(
+                            CreatePlatform(dockerfile2, new string[0])))
+                );
+                File.WriteAllText(Path.Combine(context.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));
+
+                command.LoadManifest();
+                await command.ExecuteAsync();
+
+                string resultsContent = File.ReadAllText(command.Options.DestinationImageInfoPath);
+                RepoData[] actual = JsonConvert.DeserializeObject<RepoData[]>(resultsContent);
+
+                RepoData[] expected = new RepoData[]
+                {
+                    new RepoData
+                    {
+                        Repo = "repo1",
+                        Images = new List<ImageData>
+                        {
+                            new ImageData
+                            {
+                                Platforms = new List<PlatformData>
+                                {
+                                    new PlatformData
+                                    {
+                                        Architecture = "arm",
+                                        Digest = "digest1",
+                                        Path = dockerfile1,
+                                        SimpleTags =
+                                        {
+                                            "tag1",
+                                            "tag2"
+                                        }
+                                    },
+                                    new PlatformData
+                                    {
+                                        Architecture = "arm64",
+                                        Digest = "digest2-new",
+                                        Path = dockerfile1,
+                                        SimpleTags =
+                                        {
+                                            "tag2",
+                                            "tag3"
+                                        }
+                                    }
+                                }
+                            },
+                            new ImageData
+                            {
+                                Platforms = new List<PlatformData>
+                                {
+                                    new PlatformData
+                                    {
+                                        Digest = "digest3",
+                                        Path = dockerfile2,
+                                        SimpleTags =
+                                        {
+                                            "tag1"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 };
 
                 ImageInfoHelperTests.CompareRepos(expected, actual);

--- a/src/Microsoft.DotNet.ImageBuilder/tests/MergeImageInfoFilesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/MergeImageInfoFilesCommandTests.cs
@@ -12,6 +12,7 @@ using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
 using Newtonsoft.Json;
 using Xunit;
+using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ImageInfoHelper;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
@@ -45,24 +46,19 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                 {
                                     Platforms = new List<PlatformData>
                                     {
-                                        new PlatformData
-                                        {
-                                            Path = repo2Image1Dockerfile,
-                                            SimpleTags =
+                                        CreatePlatform(
+                                            repo2Image1Dockerfile,
+                                            simpleTags: new List<string>
                                             {
                                                 "tag3"
-                                            }
-                                        }
+                                            })
                                     }
                                 },
                                 new ImageData
                                 {
                                     Platforms = new List<PlatformData>
                                     {
-                                        new PlatformData
-                                        {
-                                            Path = repo2Image2Dockerfile
-                                        }
+                                        CreatePlatform(repo2Image2Dockerfile)
                                     }
                                 }
                             }
@@ -76,14 +72,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                 {
                                     Platforms = new List<PlatformData>
                                     {
-                                        new PlatformData
-                                        {
-                                            Path = repo4Image2Dockerfile,
-                                            SimpleTags =
+                                        CreatePlatform(
+                                            repo4Image2Dockerfile,
+                                            simpleTags: new List<string>
                                             {
                                                 "tag1"
-                                            }
-                                        }
+                                            })
                                     }
                                 }
                             }
@@ -100,32 +94,28 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                 {
                                     Platforms = new List<PlatformData>
                                     {
-                                        new PlatformData
-                                        {
-                                            Path = repo2Image1Dockerfile,
-                                            BaseImages = new SortedDictionary<string, string>
-                                            {
-                                                { "base1", "base1hash" }
-                                            },
-                                            SimpleTags =
+                                        CreatePlatform(
+                                            repo2Image1Dockerfile,
+                                            simpleTags: new List<string>
                                             {
                                                 "tag1"
-                                            }
-                                        }
+                                            },
+                                            baseImages: new SortedDictionary<string, string>
+                                            {
+                                                { "base1", "base1hash" }
+                                            })
                                     }
                                 },
                                 new ImageData
                                 {
                                     Platforms = new List<PlatformData>
                                     {
-                                        new PlatformData
-                                        {
-                                            Path = repo2Image2Dockerfile,
-                                            SimpleTags =
+                                        CreatePlatform(
+                                            repo2Image2Dockerfile,
+                                            simpleTags: new List<string>
                                             {
                                                 "tag2"
-                                            }
-                                        }
+                                            })
                                     }
                                 }
                             }
@@ -143,28 +133,24 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                 {
                                     Platforms = new List<PlatformData>
                                     {
-                                        new PlatformData
-                                        {
-                                            Path = repo4Image2Dockerfile,
-                                            SimpleTags =
+                                        CreatePlatform(
+                                            repo4Image2Dockerfile,
+                                            simpleTags: new List<string>
                                             {
                                                 "tag2"
-                                            }
-                                        }
+                                            })
                                     }
                                 },
                                 new ImageData
                                 {
                                     Platforms = new List<PlatformData>
                                     {
-                                        new PlatformData
-                                        {
-                                            Path = repo4Image3Dockerfile,
-                                            SimpleTags =
+                                        CreatePlatform(
+                                            repo4Image3Dockerfile,
+                                            simpleTags: new List<string>
                                             {
                                                 "tag1"
-                                            }
-                                        }
+                                            })
                                     }
                                 }
                             }
@@ -194,7 +180,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     CreateRepo("repo3"),
                     CreateRepo("repo4",
                         CreateImage(
-                            CreatePlatform(repo4Image2Dockerfile, new string[0])))
+                            CreatePlatform(repo4Image2Dockerfile, new string[0])),
+                        CreateImage(
+                            CreatePlatform(repo4Image3Dockerfile, new string[0])))
                 );
                 File.WriteAllText(Path.Combine(context.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));
 
@@ -219,33 +207,29 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             {
                                 Platforms = new List<PlatformData>
                                 {
-                                    new PlatformData
-                                    {
-                                        Path = repo2Image1Dockerfile,
-                                        BaseImages = new SortedDictionary<string, string>
-                                        {
-                                            { "base1", "base1hash" }
-                                        },
-                                        SimpleTags =
+                                    CreatePlatform(
+                                        repo2Image1Dockerfile,
+                                        simpleTags: new List<string>
                                         {
                                             "tag1",
                                             "tag3"
-                                        }
-                                    }
+                                        },
+                                        baseImages: new SortedDictionary<string, string>
+                                        {
+                                            { "base1", "base1hash" }
+                                        })
                                 }
                             },
                             new ImageData
                             {
                                 Platforms = new List<PlatformData>
                                 {
-                                    new PlatformData
-                                    {
-                                        Path = repo2Image2Dockerfile,
-                                        SimpleTags =
+                                    CreatePlatform(
+                                        repo2Image2Dockerfile,
+                                        simpleTags: new List<string>
                                         {
                                             "tag2"
-                                        }
-                                    }
+                                        })
                                 }
                             }
                         }
@@ -263,29 +247,25 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             {
                                 Platforms = new List<PlatformData>
                                 {
-                                    new PlatformData
-                                    {
-                                        Path = repo4Image2Dockerfile,
-                                        SimpleTags =
+                                    CreatePlatform(
+                                        repo4Image2Dockerfile,
+                                        simpleTags: new List<string>
                                         {
                                             "tag1",
                                             "tag2"
-                                        }
-                                    }
+                                        })
                                 }
                             },
                             new ImageData
                             {
                                 Platforms = new List<PlatformData>
                                 {
-                                    new PlatformData
-                                    {
-                                        Path = repo4Image3Dockerfile,
-                                        SimpleTags =
+                                    CreatePlatform(
+                                        repo4Image3Dockerfile,
+                                        simpleTags: new List<string>
                                         {
                                             "tag1"
-                                        }
-                                    }
+                                        })
                                 }
                             }
                         }
@@ -299,6 +279,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         [Fact]
         public async Task MergeImageInfoFilesCommand_DuplicateDockerfilePaths()
         {
+            const string OsType = "Linux";
+            const string Os1 = "bionic";
+            const string Os2 = "focal";
+            const string Os1DisplayName = "Ubuntu 18.04";
+            const string Os2DisplayName = "Ubuntu 20.04";
+
             using (TempFolderContext context = TestHelper.UseTempFolder())
             {
                 string dockerfile1 = CreateDockerfile("1.0/repo1/os1", context);
@@ -319,9 +305,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     {
                                         new PlatformData
                                         {
-                                            Architecture = "arm",
+                                            Architecture = "arm32",
+                                            OsVersion = Os1DisplayName,
+                                            OsType = OsType,
                                             Digest = "digest1",
-                                            Path = dockerfile1,
+                                            Dockerfile = dockerfile1,
                                             SimpleTags =
                                             {
                                                 "tag1",
@@ -331,11 +319,31 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         new PlatformData
                                         {
                                             Architecture = "arm64",
+                                            OsVersion = Os1DisplayName,
+                                            OsType = OsType,
                                             Digest = "digest2",
-                                            Path = dockerfile1,
+                                            Dockerfile = dockerfile1,
                                             SimpleTags =
                                             {
                                                 "tag2"
+                                            }
+                                        }
+                                    }
+                                },
+                                new ImageData
+                                {
+                                    Platforms = new List<PlatformData>
+                                    {
+                                        new PlatformData
+                                        {
+                                            Architecture = "arm32",
+                                            OsVersion = Os2DisplayName,
+                                            OsType = OsType,
+                                            Digest = "digest4",
+                                            Dockerfile = dockerfile1,
+                                            SimpleTags =
+                                            {
+                                                "tagA"
                                             }
                                         }
                                     }
@@ -357,8 +365,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         new PlatformData
                                         {
                                             Architecture = "arm64",
+                                            OsVersion = Os1DisplayName,
+                                            OsType = OsType,
                                             Digest = "digest2-new",
-                                            Path = dockerfile1,
+                                            Dockerfile = dockerfile1,
                                             SimpleTags =
                                             {
                                                 "tag3",
@@ -383,11 +393,32 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     {
                                         new PlatformData
                                         {
+                                            Architecture = "amd64",
                                             Digest = "digest3",
-                                            Path = dockerfile2,
+                                            OsVersion = Os1DisplayName,
+                                            OsType = OsType,
+                                            Dockerfile = dockerfile2,
                                             SimpleTags =
                                             {
                                                 "tag1"
+                                            }
+                                        }
+                                    }
+                                },
+                                new ImageData
+                                {
+                                    Platforms = new List<PlatformData>
+                                    {
+                                        new PlatformData
+                                        {
+                                            Architecture = "arm32",
+                                            OsVersion = Os2DisplayName,
+                                            OsType = OsType,
+                                            Digest = "digest4-new",
+                                            Dockerfile = dockerfile1,
+                                            SimpleTags =
+                                            {
+                                                "tagB"
                                             }
                                         }
                                     }
@@ -412,10 +443,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Manifest manifest = CreateManifest(
                     CreateRepo("repo1",
                         CreateImage(
-                            CreatePlatform(dockerfile1, new string[0]),
-                            CreatePlatform(dockerfile1, new string[0])),
+                            CreatePlatform(dockerfile1, new string[0], osVersion: Os1, architecture: Architecture.ARM),
+                            CreatePlatform(dockerfile1, new string[0], osVersion: Os1, architecture: Architecture.ARM64)),
                         CreateImage(
-                            CreatePlatform(dockerfile2, new string[0])))
+                            CreatePlatform(dockerfile1, new string[0], osVersion: Os2, architecture: Architecture.ARM)),
+                        CreateImage(
+                            CreatePlatform(dockerfile2, new string[0], osVersion: Os1)))
                 );
                 File.WriteAllText(Path.Combine(context.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));
 
@@ -438,9 +471,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                 {
                                     new PlatformData
                                     {
-                                        Architecture = "arm",
+                                        Architecture = "arm32",
+                                        OsVersion = Os1DisplayName,
+                                        OsType = OsType,
                                         Digest = "digest1",
-                                        Path = dockerfile1,
+                                        Dockerfile = dockerfile1,
                                         SimpleTags =
                                         {
                                             "tag1",
@@ -450,8 +485,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     new PlatformData
                                     {
                                         Architecture = "arm64",
+                                        OsVersion = Os1DisplayName,
+                                        OsType = OsType,
                                         Digest = "digest2-new",
-                                        Path = dockerfile1,
+                                        Dockerfile = dockerfile1,
                                         SimpleTags =
                                         {
                                             "tag2",
@@ -466,8 +503,30 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                 {
                                     new PlatformData
                                     {
+                                        Architecture = "arm32",
+                                        OsVersion = Os2DisplayName,
+                                        OsType = OsType,
+                                        Digest = "digest4-new",
+                                        Dockerfile = dockerfile1,
+                                        SimpleTags =
+                                        {
+                                            "tagA",
+                                            "tagB"
+                                        }
+                                    }
+                                }
+                            },
+                            new ImageData
+                            {
+                                Platforms = new List<PlatformData>
+                                {
+                                    new PlatformData
+                                    {
+                                        Architecture = "amd64",
                                         Digest = "digest3",
-                                        Path = dockerfile2,
+                                        OsVersion = Os1DisplayName,
+                                        OsType = OsType,
+                                        Dockerfile = dockerfile2,
                                         SimpleTags =
                                         {
                                             "tag1"

--- a/src/Microsoft.DotNet.ImageBuilder/tests/MergeImageInfoFilesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/MergeImageInfoFilesCommandTests.cs
@@ -8,9 +8,11 @@ using System.IO;
 using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Commands;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
+using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
 using Newtonsoft.Json;
 using Xunit;
+using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
@@ -21,6 +23,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         {
             using (TempFolderContext context = TestHelper.UseTempFolder())
             {
+                string repo2Image1Dockerfile = CreateDockerfile("1.0/repo2/os1", context);
+                string repo2Image2Dockerfile = CreateDockerfile("1.0/repo2/os2", context);
+                string repo4Image2Dockerfile = CreateDockerfile("1.0/repo4/os2", context);
+                string repo4Image3Dockerfile = CreateDockerfile("1.0/repo4/os3", context);
+
                 List<RepoData[]> repoDataSets = new List<RepoData[]>
                 {
                     new RepoData[]
@@ -32,26 +39,54 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         new RepoData
                         {
                             Repo = "repo2",
-                            Images = new SortedDictionary<string, ImageData>
+                            Images = new List<ImageData>
                             {
+                                new ImageData
                                 {
-                                    "image1",
-                                    new ImageData()
+                                    Platforms = new SortedDictionary<string, PlatformData>
+                                    {
+                                        {
+                                            repo2Image1Dockerfile,
+                                            new PlatformData
+                                            {
+                                                SimpleTags =
+                                                {
+                                                    "tag3"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                new ImageData
+                                {
+                                    Platforms = new SortedDictionary<string, PlatformData>
+                                    {
+                                        {
+                                            repo2Image2Dockerfile,
+                                            new PlatformData()
+                                        }
+                                    }
                                 }
                             }
                         },
                         new RepoData
                         {
                             Repo = "repo4",
-                            Images = new SortedDictionary<string, ImageData>
+                            Images = new List<ImageData>
                             {
+                                new ImageData
                                 {
-                                    "image2",
-                                    new ImageData
+                                    Platforms = new SortedDictionary<string, PlatformData>
                                     {
-                                        SimpleTags =
                                         {
-                                            "tag1"
+                                            repo4Image2Dockerfile,
+                                            new PlatformData
+                                            {
+                                                SimpleTags =
+                                                {
+                                                    "tag1"
+                                                }
+                                            }
                                         }
                                     }
                                 }
@@ -63,19 +98,41 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         new RepoData
                         {
                             Repo = "repo2",
-                            Images = new SortedDictionary<string, ImageData>
+                            Images = new List<ImageData>
                             {
+                                new ImageData
                                 {
-                                    "image1",
-                                    new ImageData
+                                    Platforms = new SortedDictionary<string, PlatformData>
                                     {
-                                        BaseImages = new SortedDictionary<string, string>
                                         {
-                                            { "base1", "base1hash" }
-                                        },
-                                        SimpleTags =
+                                            repo2Image1Dockerfile,
+                                            new PlatformData
+                                            {
+                                                BaseImages = new SortedDictionary<string, string>
+                                                {
+                                                    { "base1", "base1hash" }
+                                                },
+                                                SimpleTags =
+                                                {
+                                                    "tag1"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                new ImageData
+                                {
+                                    Platforms = new SortedDictionary<string, PlatformData>
+                                    {
                                         {
-                                            "tag1"
+                                            repo2Image2Dockerfile,
+                                            new PlatformData
+                                            {
+                                                SimpleTags =
+                                                {
+                                                    "tag2"
+                                                }
+                                            }
                                         }
                                     }
                                 }
@@ -88,15 +145,37 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         new RepoData
                         {
                             Repo = "repo4",
-                            Images = new SortedDictionary<string, ImageData>
+                            Images = new List<ImageData>
                             {
+                                new ImageData
                                 {
-                                    "image2",
-                                    new ImageData
+                                    Platforms = new SortedDictionary<string, PlatformData>
                                     {
-                                        SimpleTags =
                                         {
-                                            "tag2"
+                                            repo4Image2Dockerfile,
+                                            new PlatformData
+                                            {
+                                                SimpleTags =
+                                                {
+                                                    "tag2"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                new ImageData
+                                {
+                                    Platforms = new SortedDictionary<string, PlatformData>
+                                    {
+                                        {
+                                            repo4Image3Dockerfile,
+                                            new PlatformData
+                                            {
+                                                SimpleTags =
+                                                {
+                                                    "tag1"
+                                                }
+                                            }
                                         }
                                     }
                                 }
@@ -105,15 +184,33 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     }
                 };
 
+                MergeImageInfoCommand command = new MergeImageInfoCommand();
+                command.Options.SourceImageInfoFolderPath = Path.Combine(context.Path, "image-infos");
+                command.Options.DestinationImageInfoPath = Path.Combine(context.Path, "output.json");
+                command.Options.Manifest = Path.Combine(context.Path, "manifest.json");
+
+                Directory.CreateDirectory(command.Options.SourceImageInfoFolderPath);
                 for (int i = 0; i < repoDataSets.Count; i++)
                 {
-                    string file = Path.Combine(context.Path, $"{i}.json");
+                    string file = Path.Combine(command.Options.SourceImageInfoFolderPath, $"{i}.json");
                     File.WriteAllText(file, JsonHelper.SerializeObject(repoDataSets[i]));
                 }
 
-                MergeImageInfoCommand command = new MergeImageInfoCommand();
-                command.Options.SourceImageInfoFolderPath = context.Path;
-                command.Options.DestinationImageInfoPath = Path.Combine(context.Path, "output.json");
+                Manifest manifest = CreateManifest(
+                    CreateRepo("repo1"),
+                    CreateRepo("repo2",
+                        CreateImage(
+                            CreatePlatform(repo2Image1Dockerfile, new string[0])),
+                        CreateImage(
+                            CreatePlatform(repo2Image2Dockerfile, new string[0]))),
+                    CreateRepo("repo3"),
+                    CreateRepo("repo4",
+                        CreateImage(
+                            CreatePlatform(repo4Image2Dockerfile, new string[0])))
+                );
+                File.WriteAllText(Path.Combine(context.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));
+
+                command.LoadManifest();
                 await command.ExecuteAsync();
 
                 string resultsContent = File.ReadAllText(command.Options.DestinationImageInfoPath);
@@ -128,18 +225,40 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     new RepoData
                     {
                         Repo = "repo2",
-                        Images = new SortedDictionary<string, ImageData>
+                        Images = new List<ImageData>
                         {
+                            new ImageData
                             {
-                                "image1",
-                                new ImageData {
-                                    BaseImages = new SortedDictionary<string, string>
+                                Platforms = new SortedDictionary<string, PlatformData>
+                                {
                                     {
-                                        { "base1", "base1hash" }
-                                    },
-                                    SimpleTags =
+                                        repo2Image1Dockerfile,
+                                        new PlatformData {
+                                            BaseImages = new SortedDictionary<string, string>
+                                            {
+                                                { "base1", "base1hash" }
+                                            },
+                                            SimpleTags =
+                                            {
+                                                "tag1",
+                                                "tag3"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            new ImageData
+                            {
+                                Platforms = new SortedDictionary<string, PlatformData>
+                                {
                                     {
-                                        "tag1"
+                                        repo2Image2Dockerfile,
+                                        new PlatformData {
+                                            SimpleTags =
+                                            {
+                                                "tag2"
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -152,15 +271,36 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     new RepoData
                     {
                         Repo = "repo4",
-                        Images = new SortedDictionary<string, ImageData>
+                        Images = new List<ImageData>
                         {
+                            new ImageData
                             {
-                                "image2",
-                                new ImageData {
-                                    SimpleTags =
+                                Platforms = new SortedDictionary<string, PlatformData>
+                                {
                                     {
-                                        "tag1",
-                                        "tag2"
+                                        repo4Image2Dockerfile,
+                                        new PlatformData {
+                                            SimpleTags =
+                                            {
+                                                "tag1",
+                                                "tag2"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            new ImageData
+                            {
+                                Platforms = new SortedDictionary<string, PlatformData>
+                                {
+                                    {
+                                        repo4Image3Dockerfile,
+                                        new PlatformData {
+                                            SimpleTags =
+                                            {
+                                                "tag1"
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -197,6 +337,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
                 await Assert.ThrowsAsync<InvalidOperationException>(() => command.ExecuteAsync());
             }
+        }
+
+        private static string CreateDockerfile(string relativeDirectory, TempFolderContext context)
+        {
+            Directory.CreateDirectory(Path.Combine(context.Path, relativeDirectory));
+            string dockerfileRelativePath = Path.Combine(relativeDirectory, "Dockerfile");
+            File.WriteAllText(PathHelper.NormalizePath(Path.Combine(context.Path, dockerfileRelativePath)), "FROM base");
+            return PathHelper.NormalizePath(dockerfileRelativePath);
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/PublishImageInfoCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/PublishImageInfoCommandTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                 {
                                     new PlatformData
                                     {
-                                        Path = "image1",
+                                        Dockerfile = "image1",
                                         SimpleTags =
                                         {
                                             "newtag"
@@ -67,7 +67,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                 {
                                     new PlatformData
                                     {
-                                        Path = "image2",
+                                        Dockerfile = "image2",
                                         SimpleTags =
                                         {
                                             "tag1"
@@ -95,7 +95,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                 {
                                     new PlatformData
                                     {
-                                        Path = "image1",
+                                        Dockerfile = "image1",
                                         SimpleTags =
                                         {
                                             "oldtag"
@@ -138,7 +138,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                 {
                                     new PlatformData
                                     {
-                                        Path = "image1",
+                                        Dockerfile = "image1",
                                         SimpleTags =
                                         {
                                             "newtag"

--- a/src/Microsoft.DotNet.ImageBuilder/tests/PublishImageInfoCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/PublishImageInfoCommandTests.cs
@@ -42,16 +42,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             new ImageData
                             {
-                                Platforms = new SortedDictionary<string, PlatformData>
+                                Platforms = new List<PlatformData>
                                 {
+                                    new PlatformData
                                     {
-                                        "image1",
-                                        new PlatformData
+                                        Path = "image1",
+                                        SimpleTags =
                                         {
-                                            SimpleTags =
-                                            {
-                                                "newtag"
-                                            }
+                                            "newtag"
                                         }
                                     }
                                 }
@@ -65,16 +63,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             new ImageData
                             {
-                                Platforms = new SortedDictionary<string, PlatformData>
+                                Platforms = new List<PlatformData>
                                 {
+                                    new PlatformData
                                     {
-                                        "image2",
-                                        new PlatformData
+                                        Path = "image2",
+                                        SimpleTags =
                                         {
-                                            SimpleTags =
-                                            {
-                                                "tag1"
-                                            }
+                                            "tag1"
                                         }
                                     }
                                 }
@@ -95,16 +91,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             new ImageData
                             {
-                                Platforms = new SortedDictionary<string, PlatformData>
+                                Platforms = new List<PlatformData>
                                 {
+                                    new PlatformData
                                     {
-                                        "image1",
-                                        new PlatformData
+                                        Path = "image1",
+                                        SimpleTags =
                                         {
-                                            SimpleTags =
-                                            {
-                                                "oldtag"
-                                            }
+                                            "oldtag"
                                         }
                                     }
                                 }
@@ -140,16 +134,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             new ImageData
                             {
-                                Platforms = new SortedDictionary<string, PlatformData>
+                                Platforms = new List<PlatformData>
                                 {
+                                    new PlatformData
                                     {
-                                        "image1",
-                                        new PlatformData
+                                        Path = "image1",
+                                        SimpleTags =
                                         {
-                                            SimpleTags =
-                                            {
-                                                "newtag"
-                                            }
+                                            "newtag"
                                         }
                                     }
                                 }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/PublishImageInfoCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/PublishImageInfoCommandTests.cs
@@ -8,10 +8,12 @@ using System.IO;
 using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Commands;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
+using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
 using Microsoft.DotNet.VersionTools.Automation;
 using Microsoft.DotNet.VersionTools.Automation.GitHubApi;
 using Moq;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
@@ -36,15 +38,21 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     new RepoData
                     {
                         Repo = "repo1",
-                        Images = new SortedDictionary<string, ImageData>
+                        Images = new List<ImageData>
                         {
+                            new ImageData
                             {
-                                "image1",
-                                new ImageData
+                                Platforms = new SortedDictionary<string, PlatformData>
                                 {
-                                    SimpleTags =
                                     {
-                                        "newtag"
+                                        "image1",
+                                        new PlatformData
+                                        {
+                                            SimpleTags =
+                                            {
+                                                "newtag"
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -53,15 +61,21 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     repo2 = new RepoData
                     {
                         Repo = "repo2",
-                        Images = new SortedDictionary<string, ImageData>
+                        Images = new List<ImageData>
                         {
+                            new ImageData
                             {
-                                "image2",
-                                new ImageData
+                                Platforms = new SortedDictionary<string, PlatformData>
                                 {
-                                    SimpleTags =
                                     {
-                                        "tag1"
+                                        "image2",
+                                        new PlatformData
+                                        {
+                                            SimpleTags =
+                                            {
+                                                "tag1"
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -77,15 +91,21 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     new RepoData
                     {
                         Repo = "repo1",
-                        Images = new SortedDictionary<string, ImageData>
+                        Images = new List<ImageData>
                         {
+                            new ImageData
                             {
-                                "image1",
-                                new ImageData
+                                Platforms = new SortedDictionary<string, PlatformData>
                                 {
-                                    SimpleTags =
                                     {
-                                        "oldtag"
+                                        "image1",
+                                        new PlatformData
+                                        {
+                                            SimpleTags =
+                                            {
+                                                "oldtag"
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -103,7 +123,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 PublishImageInfoCommand command = new PublishImageInfoCommand(gitHubClientFactoryMock.Object);
                 command.Options.ImageInfoPath = file;
                 command.Options.GitOptions.AuthToken = "token";
+                command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
 
+                Manifest manifest = ManifestHelper.CreateManifest();
+                File.WriteAllText(Path.Combine(tempFolderContext.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));
+
+                command.LoadManifest();
                 await command.ExecuteAsync();
 
                 RepoData[] expectedRepos = new RepoData[]
@@ -111,15 +136,21 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     new RepoData
                     {
                         Repo = "repo1",
-                        Images = new SortedDictionary<string, ImageData>
+                        Images = new List<ImageData>
                         {
+                            new ImageData
                             {
-                                "image1",
-                                new ImageData
+                                Platforms = new SortedDictionary<string, PlatformData>
                                 {
-                                    SimpleTags =
                                     {
-                                        "newtag"
+                                        "image1",
+                                        new PlatformData
+                                        {
+                                            SimpleTags =
+                                            {
+                                                "newtag"
+                                            }
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
In order to support data like shared tags in the image info file, the schema needs to be updated to group Dockerfiles associated with a single manifest tag just as the manifest does.  This grouping is referred to as an image while each of the underlying items are referred to as a platform.  I've updated the schema to reflect this by renaming the previously named `ImageData` to `PlatformData` because that is really what it represents now and introducing a new `ImageData` class that groups the `PlatformData` instances.

OLD schema example:
```
[
  {
    "repo": "repo2",
    "images": [
      {
        "1.0/repo2/os1/Dockerfile": {
          "simpleTags": [
            "tag1"
          ],
        },
        "1.0/repo2/os2/Dockerfile": {
          "simpleTags": [
            "tag2"
          ],
        }
      }
    ]
  }
]
```

NEW schema example:
```
[
  {
    "repo": "repo2",
    "images": [
      {
        "platforms": {
          "1.0/repo2/os1/Dockerfile": {
            "simpleTags": [
              "tag1"
            ]
          }
        }
      },
      {
        "platforms": {
          "1.0/repo2/os2/Dockerfile": {
            "simpleTags": [
              "tag2"
            ]
          }
        }
      }
    ]
  }
]
```

The main impact this change causes is with the merging behavior.  There needs to be a way to determine which image instance a platform belongs when merging a source to a target.  The image has no identifying data.  This is accomplished by correlating in memory each image in an image info file with its related image in the manifest file.  That can then be used as a reference identifier to pair up related images between two separate image info files.

Fixes #286