### PR TITLE
Clean out-of-date image info content on publish

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -118,7 +118,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             {
                 RepoData repoData = new RepoData
                 {
-                    Repo = repoInfo.Model.Name
+                    Repo = repoInfo.Name
                 };
                 imageArtifactDetails.Repos.Add(repoData);
 
@@ -191,7 +191,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                             .OrderBy(name => name)
                             .ToList();
                         platformData.FullyQualifiedSimpleTags = platformData.SimpleTags
-                            .Select(tag => TagInfo.GetFullyQualifiedName(repoInfo.Name, tag))
+                            .Select(tag => TagInfo.GetFullyQualifiedName(repoInfo.QualifiedName, tag))
                             .ToList();
                         platformData.AllTags = allTags;
                     }
@@ -356,7 +356,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 {
                     string fromRepo = DockerHelper.GetRepo(fromImage);
                     RepoInfo repo = Manifest.FilteredRepos.First(r => r.FullModelName == fromRepo);
-                    string newFromImage = DockerHelper.ReplaceRepo(fromImage, repo.Name);
+                    string newFromImage = DockerHelper.ReplaceRepo(fromImage, repo.QualifiedName);
                     this.loggerService.WriteMessage($"Replacing FROM `{fromImage}` with `{newFromImage}`");
                     Regex fromRegex = new Regex($@"FROM\s+{Regex.Escape(fromImage)}[^\S\r\n]*");
                     dockerfileContents = fromRegex.Replace(dockerfileContents, $"FROM {newFromImage}");

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
@@ -102,7 +102,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             // the manifest.
             if (imageArtifactDetails.Value != null)
             {
-                RepoData repoData = imageArtifactDetails.Value.Repos.FirstOrDefault(repoData => repoData.Repo == repo.Model.Name);
+                RepoData repoData = imageArtifactDetails.Value.Repos.FirstOrDefault(repoData => repoData.Repo == repo.Name);
                 if (repoData != null)
                 {
                     PlatformData platformData = repoData.Images
@@ -111,7 +111,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     if (platformData != null)
                     {
                         destTagNames = platformData.SimpleTags
-                            .Select(tag => TagInfo.GetFullyQualifiedName(repo.Name, tag));
+                            .Select(tag => TagInfo.GetFullyQualifiedName(repo.QualifiedName, tag));
                     }
                     else
                     {
@@ -121,7 +121,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 }
                 else
                 {
-                    Logger.WriteError($"Unable to find image info data for repo '{repo.Model.Name}'.");
+                    Logger.WriteError($"Unable to find image info data for repo '{repo.Name}'.");
                     this.environmentService.Exit(1);
                 }
             }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateTagsReadmeCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateTagsReadmeCommand.cs
@@ -78,7 +78,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     string outputPath = Path.Combine(tempDir, "output.md");
                     ExecuteHelper.Execute(
                         "docker",
-                        $"cp {renderingToolId}:/tableapp/files/{repo.Model.Name.Replace('/', '-')}.md {outputPath}",
+                        $"cp {renderingToolId}:/tableapp/files/{repo.Name.Replace('/', '-')}.md {outputPath}",
                         Options.IsDryRun
                     );
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
@@ -121,7 +121,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     .Where(platform => !platform.IsInternalFromImage(platform.FinalStageFromImage));
 
                 RepoData repoData = imageArtifactDetails.Repos
-                    .FirstOrDefault(s => s.Repo == repo.Model.Name);
+                    .FirstOrDefault(s => s.Repo == repo.Name);
 
                 foreach (PlatformInfo platform in platforms)
                 {

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ImageSizeCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ImageSizeCommand.cs
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 foreach (PlatformInfo platform in platforms)
                 {
                     string tagName = platform.Tags.First().FullyQualifiedName;
-                    processImage(repo.Model.Name, platform.Model.Dockerfile, tagName);
+                    processImage(repo.Name, platform.Model.Dockerfile, tagName);
                 }
             }
         }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestOptions.cs
@@ -16,7 +16,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public string RegistryOverride { get; set; }
         public string Repo { get; set; }
         public string RepoPrefix { get; set; }
-        public IDictionary<string, string> RepoOverrides { get; set; } = new Dictionary<string, string>();
         public IDictionary<string, string> Variables { get; set; } = new Dictionary<string, string>();
 
         protected ManifestOptions()
@@ -57,12 +56,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             string repo = null;
             syntax.DefineOption("repo", ref repo, "Repo to operate on (Default is all)");
             Repo = repo;
-
-            IReadOnlyList<string> repoOverrides = Array.Empty<string>();
-            syntax.DefineOptionList("repo-override", ref repoOverrides, "Alternative repos which overrides the manifest (<target repo>=<override>)");
-            RepoOverrides = repoOverrides
-                .Select(pair => pair.Split(new char[] { '=' }, 2))
-                .ToDictionary(split => split[0], split => split[1]);
 
             string repoPrefix = null;
             syntax.DefineOption("repo-prefix", ref repoPrefix, "Prefix to add to the repo names specified in the manifest");

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
@@ -109,7 +109,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             for (int repoIndex = imageArtifactDetails.Repos.Count - 1; repoIndex >= 0; repoIndex--)
             {
                 RepoData repoData = imageArtifactDetails.Repos[repoIndex];
-                RepoInfo manifestRepo = Manifest.AllRepos.FirstOrDefault(manifestRepo => manifestRepo.Name == repoData.Repo);
+                
+                // Since the registry name is not represented in the image info, make sure to compare the repo name with the
+                // manifest's repo model name which isn't registry-qualified.
+                RepoInfo manifestRepo = Manifest.AllRepos.FirstOrDefault(manifestRepo => manifestRepo.Model.Name == repoData.Repo);
 
                 // If there doesn't exist a matching repo in the manifest, remove it from the image info
                 if (manifestRepo is null)
@@ -143,6 +146,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         }
                     }
                 }
