### PR TITLE
Disable dotnet-docker/nightly branch subscription

### DIFF
--- a/eng/check-base-image-subscriptions.json
+++ b/eng/check-base-image-subscriptions.json
@@ -16,19 +16,6 @@
     "repoInfo": {
       "owner": "dotnet",
       "name": "dotnet-docker",
-      "branch": "nightly"
-    },
-    "manifestPath": "manifest.json",
-    "pipelineTrigger": {
-      "id": 359,
-      "pathVariable": "imageBuilder.pathArgs"
-    },
-    "osType": "linux"
-  },
-  {
-    "repoInfo": {
-      "owner": "dotnet",
-      "name": "dotnet-docker",
       "branch": "master"
     },
     "manifestPath": "manifest.samples.json",


### PR DESCRIPTION
The subscription is causing failures in the pipeline to check base image updates because the image info schema has changed.  Disabling for now.