### PR TITLE
Clean old data from image info file on publish

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
@@ -216,7 +216,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 imageDataJson = await gitHubClient.GetGitHubFileContentsAsync(imageInfoPath, branch);
             }
 
-            return ImageInfoHelper.LoadFromContent(imageDataJson, manifest);
+            return ImageInfoHelper.LoadFromContent(imageDataJson, manifest, skipManifestValidation: true);
         }
 
         private async Task<string> GetGitRepoPath(Subscription sub)

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
@@ -133,7 +133,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     for (int platformIndex = imageData.Platforms.Count - 1; platformIndex >= 0; platformIndex--)
                     {
                         PlatformData platformData = imageData.Platforms[platformIndex];
-
                         PlatformInfo manifestPlatform = manifestImage.AllPlatforms
                             .FirstOrDefault(manifestPlatform => platformData.Equals(manifestPlatform));
 
@@ -143,18 +142,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                             imageData.Platforms.Remove(platformData);
                         }
                     }
-
-                    // If all of the image's platforms were removed, then remove the image too
-                    if (!imageData.Platforms.Any())
-                    {
-                        repoData.Images.Remove(imageData);
-                    }
-                }
-
-                // If all of the repo's images were removed, then remove the repo too
-                if (!repoData.Images.Any())
-                {
-                    imageArtifactDetails.Repos.Remove(repoData);
                 }
             }
         }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
@@ -3,13 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
+using Microsoft.DotNet.ImageBuilder.ViewModel;
 using Microsoft.DotNet.VersionTools.Automation.GitHubApi;
-using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
@@ -40,7 +39,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
                         if (originalTargetImageInfoContents != null)
                         {
-                            ImageArtifactDetails targetImageArtifactDetails = ImageInfoHelper.LoadFromContent(originalTargetImageInfoContents, Manifest);
+                            ImageArtifactDetails targetImageArtifactDetails = ImageInfoHelper.LoadFromContent(
+                                originalTargetImageInfoContents, Manifest, skipManifestValidation: true);
+
+                            RemoveOutOfDateContent(targetImageArtifactDetails);
 
                             ImageInfoMergeOptions options = new ImageInfoMergeOptions
                             {
@@ -99,6 +101,61 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         Logger.WriteMessage($"No changes to the '{imageInfoPathIdentifier}' file were needed.");
                     }
                 });
