### PR TITLE
Command to delete unnecessary images from ACR

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/AcrClient.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/AcrClient.cs
@@ -1,0 +1,128 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.DotNet.ImageBuilder.Models.Acr;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.ImageBuilder
+{
+    public class AcrClient : IAcrClient, IDisposable
+    {
+        private readonly HttpClient httpClient = new HttpClient();
+        private readonly string acrV1BaseUrl;
+        private readonly string acrV2BaseUrl;
+
+        private AcrClient(HttpClient httpClient,string acrName)
+        {
+            this.httpClient = httpClient;
+            this.acrV1BaseUrl = $"https://{acrName}/acr/v1";
+            this.acrV2BaseUrl = $"https://{acrName}/v2";
+        }
+
+        public async Task<Catalog> GetCatalogAsync()
+        {
+            HttpResponseMessage response = await this.httpClient.GetAsync($"{this.acrV1BaseUrl}/_catalog?n={Int32.MaxValue}");
+            response.EnsureSuccessStatusCode();
+            return JsonConvert.DeserializeObject<Catalog>(await response.Content.ReadAsStringAsync());
+        }
+
+        public async Task<Repository> GetRepositoryAsync(string name)
+        {
+            HttpResponseMessage response = await this.httpClient.GetAsync(
+                $"{this.acrV1BaseUrl}/{name}");
+            response.EnsureSuccessStatusCode();
+            return JsonConvert.DeserializeObject<Repository>(await response.Content.ReadAsStringAsync());
+        }
+
+        public async Task<DeleteRepositoryResponse> DeleteRepositoryAsync(string name)
+        {
+            HttpResponseMessage response = await this.httpClient.DeleteAsync(
+                $"{this.acrV1BaseUrl}/{name}");
+            response.EnsureSuccessStatusCode();
+            return JsonConvert.DeserializeObject<DeleteRepositoryResponse>(await response.Content.ReadAsStringAsync());
+        }
+
+        public async Task<RepositoryManifests> GetRepositoryManifests(string repositoryName)
+        {
+            HttpResponseMessage response = await this.httpClient.GetAsync(
+                $"{this.acrV1BaseUrl}/{repositoryName}/_manifests?n={Int32.MaxValue}");
+            response.EnsureSuccessStatusCode();
+            return JsonConvert.DeserializeObject<RepositoryManifests>(await response.Content.ReadAsStringAsync());
+        }
+
+        public async Task DeleteManifestAsync(string repositoryName, string digest)
+        {
+            HttpResponseMessage response = await this.httpClient.DeleteAsync(
+                $"{this.acrV2BaseUrl}/{repositoryName}/manifests/{digest}");
+            response.EnsureSuccessStatusCode();
+        }
+
+        public static async Task<IAcrClient> CreateAsync(string acrName, string tenant, string username, string password)
+        {
+            string aadAccessToken = await GetAadAccessTokenAsync(tenant, username, password);
+            
+            HttpClient httpClient = new HttpClient();
+            string acrRefreshToken = await GetAcrRefreshTokenAsync(httpClient, acrName, tenant, aadAccessToken);
+
+            string accessToken = await GetAcrAccessTokenAsync(
+                httpClient,
+                acrName,
+                acrRefreshToken,
+                "registry:catalog:*",
+                "repository:*:metadata_read",
+                "repository:*:delete");
+
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+            return new AcrClient(httpClient, acrName);
+        }
+
+        private static async Task<string> GetAadAccessTokenAsync(string tenant, string username, string password)
+        {
+            AuthenticationContext authContext = new AuthenticationContext($"https://login.microsoftonline.com/{tenant}");
+            AuthenticationResult result = await authContext.AcquireTokenAsync("https://management.azure.com", new ClientCredential(username, password));
+            return result.AccessToken;
+        }
+
+        private static async Task<string> GetAcrRefreshTokenAsync(HttpClient httpClient, string acrName, string tenant, string aadAccessToken)
+        {
+            StringContent oauthExchangeBody = new StringContent(
+                $"grant_type=access_token&service={acrName}&tenant={tenant}&access_token={aadAccessToken}",
+                Encoding.UTF8,
+                "application/x-www-form-urlencoded");
+
+            HttpResponseMessage tokenExchangeResponse = await httpClient.PostAsync($"https://{acrName}/oauth2/exchange", oauthExchangeBody);
+            tokenExchangeResponse.EnsureSuccessStatusCode();
+            OAuthExchangeResult acrRefreshTokenResult = JsonConvert.DeserializeObject<OAuthExchangeResult>(await tokenExchangeResponse.Content.ReadAsStringAsync());
+            return acrRefreshTokenResult.RefreshToken;
+        }
+
+        private static async Task<string> GetAcrAccessTokenAsync(HttpClient httpClient, string acrName, string refreshToken, params string[] scopes)
+        {
+            string scopesArgs = String.Join('&', scopes
+                .Select(scope => $"scope={scope}")
+                .ToArray());
+            StringContent oauthTokenBody = new StringContent(
+                $"grant_type=refresh_token&service={acrName}&{scopesArgs}&refresh_token={refreshToken}",
+                Encoding.UTF8,
+                "application/x-www-form-urlencoded");
+            HttpResponseMessage tokenResponse = await httpClient.PostAsync($"https://{acrName}/oauth2/token", oauthTokenBody);
+            tokenResponse.EnsureSuccessStatusCode();
+            OAuthTokenResult acrAccessTokenResult = JsonConvert.DeserializeObject<OAuthTokenResult>(await tokenResponse.Content.ReadAsStringAsync());
+            return acrAccessTokenResult.AccessToken;
+        }
+
+        public void Dispose()
+        {
+            this.httpClient.Dispose();
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/AcrClient.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/AcrClient.cs
@@ -88,24 +88,29 @@ namespace Microsoft.DotNet.ImageBuilder
         private static async Task<string> GetAadAccessTokenAsync(string tenant, string username, string password)
         {
             AuthenticationContext authContext = new AuthenticationContext($"https://login.microsoftonline.com/{tenant}");
-            AuthenticationResult result = await authContext.AcquireTokenAsync("https://management.azure.com", new ClientCredential(username, password));
+            AuthenticationResult result = await authContext.AcquireTokenAsync(
+                "https://management.azure.com", new ClientCredential(username, password));
             return result.AccessToken;
         }
 
-        private static async Task<string> GetAcrRefreshTokenAsync(HttpClient httpClient, string acrName, string tenant, string aadAccessToken)
+        private static async Task<string> GetAcrRefreshTokenAsync(
+            HttpClient httpClient, string acrName, string tenant, string aadAccessToken)
         {
             StringContent oauthExchangeBody = new StringContent(
                 $"grant_type=access_token&service={acrName}&tenant={tenant}&access_token={aadAccessToken}",
                 Encoding.UTF8,
                 "application/x-www-form-urlencoded");
 
-            HttpResponseMessage tokenExchangeResponse = await httpClient.PostAsync($"https://{acrName}/oauth2/exchange", oauthExchangeBody);
+            HttpResponseMessage tokenExchangeResponse = await httpClient.PostAsync(
+                $"https://{acrName}/oauth2/exchange", oauthExchangeBody);
             tokenExchangeResponse.EnsureSuccessStatusCode();
-            OAuthExchangeResult acrRefreshTokenResult = JsonConvert.DeserializeObject<OAuthExchangeResult>(await tokenExchangeResponse.Content.ReadAsStringAsync());
+            OAuthExchangeResult acrRefreshTokenResult = JsonConvert.DeserializeObject<OAuthExchangeResult>(
+                await tokenExchangeResponse.Content.ReadAsStringAsync());
             return acrRefreshTokenResult.RefreshToken;
         }
 
-        private static async Task<string> GetAcrAccessTokenAsync(HttpClient httpClient, string acrName, string refreshToken, params string[] scopes)
+        private static async Task<string> GetAcrAccessTokenAsync(
+            HttpClient httpClient, string acrName, string refreshToken, params string[] scopes)
         {
             string scopesArgs = String.Join('&', scopes
                 .Select(scope => $"scope={scope}")
@@ -116,7 +121,8 @@ namespace Microsoft.DotNet.ImageBuilder
                 "application/x-www-form-urlencoded");
             HttpResponseMessage tokenResponse = await httpClient.PostAsync($"https://{acrName}/oauth2/token", oauthTokenBody);
             tokenResponse.EnsureSuccessStatusCode();
-            OAuthTokenResult acrAccessTokenResult = JsonConvert.DeserializeObject<OAuthTokenResult>(await tokenResponse.Content.ReadAsStringAsync());
+            OAuthTokenResult acrAccessTokenResult = JsonConvert.DeserializeObject<OAuthTokenResult>(
+                await tokenResponse.Content.ReadAsStringAsync());
             return acrAccessTokenResult.AccessToken;
         }
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/AcrClientFactory.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/AcrClientFactory.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.ImageBuilder
+{
+    [Export(typeof(IAcrClientFactory))]
+    public class AcrClientFactory : IAcrClientFactory
+    {
+        public Task<IAcrClient> CreateAsync(string acrName, string tenant, string username, string password)
+        {
+            return AcrClient.CreateAsync(acrName, tenant, username, password);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesCommand.cs
@@ -1,0 +1,185 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.DotNet.ImageBuilder.Models.Acr;
+
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    [Export(typeof(ICommand))]
+    public class CleanAcrImagesCommand : Command<CleanAcrImagesOptions>
+    {
+        private readonly IAcrClientFactory acrClientFactory;
+        private readonly ILoggerService loggerService;
+
+        [ImportingConstructor]
+        public CleanAcrImagesCommand(IAcrClientFactory acrClientFactory, ILoggerService loggerService)
+        {
+            this.acrClientFactory = acrClientFactory ?? throw new ArgumentNullException(nameof(acrClientFactory));
+            this.loggerService = loggerService ?? throw new ArgumentNullException(nameof(loggerService));
+        }
+
+        public override async Task ExecuteAsync()
+        {
+            this.loggerService.WriteHeading("FINDING IMAGES TO CLEAN");
+
+            this.loggerService.WriteSubheading($"Connecting to ACR '{Options.RegistryName}'");
+            using IAcrClient acrClient = await this.acrClientFactory.CreateAsync(
+                Options.RegistryName, Options.Tenant, Options.Username, Options.Password);
+
+            this.loggerService.WriteSubheading($"Querying catalog of ACR '{Options.RegistryName}'");
+            Catalog catalog = await acrClient.GetCatalogAsync();
+
+            this.loggerService.WriteSubheading($"Querying repository details of ACR '{Options.RegistryName}'");
+            IEnumerable<Task<Repository>> getRepositoryTasks = catalog.RepositoryNames
+                .Where(repoName => !IsPublicRepo(repoName) || IsNightlyRepo(repoName))
+                .Select(repoName => acrClient.GetRepositoryAsync(repoName))
+                .ToArray();
+            await Task.WhenAll(getRepositoryTasks);
+            IEnumerable<Repository> repositories = getRepositoryTasks
+                .Select(task => task.Result)
+                .ToArray();
+
+            List<string> deletedRepos = new List<string>();
+            List<string> deletedImages = new List<string>();
+
+            this.loggerService.WriteHeading("DELETING IMAGES");
+            await Task.WhenAll(GetRepoProcessingTasks(acrClient, repositories, deletedRepos, deletedImages));
+
+            LogSummary(catalog, deletedRepos, deletedImages);
+        }
+
+        private IEnumerable<Task> GetRepoProcessingTasks(
+            IAcrClient acrClient, IEnumerable<Repository> repositories, List<string> deletedRepos, List<string> deletedImages)
+        {
+            int publicCount = 0;
+            int nonPublicCount = 0;
+            foreach (Repository repository in repositories)
+            {
+                if (IsPublicRepo(repository.Name))
+                {
+                    publicCount++;
+                    if (publicCount <= 2)
+                    {
+                        yield return ProcessPublicRepoAsync(acrClient, deletedImages, repository);
+                    }
+                }
+                else
+                {
+                    nonPublicCount++;
+                    if (nonPublicCount <= 20)
+                    {
+                        yield return ProcessNonPublicRepoAsync(acrClient, deletedRepos, repository);
+                    }
+                }
+            }
+        }
+
+        private void LogSummary(Catalog catalog, List<string> deletedRepos, List<string> deletedImages)
+        {
+            this.loggerService.WriteHeading("SUMMARY");
+
+            this.loggerService.WriteSubheading("Deleted repositories:");
+            foreach (string deletedRepo in deletedRepos)
+            {
+                this.loggerService.WriteMessage($"\t{deletedRepo}");
+            }
+
+            this.loggerService.WriteMessage();
+
+            this.loggerService.WriteSubheading("Deleted untagged images:");
+            foreach (string deletedImage in deletedImages)
+            {
+                this.loggerService.WriteMessage($"\t{deletedImage}");
+            }
+
+            this.loggerService.WriteMessage();
+
+            this.loggerService.WriteSubheading($"Total untagged images deleted: {deletedImages.Count}");
+            this.loggerService.WriteSubheading($"Total repos deleted: {deletedRepos.Count}");
+            this.loggerService.WriteSubheading($"Total repos remaining: {catalog.RepositoryNames.Length - deletedImages.Count}");
+        }
+
+        private async Task ProcessPublicRepoAsync(IAcrClient acrClient, List<string> deletedImages, Repository repository)
+        {
+            RepositoryManifests repoManifests = await acrClient.GetRepositoryManifests(repository.Name);
+
+            IEnumerable<Manifest> untaggedImages = repoManifests.Manifests
+                .Where(manifest => !manifest.Tags.Any() && IsExpired(manifest.LastUpdateTime, 30))
+                .Take(10);
+
+            List<Task> tasks = new List<Task>();
+            foreach (Manifest untaggedImage in untaggedImages)
+            {
+                tasks.Add(ProcessUntaggedImageAsync(acrClient, deletedImages, repository, untaggedImage));
+            }
+
+            await Task.WhenAll(tasks);
+        }
+
+        private async Task ProcessUntaggedImageAsync(IAcrClient acrClient, List<string> deletedImages, Repository repository, Manifest untaggedImage)
+        {
+            if (!Options.IsDryRun)
+            {
+                await acrClient.DeleteManifestAsync(repository.Name, untaggedImage.Digest);
+            }
+
+            string imageId = $"{repository.Name}@{untaggedImage.Digest}";
+
+            this.loggerService.WriteMessage($"Deleted untagged image '{imageId}'");
+
+            lock (deletedImages)
+            {
+                deletedImages.Add(imageId);
+            }
+        }
+
+        private async Task ProcessNonPublicRepoAsync(IAcrClient acrClient, List<string> deletedRepos, Repository repository)
+        {
+            if (IsExpired(repository.LastUpdateTime, 15))
+            {
+                if (!Options.IsDryRun)
+                {
+                    DeleteRepositoryResponse deleteResponse =
+                        await acrClient.DeleteRepositoryAsync(repository.Name);
+
+                    StringBuilder messageBuilder = new StringBuilder();
+                    messageBuilder.AppendLine($"Deleted repository '{repository.Name}'");
+                    messageBuilder.AppendLine($"\tIncluded manifests:");
+                    foreach (string manifest in deleteResponse.ManifestsDeleted)
+                    {
+                        messageBuilder.AppendLine($"\t{manifest}");
+                    }
+
+                    messageBuilder.AppendLine();
+                    messageBuilder.AppendLine($"\tIncluded tags:");
+                    foreach (string tag in deleteResponse.TagsDeleted)
+                    {
+                        messageBuilder.AppendLine($"\t{tag}");
+                    }
+
+                    this.loggerService.WriteMessage(messageBuilder.ToString());
+                }
+                else
+                {
+                    this.loggerService.WriteMessage($"Deleted repository '{repository.Name}'");
+                }
+
+                lock (deletedRepos)
+                {
+                    deletedRepos.Add(repository.Name);
+                }
+            }
+        }
+
+        private bool IsExpired(DateTime dateTime, int expirationDays) => dateTime.AddDays(expirationDays) < DateTime.Now;
+        private bool IsPublicRepo(string repoName) => repoName.StartsWith("public/");
+        private bool IsNightlyRepo(string repoName) => repoName.Contains("/core-nightly");
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesCommand.cs
@@ -221,7 +221,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private bool IsExpired(DateTime dateTime, int expirationDays) => dateTime.AddDays(expirationDays) < DateTime.Now;
         private bool IsStagingRepo(string repoName) => repoName.StartsWith("build-staging/");
         private bool IsPublicNightlyRepo(string repoName) =>
-            IsPublicRepo(repoName) && repoName.Contains("/core-nightly");
+            IsPublicRepo(repoName) && (repoName.Contains("/core-nightly/") || repoName.Contains("/nightly/"));
         private bool IsTestRepo(string repoName) => repoName.StartsWith("test/");
         private bool IsPublicRepo(string repoName) => repoName.StartsWith("public/");
     }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesCommand.cs
@@ -118,8 +118,18 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 return;
             }
 
-            IEnumerable<ManifestAttributes> expiredTestImages = repoManifests.Manifests
-                .Where(manifest => IsExpired(manifest.LastUpdateTime, 7));
+            ManifestAttributes[] expiredTestImages = repoManifests.Manifests
+                .Where(manifest => IsExpired(manifest.LastUpdateTime, 7))
+                .ToArray();
+
+            // If all the images in the repo are expired, delete the whole repo instead of 
+            // deleting each individual image.
+            if (expiredTestImages.Length == repoManifests.Manifests.Count)
+            {
+                await DeleteRepositoryAsync(acrClient, deletedRepos, repository);
+                return;
+            }
+
             await DeleteManifestsAsync(acrClient, deletedImages, repository, expiredTestImages);
         }
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesOptions.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.CommandLine;
+
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    public class CleanAcrImagesOptions : Options
+    {
+        protected override string CommandHelp => "Removes unnecessary images from an ACR";
+
+        public string Username { get; set; }
+        public string Password { get; set; }
+        public string Tenant { get; set; }
+        public string Subscription { get; set; }
+        public string ResourceGroup { get; set; }
+        public string RegistryName { get; set; }
+
+        public override void DefineParameters(ArgumentSyntax syntax)
+        {
+            base.DefineParameters(syntax);
+
+            string username = null;
+            syntax.DefineParameter("username", ref username, "The URL or name associated with the service principal to use");
+            Username = username;
+
+            string password = null;
+            syntax.DefineParameter("password", ref password, "The service principal password or the X509 certificate to use");
+            Password = password;
+
+            string tenant = null;
+            syntax.DefineParameter("tenant", ref tenant, "The tenant associated with the service principal to use");
+            Tenant = tenant;
+
+            string subscription = null;
+            syntax.DefineParameter("subscription", ref subscription, "Azure subscription to operate on");
+            Subscription = subscription;
+
+            string resourceGroup = null;
+            syntax.DefineParameter("resource-group", ref resourceGroup, "Azure resource group to operate on");
+            ResourceGroup = resourceGroup;
+
+            string registryName = null;
+            syntax.DefineParameter("registry", ref registryName, "Name of the registry");
+            RegistryName = registryName;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/IAcrClient.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/IAcrClient.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.DotNet.ImageBuilder.Models.Acr;
+
+namespace Microsoft.DotNet.ImageBuilder
+{
+    public interface IAcrClient : IDisposable
+    {
+        Task<Catalog> GetCatalogAsync();
+
+        Task<Repository> GetRepositoryAsync(string name);
+
+        Task<DeleteRepositoryResponse> DeleteRepositoryAsync(string name);
+
+        Task<RepositoryManifests> GetRepositoryManifests(string repositoryName);
+
+        Task DeleteManifestAsync(string repositoryName, string digest);
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/IAcrClient.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/IAcrClient.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.ImageBuilder
 
         Task<DeleteRepositoryResponse> DeleteRepositoryAsync(string name);
 
-        Task<RepositoryManifests> GetRepositoryManifests(string repositoryName);
+        Task<RepositoryManifests> GetRepositoryManifestsAsync(string repositoryName);
 
         Task DeleteManifestAsync(string repositoryName, string digest);
     }

--- a/src/Microsoft.DotNet.ImageBuilder/src/IAcrClientFactory.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/IAcrClientFactory.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.ImageBuilder
+{
+    public interface IAcrClientFactory
+    {
+        Task<IAcrClient> CreateAsync(string acrName, string tenant, string username, string password);
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Acr/Catalog.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Acr/Catalog.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.ImageBuilder.Models.Acr
+{
+    public class Catalog
+    {
+        [JsonProperty("repositories")]
+        public string[] RepositoryNames { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Acr/DeleteRepositoryResponse.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Acr/DeleteRepositoryResponse.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.DotNet.ImageBuilder.Models.Acr
+{
+    public class DeleteRepositoryResponse
+    {
+        public string[] ManifestsDeleted { get; set; } = Array.Empty<string>();
+        public string[] TagsDeleted { get; set; } = Array.Empty<string>();
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Acr/GetTagsResponse.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Acr/GetTagsResponse.cs
@@ -3,13 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.ImageBuilder.Models.Acr
 {
-    public class Catalog
+    public class GetTagsResponse
     {
-        [JsonProperty("repositories")]
-        public List<string> RepositoryNames { get; set; }
+        public string ImageName { get; set; }
+        public string Registry { get; set; }
+        public List<TagDetails> Tags { get; set; }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Acr/Manifest.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Acr/Manifest.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.DotNet.ImageBuilder.Models.Acr
+{
+    public class Manifest
+    {
+        public string[] Tags { get; set; } = Array.Empty<string>();
+        public string Digest { get; set; }
+        public DateTime LastUpdateTime { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Acr/ManifestAttributes.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Acr/ManifestAttributes.cs
@@ -2,14 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-using Newtonsoft.Json;
+using System;
 
 namespace Microsoft.DotNet.ImageBuilder.Models.Acr
 {
-    public class Catalog
+    public class ManifestAttributes
     {
-        [JsonProperty("repositories")]
-        public List<string> RepositoryNames { get; set; }
+        public string[] Tags { get; set; } = Array.Empty<string>();
+        public string Digest { get; set; }
+        public DateTime LastUpdateTime { get; set; }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Acr/OAuthExchangeResult.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Acr/OAuthExchangeResult.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.ImageBuilder.Models.Acr
+{
+    public class OAuthExchangeResult
+    {
+        [JsonProperty("refresh_token")]
+        public string RefreshToken { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Acr/OAuthTokenResult.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Acr/OAuthTokenResult.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.ImageBuilder.Models.Acr
+{
+    public class OAuthTokenResult
+    {
+        [JsonProperty("access_token")]
+        public string AccessToken { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Acr/Repository.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Acr/Repository.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.ImageBuilder.Models.Acr
+{
+    public class Repository
+    {
+        [JsonProperty("imageName")]
+        public string Name { get; set; }
+
+        public DateTime LastUpdateTime { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Acr/RepositoryManifests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Acr/RepositoryManifests.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.ImageBuilder.Models.Acr
+{
+    public class RepositoryManifests
+    {
+        [JsonProperty("imageName")]
+        public string RepositoryName { get; set; }
+
+        public Manifest[] Manifests { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Acr/RepositoryManifests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Acr/RepositoryManifests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.ImageBuilder.Models.Acr
@@ -11,6 +12,6 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Acr
         [JsonProperty("imageName")]
         public string RepositoryName { get; set; }
 
-        public Manifest[] Manifests { get; set; }
+        public List<ManifestAttributes> Manifests { get; set; }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Acr/TagDetails.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Acr/TagDetails.cs
@@ -2,14 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-
 namespace Microsoft.DotNet.ImageBuilder.Models.Acr
 {
-    public class Manifest
+    public class TagDetails
     {
-        public string[] Tags { get; set; } = Array.Empty<string>();
-        public string Digest { get; set; }
-        public DateTime LastUpdateTime { get; set; }
+        public string Name { get; set; }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/CleanAcrImagesCommandTest.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/CleanAcrImagesCommandTest.cs
@@ -1,0 +1,193 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.DotNet.ImageBuilder.Commands;
+using Microsoft.DotNet.ImageBuilder.Models.Acr;
+using Moq;
+using Xunit;
+
+namespace Microsoft.DotNet.ImageBuilder.Tests
+{
+    public class CleanAcrImagesCommandTest
+    {
+        [Fact]
+        public async Task NonPublicRepos()
+        {
+            const string acrName = "myacr.azurecr.io";
+            const string tenant = "mytenant";
+            const string username = "fake user";
+            const string password = "fake password";
+            const string subscription = "my sub";
+            const string resourceGroup = "group";
+
+            const string nonPublicRepo1Name = "repo1";
+            const string nonPublicRepo2Name = "repo2";
+
+            Catalog catalog = new Catalog
+            {
+                RepositoryNames = new string[]
+                {
+                    nonPublicRepo1Name,
+                    nonPublicRepo2Name
+                }
+            };
+
+            Repository nonPublicRepo1 = new Repository
+            {
+                LastUpdateTime = DateTime.Now.Subtract(TimeSpan.FromDays(14)),
+                Name = nonPublicRepo1Name
+            };
+
+            Repository nonPublicRepo2 = new Repository
+            {
+                LastUpdateTime = DateTime.Now.Subtract(TimeSpan.FromDays(16)),
+                Name = nonPublicRepo2Name
+            };
+
+            Mock<IAcrClient> acrClientMock = new Mock<IAcrClient>();
+            acrClientMock
+                .Setup(o => o.GetCatalogAsync())
+                .ReturnsAsync(catalog);
+            acrClientMock
+                .Setup(o => o.GetRepositoryAsync(nonPublicRepo1Name))
+                .ReturnsAsync(nonPublicRepo1);
+            acrClientMock
+                .Setup(o => o.GetRepositoryAsync(nonPublicRepo2Name))
+                .ReturnsAsync(nonPublicRepo2);
+            acrClientMock
+                .Setup(o => o.DeleteRepositoryAsync(nonPublicRepo2Name))
+                .ReturnsAsync(new DeleteRepositoryResponse());
+
+            Mock<IAcrClientFactory> acrClientFactoryMock = new Mock<IAcrClientFactory>();
+            acrClientFactoryMock
+                .Setup(o => o.CreateAsync(acrName, tenant, username, password))
+                .ReturnsAsync(acrClientMock.Object);
+
+            CleanAcrImagesCommand command = new CleanAcrImagesCommand(
+                acrClientFactoryMock.Object, Mock.Of<ILoggerService>());
+            command.Options.Subscription = subscription;
+            command.Options.Password = password;
+            command.Options.Username = username;
+            command.Options.Tenant = tenant;
+            command.Options.ResourceGroup = resourceGroup;
+            command.Options.RegistryName = acrName;
+
+            await command.ExecuteAsync();
+
+            acrClientMock.Verify(o => o.DeleteRepositoryAsync(nonPublicRepo1Name), Times.Never);
+            acrClientMock.Verify(o => o.DeleteRepositoryAsync(nonPublicRepo2Name));
+        }
+
+        [Fact]
+        public async Task PublicRepos()
+        {
+            const string acrName = "myacr.azurecr.io";
+            const string tenant = "mytenant";
+            const string username = "fake user";
+            const string password = "fake password";
+            const string subscription = "my sub";
+            const string resourceGroup = "group";
+
+            const string publicRepo1Name = "public/dotnet/core-nightly/repo1";
+            const string publicRepo2Name = "public/dotnet/core/repo2";
+            const string publicRepo3Name = "public/dotnet/core-nightly/repo3";
+
+            Catalog catalog = new Catalog
+            {
+                RepositoryNames = new string[]
+                {
+                    publicRepo1Name,
+                    publicRepo2Name,
+                    publicRepo3Name
+                }
+            };
+
+            const string repo1Digest1 = "sha256:repo1digest1";
+            const string repo1Digest2 = "sha256:repo1digest2";
+
+            RepositoryManifests repo1Manifests = new RepositoryManifests
+            {
+                RepositoryName = publicRepo1Name,
+                Manifests = new Manifest[]
+                {
+                    new Manifest
+                    {
+                        Digest = repo1Digest1,
+                        Tags = new string[0]
+                    },
+                    new Manifest
+                    {
+                        Digest = repo1Digest2,
+                        Tags = new string[]
+                        {
+                            "tag"
+                        }
+                    }
+                }
+            };
+
+            const string repo3Digest1 = "sha256:repo3digest1";
+            const string repo3Digest2 = "sha256:repo3digest2";
+
+            RepositoryManifests repo3Manifests = new RepositoryManifests
+            {
+                RepositoryName = publicRepo3Name,
+                Manifests = new Manifest[]
+                {
+                    new Manifest
+                    {
+                        Digest = repo3Digest1,
+                        Tags = new string[0]
+                    },
+                    new Manifest
+                    {
+                        Digest = repo3Digest2,
+                        Tags = new string[0]
+                    }
+                }
+            };
+
+            Mock<IAcrClient> acrClientMock = new Mock<IAcrClient>();
+            acrClientMock
+                .Setup(o => o.GetCatalogAsync())
+                .ReturnsAsync(catalog);
+            foreach (string repoName in catalog.RepositoryNames)
+            {
+                acrClientMock
+                    .Setup(o => o.GetRepositoryAsync(repoName))
+                    .ReturnsAsync(new Repository { Name = repoName });
+            }
+            acrClientMock
+                .Setup(o => o.GetRepositoryManifests(publicRepo1Name))
+                .ReturnsAsync(repo1Manifests);
+            acrClientMock
+                .Setup(o => o.GetRepositoryManifests(publicRepo3Name))
+                .ReturnsAsync(repo3Manifests);
+
+            Mock<IAcrClientFactory> acrClientFactoryMock = new Mock<IAcrClientFactory>();
+            acrClientFactoryMock
+                .Setup(o => o.CreateAsync(acrName, tenant, username, password))
+                .ReturnsAsync(acrClientMock.Object);
+
+            CleanAcrImagesCommand command = new CleanAcrImagesCommand(
+                acrClientFactoryMock.Object, Mock.Of<ILoggerService>());
+            command.Options.Subscription = subscription;
+            command.Options.Password = password;
+            command.Options.Username = username;
+            command.Options.Tenant = tenant;
+            command.Options.ResourceGroup = resourceGroup;
+            command.Options.RegistryName = acrName;
+
+            await command.ExecuteAsync();
+
+            acrClientMock.Verify(o => o.DeleteManifestAsync(publicRepo1Name, repo1Digest1));
+            acrClientMock.Verify(o => o.DeleteManifestAsync(publicRepo1Name, repo1Digest2), Times.Never);
+            acrClientMock.Verify(o => o.DeleteManifestAsync(publicRepo2Name, It.IsAny<string>()), Times.Never);
+            acrClientMock.Verify(o => o.DeleteManifestAsync(publicRepo3Name, repo3Digest1));
+            acrClientMock.Verify(o => o.DeleteManifestAsync(publicRepo3Name, repo3Digest2));
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/tests/CleanAcrImagesCommandTest.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/CleanAcrImagesCommandTest.cs
@@ -339,6 +339,88 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             acrClientMock.Verify(o => o.DeleteManifestAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
         }
 
+        /// <summary>
+        /// Validates that a test repo consisting of only expired images will result in the entire repo being deleted.
+        /// </summary>
+        [Fact]
+        public async Task DeleteAllExpiredImagesTestRepo()
+        {
+            const string acrName = "myacr.azurecr.io";
+            const string tenant = "mytenant";
+            const string username = "fake user";
+            const string password = "fake password";
+            const string subscription = "my sub";
+            const string resourceGroup = "group";
+
+            const string repo1Name = "test/repo1";
+
+            Catalog catalog = new Catalog
+            {
+                RepositoryNames = new List<string>
+                {
+                    repo1Name
+                }
+            };
+
+            const string repo1Digest1 = "sha256:repo1digest1";
+            const string repo1Digest2 = "sha256:repo1digest2";
+
+            RepositoryManifests repo1Manifests = new RepositoryManifests
+            {
+                RepositoryName = repo1Name,
+                Manifests = new List<ManifestAttributes>
+                {
+                    new ManifestAttributes
+                    {
+                        Digest = repo1Digest1,
+                        LastUpdateTime = DateTime.Now.Subtract(TimeSpan.FromDays(8))
+                    },
+                    new ManifestAttributes
+                    {
+                        Digest = repo1Digest2,
+                        LastUpdateTime = DateTime.Now.Subtract(TimeSpan.FromDays(9))
+                    }
+                }
+            };
+
+            Mock<IAcrClient> acrClientMock = new Mock<IAcrClient>();
+            acrClientMock
+                .Setup(o => o.GetCatalogAsync())
+                .ReturnsAsync(catalog);
+            acrClientMock
+                .Setup(o => o.DeleteRepositoryAsync(repo1Name))
+                .ReturnsAsync(new DeleteRepositoryResponse());
+
+            foreach (string repoName in catalog.RepositoryNames)
+            {
+                acrClientMock
+                    .Setup(o => o.GetRepositoryAsync(repoName))
+                    .ReturnsAsync(new Repository { Name = repoName });
+            }
+            acrClientMock
+                .Setup(o => o.GetRepositoryManifestsAsync(repo1Name))
+                .ReturnsAsync(repo1Manifests);
+
+            Mock<IAcrClientFactory> acrClientFactoryMock = new Mock<IAcrClientFactory>();
+            acrClientFactoryMock
+                .Setup(o => o.CreateAsync(acrName, tenant, username, password))
+                .ReturnsAsync(acrClientMock.Object);
+
+            CleanAcrImagesCommand command = new CleanAcrImagesCommand(
+                acrClientFactoryMock.Object, Mock.Of<ILoggerService>());
+            command.Options.Subscription = subscription;
+            command.Options.Password = password;
+            command.Options.Username = username;
+            command.Options.Tenant = tenant;
+            command.Options.ResourceGroup = resourceGroup;
+            command.Options.RegistryName = acrName;
+
+            await command.ExecuteAsync();
+
+            acrClientMock.Verify(o => o.DeleteRepositoryAsync(repo1Name));
+            acrClientMock.Verify(o => o.DeleteManifestAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        }
+
         [Fact]
         public async Task TestRepos()
         {

--- a/src/Microsoft.DotNet.ImageBuilder/tests/CleanAcrImagesCommandTest.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/CleanAcrImagesCommandTest.cs
@@ -129,6 +129,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             const string publicRepo1Name = "public/dotnet/core-nightly/repo1";
             const string publicRepo2Name = "public/dotnet/core/repo2";
             const string publicRepo3Name = "public/dotnet/core-nightly/repo3";
+            const string publicRepo4Name = "public/dotnet/nightly/repo4";
 
             Catalog catalog = new Catalog
             {
@@ -136,7 +137,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 {
                     publicRepo1Name,
                     publicRepo2Name,
-                    publicRepo3Name
+                    publicRepo3Name,
+                    publicRepo4Name
                 }
             };
 
@@ -189,6 +191,22 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
+            const string repo4Digest1 = "sha256:repo4digest1";
+
+            RepositoryManifests repo4Manifests = new RepositoryManifests
+            {
+                RepositoryName = publicRepo4Name,
+                Manifests = new List<ManifestAttributes>
+                {
+                    new ManifestAttributes
+                    {
+                        Digest = repo4Digest1,
+                        LastUpdateTime = DateTime.Now.Subtract(TimeSpan.FromDays(60)),
+                        Tags = new string[0]
+                    }
+                }
+            };
+
             Mock<IAcrClient> acrClientMock = new Mock<IAcrClient>();
             acrClientMock
                 .Setup(o => o.GetCatalogAsync())
@@ -205,6 +223,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             acrClientMock
                 .Setup(o => o.GetRepositoryManifestsAsync(publicRepo3Name))
                 .ReturnsAsync(repo3Manifests);
+            acrClientMock
+                .Setup(o => o.GetRepositoryManifestsAsync(publicRepo4Name))
+                .ReturnsAsync(repo4Manifests);
 
             Mock<IAcrClientFactory> acrClientFactoryMock = new Mock<IAcrClientFactory>();
             acrClientFactoryMock
@@ -227,6 +248,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             acrClientMock.Verify(o => o.DeleteManifestAsync(publicRepo2Name, It.IsAny<string>()), Times.Never);
             acrClientMock.Verify(o => o.DeleteManifestAsync(publicRepo3Name, repo3Digest1), Times.Never);
             acrClientMock.Verify(o => o.DeleteManifestAsync(publicRepo3Name, repo3Digest2));
+            acrClientMock.Verify(o => o.DeleteManifestAsync(publicRepo4Name, repo4Digest1));
         }
 
         /// <summary>


### PR DESCRIPTION
Adds a command that is intended to replace the logic in https://github.com/dotnet/docker-tools/blob/master/eng/Invoke-AcrCleanup.ps1.  It provides a parallel implementation to query and delete all unnecessary images from ACR in a much faster execution time.

There doesn't exist a .NET library for communicating with the ACR REST API so I had to implement my own.  Note that the [Container Registry REST API](https://docs.microsoft.com/en-us/rest/api/containerregistry/) isn't actually sufficient because that API only provides access for managing Azure resources.  But the things that we need to access are within the registry itself which is outside the jurisdiction of Azure resources.

Related to #419
Related to #461