### PR TITLE
Store commit URL in image info file

### DIFF
--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -35,6 +35,7 @@ jobs:
       --os-version "$(osVersion)"
       --architecture $(architecture)
       --retry
+      --source-repo $(publicGitRepoUri)
       $(imageBuilderBuildArgs)
       $(imageBuilderImageInfoArg)
     displayName: Build Images

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -61,6 +61,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 return;
             }
 
+            if (String.IsNullOrEmpty(Options.SourceRepoUrl))
+            {
+                throw new InvalidOperationException("Source repo URL must be provided when outputting to an image info file.");
+            }
+
             foreach (var platform in GetBuiltPlatforms())
             {
                 foreach (string tag in platform.FullyQualifiedSimpleTags)

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -25,14 +25,17 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private readonly IDockerService dockerService;
         private readonly ILoggerService loggerService;
         private readonly IEnvironmentService environmentService;
+        private readonly IGitService gitService;
         private readonly ImageArtifactDetails imageArtifactDetails = new ImageArtifactDetails();
 
         [ImportingConstructor]
-        public BuildCommand(IDockerService dockerService, ILoggerService loggerService, IEnvironmentService environmentService)
+        public BuildCommand(IDockerService dockerService, ILoggerService loggerService, IEnvironmentService environmentService,
+            IGitService gitService)
         {
             this.dockerService = dockerService ?? throw new ArgumentNullException(nameof(dockerService));
             this.loggerService = loggerService ?? throw new ArgumentNullException(nameof(loggerService));
             this.environmentService = environmentService ?? throw new ArgumentNullException(nameof(environmentService));
+            this.gitService = gitService ?? throw new ArgumentNullException(nameof(gitService));
         }
 
         public override Task ExecuteAsync()
@@ -90,6 +93,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     }
 
                     platform.Created = createdDate;
+
+                    PlatformInfo manifestPlatform = Manifest.GetFilteredPlatforms()
+                        .First(manifestPlatform => platform.Equals(manifestPlatform));
+
+                    platform.CommitUrl = gitService.GetDockerfileCommitUrl(manifestPlatform, Options.SourceRepoUrl);
                 }
             }
 
@@ -308,7 +316,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             .SelectMany(imageData => imageData.Platforms);
 
         private IEnumerable<string> GetBuiltTags() =>
-            GetBuiltPlatforms().SelectMany(image => image.AllTags);
+            GetBuiltPlatforms().SelectMany(platform => platform.AllTags);
 
         private void PushImages()
         {

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
@@ -8,13 +8,14 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     public class BuildOptions : DockerRegistryOptions, IFilterableOptions
     {
-        protected override string CommandHelp => "Builds and Tests Dockerfiles";
+        protected override string CommandHelp => "Builds Dockerfiles";
 
         public ManifestFilterOptions FilterOptions { get; } = new ManifestFilterOptions();
         public bool IsPushEnabled { get; set; }
         public bool IsRetryEnabled { get; set; }
         public bool IsSkipPullingEnabled { get; set; }
         public string ImageInfoOutputPath { get; set; }
+        public string SourceRepoUrl { get; set; }
 
         public BuildOptions() : base()
         {
@@ -41,6 +42,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             string imageInfoOutputPath = null;
             syntax.DefineOption("image-info-output-path", ref imageInfoOutputPath, "Path to output image info");
             ImageInfoOutputPath = imageInfoOutputPath;
+
+            string sourceRepoUrl = null;
+            syntax.DefineOption("source-repo", ref sourceRepoUrl, "Repo URL of the Dockerfile sources");
+            SourceRepoUrl = sourceRepoUrl;
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/GitServiceExtensions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/GitServiceExtensions.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.ImageBuilder.ViewModel;
+
+namespace Microsoft.DotNet.ImageBuilder
+{
+    public static class GitServiceExtensions
+    {
+        public static string GetDockerfileCommitUrl(
+            this IGitService gitService,
+            PlatformInfo platform,
+            string sourceRepoUrl,
+            string sourceBranch = null)
+        {
+            string branchOrShaPathSegment = sourceBranch ??
+                gitService.GetCommitSha(platform.DockerfilePath, useFullHash: true);
+
+            string dockerfileRelativePath = PathHelper.NormalizePath(platform.DockerfilePathRelativeToManifest);
+            return $"{sourceRepoUrl}/blob/{branchOrShaPathSegment}/{dockerfileRelativePath}";
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/McrTagsMetadataGenerator.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/McrTagsMetadataGenerator.cs
@@ -89,11 +89,7 @@ namespace Microsoft.DotNet.ImageBuilder
 
         private string GetTagGroupYaml(ImageDocumentationInfo info)
         {
-            string branchOrShaPathSegment = _sourceBranch ??
-                _gitService.GetCommitSha(info.Platform.DockerfilePath, useFullHash: true);
-
-            string dockerfileRelativePath = PathHelper.NormalizePath(info.Platform.DockerfilePathRelativeToManifest);
-            string dockerfilePath = $"{_sourceRepoUrl}/blob/{branchOrShaPathSegment}/{dockerfileRelativePath}";
+            string dockerfilePath = _gitService.GetDockerfileCommitUrl(info.Platform, _sourceRepoUrl, _sourceBranch);
 
             StringBuilder yaml = new StringBuilder();
             yaml.AppendLine($"  - tags: [ {info.FormattedDocumentedTags} ]");

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/PlatformData.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/PlatformData.cs
@@ -29,6 +29,8 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Image
 
         public DateTime Created { get; set; }
 
+        public string CommitUrl { get; set; }
+
         [JsonIgnore]
         public IEnumerable<string> FullyQualifiedSimpleTags { get; set; }
 

--- a/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
@@ -244,6 +244,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     gitServiceMock.Object);
                 command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
                 command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "image-info.json");
+                command.Options.SourceRepoUrl = "https://source";
 
                 Manifest manifest = CreateManifest(
                     CreateRepo("runtime",


### PR DESCRIPTION
Includes a `commitUrl` field in the image info file to provide a link to the specific Dockerfile the image was built from.

Fixes #438