### PR TITLE
Fix graph generation for base image change detection

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
@@ -143,7 +143,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             {
                 this.loggerService.WriteMessage(
                     $"WARNING: Image info not found for '{platform.DockerfilePath}'. Adding path to build to be queued anyway.");
-                pathsToRebuild.Add(platform.Model.Dockerfile);
+                IEnumerable<PlatformInfo> dependentPlatforms = platform.GetDependencyGraph(allPlatforms);
+                pathsToRebuild.AddRange(dependentPlatforms.Select(p => p.Model.Dockerfile));
             }
 
             if (repoData == null || repoData.Images == null)

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
@@ -129,8 +129,6 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         {
             string displayName;
             string os = Model.OsVersion;
-            Logger.WriteMessage($"os: {os}");
-            Logger.WriteMessage($"osType: {Model.OS}");
 
             if (Model.OS == OS.Windows)
             {


### PR DESCRIPTION
The logic in `GetStaleImagesCommand` produced an incorrect set of Dockerfile paths to be rebuild in the case where image info data didn't exist for a Dockerfile which other Dockerfiles were dependent upon.  For example, it there was no image data for a runtime-deps Dockerfile, then the command would only output that the runtime-deps Dockerfile needed to be rebuilt.  It didn't walk the graph and also output that runtime and aspnet also needed to be rebuilt.

There already existed logic for handling the graph walking when the image info _did_ exist but that wasn't executed for the scenario where it didn't exist.  Updated the logic to fix this.

Other changes:
* Added a test to catch this case and also fixed the logic in another test because it wasn't correctly constructing a graph of Dockerfiles.
* Removed some logging logic in `PlatformInfo.GetOSDisplayName` because that gets executed a lot when loading image info files now (not caused by these changes) which leads to a lot of unnecessary log output.