### PR TITLE
Update common build.ps1 scipt's handling of path arg

### DIFF
--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -16,7 +16,7 @@ param(
     # Type of architecture to filter by
     [string]$Architecture,
 
-    # Additional custom path filters (overrides Version)
+    # Additional custom path filter (overrides Version)
     [string]$Path,
 
     # Path to manifest file
@@ -58,7 +58,7 @@ try {
     }
 
     if ($Path) {
-        $args += " $Path"
+        $args += " --path $Path"
     }
     else {
         $args += " --path '$Version/*'"

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -16,8 +16,8 @@ param(
     # Type of architecture to filter by
     [string]$Architecture,
 
-    # Additional custom path filter (overrides Version)
-    [string]$Path,
+    # Additional custom path filters (overrides Version)
+    [string[]]$Paths,
 
     # Path to manifest file
     [string]$Manifest = "manifest.json",
@@ -57,8 +57,8 @@ try {
         $args += " --architecture $Architecture"
     }
 
-    if ($Path) {
-        $args += " --path $Path"
+    if ($Paths) {
+        $args += " --path " + ($Paths -join " --path ")
     }
     else {
         $args += " --path '$Version/*'"


### PR DESCRIPTION
The way the `Path` filter was being appended to the ImageBuilder args made it difficult and confusing to use.  The `--path` option wasn't being prepended so the user needed to include it in the arg value. It was in a way behaving no different than the `OptionalImageBuilderArgs` except that it overrode the `Version` arg.  I changed the behavior so that `--path` gets prepended to the arg value.