### PR TITLE
Fix parsing of product version

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             {
                                 ManifestHelper.CreatePlatform(runtimeRelativeDir, new string[] { "runtime" })
                             },
-                            productVersion: "2.2.3"))
+                            productVersion: "2.2.3-preview"))
                 );
 
                 File.WriteAllText(Path.Combine(tempFolderContext.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));


### PR DESCRIPTION
Matrix generation logic doesn't correctly handle parsing of the product versions defined in the manifest if the version string contains extra text besides digits and periods (e.g. 5.0.0-preview).

Fixed the parsing to use a regex for parsing instead so that it only grabs the first portion of the string.