### PR TITLE
Store a schema version in the image info file

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private readonly IDockerService dockerService;
         private readonly ILoggerService loggerService;
         private readonly IEnvironmentService environmentService;
-        private readonly List<RepoData> repoList = new List<RepoData>();
+        private readonly ImageArtifactDetails imageArtifactDetails = new ImageArtifactDetails();
 
         [ImportingConstructor]
         public BuildCommand(IDockerService dockerService, ILoggerService loggerService, IEnvironmentService environmentService)
@@ -79,7 +79,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 }
             }
 
-            string imageInfoString = JsonHelper.SerializeObject(repoList.OrderBy(r => r.Repo).ToArray());
+            string imageInfoString = JsonHelper.SerializeObject(imageArtifactDetails);
             File.WriteAllText(Options.ImageInfoOutputPath, imageInfoString);
         }
 
@@ -93,7 +93,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 {
                     Repo = repoInfo.Model.Name
                 };
-                repoList.Add(repoData);
+                imageArtifactDetails.Repos.Add(repoData);
 
                 foreach (ImageInfo image in repoInfo.FilteredImages)
                 {
@@ -274,7 +274,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             }
         }
 
-        private IEnumerable<PlatformData> GetBuiltPlatforms() => this.repoList
+        private IEnumerable<PlatformData> GetBuiltPlatforms() => this.imageArtifactDetails.Repos
             .Where(repoData => repoData.Images != null)
             .SelectMany(repoData => repoData.Images)
             .SelectMany(imageData => imageData.Platforms);

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     [Export(typeof(ICommand))]
     public class CopyAcrImagesCommand : ManifestCommand<CopyAcrImagesOptions>
     {
-        private Lazy<RepoData[]> imageInfoRepos;
+        private Lazy<ImageArtifactDetails> imageArtifactDetails;
         private readonly IAzureManagementFactory azureManagementFactory;
         private readonly IEnvironmentService environmentService;
 
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             this.azureManagementFactory = azureManagementFactory ?? throw new ArgumentNullException(nameof(azureManagementFactory));
             this.environmentService = environmentService ?? throw new ArgumentNullException(nameof(environmentService));
-            this.imageInfoRepos = new Lazy<RepoData[]>(() =>
+            this.imageArtifactDetails = new Lazy<ImageArtifactDetails>(() =>
             {
                 if (!String.IsNullOrEmpty(Options.ImageInfoPath))
                 {
@@ -100,9 +100,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             // to handle scenarios where the tag's value is dynamic, such as a timestamp, and we need to know the value
             // of the tag for the image that was actually built rather than just generating new tag values when parsing
             // the manifest.
-            if (imageInfoRepos.Value != null)
+            if (imageArtifactDetails.Value != null)
             {
-                RepoData repoData = imageInfoRepos.Value.FirstOrDefault(repoData => repoData.Repo == repo.Model.Name);
+                RepoData repoData = imageArtifactDetails.Value.Repos.FirstOrDefault(repoData => repoData.Repo == repo.Model.Name);
                 if (repoData != null)
                 {
                     PlatformData platformData = repoData.Images

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
@@ -108,7 +108,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             ManifestInfo manifest = ManifestInfo.Load(manifestOptions);
 
-            RepoData[] repos = await GetImageInfoForSubscriptionAsync(subscription, manifest);
+            ImageArtifactDetails imageArtifactDetails = await GetImageInfoForSubscriptionAsync(subscription, manifest);
 
             List<string> pathsToRebuild = new List<string>();
 
@@ -120,7 +120,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     .SelectMany(image => image.FilteredPlatforms)
                     .Where(platform => !platform.IsInternalFromImage(platform.FinalStageFromImage));
 
-                RepoData repoData = repos
+                RepoData repoData = imageArtifactDetails.Repos
                     .FirstOrDefault(s => s.Repo == repo.Model.Name);
 
                 foreach (PlatformInfo platform in platforms)
@@ -203,7 +203,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             return pathsToRebuild;
         }
 
-        private async Task<RepoData[]> GetImageInfoForSubscriptionAsync(Subscription subscription, ManifestInfo manifest)
+        private async Task<ImageArtifactDetails> GetImageInfoForSubscriptionAsync(Subscription subscription, ManifestInfo manifest)
         {
             string imageDataJson;
             using (IGitHubClient gitHubClient = this.gitHubClientFactory.GetClient(Options.GitOptions.ToGitHubAuth(), Options.IsDryRun))

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/MergeImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/MergeImageInfoCommand.cs
@@ -22,28 +22,24 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 "*.json",
                 SearchOption.AllDirectories);
 
-            List<RepoData[]> srcReposList = imageInfoFiles
+            List<ImageArtifactDetails> srcImageArtifactDetailsList = imageInfoFiles
                 .OrderBy(file => file) // Ensure the files are ordered for testing consistency between OS's.
                 .Select(imageDataPath => ImageInfoHelper.LoadFromFile(imageDataPath, Manifest))
                 .ToList();
 
-            if (!srcReposList.Any())
+            if (!srcImageArtifactDetailsList.Any())
             {
                 throw new InvalidOperationException(
                     $"No JSON files found in source folder '{Options.SourceImageInfoFolderPath}'");
             }
 
-            List<RepoData> combinedRepos = new List<RepoData>();
-            foreach (RepoData[] repos in srcReposList)
+            ImageArtifactDetails targetImageArtifactDetails = new ImageArtifactDetails();
+            foreach (ImageArtifactDetails srcImageArtifactDetails in srcImageArtifactDetailsList)
             {
-                ImageInfoHelper.MergeRepos(repos, combinedRepos);
+                ImageInfoHelper.MergeImageArtifactDetails(srcImageArtifactDetails, targetImageArtifactDetails);
             }
 
-            RepoData[] reposArray = combinedRepos
-                .OrderBy(r => r.Repo)
-                .ToArray();
-
-            string destinationContents = JsonHelper.SerializeObject(reposArray) + Environment.NewLine;
+            string destinationContents = JsonHelper.SerializeObject(targetImageArtifactDetails) + Environment.NewLine;
             File.WriteAllText(Options.DestinationImageInfoPath, destinationContents);
 
             return Task.CompletedTask;

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/ImageArtifactDetails.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/ImageArtifactDetails.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.ImageBuilder.Models.Image
+{
+    public class ImageArtifactDetails
+    {
+        private const string schemaVersion = "1.0";
+
+        public string SchemaVersion
+        {
+            get { return schemaVersion; }
+            set { }
+        }
+
+        public List<RepoData> Repos { get; set; } = new List<RepoData>();
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/RepoData.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/RepoData.cs
@@ -2,16 +2,28 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.ImageBuilder.Models.Image
 {
-    public class RepoData
+    public class RepoData : IComparable<RepoData>
     {
         [JsonProperty(Required = Required.Always)]
         public string Repo { get; set; }
 
         public List<ImageData> Images { get; set; } = new List<ImageData>();
+
+        public int CompareTo([AllowNull] RepoData other)
+        {
+            if (other is null)
+            {
+                return 1;
+            }
+
+            return Repo.CompareTo(other.Repo);
+        }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
@@ -77,28 +77,31 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 command.LoadManifest();
                 await command.ExecuteAsync();
 
-                List<RepoData> repos = new List<RepoData>
+                ImageArtifactDetails imageArtifactDetails = new ImageArtifactDetails
                 {
-                    new RepoData
+                    Repos =
                     {
-                        Repo = repoName,
-                        Images = new List<ImageData>
+                        new RepoData
                         {
-                            new ImageData
+                            Repo = repoName,
+                            Images =
                             {
-                                Platforms = new List<PlatformData>
+                                new ImageData
                                 {
-                                    new PlatformData
+                                    Platforms =
                                     {
-                                        Dockerfile = $"{runtimeRelativeDir}/Dockerfile",
-                                        Architecture = "amd64",
-                                        OsType = "Linux",
-                                        OsVersion = "Ubuntu 19.04",
-                                        Digest = sha,
-                                        BaseImageDigest = baseImageDigest,
-                                        SimpleTags = new List<string>
+                                        new PlatformData
                                         {
-                                            tag
+                                            Dockerfile = $"{runtimeRelativeDir}/Dockerfile",
+                                            Architecture = "amd64",
+                                            OsType = "Linux",
+                                            OsVersion = "Ubuntu 19.04",
+                                            Digest = sha,
+                                            BaseImageDigest = baseImageDigest,
+                                            SimpleTags =
+                                            {
+                                                tag
+                                            }
                                         }
                                     }
                                 }
@@ -107,7 +110,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     }
                 };
 
-                string expectedOutput = JsonHelper.SerializeObject(repos);
+                string expectedOutput = JsonHelper.SerializeObject(imageArtifactDetails);
                 string actualOutput = File.ReadAllText(command.Options.ImageInfoOutputPath);
 
                 Assert.Equal(expectedOutput, actualOutput);
@@ -216,8 +219,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 command.LoadManifest();
                 await command.ExecuteAsync();
 
-                RepoData[] repos = JsonConvert.DeserializeObject<RepoData[]>(File.ReadAllText(command.Options.ImageInfoOutputPath));
-                Assert.Equal(PathHelper.NormalizePath(dockerfileRelativePath), repos[0].Images.First().Platforms.First().Dockerfile);
+                ImageArtifactDetails imageArtifactDetails = JsonConvert.DeserializeObject<ImageArtifactDetails>(
+                    File.ReadAllText(command.Options.ImageInfoOutputPath));
+                Assert.Equal(
+                    PathHelper.NormalizePath(dockerfileRelativePath),
+                    imageArtifactDetails.Repos[0].Images.First().Platforms.First().Dockerfile);
             }
         }
     }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/CopyAcrImagesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/CopyAcrImagesCommandTests.cs
@@ -66,31 +66,36 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
                 RepoData runtimeRepo;
 
-                RepoData[] repos = new RepoData[]
+                ImageArtifactDetails imageArtifactDetails = new ImageArtifactDetails
                 {
-                    runtimeRepo = new RepoData
+                    Repos =
                     {
-                        Repo = "runtime",
-                        Images = new List<ImageData>
                         {
-                            new ImageData
+                            runtimeRepo = new RepoData
                             {
-                                Platforms = new List<PlatformData>
+                                Repo = "runtime",
+                                Images =
                                 {
-                                    CreatePlatform(
-                                        PathHelper.NormalizePath(dockerfileRelativePath),
-                                        simpleTags: new List<string>
+                                    new ImageData
+                                    {
+                                        Platforms =
                                         {
-                                            "tag1",
-                                            "tag2"
-                                        })
+                                            CreatePlatform(
+                                                PathHelper.NormalizePath(dockerfileRelativePath),
+                                                simpleTags: new List<string>
+                                                {
+                                                    "tag1",
+                                                    "tag2"
+                                                })
+                                        }
+                                    }
                                 }
                             }
                         }
                     }
                 };
 
-                File.WriteAllText(command.Options.ImageInfoPath, JsonConvert.SerializeObject(repos));
+                File.WriteAllText(command.Options.ImageInfoPath, JsonConvert.SerializeObject(imageArtifactDetails));
 
                 command.LoadManifest();
                 await command.ExecuteAsync();

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
@@ -52,21 +52,27 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             ManifestHelper.CreateImage(
                                 ManifestHelper.CreatePlatform(dockerfile1Path, new string[] { "tag1" }),
                                 ManifestHelper.CreatePlatform(dockerfile2Path, new string[] { "tag2" })))),
-                    new RepoData
+                    new ImageArtifactDetails
                     {
-                        Repo = repo1,
-                        Images = new List<ImageData>
+                        Repos =
                         {
-                            new ImageData
+                            new RepoData
                             {
-                                Platforms = new List<PlatformData>
+                                Repo = repo1,
+                                Images =
                                 {
-                                    CreatePlatform(
-                                        dockerfile1Path,
-                                        baseImageDigest: "base1digest-diff"),
-                                    CreatePlatform(
-                                        dockerfile2Path,
-                                        baseImageDigest: "base2digest")
+                                    new ImageData
+                                    {
+                                        Platforms =
+                                        {
+                                            CreatePlatform(
+                                                dockerfile1Path,
+                                                baseImageDigest: "base1digest-diff"),
+                                            CreatePlatform(
+                                                dockerfile2Path,
+                                                baseImageDigest: "base2digest")
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -129,21 +135,27 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             ManifestHelper.CreateImage(
                                 ManifestHelper.CreatePlatform(dockerfile1Path, new string[] { "tag1" }),
                                 ManifestHelper.CreatePlatform(dockerfile2Path, new string[] { "tag2" })))),
-                    new RepoData
+                    new ImageArtifactDetails
                     {
-                        Repo = repo1,
-                        Images = new List<ImageData>
+                        Repos =
                         {
-                            new ImageData
+                            new RepoData
                             {
-                                Platforms = new List<PlatformData>
+                                Repo = repo1,
+                                Images =
                                 {
-                                    CreatePlatform(
-                                        dockerfile1Path,
-                                        baseImageDigest: "base2digest-diff"),
-                                    CreatePlatform(
-                                        dockerfile2Path,
-                                        baseImageDigest: "base3digest")
+                                    new ImageData
+                                    {
+                                        Platforms =
+                                        {
+                                            CreatePlatform(
+                                                dockerfile1Path,
+                                                baseImageDigest: "base2digest-diff"),
+                                            CreatePlatform(
+                                                dockerfile2Path,
+                                                baseImageDigest: "base3digest")
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -213,7 +225,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             ManifestHelper.CreateImage(
                                 ManifestHelper.CreatePlatform(dockerfile1Path, new string[] { "tag1" }, OS.Windows),
                                 ManifestHelper.CreatePlatform(dockerfile2Path, new string[] { "tag2" }, OS.Linux),
-                                ManifestHelper.CreatePlatform(dockerfile3Path, new string[] { "tag3" }, OS.Windows))))
+                                ManifestHelper.CreatePlatform(dockerfile3Path, new string[] { "tag3" }, OS.Windows)))),
+                    new ImageArtifactDetails()
                 )
             };
 
@@ -278,7 +291,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             ManifestHelper.CreateImage(
                                 ManifestHelper.CreatePlatform(dockerfile1Path, new string[] { "tag1" }, OS.Windows),
                                 ManifestHelper.CreatePlatform(dockerfile2Path, new string[] { "tag2" }, OS.Linux),
-                                ManifestHelper.CreatePlatform(dockerfile3Path, new string[] { "tag3" }, OS.Windows))))
+                                ManifestHelper.CreatePlatform(dockerfile3Path, new string[] { "tag3" }, OS.Windows)))),
+                    new ImageArtifactDetails()
                 )
             };
 
@@ -334,7 +348,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             repo1,
                             ManifestHelper.CreateImage(
                                 ManifestHelper.CreatePlatform(dockerfile1Path, new string[] { "tag1" }),
-                                ManifestHelper.CreatePlatform(dockerfile2Path, new string[] { "tag2" }))))
+                                ManifestHelper.CreatePlatform(dockerfile2Path, new string[] { "tag2" })))),
+                    new ImageArtifactDetails()
                 )
             };
 
