### PR TITLE
Explicitly define manifest for merging image infos

### DIFF
--- a/eng/common/templates/jobs/post-build.yml
+++ b/eng/common/templates/jobs/post-build.yml
@@ -9,6 +9,7 @@ jobs:
       targetPath: $(Build.ArtifactStagingDirectory)
   - script: >
       $(runImageBuilderCmd) mergeImageInfo
+      --manifest $(manifest)
       $(artifactsPath)
       $(artifactsPath)/image-info.json
     displayName: Merge Image Info Files

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -63,6 +63,7 @@ jobs:
       $(dotnetDockerBot.email)
       $(BotAccount-dotnet-docker-bot-PAT)
       $(artifactsPath)/image-info.json
+      --manifest $(manifest)
       --git-owner dotnet
       --git-repo versions
       --git-branch master


### PR DESCRIPTION
The changes in #437 caused `MergeImageInfoCommand` to consume a manifest.  But the pipeline YAML wasn't updated to specify a manifest option.  So, by default, the command uses `manifest.json` as the manifest path.  This will break any scenario where the manifest is not at that path.

Updating the pipeline to explicitly set the manifest option.