+            }
+
+            if (imageArtifactDetails.Repos.Count == 0)
+            {
+                // Failsafe to prevent wiping out the image info due to a bug in the logic
+                throw new InvalidOperationException(
+                    "Removal of out-of-date content resulted in there being no content remaining in the target image info file. Something is probably wrong with the logic.");
             }
         }
     }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
@@ -112,7 +112,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 
                 // Since the registry name is not represented in the image info, make sure to compare the repo name with the
                 // manifest's repo model name which isn't registry-qualified.
-                RepoInfo manifestRepo = Manifest.AllRepos.FirstOrDefault(manifestRepo => manifestRepo.Model.Name == repoData.Repo);
+                RepoInfo manifestRepo = Manifest.AllRepos.FirstOrDefault(manifestRepo => manifestRepo.Name == repoData.Repo);
 
                 // If there doesn't exist a matching repo in the manifest, remove it from the image info
                 if (manifestRepo is null)

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
@@ -7,6 +7,7 @@ using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
+using Microsoft.DotNet.ImageBuilder.ViewModel;
 using Microsoft.DotNet.VersionTools.Automation.GitHubApi;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
@@ -40,6 +41,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         {
                             ImageArtifactDetails targetImageArtifactDetails = ImageInfoHelper.LoadFromContent(
                                 originalTargetImageInfoContents, Manifest, skipManifestValidation: true);
+
+                            RemoveOutOfDateContent(targetImageArtifactDetails);
 
                             ImageInfoMergeOptions options = new ImageInfoMergeOptions
                             {
@@ -98,6 +101,48 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         Logger.WriteMessage($"No changes to the '{imageInfoPathIdentifier}' file were needed.");
                     }
                 });