@@ -397,38 +412,44 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             repo1,
                             ManifestHelper.CreateImage(
                                 ManifestHelper.CreatePlatform(dockerfile1Path, new string[] { "tag1" })))),
-                    new RepoData
+                    new ImageArtifactDetails
                     {
-                        Repo = repo1,
-                        Images = new List<ImageData>
+                        Repos =
                         {
-                            new ImageData
+                            new RepoData
                             {
-                                Platforms = new List<PlatformData>
+                                Repo = repo1,
+                                Images =
                                 {
-                                    CreatePlatform(
-                                        dockerfile1Path,
-                                        baseImageDigest: "base1digest-diff")
+                                    new ImageData
+                                    {
+                                        Platforms =
+                                        {
+                                            CreatePlatform(
+                                                dockerfile1Path,
+                                                baseImageDigest: "base1digest-diff")
+                                        }
+                                    }
+                                }
+                            },
+                            new RepoData
+                            {
+                                Repo = repo2,
+                                Images =
+                                {
+                                    new ImageData
+                                    {
+                                        Platforms =
+                                        {
+                                            CreatePlatform(
+                                                dockerfile2Path,
+                                                baseImageDigest: "base2digest-diff")
+                                        }
+                                    }
                                 }
                             }
                         }
-                    },
-                    new RepoData
-                    {
-                        Repo = repo2,
-                        Images = new List<ImageData>
-                        {
-                            new ImageData
-                            {
-                                Platforms = new List<PlatformData>
-                                {
-                                    CreatePlatform(
-                                        dockerfile2Path,
-                                        baseImageDigest: "base2digest-diff")
-                                }
-                            }
-                        }
-                    }                    
+                    }
                 ),
                 new SubscriptionInfo(
                     CreateSubscription(repo2, 2),
@@ -441,50 +462,56 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             repo3,
                             ManifestHelper.CreateImage(
                                 ManifestHelper.CreatePlatform(dockerfile3Path, new string[] { "tag3" })))),
