### PR TITLE
Specify product version components option for matrix

### DIFF
--- a/eng/common/templates/jobs/generate-matrix.yml
+++ b/eng/common/templates/jobs/generate-matrix.yml
@@ -16,6 +16,7 @@ jobs:
       --os-type '*'
       --architecture '*'
       --customBuildLegGrouping "${{ parameters.customBuildLegGrouping }}"
+      --productVersionComponents $(productVersionComponents)
       $(imageBuilder.pathArgs)
     displayName: Generate ${{ parameters.matrixType }} Matrix
     name: matrix

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -11,6 +11,8 @@ variables:
   value: ""
 - name: imageBuilderDockerRunExtraOptions
   value: ""
+- name: productVersionComponents
+  value: 2
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNet-Docker-Common
   - group: DotNet-Docker-Secrets


### PR DESCRIPTION
Set the product version components option as part of the pipeline when generating the build matrix.