+            }
+        }
+
+        private void RemoveOutOfDateContent(ImageArtifactDetails imageArtifactDetails)
+        {
+            for (int repoIndex = imageArtifactDetails.Repos.Count - 1; repoIndex >= 0; repoIndex--)
+            {
+                RepoData repoData = imageArtifactDetails.Repos[repoIndex];
+                RepoInfo manifestRepo = Manifest.AllRepos.FirstOrDefault(manifestRepo => manifestRepo.Name == repoData.Repo);
+
+                // If there doesn't exist a matching repo in the manifest, remove it from the image info
+                if (manifestRepo is null)
+                {
+                    imageArtifactDetails.Repos.Remove(repoData);
+                    continue;
+                }
+
+                for (int imageIndex = repoData.Images.Count - 1; imageIndex >= 0; imageIndex--)
+                {
+                    ImageData imageData = repoData.Images[imageIndex];
+                    ImageInfo manifestImage = imageData.ManifestImage;
+
+                    // If there doesn't exist a matching image in the manifest, remove it from the image info
+                    if (manifestImage is null)
+                    {
+                        repoData.Images.Remove(imageData);
+                        continue;
+                    }
+                    
+                    for (int platformIndex = imageData.Platforms.Count - 1; platformIndex >= 0; platformIndex--)
+                    {
+                        PlatformData platformData = imageData.Platforms[platformIndex];
+                        PlatformInfo manifestPlatform = manifestImage.AllPlatforms
+                            .FirstOrDefault(manifestPlatform => platformData.Equals(manifestPlatform));
+
+                        // If there doesn't exist a matching platform in the manifest, remove it from the image info
+                        if (manifestPlatform is null)
+                        {
+                            imageData.Platforms.Remove(platformData);
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsCommand.cs
@@ -80,7 +80,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         private string GetProductRepo()
         {
-            string firstRepoName = Manifest.AllRepos.First().Name
+            string firstRepoName = Manifest.AllRepos.First().QualifiedName
                 .TrimStart($"{Manifest.Registry}/");
             return firstRepoName.Substring(0, firstRepoName.LastIndexOf('/'));
         }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.ImageBuilder
 
             foreach (RepoData repoData in imageArtifactDetails.Repos)
             {
-                RepoInfo manifestRepo = manifest.AllRepos.FirstOrDefault(repo => repo.Model.Name == repoData.Repo);
+                RepoInfo manifestRepo = manifest.AllRepos.FirstOrDefault(repo => repo.Name == repoData.Repo);
                 if (manifestRepo == null)
                 {
                     continue;

--- a/src/Microsoft.DotNet.ImageBuilder/src/McrTagsMetadataGenerator.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/McrTagsMetadataGenerator.cs
@@ -80,7 +80,7 @@ namespace Microsoft.DotNet.ImageBuilder
         private static string GetRepoYaml(RepoInfo repo)
         {
             StringBuilder yaml = new StringBuilder();
-            yaml.AppendLine($"- repoName: public/{repo.Model.Name}");
+            yaml.AppendLine($"- repoName: public/{repo.Name}");
             yaml.AppendLine("  customTablePivots: true");
             yaml.Append("  tagGroups:");
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/IManifestOptionsInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/IManifestOptionsInfo.cs
@@ -11,7 +11,6 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
     {
         string Manifest { get; }
         string RegistryOverride { get; }
-        IDictionary<string, string> RepoOverrides { get; }
         string RepoPrefix { get; }
         IDictionary<string, string> Variables { get; }
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
@@ -78,7 +78,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
                     manifestInfo.Directory))
                 .ToArray();
 
-            IEnumerable<string> repoNames = manifestInfo.AllRepos.Select(repo => repo.Name).ToArray();
+            IEnumerable<string> repoNames = manifestInfo.AllRepos.Select(repo => repo.QualifiedName).ToArray();
             foreach (PlatformInfo platform in manifestInfo.GetAllPlatforms())
             {
                 platform.Initialize(repoNames, manifestInfo.Registry);

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/RepoInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/RepoInfo.cs
@@ -41,20 +41,15 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             VariableHelper variableHelper,
             string baseDirectory)
         {
-            RepoInfo repoInfo = new RepoInfo();
-            repoInfo.Model = model;
-            repoInfo.FullModelName = (string.IsNullOrEmpty(modelRegistryName) ? string.Empty : $"{modelRegistryName}/") + model.Name;
-            repoInfo.Id = model.Id ?? model.Name;
+            RepoInfo repoInfo = new RepoInfo
+            {
+                Model = model,
+                FullModelName = (string.IsNullOrEmpty(modelRegistryName) ? string.Empty : $"{modelRegistryName}/") + model.Name,
+                Id = model.Id ?? model.Name
+            };
 
-            if (options.RepoOverrides.TryGetValue(model.Name, out string nameOverride))
-            {
-                repoInfo.QualifiedName = nameOverride;
-            }
-            else
-            {
-                registry = string.IsNullOrEmpty(registry) ? string.Empty : $"{registry}/";
-                repoInfo.QualifiedName = registry + options.RepoPrefix + model.Name;
-            }
+            registry = string.IsNullOrEmpty(registry) ? string.Empty : $"{registry}/";
+            repoInfo.QualifiedName = registry + options.RepoPrefix + model.Name;
 
             repoInfo.AllImages = model.Images
                 .Select(image => ImageInfo.Create(image, repoInfo.FullModelName, repoInfo.QualifiedName, manifestFilter, variableHelper, baseDirectory))

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/RepoInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/RepoInfo.cs
@@ -24,7 +24,8 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 
         public string FullModelName { get; private set; }    
         public string Id { get; private set; }
-        public string Name { get; private set; }
+        public string QualifiedName { get; private set; }
+        public string Name => Model.Name;
         public Repo Model { get; private set; }
 
         private RepoInfo()
@@ -47,16 +48,16 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 
             if (options.RepoOverrides.TryGetValue(model.Name, out string nameOverride))
             {
-                repoInfo.Name = nameOverride;
+                repoInfo.QualifiedName = nameOverride;
             }
             else
             {
                 registry = string.IsNullOrEmpty(registry) ? string.Empty : $"{registry}/";
-                repoInfo.Name = registry + options.RepoPrefix + model.Name;
+                repoInfo.QualifiedName = registry + options.RepoPrefix + model.Name;
             }
 
             repoInfo.AllImages = model.Images
-                .Select(image => ImageInfo.Create(image, repoInfo.FullModelName, repoInfo.Name, manifestFilter, variableHelper, baseDirectory))
+                .Select(image => ImageInfo.Create(image, repoInfo.FullModelName, repoInfo.QualifiedName, manifestFilter, variableHelper, baseDirectory))
                 .ToArray();
 
             repoInfo.FilteredImages = repoInfo.AllImages

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
@@ -90,7 +90,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             }
             else if (string.Equals(variableType, RepoVariableTypeId, StringComparison.Ordinal))
             {
-                variableValue = GetRepoById(variableName)?.Name;
+                variableValue = GetRepoById(variableName)?.QualifiedName;
             }
             else if (getContextBasedSystemValue != null)
             {

--- a/src/Microsoft.DotNet.ImageBuilder/tests/McrTagsMetadataGeneratorTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/McrTagsMetadataGeneratorTests.cs
@@ -102,10 +102,6 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 .Returns(manifestPath);
 
             manifestOptionsMock
-                .SetupGet(o => o.RepoOverrides)
-                .Returns(new Dictionary<string, string>());
-
-            manifestOptionsMock
                 .Setup(o => o.GetManifestFilter())
                 .Returns(new ManifestFilter());
 

--- a/src/Microsoft.DotNet.ImageBuilder/tests/PublishImageInfoCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/PublishImageInfoCommandTests.cs
@@ -195,6 +195,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         CreateImage(
                             CreatePlatform(repo2Image2DockerfilePath, new string[0])))
                 );
+                manifest.Registry = "mcr.microsoft.com";
 
                 RepoData repo2;
 

--- a/src/Microsoft.DotNet.ImageBuilder/tests/PublishImageInfoCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/PublishImageInfoCommandTests.cs
@@ -176,6 +176,155 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             }
         }
 
+        /// <summary>
+        /// Verifies the command will remove any out-of-date content that exists within the target image info file,
+        /// meaning that it has content which isn't reflected in the manifest.
+        /// </summary>
+        [Fact]
+        public async Task PublishImageInfoCommand_RemoveOutOfDateContent()
+        {
+            using (TempFolderContext tempFolderContext = TestHelper.UseTempFolder())
+            {
+                string repo1Image1DockerfilePath = DockerfileHelper.CreateDockerfile("1.0/runtime/os", tempFolderContext);
+                string repo2Image2DockerfilePath = DockerfileHelper.CreateDockerfile("2.0/runtime/os", tempFolderContext);
+                Manifest manifest = CreateManifest(
+                    CreateRepo("repo1",
+                        CreateImage(
+                            CreatePlatform(repo1Image1DockerfilePath, new string[0]))),
+                    CreateRepo("repo2",
+                        CreateImage(
+                            CreatePlatform(repo2Image2DockerfilePath, new string[0])))
+                );
+
+                RepoData repo2;
+
+                ImageArtifactDetails srcImageArtifactDetails = new ImageArtifactDetails
+                {
+                    Repos =
+                    {
+                        new RepoData
+                        {
+                            Repo = "repo1",
+                            Images =
+                            {
+                                new ImageData
+                                {
+                                    Platforms =
+                                    {
+                                        Helpers.ImageInfoHelper.CreatePlatform(repo1Image1DockerfilePath)
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            repo2 = new RepoData
+                            {
+                                Repo = "repo2",
+                                Images =
+                                {
+                                    new ImageData
+                                    {
+                                        Platforms =
+                                        {
+                                            Helpers.ImageInfoHelper.CreatePlatform(repo2Image2DockerfilePath)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+
+                string file = Path.Combine(tempFolderContext.Path, "image-info.json");
+                File.WriteAllText(file, JsonHelper.SerializeObject(srcImageArtifactDetails));
+
+                ImageArtifactDetails targetImageArtifactDetails = new ImageArtifactDetails
+                {
+                    Repos =
+                    {
+                        new RepoData
+                        {
+                            Repo = "repo1",
+                            Images =
+                            {
+                                new ImageData
+                                {
+                                    Platforms =
+                                    {
+                                        Helpers.ImageInfoHelper.CreatePlatform(repo1Image1DockerfilePath)
+                                    }
+                                },
+                                new ImageData
+                                {
+                                    Platforms =
+                                    {
+                                        Helpers.ImageInfoHelper.CreatePlatform(
+                                            DockerfileHelper.CreateDockerfile("1.0/runtime2/os", tempFolderContext))
+                                    }
+                                }
+                            }
+                        },
+                        new RepoData
+                        {
+                            Repo = "repo4"
+                        }
+                    }
+                };
+
+                Mock<IGitHubClient> gitHubClientMock = GetGitHubClientMock(targetImageArtifactDetails);
+
+                Mock<IGitHubClientFactory> gitHubClientFactoryMock = new Mock<IGitHubClientFactory>();
+                gitHubClientFactoryMock
+                    .Setup(o => o.GetClient(It.IsAny<GitHubAuth>(), false))
+                    .Returns(gitHubClientMock.Object);
+
+                PublishImageInfoCommand command = new PublishImageInfoCommand(gitHubClientFactoryMock.Object);
+                command.Options.ImageInfoPath = file;
+                command.Options.GitOptions.AuthToken = "token";
+                command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
+
+                File.WriteAllText(Path.Combine(tempFolderContext.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));
+
+                command.LoadManifest();
+                await command.ExecuteAsync();
+
+                ImageArtifactDetails expectedImageArtifactDetails = new ImageArtifactDetails
+                {
+                    Repos =
+                    {
+                        new RepoData
+                        {
+                            Repo = "repo1",
+                            Images =
+                            {
+                                new ImageData
+                                {
+                                    Platforms =
+                                    {
+                                        Helpers.ImageInfoHelper.CreatePlatform(repo1Image1DockerfilePath)
+                                    }
+                                }
+                            }
+                        },
+                        repo2
+                    }
+                };
+
+                Func<GitObject[], bool> verifyGitObjects = (gitObjects) =>
+                {
+                    if (gitObjects.Length != 1)
+                    {
+                        return false;
+                    }
+
+                    return gitObjects[0].Content.Trim() == JsonHelper.SerializeObject(expectedImageArtifactDetails).Trim();
+                };
+
+                gitHubClientMock.Verify(
+                    o => o.PostTreeAsync(It.IsAny<GitHubProject>(), It.IsAny<string>(), It.Is<GitObject[]>(gitObjects => verifyGitObjects(gitObjects))));
+            }
+        }
+
         private static Mock<IGitHubClient> GetGitHubClientMock(ImageArtifactDetails imageArtifactDetails)
         {
             Mock<IGitHubClient> gitHubClientMock = new Mock<IGitHubClient>();


### PR DESCRIPTION
We want to ensure the published image info files contain data only for currently supported images. The manifest represents what is currently supported. This updates the publish logic to remove any content from the target image info file that isn't represented in the manifest.

This is mostly just restoring the code from https://github.com/dotnet/docker-tools/pull/459 but fixes the bug that was contained in it and updates the test to account for the bug.  The bug was that it was ending up not finding any matching content between the manifest and target image info file because repo names weren't being compared correctly.  This meant that the source image info would simply overwrite the contents of the target image info.

Fixes #436