### PR TITLE
Adds option to specify which version components are significant

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
@@ -116,8 +116,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             Match match = s_versionRegex.Match(image.ProductVersion);
             if (match.Success)
             {
+                if (Options.ProductVersionComponents <= 0)
+                {
+                    throw new InvalidOperationException($"The {nameof(Options.ProductVersionComponents)} option must be set to a value greater than zero.");
+                }
+
                 Version version = Version.Parse(match.Groups[VersionRegGroupName].Value);
-                return version.ToString(2); // Return major.minor
+                return version.ToString(Options.ProductVersionComponents); // Return major.minor
             }
 
             return null;            

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixOptions.cs
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 "Name of custom build leg grouping to use.");
             CustomBuildLegGrouping = customBuildLegGrouping;
 
-            int productVersionComponents = 0;
+            int productVersionComponents = 2;
             syntax.DefineOption(
                 "productVersionComponents",
                 ref productVersionComponents,

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixOptions.cs
@@ -10,11 +10,12 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     public class GenerateBuildMatrixOptions : ManifestOptions, IFilterableOptions
     {
-        protected override string CommandHelp => "Generate the VSTS build matrix for building the images";
+        protected override string CommandHelp => "Generate the Azure DevOps build matrix for building the images";
 
         public ManifestFilterOptions FilterOptions { get; } = new ManifestFilterOptions();
         public MatrixType MatrixType { get; set; }
         public string CustomBuildLegGrouping { get; set; }
+        public int ProductVersionComponents { get; set; }
 
         public GenerateBuildMatrixOptions() : base()
         {
@@ -40,6 +41,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 ref customBuildLegGrouping,
                 "Name of custom build leg grouping to use.");
             CustomBuildLegGrouping = customBuildLegGrouping;
+
+            int productVersionComponents = 0;
+            syntax.DefineOption(
+                "productVersionComponents",
+                ref productVersionComponents,
+                "Number of components of the product version considered to be significant");
+            ProductVersionComponents = productVersionComponents;
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
@@ -32,6 +32,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 GenerateBuildMatrixCommand command = new GenerateBuildMatrixCommand();
                 command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
                 command.Options.MatrixType = MatrixType.PlatformVersionedOs;
+                command.Options.ProductVersionComponents = 2;
                 if (filterPaths != null)
                 {
                     command.Options.FilterOptions.Paths = filterPaths.Replace("--path ", "").Split(" ");


### PR DESCRIPTION
The current logic for consuming the productVersion attribute from the manifest is broken because it only makes use of the major/minor components of the value.  That's fine for .NET Core but doesn't work for .NET Framework for framework versions like 4.7.2 where the "2" is significant in the generation of the matrix.  This results in incorrectly defined build/test legs.

Fixing this by adding an option to specify how many components of the product version are significant.