### PR TITLE
Update schedule trigger for base image update pipeline

### DIFF
--- a/eng/pipelines/check-base-image-updates.yml
+++ b/eng/pipelines/check-base-image-updates.yml
@@ -1,6 +1,14 @@
 trigger: none
 pr: none
 
+schedules:
+- cron: "0 0,4,8,12,16,20 * * *"
+  displayName: Daily build
+  branches:
+    include:
+    - master
+    - feature/image-info-schema
+
 variables:
 - template: templates/variables/common.yml
 


### PR DESCRIPTION
The changes in https://github.com/dotnet/docker-tools/pull/452 were intended to setup scheduled builds for the feature/image-info-schema branch but AzDO doesn't support defining new build definitions that target a pipeline YAML file in a non-master branch if the same path exists in the master branch.  At least, that's my guess.  I had setup a new build definition that referenced the pipeline YAML file in that branch but it just ends up defaulting to the master branch where the scheduled trigger is defined for the feature/image-info-schema branch.  I've actually verified this by looking at the definition of the pipeline from the REST API and it doesn't even mention the feature/image-info-schema branch.  This resulted in no scheduled builds running for that branch.

To fix this, I'm updating the pipeline YAML file in the _master_ branch so that it includes the feature branch in the trigger.