+            }
+        }
+
+        private void RemoveOutOfDateContent(ImageArtifactDetails imageArtifactDetails)
+        {
+            for (int repoIndex = imageArtifactDetails.Repos.Count - 1; repoIndex >= 0; repoIndex--)
+            {
+                RepoData repoData = imageArtifactDetails.Repos[repoIndex];
+                RepoInfo manifestRepo = Manifest.AllRepos.FirstOrDefault(manifestRepo => manifestRepo.Name == repoData.Repo);
+
+                // If there doesn't exist a matching repo in the manifest, remove it from the image info
+                if (manifestRepo is null)
+                {
+                    imageArtifactDetails.Repos.Remove(repoData);
+                    continue;
+                }
+
+                for (int imageIndex = repoData.Images.Count - 1; imageIndex >= 0; imageIndex--)
+                {
+                    ImageData imageData = repoData.Images[imageIndex];
+                    ImageInfo manifestImage = imageData.ManifestImage;
+
+                    // If there doesn't exist a matching image in the manifest, remove it from the image info
+                    if (manifestImage is null)
+                    {
+                        repoData.Images.Remove(imageData);
+                        continue;
+                    }
+                    
+                    for (int platformIndex = imageData.Platforms.Count - 1; platformIndex >= 0; platformIndex--)
+                    {
+                        PlatformData platformData = imageData.Platforms[platformIndex];
+
+                        PlatformInfo manifestPlatform = manifestImage.AllPlatforms
+                            .FirstOrDefault(manifestPlatform => platformData.Equals(manifestPlatform));
+
+                        // If there doesn't exist a matching platform in the manifest, remove it from the image info
+                        if (manifestPlatform is null)
+                        {
+                            imageData.Platforms.Remove(platformData);
+                        }
+                    }
+
+                    // If all of the image's platforms were removed, then remove the image too
+                    if (!imageData.Platforms.Any())
+                    {
+                        repoData.Images.Remove(imageData);
+                    }
+                }
+
+                // If all of the repo's images were removed, then remove the repo too
+                if (!repoData.Images.Any())
+                {
+                    imageArtifactDetails.Repos.Remove(repoData);
+                }
             }
         }
     }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.ImageBuilder
 {
     public static class ImageInfoHelper
     {
-        public static ImageArtifactDetails LoadFromContent(string imageInfoContent, ManifestInfo manifest)
+        public static ImageArtifactDetails LoadFromContent(string imageInfoContent, ManifestInfo manifest, bool skipManifestValidation = false)
         {
             ImageArtifactDetails imageArtifactDetails = JsonConvert.DeserializeObject<ImageArtifactDetails>(imageInfoContent);
 
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.ImageBuilder
                             }
                         }
 
-                        if (imageData.ManifestImage == null)
+                        if (!skipManifestValidation && imageData.ManifestImage == null)
                         {
                             throw new InvalidOperationException(
                                 $"Unable to find matching platform in manifest for platform '{platformData.GetIdentifier()}'.");

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/ImageData.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/ImageData.cs
@@ -24,6 +24,10 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Image
         /// <summary>
         /// Gets or sets a reference to the corresponding image definition in the manifest.
         /// </summary>
+        /// <remarks>
+        /// This can be null for an image info file that contains content for a platform that was once supported
+        /// but has since been removed from the manifest.
+        /// </remarks>
         [JsonIgnore]
         public ImageInfo ManifestImage { get; set; }
 
@@ -32,6 +36,11 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Image
             if (other is null)
             {
                 return 1;
+            }
+
+            if (ManifestImage is null || other.ManifestImage is null)
+            {
+                throw new InvalidOperationException($"Can't compare {nameof(ImageData)} objects if {nameof(ManifestImage)} is null.");
             }
 
             if (ManifestImage == other.ManifestImage)

--- a/src/Microsoft.DotNet.ImageBuilder/tests/ImageInfoHelperTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/ImageInfoHelperTests.cs
@@ -3,9 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
+using Microsoft.DotNet.ImageBuilder.ViewModel;
+using Moq;
 using Xunit;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
@@ -15,6 +16,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         [Fact]
         public void ImageInfoHelper_MergeRepos_ImageDigest()
         {
+            ImageInfo imageInfo1 = CreateImageInfo();
+
             ImageArtifactDetails imageArtifactDetails = new ImageArtifactDetails
             {
                 Repos =
@@ -26,6 +29,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             new ImageData
                             {
+                                ManifestImage = imageInfo1,
                                 Platforms =
                                 {
                                     new PlatformData
@@ -51,6 +55,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             new ImageData
                             {
+                                ManifestImage = imageInfo1,
                                 Platforms =
                                 {
                                     new PlatformData
@@ -116,6 +121,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             DateTime oldCreatedDate = DateTime.Now.Subtract(TimeSpan.FromDays(1));
             DateTime newCreatedDate = DateTime.Now;
 
+            ImageInfo imageInfo1 = CreateImageInfo();
+            ImageInfo imageInfo2 = CreateImageInfo();
+
             ImageArtifactDetails imageArtifactDetails = new ImageArtifactDetails
             {
                 Repos =
@@ -127,6 +135,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             new ImageData
                             {
+                                ManifestImage = imageInfo1,
                                 Platforms =
                                 {
                                     {
@@ -154,6 +163,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             new ImageData
                             {
+                                ManifestImage = imageInfo2,
                                 Platforms =
                                 {
                                     {
@@ -188,6 +198,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             new ImageData
                             {
+                                ManifestImage = imageInfo1,
                                 Platforms =
                                 {
                                     new PlatformData
@@ -273,6 +284,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             PlatformData srcImage1;
             PlatformData targetImage2;
 
+            ImageInfo imageInfo1 = CreateImageInfo();
+
             ImageArtifactDetails imageArtifactDetails = new ImageArtifactDetails
             {
                 Repos =
@@ -284,6 +297,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             new ImageData
                             {
+                                ManifestImage = imageInfo1,
                                 Platforms =
                                 {
                                     {
@@ -323,6 +337,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             new ImageData
                             {
+                                ManifestImage = imageInfo1,
                                 Platforms =
                                 {
                                     new PlatformData
@@ -417,6 +432,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             PlatformData srcPlatform1;
             PlatformData targetPlatform2;
 
+            ImageInfo imageInfo1 = CreateImageInfo();
+
             ImageArtifactDetails imageArtifactDetails = new ImageArtifactDetails
             {
                 Repos =
@@ -428,6 +445,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             new ImageData
                             {
+                                ManifestImage = imageInfo1,
                                 Platforms =
                                 {
                                     {
@@ -466,6 +484,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             new ImageData
                             {
+                                ManifestImage = imageInfo1,
                                 Platforms =
                                 {
                                     {
@@ -546,6 +565,20 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         public static void CompareImageArtifactDetails(ImageArtifactDetails expected, ImageArtifactDetails actual)
         {
             Assert.Equal(JsonHelper.SerializeObject(expected), JsonHelper.SerializeObject(actual));
+        }
+
+        private static ImageInfo CreateImageInfo()
+        {
+            return ImageInfo.Create(
+                new Image
+                {
+                    Platforms = Array.Empty<Platform>()
+                },
+                "fullrepo",
+                "repo",
+                new ManifestFilter(),
+                new VariableHelper(new Manifest(), Mock.Of<IManifestOptionsInfo>(), null),
+                "base");
         }
     }
 }


### PR DESCRIPTION
We want to ensure the published image info files contain data only for currently supported images.  The manifest represents what is currently supported.  This updates the publish logic to remove any content from the target image info file that isn't represented in the manifest.

Related to #436