### PR TITLE
Resolve variable refs in ProductVersion

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -99,7 +99,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 {
                     ImageData imageData = new ImageData
                     {
-                        ProductVersion = image.Model.ProductVersion
+                        ProductVersion = image.ProductVersion
                     };
                  	if (image.SharedTags.Any())
                     {

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
@@ -104,7 +104,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         private string GetDotNetVersion(ImageInfo image)
         {
-            Version version = Version.Parse(image.Model.ProductVersion);
+            Version version = Version.Parse(image.ProductVersion);
             return version.ToString(2); // Return major.minor
         }
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ImageInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ImageInfo.cs
@@ -22,6 +22,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 
         public Image Model { get; private set; }
         public IEnumerable<TagInfo> SharedTags { get; private set; }
+        public string ProductVersion { get; private set; }
 
         private ImageInfo()
         {
@@ -32,6 +33,8 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         {
             ImageInfo imageInfo = new ImageInfo();
             imageInfo.Model = model;
+
+            imageInfo.ProductVersion = variableHelper.SubstituteValues(model.ProductVersion);
 
             if (model.SharedTags == null)
             {

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
@@ -35,6 +35,11 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 
         public string SubstituteValues(string expression, Func<string, string, string> getContextBasedSystemValue = null)
         {
+            if (expression == null)
+            {
+                return null;
+            }
+
             foreach (Match match in Regex.Matches(expression, s_tagVariablePattern))
             {
                 string variableValue;


### PR DESCRIPTION
References to variables in the ProductVersion of the manifest were not being resolved to their underlying values.  This caused the consumers of the value from using the raw variable reference syntax value instead of the variable value.  Fixed by making the call to substitute variable values.