-                    new RepoData
+                    new ImageArtifactDetails
                     {
-                        Repo = repo1,
-                        Images = new List<ImageData>
+                        Repos =
                         {
-                            new ImageData
+                            new RepoData
                             {
-                                Platforms = new List<PlatformData>
+                                Repo = repo1,
+                                Images =
                                 {
-                                    CreatePlatform(
-                                        dockerfile1Path,
-                                        baseImageDigest: "base1digest-diff")
+                                    new ImageData
+                                    {
+                                        Platforms =
+                                        {
+                                            CreatePlatform(
+                                                dockerfile1Path,
+                                                baseImageDigest: "base1digest-diff")
+                                        }
+                                    }
                                 }
-                            }
-                        }
-                    },
-                    new RepoData
-                    {
-                        Repo = repo2,
-                        Images = new List<ImageData>
-                        {
-                            new ImageData
+                            },
+                            new RepoData
                             {
-                                Platforms = new List<PlatformData>
+                                Repo = repo2,
+                                Images =
                                 {
-                                    CreatePlatform(
-                                        dockerfile2Path,
-                                        baseImageDigest: "base2digest-diff")
+                                    new ImageData
+                                    {
+                                        Platforms =
+                                        {
+                                            CreatePlatform(
+                                                dockerfile2Path,
+                                                baseImageDigest: "base2digest-diff")
+                                        }
+                                    }
                                 }
-                            }
-                        }
-                    },
-                    new RepoData
-                    {
-                        Repo = repo3,
-                        Images = new List<ImageData>
-                        {
-                            new ImageData
+                            },
+                            new RepoData
                             {
-                                Platforms = new List<PlatformData>
+                                Repo = repo3,
+                                Images =
                                 {
-                                    CreatePlatform(
-                                        dockerfile3Path,
-                                        baseImageDigest: "base3digest")
+                                    new ImageData
+                                    {
+                                        Platforms =
+                                        {
+                                            CreatePlatform(
+                                                dockerfile3Path,
+                                                baseImageDigest: "base3digest")
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -562,21 +589,27 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             ManifestHelper.CreateImage(
                                 ManifestHelper.CreatePlatform(dockerfile1Path, new string[] { "tag1" }),
                                 ManifestHelper.CreatePlatform(dockerfile2Path, new string[] { "tag2" })))),
-                    new RepoData
+                    new ImageArtifactDetails
                     {
-                        Repo = repo1,
-                        Images = new List<ImageData>
+                        Repos =
                         {
-                            new ImageData
+                            new RepoData
                             {
-                                Platforms = new List<PlatformData>
+                                Repo = repo1,
+                                Images = new List<ImageData>
                                 {
-                                    CreatePlatform(
-                                        dockerfile1Path,
-                                        baseImageDigest: baseImageDigest + "-diff"),
-                                    CreatePlatform(
-                                        dockerfile2Path,
-                                        baseImageDigest: baseImageDigest + "-diff")
+                                    new ImageData
+                                    {
+                                        Platforms = new List<PlatformData>
+                                        {
+                                            CreatePlatform(
+                                                dockerfile1Path,
+                                                baseImageDigest: baseImageDigest + "-diff"),
+                                            CreatePlatform(
+                                                dockerfile2Path,
+                                                baseImageDigest: baseImageDigest + "-diff")
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -647,18 +680,24 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             repo1,
                             ManifestHelper.CreateImage(
                                 ManifestHelper.CreatePlatform(dockerfile1Path, new string[] { "tag1" })))),
-                    new RepoData
+                    new ImageArtifactDetails
                     {
-                        Repo = repo1,
-                        Images = new List<ImageData>
+                        Repos =
                         {
-                            new ImageData
+                            new RepoData
                             {
-                                Platforms = new List<PlatformData>
+                                Repo = repo1,
+                                Images =
                                 {
-                                    CreatePlatform(
-                                        dockerfile1Path,
-                                        baseImageDigest: baseImageDigest)
+                                    new ImageData
+                                    {
+                                        Platforms =
+                                        {
+                                            CreatePlatform(
+                                                dockerfile1Path,
+                                                baseImageDigest: baseImageDigest)
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -739,47 +778,53 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             otherRepo,
                             ManifestHelper.CreateImage(
                                 ManifestHelper.CreatePlatform(otherDockerfilePath, new string[] { "tag1" })))),
-                    new RepoData
+                    new ImageArtifactDetails
                     {
-                        Repo = runtimeDepsRepo,
-                        Images = new List<ImageData>
+                        Repos =
                         {
-                            new ImageData
+                            new RepoData
                             {
-                                Platforms = new List<PlatformData>
+                                Repo = runtimeDepsRepo,
+                                Images =
                                 {
-                                    CreatePlatform(
-                                        runtimeDepsDockerfilePath,
-                                        baseImageDigest: baseImageDigest + "-diff")
+                                    new ImageData
+                                    {
+                                        Platforms =
+                                        {
+                                            CreatePlatform(
+                                                runtimeDepsDockerfilePath,
+                                                baseImageDigest: baseImageDigest + "-diff")
+                                        }
+                                    }
                                 }
-                            }
-                        }
-                    },
-                    new RepoData
-                    {
-                        Repo = runtimeRepo
-                    },
-                    new RepoData
-                    {
-                        Repo = sdkRepo
-                    },
-                    new RepoData
-                    {
-                        Repo = aspnetRepo
-                    },
-                    // Include an image that has not been changed and should not be included in the expected paths.
-                    new RepoData
-                    {
-                        Repo = otherRepo,
-                        Images = new List<ImageData>
-                        {
-                            new ImageData
+                            },
+                            new RepoData
                             {
-                                Platforms = new List<PlatformData>
+                                Repo = runtimeRepo
+                            },
+                            new RepoData
+                            {
+                                Repo = sdkRepo
+                            },
+                            new RepoData
+                            {
+                                Repo = aspnetRepo
+                            },
+                            // Include an image that has not been changed and should not be included in the expected paths.
+                            new RepoData
+                            {
+                                Repo = otherRepo,
+                                Images =
                                 {
-                                    CreatePlatform(
-                                        otherDockerfilePath,
-                                        baseImageDigest: otherImageDigest)
+                                    new ImageData
+                                    {
+                                        Platforms =
+                                        {
+                                            CreatePlatform(
+                                                otherDockerfilePath,
+                                                baseImageDigest: otherImageDigest)
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -848,21 +893,27 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             ManifestHelper.CreateImage(
                                 ManifestHelper.CreatePlatform(dockerfile1Path, new string[] { "tag1" }),
                                 ManifestHelper.CreatePlatform(dockerfile2Path, new string[] { "tag2" })))),
-                    new RepoData
+                    new ImageArtifactDetails
                     {
-                        Repo = repo1,
-                        Images = new List<ImageData>
+                        Repos =
                         {
-                            new ImageData
+                            new RepoData
                             {
-                                Platforms = new List<PlatformData>
+                                Repo = repo1,
+                                Images =
                                 {
-                                    CreatePlatform(
-                                        dockerfile1Path,
-                                        baseImageDigest: "base1digest-diff"),
-                                    CreatePlatform(
-                                        dockerfile2Path,
-                                        baseImageDigest: "base2digest")
+                                    new ImageData
+                                    {
+                                        Platforms =
+                                        {
+                                            CreatePlatform(
+                                                dockerfile1Path,
+                                                baseImageDigest: "base1digest-diff"),
+                                            CreatePlatform(
+                                                dockerfile2Path,
+                                                baseImageDigest: "base2digest")
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -923,18 +974,24 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             repo1,
                             ManifestHelper.CreateImage(
                                 ManifestHelper.CreatePlatform(dockerfile1Path, new string[] { "tag1" })))),
-                    new RepoData
+                    new ImageArtifactDetails
                     {
-                        Repo = repo1,
-                        Images = new List<ImageData>
+                        Repos =
                         {
-                            new ImageData
+                            new RepoData
                             {
-                                Platforms = new List<PlatformData>
+                                Repo = repo1,
+                                Images =
                                 {
-                                    CreatePlatform(
-                                        dockerfile1Path,
-                                        baseImageDigest: "base1digest")
+                                    new ImageData
+                                    {
+                                        Platforms =
+                                        {
+                                            CreatePlatform(
+                                                dockerfile1Path,
+                                                baseImageDigest: "base1digest")
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -996,19 +1053,25 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                 CreatePlatformWithRepoBuildArg(dockerfile1Path, $"{repo1}:tag2", new string[] { "tag1" })),
                             ManifestHelper.CreateImage(
                                 ManifestHelper.CreatePlatform(dockerfile2Path, new string[] { "tag2" })))),
-                    new RepoData
+                    new ImageArtifactDetails
                     {
-                        Repo = repo1,
-                        Images = new List<ImageData>
+                        Repos =
                         {
-                            new ImageData
+                            new RepoData
                             {
-                                Platforms = new List<PlatformData>
+                                Repo = repo1,
+                                Images =
                                 {
-                                    CreatePlatform(dockerfile1Path),
-                                    CreatePlatform(
-                                        dockerfile2Path,
-                                        baseImageDigest: "base1digest")
+                                    new ImageData
+                                    {
+                                        Platforms =
+                                        {
+                                            CreatePlatform(dockerfile1Path),
+                                            CreatePlatform(
+                                                dockerfile2Path,
+                                                baseImageDigest: "base1digest")
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -1214,10 +1277,13 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
                 foreach (SubscriptionInfo subscriptionInfo in subscriptionInfos)
                 {
-                    string imageInfoContents = JsonConvert.SerializeObject(subscriptionInfo.ImageInfo);
-                    gitHubClientMock
-                        .Setup(o => o.GetGitHubFileContentsAsync(It.IsAny<string>(), It.Is<GitHubBranch>(branch => IsMatchingBranch(branch))))
-                        .ReturnsAsync(imageInfoContents);
+                    if (subscriptionInfo.ImageInfo != null)
+                    {
+                        string imageInfoContents = JsonConvert.SerializeObject(subscriptionInfo.ImageInfo);
+                        gitHubClientMock
+                            .Setup(o => o.GetGitHubFileContentsAsync(It.IsAny<string>(), It.Is<GitHubBranch>(branch => IsMatchingBranch(branch))))
+                            .ReturnsAsync(imageInfoContents);
+                    }
                 }
 
                 Mock<IGitHubClientFactory> gitHubClientFactoryMock = new Mock<IGitHubClientFactory>();
@@ -1421,7 +1487,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
         private class SubscriptionInfo
         {
-            public SubscriptionInfo(Subscription subscription, Manifest manifest, params RepoData[] imageInfo)
+            public SubscriptionInfo(Subscription subscription, Manifest manifest, ImageArtifactDetails imageInfo)
             {
                 Subscription = subscription;
                 Manifest = manifest;
@@ -1430,7 +1496,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             public Subscription Subscription { get; }
             public Manifest Manifest { get; }
-            public RepoData[] ImageInfo { get; }
+            public ImageArtifactDetails ImageInfo { get; }
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/ImageInfoHelperTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/ImageInfoHelperTests.cs
@@ -14,21 +14,24 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         [Fact]
         public void ImageInfoHelper_MergeRepos_ImageDigest()
         {
-            RepoData[] repoDataSet = new RepoData[]
+            ImageArtifactDetails imageArtifactDetails = new ImageArtifactDetails
             {
-                new RepoData
+                Repos =
                 {
-                    Repo = "repo",
-                    Images = new List<ImageData>
+                    new RepoData
                     {
-                        new ImageData
+                        Repo = "repo",
+                        Images =
                         {
-                            Platforms = new List<PlatformData>
+                            new ImageData
                             {
-                                new PlatformData
+                                Platforms =
                                 {
-                                    Dockerfile = "image1",
-                                    Digest = "digest"
+                                    new PlatformData
+                                    {
+                                        Dockerfile = "image1",
+                                        Digest = "digest"
+                                    }
                                 }
                             }
                         }
@@ -36,20 +39,23 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            List<RepoData> targetRepos = new List<RepoData>
+            ImageArtifactDetails targetImageArtifactDetails = new ImageArtifactDetails
             {
-                new RepoData
+                Repos =
                 {
-                    Repo = "repo",
-                    Images = new List<ImageData>
+                    new RepoData
                     {
-                        new ImageData
+                        Repo = "repo",
+                        Images =
                         {
-                            Platforms = new List<PlatformData>
+                            new ImageData
                             {
-                                new PlatformData
+                                Platforms =
                                 {
-                                    Dockerfile = "image1"
+                                    new PlatformData
+                                    {
+                                        Dockerfile = "image1"
+                                    }
                                 }
                             }
                         }
@@ -57,31 +63,34 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            ImageInfoHelper.MergeRepos(repoDataSet, targetRepos);
-            CompareRepos(repoDataSet, targetRepos);
+            ImageInfoHelper.MergeImageArtifactDetails(imageArtifactDetails, targetImageArtifactDetails);
+            CompareImageArtifactDetails(imageArtifactDetails, targetImageArtifactDetails);
         }
 
         [Fact]
         public void ImageInfoHelper_MergeRepos_EmptyTarget()
         {
-            RepoData[] repoDataSet = new RepoData[]
+            ImageArtifactDetails imageArtifactDetails = new ImageArtifactDetails
             {
-                new RepoData
+                Repos =
                 {
-                    Repo = "repo1",
-                },
-                new RepoData
-                {
-                    Repo = "repo2",
-                    Images = new List<ImageData>
+                    new RepoData
                     {
-                        new ImageData
+                        Repo = "repo1",
+                    },
+                    new RepoData
+                    {
+                        Repo = "repo2",
+                        Images =
                         {
-                            Platforms = new List<PlatformData>
+                            new ImageData
                             {
-                                new PlatformData
+                                Platforms =
                                 {
-                                    Dockerfile = "image1"
+                                    new PlatformData
+                                    {
+                                        Dockerfile = "image1"
+                                    }
                                 }
                             }
                         }
@@ -89,10 +98,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            List<RepoData> targetRepos = new List<RepoData>();
-            ImageInfoHelper.MergeRepos(repoDataSet, targetRepos);
+            ImageArtifactDetails targetImageArtifactDetails = new ImageArtifactDetails();
+            ImageInfoHelper.MergeImageArtifactDetails(imageArtifactDetails, targetImageArtifactDetails);
 
-            CompareRepos(repoDataSet, targetRepos);
+            CompareImageArtifactDetails(imageArtifactDetails, targetImageArtifactDetails);
         }
 
         [Fact]
@@ -103,141 +112,150 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             PlatformData repo2Image3;
             PlatformData repo3Image1;
 
-            RepoData[] repoDataSet = new RepoData[]
+            ImageArtifactDetails imageArtifactDetails = new ImageArtifactDetails
             {
-                new RepoData
+                Repos =
                 {
-                    Repo = "repo2",
-                    Images = new List<ImageData>
+                    new RepoData
                     {
-                        new ImageData
+                        Repo = "repo2",
+                        Images =
                         {
-                            Platforms = new List<PlatformData>
+                            new ImageData
                             {
+                                Platforms =
                                 {
-                                    repo2Image1 = new PlatformData
+                                    {
+                                        repo2Image1 = new PlatformData
+                                        {
+                                            Dockerfile = "image1",
+                                            BaseImageDigest = "base1digest-NEW"
+                                        }
+                                    },
+                                    {
+                                        repo2Image3  = new PlatformData
+                                        {
+                                            Dockerfile = "image3"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    new RepoData
+                    {
+                        Repo = "repo3",
+                        Images =
+                        {
+                            new ImageData
+                            {
+                                Platforms =
+                                {
+                                    {
+                                        repo3Image1 = new PlatformData
+                                        {
+                                            Dockerfile = "image1"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    new RepoData
+                    {
+                        Repo = "repo4",
+                    }
+                }
+            };
+
+            ImageArtifactDetails targetImageArtifactDetails = new ImageArtifactDetails
+            {
+                Repos =
+                {
+                    new RepoData
+                    {
+                        Repo = "repo1"
+                    },
+                    new RepoData
+                    {
+                        Repo = "repo2",
+                        Images =
+                        {
+                            new ImageData
+                            {
+                                Platforms =
+                                {
+                                    new PlatformData
                                     {
                                         Dockerfile = "image1",
-                                        BaseImageDigest = "base1digest-NEW"
-                                    }
-                                },
-                                {
-                                    repo2Image3  = new PlatformData
+                                        BaseImageDigest = "base1digest"
+                                    },
                                     {
-                                        Dockerfile = "image3"
+                                        repo2Image2 = new PlatformData
+                                        {
+                                            Dockerfile = "image2",
+                                            BaseImageDigest = "base2digest"
+                                        }
                                     }
                                 }
                             }
                         }
-                    }
-                },
-                new RepoData
-                {
-                    Repo = "repo3",
-                    Images = new List<ImageData>
+                    },
+                    new RepoData
                     {
-                        new ImageData
-                        {
-                            Platforms = new List<PlatformData>
-                            {
-                                {
-                                    repo3Image1 = new PlatformData
-                                    {
-                                        Dockerfile = "image1"
-                                    }
-                                }
-                            }
-                        }
+                        Repo = "repo3"
                     }
-                },
-                new RepoData
-                {
-                    Repo = "repo4",
                 }
             };
 
-            List<RepoData> targetRepos = new List<RepoData>
+            ImageInfoHelper.MergeImageArtifactDetails(imageArtifactDetails, targetImageArtifactDetails);
+
+            ImageArtifactDetails expected = new ImageArtifactDetails
             {
-                new RepoData
+                Repos =
                 {
-                    Repo = "repo1"
-                },
-                new RepoData
-                {
-                    Repo = "repo2",
-                    Images = new List<ImageData>
+                    new RepoData
                     {
-                        new ImageData
+                        Repo = "repo1"
+                    },
+                    new RepoData
+                    {
+                        Repo = "repo2",
+                        Images =
                         {
-                            Platforms = new List<PlatformData>
+                            new ImageData
                             {
-                                new PlatformData
+                                Platforms =
                                 {
-                                    Dockerfile = "image1",
-                                    BaseImageDigest = "base1digest"
-                                },
-                                {
-                                    repo2Image2 = new PlatformData
-                                    {
-                                        Dockerfile = "image2",
-                                        BaseImageDigest = "base2digest"
-                                    }
+                                    repo2Image1,
+                                    repo2Image2,
+                                    repo2Image3
                                 }
                             }
                         }
+                    },
+                    new RepoData
+                    {
+                        Repo = "repo3",
+                        Images =
+                        {
+                            new ImageData
+                            {
+                                Platforms =
+                                {
+                                    repo3Image1
+                                }
+                            }
+                        }
+                    },
+                    new RepoData
+                    {
+                        Repo = "repo4",
                     }
-                },
-                new RepoData
-                {
-                    Repo = "repo3"
                 }
             };
 
-            ImageInfoHelper.MergeRepos(repoDataSet, targetRepos);
-
-            List<RepoData> expected = new List<RepoData>
-            {
-                new RepoData
-                {
-                    Repo = "repo1"
-                },
-                new RepoData
-                {
-                    Repo = "repo2",
-                    Images = new List<ImageData>
-                    {
-                        new ImageData
-                        {
-                            Platforms = new List<PlatformData>
-                            {
-                                repo2Image1,
-                                repo2Image2,
-                                repo2Image3
-                            }
-                        }
-                    }
-                },
-                new RepoData
-                {
-                    Repo = "repo3",
-                    Images = new List<ImageData>
-                    {
-                        new ImageData
-                        {
-                            Platforms = new List<PlatformData>
-                            {
-                                repo3Image1
-                            }
-                        }
-                    }
-                },
-                new RepoData
-                {
-                    Repo = "repo4",
-                }
-            };
-
-            CompareRepos(expected, targetRepos);
+            CompareImageArtifactDetails(expected, targetImageArtifactDetails);
         }
 
         /// <summary>
@@ -249,25 +267,68 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             PlatformData srcImage1;
             PlatformData targetImage2;
 
-            RepoData[] repoDataSet = new RepoData[]
+            ImageArtifactDetails imageArtifactDetails = new ImageArtifactDetails
             {
-                new RepoData
+                Repos =
                 {
-                    Repo = "repo1",
-                    Images = new List<ImageData>
+                    new RepoData
                     {
-                        new ImageData
+                        Repo = "repo1",
+                        Images =
                         {
-                            Platforms = new List<PlatformData>
+                            new ImageData
                             {
+                                Platforms =
                                 {
-                                    srcImage1 = new PlatformData
+                                    {
+                                        srcImage1 = new PlatformData
+                                        {
+                                            Dockerfile = "image1",
+                                            SimpleTags =
+                                            {
+                                                "tag1",
+                                                "tag3"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            ImageArtifactDetails targetImageArtifactDetails = new ImageArtifactDetails
+            {
+                Repos =
+                {
+                    new RepoData
+                    {
+                        Repo = "repo1",
+                        Images =
+                        {
+                            new ImageData
+                            {
+                                Platforms =
+                                {
+                                    new PlatformData
                                     {
                                         Dockerfile = "image1",
                                         SimpleTags =
                                         {
                                             "tag1",
-                                            "tag3"
+                                            "tag2",
+                                            "tag4"
+                                        }
+                                    },
+                                    {
+                                        targetImage2 = new PlatformData
+                                        {
+                                            Dockerfile = "image2",
+                                            SimpleTags =
+                                            {
+                                                "a"
+                                            }
                                         }
                                     }
                                 }
@@ -277,36 +338,33 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            List<RepoData> targetRepos = new List<RepoData>
+            ImageInfoHelper.MergeImageArtifactDetails(imageArtifactDetails, targetImageArtifactDetails);
+
+            ImageArtifactDetails expected = new ImageArtifactDetails
             {
-                new RepoData
+                Repos =
                 {
-                    Repo = "repo1",
-                    Images = new List<ImageData>
+                    new RepoData
                     {
-                        new ImageData
+                        Repo = "repo1",
+                        Images =
                         {
-                            Platforms = new List<PlatformData>
+                            new ImageData
                             {
-                                new PlatformData
+                                Platforms =
                                 {
-                                    Dockerfile = "image1",
-                                    SimpleTags =
+                                    new PlatformData
                                     {
-                                        "tag1",
-                                        "tag2",
-                                        "tag4"
-                                    }
-                                },
-                                {
-                                    targetImage2 = new PlatformData
-                                    {
-                                        Dockerfile = "image2",
+                                        Dockerfile = "image1",
                                         SimpleTags =
                                         {
-                                            "a"
+                                            "tag1",
+                                            "tag2",
+                                            "tag3",
+                                            "tag4"
                                         }
-                                    }
+                                    },
+                                    targetImage2
                                 }
                             }
                         }
@@ -314,38 +372,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            ImageInfoHelper.MergeRepos(repoDataSet, targetRepos);
-
-            List<RepoData> expected = new List<RepoData>
-            {
-                new RepoData
-                {
-                    Repo = "repo1",
-                    Images = new List<ImageData>
-                    {
-                        new ImageData
-                        {
-                            Platforms = new List<PlatformData>
-                            {
-                                new PlatformData
-                                {
-                                    Dockerfile = "image1",
-                                    SimpleTags =
-                                    {
-                                        "tag1",
-                                        "tag2",
-                                        "tag3",
-                                        "tag4"
-                                    }
-                                },
-                                targetImage2
-                            }
-                        }
-                    }
-                }
-            };
-
-            CompareRepos(expected, targetRepos);
+            CompareImageArtifactDetails(expected, targetImageArtifactDetails);
         }
 
         /// <summary>
@@ -359,25 +386,28 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             PlatformData srcImage1;
             PlatformData targetImage2;
 
-            RepoData[] repoDataSet = new RepoData[]
+            ImageArtifactDetails imageArtifactDetails = new ImageArtifactDetails
             {
-                new RepoData
+                Repos =
                 {
-                    Repo = "repo1",
-                    Images = new List<ImageData>
+                    new RepoData
                     {
-                        new ImageData
+                        Repo = "repo1",
+                        Images =
                         {
-                            Platforms = new List<PlatformData>
+                            new ImageData
                             {
+                                Platforms =
                                 {
-                                    srcImage1 = new PlatformData
                                     {
-                                        Dockerfile = "image1",
-                                        SimpleTags =
+                                        srcImage1 = new PlatformData
                                         {
-                                            "tag1",
-                                            "tag3"
+                                            Dockerfile = "image1",
+                                            SimpleTags =
+                                            {
+                                                "tag1",
+                                                "tag3"
+                                            }
                                         }
                                     }
                                 }
@@ -387,36 +417,39 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            List<RepoData> targetRepos = new List<RepoData>
+            ImageArtifactDetails targetImageArtifactDetails = new ImageArtifactDetails
             {
-                new RepoData
+                Repos =
                 {
-                    Repo = "repo1",
-                    Images = new List<ImageData>
+                    new RepoData
                     {
-                        new ImageData
+                        Repo = "repo1",
+                        Images =
                         {
-                            Platforms = new List<PlatformData>
+                            new ImageData
                             {
+                                Platforms =
                                 {
-                                    new PlatformData
                                     {
-                                        Dockerfile = "image1",
-                                        SimpleTags =
+                                        new PlatformData
                                         {
-                                            "tag1",
-                                            "tag2",
-                                            "tag4"
+                                            Dockerfile = "image1",
+                                            SimpleTags =
+                                            {
+                                                "tag1",
+                                                "tag2",
+                                                "tag4"
+                                            }
                                         }
-                                    }
-                                },
-                                {
-                                    targetImage2 = new PlatformData
+                                    },
                                     {
-                                        Dockerfile = "image2",
-                                        SimpleTags =
+                                        targetImage2 = new PlatformData
                                         {
-                                            "a"
+                                            Dockerfile = "image2",
+                                            SimpleTags =
+                                            {
+                                                "a"
+                                            }
                                         }
                                     }
                                 }
@@ -431,31 +464,34 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 ReplaceTags = true
             };
 
-            ImageInfoHelper.MergeRepos(repoDataSet, targetRepos, options);
+            ImageInfoHelper.MergeImageArtifactDetails(imageArtifactDetails, targetImageArtifactDetails, options);
 
-            List<RepoData> expected = new List<RepoData>
+            ImageArtifactDetails expected = new ImageArtifactDetails
             {
-                new RepoData
+                Repos =
                 {
-                    Repo = "repo1",
-                    Images = new List<ImageData>
+                    new RepoData
                     {
-                        new ImageData
+                        Repo = "repo1",
+                        Images =
                         {
-                            Platforms = new List<PlatformData>
+                            new ImageData
                             {
-                                srcImage1,
-                                targetImage2
+                                Platforms =
+                                {
+                                    srcImage1,
+                                    targetImage2
+                                }
                             }
                         }
                     }
                 }
             };
 
-            CompareRepos(expected, targetRepos);
+            CompareImageArtifactDetails(expected, targetImageArtifactDetails);
         }
 
-        public static void CompareRepos(IList<RepoData> expected, IList<RepoData> actual)
+        public static void CompareImageArtifactDetails(ImageArtifactDetails expected, ImageArtifactDetails actual)
         {
             Assert.Equal(JsonHelper.SerializeObject(expected), JsonHelper.SerializeObject(actual));
         }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/MergeImageInfoFilesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/MergeImageInfoFilesCommandTests.cs
@@ -29,129 +29,135 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 string repo4Image2Dockerfile = CreateDockerfile("1.0/repo4/os2", context);
                 string repo4Image3Dockerfile = CreateDockerfile("1.0/repo4/os3", context);
 
-                List<RepoData[]> repoDataSets = new List<RepoData[]>
+                List<ImageArtifactDetails> imageArtifactDetailsList = new List<ImageArtifactDetails>
                 {
-                    new RepoData[]
+                    new ImageArtifactDetails
                     {
-                        new RepoData
+                        Repos =
                         {
-                            Repo = "repo1"
-                        },
-                        new RepoData
-                        {
-                            Repo = "repo2",
-                            Images = new List<ImageData>
+                            new RepoData
                             {
-                                new ImageData
+                                Repo = "repo1"
+                            },
+                            new RepoData
+                            {
+                                Repo = "repo2",
+                                Images =
                                 {
-                                    Platforms = new List<PlatformData>
+                                    new ImageData
                                     {
-                                        CreatePlatform(
-                                            repo2Image1Dockerfile,
-                                            simpleTags: new List<string>
-                                            {
-                                                "tag3"
-                                            })
+                                        Platforms =
+                                        {
+                                            CreatePlatform(
+                                                repo2Image1Dockerfile,
+                                                simpleTags: new List<string>
+                                                {
+                                                    "tag3"
+                                                })
+                                        }
+                                    },
+                                    new ImageData
+                                    {
+                                        Platforms =
+                                        {
+                                            CreatePlatform(repo2Image2Dockerfile)
+                                        }
                                     }
-                                },
-                                new ImageData
+                                }
+                            },
+                            new RepoData
+                            {
+                                Repo = "repo4",
+                                Images =
                                 {
-                                    Platforms = new List<PlatformData>
+                                    new ImageData
                                     {
-                                        CreatePlatform(repo2Image2Dockerfile)
+                                        Platforms =
+                                        {
+                                            CreatePlatform(
+                                                repo4Image2Dockerfile,
+                                                simpleTags: new List<string>
+                                                {
+                                                    "tag1"
+                                                })
+                                        }
                                     }
                                 }
                             }
-                        },
-                        new RepoData
-                        {
-                            Repo = "repo4",
-                            Images = new List<ImageData>
-                            {
-                                new ImageData
-                                {
-                                    Platforms = new List<PlatformData>
-                                    {
-                                        CreatePlatform(
-                                            repo4Image2Dockerfile,
-                                            simpleTags: new List<string>
-                                            {
-                                                "tag1"
-                                            })
-                                    }
-                                }
-                            }
-                        },
+                        }
                     },
-                    new RepoData[]
+                    new ImageArtifactDetails
                     {
-                        new RepoData
+                        Repos =
                         {
-                            Repo = "repo2",
-                            Images = new List<ImageData>
+                            new RepoData
                             {
-                                new ImageData
+                                Repo = "repo2",
+                                Images =
                                 {
-                                    Platforms = new List<PlatformData>
+                                    new ImageData
                                     {
-                                        CreatePlatform(
-                                            repo2Image1Dockerfile,
-                                            simpleTags: new List<string>
-                                            {
-                                                "tag1"
-                                            },
-                                            baseImageDigest: "base1hash")
+                                        Platforms =
+                                        {
+                                            CreatePlatform(
+                                                repo2Image1Dockerfile,
+                                                simpleTags: new List<string>
+                                                {
+                                                    "tag1"
+                                                },
+                                                baseImageDigest: "base1hash")
+                                        }
+                                    },
+                                    new ImageData
+                                    {
+                                        Platforms =
+                                        {
+                                            CreatePlatform(
+                                                repo2Image2Dockerfile,
+                                                simpleTags: new List<string>
+                                                {
+                                                    "tag2"
+                                                })
+                                        }
                                     }
-                                },
-                                new ImageData
+                                }
+                            },
+                            new RepoData
+                            {
+                                Repo = "repo3",
+                            },
+                            new RepoData
+                            {
+                                Repo = "repo4",
+                                Images =
                                 {
-                                    Platforms = new List<PlatformData>
+                                    new ImageData
                                     {
-                                        CreatePlatform(
-                                            repo2Image2Dockerfile,
-                                            simpleTags: new List<string>
-                                            {
-                                                "tag2"
-                                            })
+                                        Platforms =
+                                        {
+                                            CreatePlatform(
+                                                repo4Image2Dockerfile,
+                                                simpleTags: new List<string>
+                                                {
+                                                    "tag2"
+                                                })
+                                        }
+                                    },
+                                    new ImageData
+                                    {
+                                        Platforms =
+                                        {
+                                            CreatePlatform(
+                                                repo4Image3Dockerfile,
+                                                simpleTags: new List<string>
+                                                {
+                                                    "tag1"
+                                                })
+                                        }
                                     }
                                 }
                             }
-                        },
-                        new RepoData
-                        {
-                            Repo = "repo3",
-                        },
-                        new RepoData
-                        {
-                            Repo = "repo4",
-                            Images = new List<ImageData>
-                            {
-                                new ImageData
-                                {
-                                    Platforms = new List<PlatformData>
-                                    {
-                                        CreatePlatform(
-                                            repo4Image2Dockerfile,
-                                            simpleTags: new List<string>
-                                            {
-                                                "tag2"
-                                            })
-                                    }
-                                },
-                                new ImageData
-                                {
-                                    Platforms = new List<PlatformData>
-                                    {
-                                        CreatePlatform(
-                                            repo4Image3Dockerfile,
-                                            simpleTags: new List<string>
-                                            {
-                                                "tag1"
-                                            })
-                                    }
-                                }
-                            }
-                        },
+                        }
                     }
                 };
 
@@ -161,10 +167,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 command.Options.Manifest = Path.Combine(context.Path, "manifest.json");
 
                 Directory.CreateDirectory(command.Options.SourceImageInfoFolderPath);
-                for (int i = 0; i < repoDataSets.Count; i++)
+                for (int i = 0; i < imageArtifactDetailsList.Count; i++)
                 {
                     string file = Path.Combine(command.Options.SourceImageInfoFolderPath, $"{i}.json");
-                    File.WriteAllText(file, JsonHelper.SerializeObject(repoDataSets[i]));
+                    File.WriteAllText(file, JsonHelper.SerializeObject(imageArtifactDetailsList[i]));
                 }
 
                 Manifest manifest = CreateManifest(
@@ -187,86 +193,89 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 await command.ExecuteAsync();
 
                 string resultsContent = File.ReadAllText(command.Options.DestinationImageInfoPath);
-                RepoData[] actual = JsonConvert.DeserializeObject<RepoData[]>(resultsContent);
+                ImageArtifactDetails actual = JsonConvert.DeserializeObject<ImageArtifactDetails>(resultsContent);
 
-                RepoData[] expected = new RepoData[]
+                ImageArtifactDetails expected = new ImageArtifactDetails
                 {
-                    new RepoData
+                    Repos =
                     {
-                        Repo = "repo1"
-                    },
-                    new RepoData
-                    {
-                        Repo = "repo2",
-                        Images = new List<ImageData>
+                        new RepoData
                         {
-                            new ImageData
+                            Repo = "repo1"
+                        },
+                        new RepoData
+                        {
+                            Repo = "repo2",
+                            Images =
                             {
-                                Platforms = new List<PlatformData>
+                                new ImageData
                                 {
-                                    CreatePlatform(
-                                        repo2Image1Dockerfile,
-                                        simpleTags: new List<string>
-                                        {
-                                            "tag1",
-                                            "tag3"
-                                        },
-                                        baseImageDigest: "base1hash")
+                                    Platforms =
+                                    {
+                                        CreatePlatform(
+                                            repo2Image1Dockerfile,
+                                            simpleTags: new List<string>
+                                            {
+                                                "tag1",
+                                                "tag3"
+                                            },
+                                            baseImageDigest: "base1hash")
+                                    }
+                                },
+                                new ImageData
+                                {
+                                    Platforms =
+                                    {
+                                        CreatePlatform(
+                                            repo2Image2Dockerfile,
+                                            simpleTags: new List<string>
+                                            {
+                                                "tag2"
+                                            })
+                                    }
                                 }
-                            },
-                            new ImageData
+                            }
+                        },
+                        new RepoData
+                        {
+                            Repo = "repo3",
+                        },
+                        new RepoData
+                        {
+                            Repo = "repo4",
+                            Images =
                             {
-                                Platforms = new List<PlatformData>
+                                new ImageData
                                 {
-                                    CreatePlatform(
-                                        repo2Image2Dockerfile,
-                                        simpleTags: new List<string>
-                                        {
-                                            "tag2"
-                                        })
+                                    Platforms =
+                                    {
+                                        CreatePlatform(
+                                            repo4Image2Dockerfile,
+                                            simpleTags: new List<string>
+                                            {
+                                                "tag1",
+                                                "tag2"
+                                            })
+                                    }
+                                },
+                                new ImageData
+                                {
+                                    Platforms =
+                                    {
+                                        CreatePlatform(
+                                            repo4Image3Dockerfile,
+                                            simpleTags: new List<string>
+                                            {
+                                                "tag1"
+                                            })
+                                    }
                                 }
                             }
                         }
-                    },
-                    new RepoData
-                    {
-                        Repo = "repo3",
-                    },
-                    new RepoData
-                    {
-                        Repo = "repo4",
-                        Images = new List<ImageData>
-                        {
-                            new ImageData
-                            {
-                                Platforms = new List<PlatformData>
-                                {
-                                    CreatePlatform(
-                                        repo4Image2Dockerfile,
-                                        simpleTags: new List<string>
-                                        {
-                                            "tag1",
-                                            "tag2"
-                                        })
-                                }
-                            },
-                            new ImageData
-                            {
-                                Platforms = new List<PlatformData>
-                                {
-                                    CreatePlatform(
-                                        repo4Image3Dockerfile,
-                                        simpleTags: new List<string>
-                                        {
-                                            "tag1"
-                                        })
-                                }
-                            }
-                        }
-                    },
+                    }
                 };
 
-                ImageInfoHelperTests.CompareRepos(expected, actual);
+                ImageInfoHelperTests.CompareImageArtifactDetails(expected, actual);
             }
         }
 
@@ -284,18 +293,195 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 string dockerfile1 = CreateDockerfile("1.0/repo1/os1", context);
                 string dockerfile2 = CreateDockerfile("1.0/repo1/os2", context);
 
-                List<RepoData[]> repoDataSets = new List<RepoData[]>
+                List<ImageArtifactDetails> imageArtifactDetailsList = new List<ImageArtifactDetails>
                 {
-                    new RepoData[]
+                    new ImageArtifactDetails
+                    {
+                        Repos =
+                        {
+                            new RepoData
+                            {
+                                Repo = "repo1",
+                                Images =
+                                {
+                                    new ImageData
+                                    {
+                                        Platforms =
+                                        {
+                                            new PlatformData
+                                            {
+                                                Architecture = "arm32",
+                                                OsVersion = Os1DisplayName,
+                                                OsType = OsType,
+                                                Digest = "digest1",
+                                                Dockerfile = dockerfile1,
+                                                SimpleTags =
+                                                {
+                                                    "tag1",
+                                                    "tag2"
+                                                }
+                                            },
+                                            new PlatformData
+                                            {
+                                                Architecture = "arm64",
+                                                OsVersion = Os1DisplayName,
+                                                OsType = OsType,
+                                                Digest = "digest2",
+                                                Dockerfile = dockerfile1,
+                                                SimpleTags =
+                                                {
+                                                    "tag2"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    new ImageData
+                                    {
+                                        Platforms =
+                                        {
+                                            new PlatformData
+                                            {
+                                                Architecture = "arm32",
+                                                OsVersion = Os2DisplayName,
+                                                OsType = OsType,
+                                                Digest = "digest4",
+                                                Dockerfile = dockerfile1,
+                                                SimpleTags =
+                                                {
+                                                    "tagA"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    new ImageArtifactDetails
+                    {
+                        Repos =
+                        {
+                            new RepoData
+                            {
+                                Repo = "repo1",
+                                Images =
+                                {
+                                    new ImageData
+                                    {
+                                        Platforms =
+                                        {
+                                            new PlatformData
+                                            {
+                                                Architecture = "arm64",
+                                                OsVersion = Os1DisplayName,
+                                                OsType = OsType,
+                                                Digest = "digest2-new",
+                                                Dockerfile = dockerfile1,
+                                                SimpleTags =
+                                                {
+                                                    "tag3",
+                                                    "tag2"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    new ImageArtifactDetails
+                    {
+                        Repos =
+                        {
+                            new RepoData
+                            {
+                                Repo = "repo1",
+                                Images =
+                                {
+                                    new ImageData
+                                    {
+                                        Platforms =
+                                        {
+                                            new PlatformData
+                                            {
+                                                Architecture = "amd64",
+                                                Digest = "digest3",
+                                                OsVersion = Os1DisplayName,
+                                                OsType = OsType,
+                                                Dockerfile = dockerfile2,
+                                                SimpleTags =
+                                                {
+                                                    "tag1"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    new ImageData
+                                    {
+                                        Platforms =
+                                        {
+                                            new PlatformData
+                                            {
+                                                Architecture = "arm32",
+                                                OsVersion = Os2DisplayName,
+                                                OsType = OsType,
+                                                Digest = "digest4-new",
+                                                Dockerfile = dockerfile1,
+                                                SimpleTags =
+                                                {
+                                                    "tagB"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+
+                MergeImageInfoCommand command = new MergeImageInfoCommand();
+                command.Options.SourceImageInfoFolderPath = Path.Combine(context.Path, "image-infos");
+                command.Options.DestinationImageInfoPath = Path.Combine(context.Path, "output.json");
+                command.Options.Manifest = Path.Combine(context.Path, "manifest.json");
+
+                Directory.CreateDirectory(command.Options.SourceImageInfoFolderPath);
+                for (int i = 0; i < imageArtifactDetailsList.Count; i++)
+                {
+                    string file = Path.Combine(command.Options.SourceImageInfoFolderPath, $"{i}.json");
+                    File.WriteAllText(file, JsonHelper.SerializeObject(imageArtifactDetailsList[i]));
+                }
+
+                Manifest manifest = CreateManifest(
+                    CreateRepo("repo1",
+                        CreateImage(
+                            CreatePlatform(dockerfile1, new string[0], osVersion: Os1, architecture: Architecture.ARM),
+                            CreatePlatform(dockerfile1, new string[0], osVersion: Os1, architecture: Architecture.ARM64)),
+                        CreateImage(
+                            CreatePlatform(dockerfile1, new string[0], osVersion: Os2, architecture: Architecture.ARM)),
+                        CreateImage(
+                            CreatePlatform(dockerfile2, new string[0], osVersion: Os1)))
+                );
+                File.WriteAllText(Path.Combine(context.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));
+
+                command.LoadManifest();
+                await command.ExecuteAsync();
+
+                string resultsContent = File.ReadAllText(command.Options.DestinationImageInfoPath);
+                ImageArtifactDetails actual = JsonConvert.DeserializeObject<ImageArtifactDetails>(resultsContent);
+
+                ImageArtifactDetails expected = new ImageArtifactDetails
+                {
+                    Repos =
                     {
                         new RepoData
                         {
                             Repo = "repo1",
-                            Images = new List<ImageData>
+                            Images =
                             {
                                 new ImageData
                                 {
-                                    Platforms = new List<PlatformData>
+                                    Platforms =
                                     {
                                         new PlatformData
                                         {
@@ -315,75 +501,38 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                             Architecture = "arm64",
                                             OsVersion = Os1DisplayName,
                                             OsType = OsType,
-                                            Digest = "digest2",
+                                            Digest = "digest2-new",
                                             Dockerfile = dockerfile1,
                                             SimpleTags =
                                             {
-                                                "tag2"
+                                                "tag2",
+                                                "tag3"
                                             }
                                         }
                                     }
                                 },
                                 new ImageData
                                 {
-                                    Platforms = new List<PlatformData>
+                                    Platforms =
                                     {
                                         new PlatformData
                                         {
                                             Architecture = "arm32",
                                             OsVersion = Os2DisplayName,
                                             OsType = OsType,
-                                            Digest = "digest4",
+                                            Digest = "digest4-new",
                                             Dockerfile = dockerfile1,
                                             SimpleTags =
                                             {
-                                                "tagA"
+                                                "tagA",
+                                                "tagB"
                                             }
                                         }
                                     }
-                                }
-                            }
-                        }
-                    },
-                    new RepoData[]
-                    {
-                        new RepoData
-                        {
-                            Repo = "repo1",
-                            Images = new List<ImageData>
-                            {
+                                },
                                 new ImageData
                                 {
-                                    Platforms = new List<PlatformData>
-                                    {
-                                        new PlatformData
-                                        {
-                                            Architecture = "arm64",
-                                            OsVersion = Os1DisplayName,
-                                            OsType = OsType,
-                                            Digest = "digest2-new",
-                                            Dockerfile = dockerfile1,
-                                            SimpleTags =
-                                            {
-                                                "tag3",
-                                                "tag2"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    new RepoData[]
-                    {
-                        new RepoData
-                        {
-                            Repo = "repo1",
-                            Images = new List<ImageData>
-                            {
-                                new ImageData
-                                {
-                                    Platforms = new List<PlatformData>
+                                    Platforms =
                                     {
                                         new PlatformData
                                         {
@@ -398,141 +547,13 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                             }
                                         }
                                     }
-                                },
-                                new ImageData
-                                {
-                                    Platforms = new List<PlatformData>
-                                    {
-                                        new PlatformData
-                                        {
-                                            Architecture = "arm32",
-                                            OsVersion = Os2DisplayName,
-                                            OsType = OsType,
-                                            Digest = "digest4-new",
-                                            Dockerfile = dockerfile1,
-                                            SimpleTags =
-                                            {
-                                                "tagB"
-                                            }
-                                        }
-                                    }
                                 }
                             }
                         }
                     }
                 };
 
-                MergeImageInfoCommand command = new MergeImageInfoCommand();
-                command.Options.SourceImageInfoFolderPath = Path.Combine(context.Path, "image-infos");
-                command.Options.DestinationImageInfoPath = Path.Combine(context.Path, "output.json");
-                command.Options.Manifest = Path.Combine(context.Path, "manifest.json");
-
-                Directory.CreateDirectory(command.Options.SourceImageInfoFolderPath);
-                for (int i = 0; i < repoDataSets.Count; i++)
-                {
-                    string file = Path.Combine(command.Options.SourceImageInfoFolderPath, $"{i}.json");
-                    File.WriteAllText(file, JsonHelper.SerializeObject(repoDataSets[i]));
-                }
-
-                Manifest manifest = CreateManifest(
-                    CreateRepo("repo1",
-                        CreateImage(
-                            CreatePlatform(dockerfile1, new string[0], osVersion: Os1, architecture: Architecture.ARM),
-                            CreatePlatform(dockerfile1, new string[0], osVersion: Os1, architecture: Architecture.ARM64)),
-                        CreateImage(
-                            CreatePlatform(dockerfile1, new string[0], osVersion: Os2, architecture: Architecture.ARM)),
-                        CreateImage(
-                            CreatePlatform(dockerfile2, new string[0], osVersion: Os1)))
-                );
-                File.WriteAllText(Path.Combine(context.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));
-
-                command.LoadManifest();
-                await command.ExecuteAsync();
-
-                string resultsContent = File.ReadAllText(command.Options.DestinationImageInfoPath);
-                RepoData[] actual = JsonConvert.DeserializeObject<RepoData[]>(resultsContent);
-
-                RepoData[] expected = new RepoData[]
-                {
-                    new RepoData
-                    {
-                        Repo = "repo1",
-                        Images = new List<ImageData>
-                        {
-                            new ImageData
-                            {
-                                Platforms = new List<PlatformData>
-                                {
-                                    new PlatformData
-                                    {
-                                        Architecture = "arm32",
-                                        OsVersion = Os1DisplayName,
-                                        OsType = OsType,
-                                        Digest = "digest1",
-                                        Dockerfile = dockerfile1,
-                                        SimpleTags =
-                                        {
-                                            "tag1",
-                                            "tag2"
-                                        }
-                                    },
-                                    new PlatformData
-                                    {
-                                        Architecture = "arm64",
-                                        OsVersion = Os1DisplayName,
-                                        OsType = OsType,
-                                        Digest = "digest2-new",
-                                        Dockerfile = dockerfile1,
-                                        SimpleTags =
-                                        {
-                                            "tag2",
-                                            "tag3"
-                                        }
-                                    }
-                                }
-                            },
-                            new ImageData
-                            {
-                                Platforms = new List<PlatformData>
-                                {
-                                    new PlatformData
-                                    {
-                                        Architecture = "arm32",
-                                        OsVersion = Os2DisplayName,
-                                        OsType = OsType,
-                                        Digest = "digest4-new",
-                                        Dockerfile = dockerfile1,
-                                        SimpleTags =
-                                        {
-                                            "tagA",
-                                            "tagB"
-                                        }
-                                    }
-                                }
-                            },
-                            new ImageData
-                            {
-                                Platforms = new List<PlatformData>
-                                {
-                                    new PlatformData
-                                    {
-                                        Architecture = "amd64",
-                                        Digest = "digest3",
-                                        OsVersion = Os1DisplayName,
-                                        OsType = OsType,
-                                        Dockerfile = dockerfile2,
-                                        SimpleTags =
-                                        {
-                                            "tag1"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                };
-
-                ImageInfoHelperTests.CompareRepos(expected, actual);
+                ImageInfoHelperTests.CompareImageArtifactDetails(expected, actual);
             }
         }
 
@@ -551,9 +572,16 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         {
             using (TempFolderContext context = TestHelper.UseTempFolder())
             {
+                ImageArtifactDetails imageArtifactDetails = new ImageArtifactDetails
+                {
+                    Repos =
+                    {
+                        new RepoData { Repo = "repo" }
+                    }
+                };
+                        
                 // Store the content in a .txt file which the command should NOT be looking for.
-                File.WriteAllText("image-info.txt",
-                    JsonHelper.SerializeObject(new RepoData[] { new RepoData { Repo = "repo" } }));
+                File.WriteAllText("image-info.txt", JsonHelper.SerializeObject(imageArtifactDetails));
 
                 MergeImageInfoCommand command = new MergeImageInfoCommand();
                 command.Options.SourceImageInfoFolderPath = context.Path;

--- a/src/Microsoft.DotNet.ImageBuilder/tests/PublishImageInfoCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/PublishImageInfoCommandTests.cs
@@ -33,44 +33,49 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             {
                 RepoData repo2;
 
-                RepoData[] sourceRepos = new RepoData[]
+                ImageArtifactDetails srcImageArtifactDetails = new ImageArtifactDetails
                 {
-                    new RepoData
+                    Repos =
                     {
-                        Repo = "repo1",
-                        Images = new List<ImageData>
+                        new RepoData
                         {
-                            new ImageData
+                            Repo = "repo1",
+                            Images =
                             {
-                                Platforms = new List<PlatformData>
+                                new ImageData
                                 {
-                                    new PlatformData
+                                    Platforms =
                                     {
-                                        Dockerfile = "image1",
-                                        SimpleTags =
+                                        new PlatformData
                                         {
-                                            "newtag"
+                                            Dockerfile = "image1",
+                                            SimpleTags =
+                                            {
+                                                "newtag"
+                                            }
                                         }
                                     }
                                 }
                             }
-                        }
-                    },
-                    repo2 = new RepoData
-                    {
-                        Repo = "repo2",
-                        Images = new List<ImageData>
+                        },
                         {
-                            new ImageData
+                            repo2 = new RepoData
                             {
-                                Platforms = new List<PlatformData>
+                                Repo = "repo2",
+                                Images =
                                 {
-                                    new PlatformData
+                                    new ImageData
                                     {
-                                        Dockerfile = "image2",
-                                        SimpleTags =
+                                        Platforms =
                                         {
-                                            "tag1"
+                                            new PlatformData
+                                            {
+                                                Dockerfile = "image2",
+                                                SimpleTags =
+                                                {
+                                                    "tag1"
+                                                }
+                                            }
                                         }
                                     }
                                 }
@@ -80,25 +85,28 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 };
 
                 string file = Path.Combine(tempFolderContext.Path, "image-info.json");
-                File.WriteAllText(file, JsonHelper.SerializeObject(sourceRepos));
+                File.WriteAllText(file, JsonHelper.SerializeObject(srcImageArtifactDetails));
 
-                RepoData[] targetRepos = new RepoData[]
+                ImageArtifactDetails targetImageArtifactDetails = new ImageArtifactDetails
                 {
-                    new RepoData
+                    Repos =
                     {
-                        Repo = "repo1",
-                        Images = new List<ImageData>
+                        new RepoData
                         {
-                            new ImageData
+                            Repo = "repo1",
+                            Images =
                             {
-                                Platforms = new List<PlatformData>
+                                new ImageData
                                 {
-                                    new PlatformData
+                                    Platforms =
                                     {
-                                        Dockerfile = "image1",
-                                        SimpleTags =
+                                        new PlatformData
                                         {
-                                            "oldtag"
+                                            Dockerfile = "image1",
+                                            SimpleTags =
+                                            {
+                                                "oldtag"
+                                            }
                                         }
                                     }
                                 }
@@ -107,7 +115,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     }
                 };
 
-                Mock<IGitHubClient> gitHubClientMock = GetGitHubClientMock(targetRepos);
+                Mock<IGitHubClient> gitHubClientMock = GetGitHubClientMock(targetImageArtifactDetails);
 
                 Mock<IGitHubClientFactory> gitHubClientFactoryMock = new Mock<IGitHubClientFactory>();
                 gitHubClientFactoryMock
@@ -125,30 +133,33 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 command.LoadManifest();
                 await command.ExecuteAsync();
 
-                RepoData[] expectedRepos = new RepoData[]
+                ImageArtifactDetails expectedImageArtifactDetails = new ImageArtifactDetails
                 {
-                    new RepoData
+                    Repos =
                     {
-                        Repo = "repo1",
-                        Images = new List<ImageData>
+                        new RepoData
                         {
-                            new ImageData
+                            Repo = "repo1",
+                            Images =
                             {
-                                Platforms = new List<PlatformData>
+                                new ImageData
                                 {
-                                    new PlatformData
+                                    Platforms =
                                     {
-                                        Dockerfile = "image1",
-                                        SimpleTags =
+                                        new PlatformData
                                         {
-                                            "newtag"
+                                            Dockerfile = "image1",
+                                            SimpleTags =
+                                            {
+                                                "newtag"
+                                            }
                                         }
                                     }
                                 }
                             }
-                        }
-                    },
-                    repo2
+                        },
+                        repo2
+                    }
                 };
 
                 Func<GitObject[], bool> verifyGitObjects = (gitObjects) =>
@@ -158,7 +169,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         return false;
                     }
 
-                    return gitObjects[0].Content.Trim() == JsonHelper.SerializeObject(expectedRepos).Trim();
+                    return gitObjects[0].Content.Trim() == JsonHelper.SerializeObject(expectedImageArtifactDetails).Trim();
                 };
 
                 gitHubClientMock.Verify(
@@ -166,12 +177,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             }
         }
 
-        private static Mock<IGitHubClient> GetGitHubClientMock(RepoData[] targetRepos)
+        private static Mock<IGitHubClient> GetGitHubClientMock(ImageArtifactDetails imageArtifactDetails)
         {
             Mock<IGitHubClient> gitHubClientMock = new Mock<IGitHubClient>();
             gitHubClientMock
                 .Setup(o => o.GetGitHubFileContentsAsync(It.IsAny<string>(), It.IsAny<GitHubBranch>()))
-                .ReturnsAsync(JsonHelper.SerializeObject(targetRepos));
+                .ReturnsAsync(JsonHelper.SerializeObject(imageArtifactDetails));
 
             gitHubClientMock
                 .Setup(o => o.GetReferenceAsync(It.IsAny<GitHubProject>(), It.IsAny<string>()))


### PR DESCRIPTION
Stores a schema version in the image info file.  The previous root element of the image info file was a `RepoData` array which prevents a scalar property from being set on it.  So a new `ImageArtifactDetails`  element was defined as the root which contains a list of `RepoData` objects and the schema version.