### PR TITLE
Store product version in image info

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -97,7 +97,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
                 foreach (ImageInfo image in repoInfo.FilteredImages)
                 {
-                    ImageData imageData = new ImageData();
+                    ImageData imageData = new ImageData
+                    {
+                        ProductVersion = image.Model.ProductVersion
+                    };
                     repoData.Images.Add(imageData);
 
                     foreach (PlatformInfo platform in image.FilteredPlatforms)

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
@@ -104,9 +104,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             leg.Variables.Add(("osVersion", platformGrouping.Key.OsVersion ?? "*"));
         }
 
-        private string GetDotNetVersionFromPath(string dockerfilePath)
+        private string GetDotNetVersion(ImageInfo image)
         {
-            return dockerfilePath.Split(s_pathSeparators)[0];
+            Version version = Version.Parse(image.Model.ProductVersion);
+            return version.ToString(2); // Return major.minor
         }
 
         private void AddVersionedOsLegs(BuildMatrixInfo matrix, IGrouping<PlatformId, PlatformInfo> platformGrouping)
@@ -115,7 +116,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 .GroupBy(platform => new
                 {
                     // Assumption:  Dockerfile path format <ProductVersion>/<ImageVariant>/<OsVariant>/...
-                    DotNetVersion = GetDotNetVersionFromPath(platform.DockerfilePathRelativeToManifest),
+                    DotNetVersion = GetDotNetVersion(platform.Image),
                     OsVariant = platform.Model.OsVersion
                 });
             foreach (var versionGrouping in versionGroups)

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
@@ -5,8 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
@@ -116,7 +114,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 .GroupBy(platform => new
                 {
                     // Assumption:  Dockerfile path format <ProductVersion>/<ImageVariant>/<OsVariant>/...
-                    DotNetVersion = GetDotNetVersion(platform.Image),
+                    DotNetVersion = GetDotNetVersion(Manifest.GetImageByPlatform(platform)),
                     OsVariant = platform.Model.OsVersion
                 });
             foreach (var versionGrouping in versionGroups)

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/ImageData.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/ImageData.cs
@@ -15,6 +15,9 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Image
     {
         public List<PlatformData> Platforms { get; set; } = new List<PlatformData>();
 
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string ProductVersion { get; set; }
+
         /// <summary>
         /// Gets or sets a reference to the corresponding image definition in the manifest.
         /// </summary>

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/Image.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/Image.cs
@@ -24,6 +24,9 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Manifest
             "Linux-based tag.")]
         public IDictionary<string, Tag> SharedTags { get; set; }
 
+        [Description("The full version of the product that the Docker image contains.")]
+        public string ProductVersion { get; set; }
+
         public Image()
         {
         }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ImageInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ImageInfo.cs
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             }
 
             imageInfo.AllPlatforms = model.Platforms
-                .Select(platform => PlatformInfo.Create(platform, imageInfo, fullRepoModelName, repoName, variableHelper, baseDirectory))
+                .Select(platform => PlatformInfo.Create(platform, fullRepoModelName, repoName, variableHelper, baseDirectory))
                 .ToArray();
 
             IEnumerable<Platform> filteredPlatformModels = manifestFilter.GetPlatforms(model);

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ImageInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ImageInfo.cs
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             }
 
             imageInfo.AllPlatforms = model.Platforms
-                .Select(platform => PlatformInfo.Create(platform, fullRepoModelName, repoName, variableHelper, baseDirectory))
+                .Select(platform => PlatformInfo.Create(platform, imageInfo, fullRepoModelName, repoName, variableHelper, baseDirectory))
                 .ToArray();
 
             IEnumerable<Platform> filteredPlatformModels = manifestFilter.GetPlatforms(model);

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
@@ -93,6 +93,10 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         }
 
         public IEnumerable<ImageInfo> GetAllImages() => AllRepos.SelectMany(repo => repo.AllImages);
+        
+        public ImageInfo GetImageByPlatform(PlatformInfo platform) =>
+            GetAllImages()
+                .FirstOrDefault(image => image.AllPlatforms.Contains(platform));
 
         public IEnumerable<PlatformInfo> GetAllPlatforms() => GetAllImages().SelectMany(image => image.AllPlatforms);
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
@@ -32,7 +32,6 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         public IEnumerable<string> ExternalFromImages { get; private set; }
         public IEnumerable<string> InternalFromImages { get; private set; }
         public Platform Model { get; private set; }
-        public ImageInfo Image { get; private set; }
         public IEnumerable<string> OverriddenFromImages { get => _overriddenFromImages; }
         private string FullRepoModelName { get; set; }
         private string RepoName { get; set; }
@@ -40,12 +39,11 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         public IDictionary<string, CustomBuildLegGroupingInfo> CustomLegGroupings { get; private set; }
         private VariableHelper VariableHelper { get; set; }
 
