### PR TITLE
Fix product version parsing for build matrix

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
@@ -122,7 +122,12 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 }
 
                 Version version = Version.Parse(match.Groups[VersionRegGroupName].Value);
-                return version.ToString(Options.ProductVersionComponents); // Return major.minor
+
+                // We can't call ToString with a number that's greater than the number of components in the actual
+                // version.  So we first need to determine how many components are in the version and then get the
+                // number of components specified in the options or contained by the actual version value, whichever is smaller.
+                int componentCount = Math.Min(version.ToString().Count(c => c == '.') + 1, Options.ProductVersionComponents);
+                return version.ToString(componentCount);
             }
 
             return null;            

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
@@ -22,9 +22,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// https://github.com/dotnet/docker-tools/issues/243
         /// </remarks>
         [Theory]
-        [InlineData(null, "--path 2.2/runtime/os --path 2.1/runtime-deps/os", "2.2")]
+        [InlineData(null, "--path 2.2/runtime/os --path 2.1.1/runtime-deps/os", "2.2")]
         [InlineData("--path 2.2/runtime/os", "--path 2.2/runtime/os", "2.2")]
-        [InlineData("--path 2.1/runtime-deps/os", "--path 2.1/runtime-deps/os", "2.1")]
+        [InlineData("--path 2.1.1/runtime-deps/os", "--path 2.1.1/runtime-deps/os", "2.1.1")]
         public void GenerateBuildMatrixCommand_PlatformVersionedOs(string filterPaths, string expectedPaths, string verificationLegName)
         {
             using (TempFolderContext tempFolderContext = TestHelper.UseTempFolder())
@@ -32,13 +32,13 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 GenerateBuildMatrixCommand command = new GenerateBuildMatrixCommand();
                 command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
                 command.Options.MatrixType = MatrixType.PlatformVersionedOs;
-                command.Options.ProductVersionComponents = 2;
+                command.Options.ProductVersionComponents = 3;
                 if (filterPaths != null)
                 {
                     command.Options.FilterOptions.Paths = filterPaths.Replace("--path ", "").Split(" ");
                 }
 
-                const string runtimeDepsRelativeDir = "2.1/runtime-deps/os";
+                const string runtimeDepsRelativeDir = "2.1.1/runtime-deps/os";
                 DirectoryInfo runtimeDepsDir = Directory.CreateDirectory(
                     Path.Combine(tempFolderContext.Path, runtimeDepsRelativeDir));
                 string dockerfileRuntimeDepsFullPath = Path.Combine(runtimeDepsDir.FullName, "Dockerfile");


### PR DESCRIPTION
Fix a parsing issue with the product version when generating a build matrix.  `Version.ToString(int)` doesn't allow a number to be passed that's greater than the number of components in the version.