### PR TITLE
Include manifest digest in image info

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
@@ -31,14 +31,14 @@ namespace Microsoft.DotNet.ImageBuilder
             return Execute(info, info => ExecuteProcess(info), isDryRun, errorMessage, executeMessageOverride);
         }
 
-        public static void ExecuteWithRetry(
+        public static string ExecuteWithRetry(
             string fileName,
             string args,
             bool isDryRun,
             string errorMessage = null,
             string executeMessageOverride = null)
         {
-            ExecuteWithRetry(
+            return ExecuteWithRetry(
                 new ProcessStartInfo(fileName, args),
                 isDryRun: isDryRun,
                 errorMessage: errorMessage,

--- a/src/Microsoft.DotNet.ImageBuilder/src/IManifestToolService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/IManifestToolService.cs
@@ -2,10 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Newtonsoft.Json.Linq;
+
 namespace Microsoft.DotNet.ImageBuilder
 {
     public interface IManifestToolService
     {
         void PushFromSpec(string manifestFile, bool isDryRun);
+        JArray Inspect(string image, bool isDryRun);
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ManifestToolService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ManifestToolService.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel.Composition;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.DotNet.ImageBuilder
 {
@@ -14,6 +16,12 @@ namespace Microsoft.DotNet.ImageBuilder
             // ExecuteWithRetry because the manifest-tool fails periodically while communicating
             // with the Docker Registry.
             ExecuteHelper.ExecuteWithRetry("manifest-tool", $"push from-spec {manifestFile}", isDryRun);
+        }
+
+        public JArray Inspect(string image, bool isDryRun)
+        {
+            string output = ExecuteHelper.ExecuteWithRetry("manifest-tool", $"inspect {image} --raw", isDryRun);
+            return JsonConvert.DeserializeObject<JArray>(output);
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/ManifestData.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/ManifestData.cs
@@ -9,6 +9,7 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Image
 {
     public class ManifestData
     {
+        public string Digest { get; set; }
         public DateTime Created { get; set; }
         public List<string> SharedTags { get; set; } = new List<string>();
     }


### PR DESCRIPTION
Adds the manifest digest to the data being tracked in image info.

Related to #438