### PR TITLE
Parameterize Linux AMD64 pool reference

### DIFF
--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -14,6 +14,9 @@ parameters:
   windowsAmdTestJobTimeout: 60
   windowsArmTestJobTimeout: 60
 
+  linuxAmdBuildPool: "Hosted Ubuntu 1604"
+  linuxAmdBuildQueue: ""
+
 stages:
 
 ################################################################################
@@ -32,7 +35,8 @@ stages:
     parameters:
       name: Build_Linux_amd64
       pool: # linuxAmd64Pool
-        name: Hosted Ubuntu 1604
+        name: ${{ parameters.linuxAmdBuildPool }}
+        queue: ${{ parameters.linuxAmdBuildQueue }}
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.LinuxAmd64']
       dockerClientOS: linux
       buildJobTimeout: ${{ parameters.linuxAmdBuildJobTimeout }}


### PR DESCRIPTION
This allows pipelines to customize which agent pool is used for building the Linux AMD64 legs.

This is related to https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/277 since those changes caused an issue with running out of disk space on the Hosted Ubuntu 16.04 pool.  These changes will allow a different pool to be used for that pipeline.