-        public static PlatformInfo Create(Platform model, ImageInfo image, string fullRepoModelName, string repoName, VariableHelper variableHelper, string baseDirectory)
+        public static PlatformInfo Create(Platform model, string fullRepoModelName, string repoName, VariableHelper variableHelper, string baseDirectory)
         {
             PlatformInfo platformInfo = new PlatformInfo
             {
                 Model = model,
-                Image = image,
                 RepoName = repoName,
                 FullRepoModelName = fullRepoModelName,
                 VariableHelper = variableHelper

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
@@ -21,7 +21,6 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 
         private static readonly string s_argPattern = $"\\$(?<{ArgGroupName}>[\\w\\d-_]+)";
 
-        private readonly string baseDirectory;
         private List<string> _overriddenFromImages;
         private IEnumerable<string> internalRepos;
 
@@ -33,6 +32,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         public IEnumerable<string> ExternalFromImages { get; private set; }
         public IEnumerable<string> InternalFromImages { get; private set; }
         public Platform Model { get; private set; }
+        public ImageInfo Image { get; private set; }
         public IEnumerable<string> OverriddenFromImages { get => _overriddenFromImages; }
         private string FullRepoModelName { get; set; }
         private string RepoName { get; set; }
@@ -40,16 +40,12 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         public IDictionary<string, CustomBuildLegGroupingInfo> CustomLegGroupings { get; private set; }
         private VariableHelper VariableHelper { get; set; }
 
-        private PlatformInfo(string baseDirectory)
+        public static PlatformInfo Create(Platform model, ImageInfo image, string fullRepoModelName, string repoName, VariableHelper variableHelper, string baseDirectory)
         {
-            this.baseDirectory = baseDirectory;
-        }
-
-        public static PlatformInfo Create(Platform model, string fullRepoModelName, string repoName, VariableHelper variableHelper, string baseDirectory)
-        {
-            PlatformInfo platformInfo = new PlatformInfo(baseDirectory)
+            PlatformInfo platformInfo = new PlatformInfo
             {
                 Model = model,
+                Image = image,
                 RepoName = repoName,
                 FullRepoModelName = fullRepoModelName,
                 VariableHelper = variableHelper

--- a/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
@@ -59,6 +59,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 string dockerfileRelativePath = Path.Combine(runtimeRelativeDir, "Dockerfile");
                 File.WriteAllText(Path.Combine(tempFolderContext.Path, dockerfileRelativePath), $"FROM {baseImageTag}");
 
+                const string ProductVersion = "1.0.1";
+
                 Manifest manifest = CreateManifest(
                     CreateRepo(repoName,
                         CreateImage(
@@ -69,7 +71,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             new Dictionary<string, Tag>
                             {
                                 { "shared", new Tag() }
-                            }))
+                            },
+                            ProductVersion))
                 );
 
                 File.WriteAllText(Path.Combine(tempFolderContext.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));
@@ -88,6 +91,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             {
                                 new ImageData
                                 {
+                                    ProductVersion = ProductVersion,
                                     Platforms =
                                     {
                                         new PlatformData

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
@@ -52,10 +52,18 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Manifest manifest = ManifestHelper.CreateManifest(
                     ManifestHelper.CreateRepo("runtime-deps",
                         ManifestHelper.CreateImage(
-                            ManifestHelper.CreatePlatform(runtimeDepsRelativeDir, new string[] { "tag" }))),
+                            new Platform[]
+                            {
+                                ManifestHelper.CreatePlatform(runtimeDepsRelativeDir, new string[] { "tag" })
+                            },
+                            productVersion: "2.1.1")),
                     ManifestHelper.CreateRepo("runtime",
                         ManifestHelper.CreateImage(
-                            ManifestHelper.CreatePlatform(runtimeRelativeDir, new string[] { "runtime" })))
+                            new Platform[]
+                            {
+                                ManifestHelper.CreatePlatform(runtimeRelativeDir, new string[] { "runtime" })
+                            },
+                            productVersion: "2.2.3"))
                 );
 
                 File.WriteAllText(Path.Combine(tempFolderContext.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));

--- a/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ManifestHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ManifestHelper.cs
@@ -36,12 +36,13 @@ namespace Microsoft.DotNet.ImageBuilder.Tests.Helpers
         public static Image CreateImage(params Platform[] platforms) =>
             CreateImage(platforms, (IDictionary<string, Tag>)null);
 
-        public static Image CreateImage(Platform[] platforms, IDictionary<string, Tag> sharedTags)
+        public static Image CreateImage(Platform[] platforms, IDictionary<string, Tag> sharedTags, string productVersion = null)
         {
             return new Image
             {
                 Platforms = platforms,
-                SharedTags = sharedTags
+                SharedTags = sharedTags,
+                ProductVersion = productVersion
             };
         }
 

--- a/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ManifestHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ManifestHelper.cs
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests.Helpers
         public static Image CreateImage(params Platform[] platforms) =>
             CreateImage(platforms, (IDictionary<string, Tag>)null);
 
-        public static Image CreateImage(Platform[] platforms, IDictionary<string, Tag> sharedTags, string productVersion = null)
+        public static Image CreateImage(Platform[] platforms, IDictionary<string, Tag> sharedTags = null, string productVersion = null)
         {
             return new Image
             {


### PR DESCRIPTION
This allows us to associate each image defined in the image info file with a specific product version.  Having this data will allow for telemetry correlation between image pulls and product version.  The product version will need to be defined in the manifest which will then flow into the outputted image info file.

Related to #438 