### PR TITLE
Support manifest-specific image infos in ImageBuilder

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
@@ -209,7 +209,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             string imageDataJson;
             using (IGitHubClient gitHubClient = this.gitHubClientFactory.GetClient(Options.GitOptions.ToGitHubAuth(), Options.IsDryRun))
             {
-                GitHubProject project = new GitHubProject(subscription.ImageInfo.RepoName, subscription.ImageInfo.Owner);
+                GitHubProject project = new GitHubProject(subscription.ImageInfo.Repo, subscription.ImageInfo.Owner);
                 GitHubBranch branch = new GitHubBranch(subscription.ImageInfo.Branch, project);
 
                 GitFile repo = subscription.Manifest;
@@ -225,7 +225,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             await gitRepoPathSemaphore.WaitAsync();
             try
             {
-                string uniqueName = $"{sub.Manifest.Owner}-{sub.Manifest.RepoName}-{sub.Manifest.Branch}";
+                string uniqueName = $"{sub.Manifest.Owner}-{sub.Manifest.Repo}-{sub.Manifest.Branch}";
                 if (!this.gitRepoIdToPathMapping.TryGetValue(uniqueName, out repoPath))
                 {
                     string extractPath = Path.Combine(Path.GetTempPath(), uniqueName);
@@ -242,7 +242,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         File.Delete(zipPath);
                     }
 
-                    repoPath = Path.Combine(extractPath, $"{sub.Manifest.RepoName}-{sub.Manifest.Branch}");
+                    repoPath = Path.Combine(extractPath, $"{sub.Manifest.Repo}-{sub.Manifest.Branch}");
                     this.gitRepoIdToPathMapping.Add(uniqueName, repoPath);
                 }
             }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesOptions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         public ManifestFilterOptions FilterOptions { get; } = new ManifestFilterOptions();
 
-        public GitOptions GitOptions { get; } = GitOptions.GetVersionsRepoImageInfoOptions();
+        public GitOptions GitOptions { get; } = new GitOptions();
 
         public string SubscriptionsPath { get; set; }
         public string VariableName { get; set; }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GitOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GitOptions.cs
@@ -18,12 +18,16 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public string Repo { get; set; }
         public string Username { get; set; }
 
-        public GitOptions(string defaultOwner = "", string defaultRepo = "", string defaultBranch = "", string defaultPath = "")
+        public GitOptions()
         {
-            this.Owner = defaultOwner ?? throw new ArgumentNullException(nameof(defaultOwner));
-            this.Repo = defaultRepo ?? throw new ArgumentNullException(nameof(defaultRepo));
-            this.Branch = defaultBranch ?? throw new ArgumentNullException(nameof(defaultBranch));
-            this.Path = defaultPath ?? throw new ArgumentNullException(nameof(defaultPath));
+        }
+
+        public GitOptions(string defaultOwner, string defaultRepo, string defaultBranch, string defaultPath)
+        {
+            this.Owner = defaultOwner;
+            this.Repo = defaultRepo;
+            this.Branch = defaultBranch;
+            this.Path = defaultPath;
         }
 
         public void DefineOptions
@@ -33,28 +37,28 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             syntax.DefineOption(
                 "git-branch",
                 ref branch,
-                $"GitHub branch to write to (defaults to {branch})");
+                $"GitHub branch to write to (defaults to '{branch}')");
             Branch = branch;
 
             string owner = Owner;
             syntax.DefineOption(
                 "git-owner",
                 ref owner,
-                $"Owner of the GitHub repo to write to (defaults to {owner})");
+                $"Owner of the GitHub repo to write to (defaults to '{owner}')");
             Owner = owner;
 
             string path = Path;
             syntax.DefineOption(
                 "git-path",
                 ref path,
-                $"Path within the GitHub repo to write to (defaults to {path})");
+                $"Path within the GitHub repo to write to (defaults to '{path}')");
             Path = path;
 
             string repo = Repo;
             syntax.DefineOption(
                 "git-repo",
                 ref repo,
-                $"GitHub repo to write to (defaults to {repo})");
+                $"GitHub repo to write to (defaults to '{repo}')");
             Repo = repo;
         }
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GitOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GitOptions.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public string Repo { get; set; }
         public string Username { get; set; }
 
-        public GitOptions(string defaultOwner, string defaultRepo, string defaultBranch, string defaultPath)
+        public GitOptions(string defaultOwner = "", string defaultRepo = "", string defaultBranch = "", string defaultPath = "")
         {
             this.Owner = defaultOwner ?? throw new ArgumentNullException(nameof(defaultOwner));
             this.Repo = defaultRepo ?? throw new ArgumentNullException(nameof(defaultRepo));
@@ -86,8 +86,5 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             return new GitHubAuth(AuthToken, Username, Email);
         }
-
-        public static GitOptions GetVersionsRepoImageInfoOptions() =>
-            new GitOptions("dotnet", "versions", "master", "build-info/docker");
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoOptions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     {
         protected override string CommandHelp => "Publishes a build's merged image info.";
 
-        public GitOptions GitOptions { get; } = GitOptions.GetVersionsRepoImageInfoOptions();
+        public GitOptions GitOptions { get; } = new GitOptions();
 
         public string ImageInfoPath { get; set; }
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/QueueBuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/QueueBuildCommand.cs
@@ -105,7 +105,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 {
                     Project = new TeamProjectReference { Id = project.Id },
                     Definition = new BuildDefinitionReference { Id = subscription.PipelineTrigger.Id },
-                    SourceBranch = subscription.RepoInfo.Branch,
+                    SourceBranch = subscription.Manifest.Branch,
                     Parameters = parameters
                 };
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/GitHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/GitHelper.cs
@@ -29,9 +29,9 @@ namespace Microsoft.DotNet.ImageBuilder
                 $"Unable to retrieve the latest commit SHA for {filePath}");
         }
 
-        public static Uri GetArchiveUrl(GitRepo gitRepo)
+        public static Uri GetArchiveUrl(GitFile gitRepo)
         {
-            return new Uri($"https://github.com/{gitRepo.Owner}/{gitRepo.Name}/archive/{gitRepo.Branch}.zip");
+            return new Uri($"https://github.com/{gitRepo.Owner}/{gitRepo.RepoName}/archive/{gitRepo.Branch}.zip");
         }
 
         public static Uri GetBlobUrl(GitOptions gitOptions)

--- a/src/Microsoft.DotNet.ImageBuilder/src/GitHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/GitHelper.cs
@@ -29,9 +29,9 @@ namespace Microsoft.DotNet.ImageBuilder
                 $"Unable to retrieve the latest commit SHA for {filePath}");
         }
 
-        public static Uri GetArchiveUrl(GitFile gitRepo)
+        public static Uri GetArchiveUrl(GitFile gitFile)
         {
-            return new Uri($"https://github.com/{gitRepo.Owner}/{gitRepo.RepoName}/archive/{gitRepo.Branch}.zip");
+            return new Uri($"https://github.com/{gitFile.Owner}/{gitFile.Repo}/archive/{gitFile.Branch}.zip");
         }
 
         public static Uri GetBlobUrl(GitOptions gitOptions)

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Subscription/GitFile.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Subscription/GitFile.cs
@@ -6,15 +6,18 @@ using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.ImageBuilder.Models.Subscription
 {
-    public class GitRepo
+    public class GitFile
     {
         [JsonProperty(Required = Required.Always)]
         public string Owner { get; set; }
 
         [JsonProperty(Required = Required.Always)]
-        public string Name { get; set; }
+        public string RepoName { get; set; }
 
         [JsonProperty(Required = Required.Always)]
         public string Branch { get; set; }
+
+        [JsonProperty(Required = Required.Always)]
+        public string Path { get; set; }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Subscription/GitFile.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Subscription/GitFile.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Subscription
         public string Owner { get; set; }
 
         [JsonProperty(Required = Required.Always)]
-        public string RepoName { get; set; }
+        public string Repo { get; set; }
 
         [JsonProperty(Required = Required.Always)]
         public string Branch { get; set; }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Subscription/Subscription.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Subscription/Subscription.cs
@@ -9,17 +9,17 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Subscription
     public class Subscription
     {
         [JsonProperty(Required = Required.Always)]
-        public GitRepo RepoInfo { get; set; }
+        public GitFile Manifest { get; set; }
 
         [JsonProperty(Required = Required.Always)]
-        public string ManifestPath { get; set; }
+        public GitFile ImageInfo { get; set; }
 
         [JsonProperty(Required = Required.Always)]
         public PipelineTrigger PipelineTrigger { get; set; }
 
         public string OsType { get; set; }
 
-        public string Id => $"{RepoInfo.Owner}/{RepoInfo.Name}/{RepoInfo.Branch}/{ManifestPath}";
+        public string Id => $"{Manifest.Owner}/{Manifest.RepoName}/{Manifest.Branch}/{Manifest.Path}";
 
         public override string ToString() => Id;
     }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Subscription/Subscription.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Subscription/Subscription.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Subscription
 
         public string OsType { get; set; }
 
-        public string Id => $"{Manifest.Owner}/{Manifest.RepoName}/{Manifest.Branch}/{Manifest.Path}";
+        public string Id => $"{Manifest.Owner}/{Manifest.Repo}/{Manifest.Branch}/{Manifest.Path}";
 
         public override string ToString() => Id;
     }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
@@ -1241,7 +1241,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Manifest = new GitFile
                 {
                     Branch = "testBranch" + index,
-                    RepoName = repoName,
+                    Repo = repoName,
                     Owner = GetRepoOwner(testMethodName, index.ToString()),
                     Path = "testmanifest.json"
                 },
@@ -1249,7 +1249,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 {
 
                     Owner = GetStaleImagesCommandTests.GitHubOwner,
-                    RepoName = GetStaleImagesCommandTests.GitHubRepo,
+                    Repo = GetStaleImagesCommandTests.GitHubRepo,
                     Branch = GetStaleImagesCommandTests.GitHubBranch,
                     Path = "docker/image-info.json"
                 },
@@ -1418,7 +1418,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     string repoZipPath = GenerateRepoZipFile(subscription, subscriptionInfo.Manifest, repoDockerfileInfos);
 
                     responses.Add(
-                        $"https://github.com/{subscription.Manifest.Owner}/{subscription.Manifest.RepoName}/archive/{subscription.Manifest.Branch}.zip",
+                        $"https://github.com/{subscription.Manifest.Owner}/{subscription.Manifest.Repo}/archive/{subscription.Manifest.Branch}.zip",
                         new HttpResponseMessage
                         {
                             StatusCode = HttpStatusCode.OK,
@@ -1455,7 +1455,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
                 // Create a sub-folder inside the temp folder that represents the repo contents.
                 string repoPath = Directory.CreateDirectory(
-                    Path.Combine(tempDir, $"{subscription.Manifest.RepoName}-{subscription.Manifest.Branch}")).FullName;
+                    Path.Combine(tempDir, $"{subscription.Manifest.Repo}-{subscription.Manifest.Branch}")).FullName;
 
                 // Serialize the manifest model to a file in the repo folder.
                 string manifestPath = Path.Combine(repoPath, subscription.Manifest.Path);

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
@@ -31,6 +31,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 {
     public class GetStaleImagesCommandTests
     {
+        private const string GitHubBranch = "my-branch";
+        private const string GitHubRepo = "my-repo";
+        private const string GitHubOwner = "my-owner";
+
         /// <summary>
         /// Verifies the correct path arguments are passed to the queued build for a basic
         /// scenario involving one image that has changed.
@@ -80,11 +84,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 )
             };
 
-            Dictionary<GitRepo, List<DockerfileInfo>> dockerfileInfos =
-                new Dictionary<GitRepo, List<DockerfileInfo>>
+            Dictionary<GitFile, List<DockerfileInfo>> dockerfileInfos =
+                new Dictionary<GitFile, List<DockerfileInfo>>
             {
                 {
-                    subscriptionInfos[0].Subscription.RepoInfo,
+                    subscriptionInfos[0].Subscription.Manifest,
                     new List<DockerfileInfo>
                     {
                         new DockerfileInfo(dockerfile1Path, new FromImageInfo("base1", "base1digest")),
@@ -163,11 +167,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 )
             };
 
-            Dictionary<GitRepo, List<DockerfileInfo>> dockerfileInfos =
-                new Dictionary<GitRepo, List<DockerfileInfo>>
+            Dictionary<GitFile, List<DockerfileInfo>> dockerfileInfos =
+                new Dictionary<GitFile, List<DockerfileInfo>>
             {
                 {
-                    subscriptionInfos[0].Subscription.RepoInfo,
+                    subscriptionInfos[0].Subscription.Manifest,
                     new List<DockerfileInfo>
                     {
                         new DockerfileInfo(
@@ -230,11 +234,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 )
             };
 
-            Dictionary<GitRepo, List<DockerfileInfo>> dockerfileInfos =
-                new Dictionary<GitRepo, List<DockerfileInfo>>
+            Dictionary<GitFile, List<DockerfileInfo>> dockerfileInfos =
+                new Dictionary<GitFile, List<DockerfileInfo>>
             {
                 {
-                    subscriptionInfos[0].Subscription.RepoInfo,
+                    subscriptionInfos[0].Subscription.Manifest,
                     new List<DockerfileInfo>
                     {
                         new DockerfileInfo(dockerfile1Path, new FromImageInfo("base1", "base1digest")),
@@ -296,11 +300,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 )
             };
 
-            Dictionary<GitRepo, List<DockerfileInfo>> dockerfileInfos =
-                new Dictionary<GitRepo, List<DockerfileInfo>>
+            Dictionary<GitFile, List<DockerfileInfo>> dockerfileInfos =
+                new Dictionary<GitFile, List<DockerfileInfo>>
             {
                 {
-                    subscriptionInfos[0].Subscription.RepoInfo,
+                    subscriptionInfos[0].Subscription.Manifest,
                     new List<DockerfileInfo>
                     {
                         new DockerfileInfo(dockerfile1Path, new FromImageInfo("base1", "base1digest")),
@@ -353,11 +357,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 )
             };
 
-            Dictionary<GitRepo, List<DockerfileInfo>> dockerfileInfos =
-                new Dictionary<GitRepo, List<DockerfileInfo>>
+            Dictionary<GitFile, List<DockerfileInfo>> dockerfileInfos =
+                new Dictionary<GitFile, List<DockerfileInfo>>
             {
                 {
-                    subscriptionInfos[0].Subscription.RepoInfo,
+                    subscriptionInfos[0].Subscription.Manifest,
                     new List<DockerfileInfo>
                     {
                         new DockerfileInfo(dockerfile1Path, new FromImageInfo("base1", "base1digest")),
@@ -519,18 +523,18 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 )
             };
 
-            Dictionary<GitRepo, List<DockerfileInfo>> dockerfileInfos =
-                new Dictionary<GitRepo, List<DockerfileInfo>>
+            Dictionary<GitFile, List<DockerfileInfo>> dockerfileInfos =
+                new Dictionary<GitFile, List<DockerfileInfo>>
             {
                 {
-                    subscriptionInfos[0].Subscription.RepoInfo,
+                    subscriptionInfos[0].Subscription.Manifest,
                     new List<DockerfileInfo>
                     {
                         new DockerfileInfo(dockerfile1Path, new FromImageInfo("base1", "base1digest"))
                     }
                 },
                 {
-                    subscriptionInfos[1].Subscription.RepoInfo,
+                    subscriptionInfos[1].Subscription.Manifest,
                     new List<DockerfileInfo>
                     {
                         new DockerfileInfo(dockerfile2Path, new FromImageInfo("base2", "base2digest")),
@@ -618,11 +622,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             };
 
 
-            Dictionary<GitRepo, List<DockerfileInfo>> dockerfileInfos =
-                new Dictionary<GitRepo, List<DockerfileInfo>>
+            Dictionary<GitFile, List<DockerfileInfo>> dockerfileInfos =
+                new Dictionary<GitFile, List<DockerfileInfo>>
             {
                 {
-                    subscriptionInfos[0].Subscription.RepoInfo,
+                    subscriptionInfos[0].Subscription.Manifest,
                     new List<DockerfileInfo>
                     {
                         new DockerfileInfo(dockerfile1Path, new FromImageInfo(baseImage, baseImageDigest)),
@@ -705,11 +709,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 )
             };
 
-            Dictionary<GitRepo, List<DockerfileInfo>> dockerfileInfos =
-                new Dictionary<GitRepo, List<DockerfileInfo>>
+            Dictionary<GitFile, List<DockerfileInfo>> dockerfileInfos =
+                new Dictionary<GitFile, List<DockerfileInfo>>
             {
                 {
-                    subscriptionInfos[0].Subscription.RepoInfo,
+                    subscriptionInfos[0].Subscription.Manifest,
                     new List<DockerfileInfo>
                     {
                         new DockerfileInfo(dockerfile1Path, new FromImageInfo(baseImage, baseImageDigest))
@@ -832,11 +836,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 )
             };
 
-            Dictionary<GitRepo, List<DockerfileInfo>> dockerfileInfos =
-                new Dictionary<GitRepo, List<DockerfileInfo>>
+            Dictionary<GitFile, List<DockerfileInfo>> dockerfileInfos =
+                new Dictionary<GitFile, List<DockerfileInfo>>
             {
                 {
-                    subscriptionInfos[0].Subscription.RepoInfo,
+                    subscriptionInfos[0].Subscription.Manifest,
                     new List<DockerfileInfo>
                     {
                         new DockerfileInfo(runtimeDepsDockerfilePath, new FromImageInfo(baseImage, baseImageDigest)),
@@ -926,11 +930,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 )
             };
 
-            Dictionary<GitRepo, List<DockerfileInfo>> dockerfileInfos =
-                new Dictionary<GitRepo, List<DockerfileInfo>>
+            Dictionary<GitFile, List<DockerfileInfo>> dockerfileInfos =
+                new Dictionary<GitFile, List<DockerfileInfo>>
             {
                 {
-                    subscriptionInfos[0].Subscription.RepoInfo,
+                    subscriptionInfos[0].Subscription.Manifest,
                     new List<DockerfileInfo>
                     {
                         new DockerfileInfo(runtimeDepsDockerfilePath, new FromImageInfo(baseImage, baseImageDigest)),
@@ -1016,11 +1020,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 )
             };
 
-            Dictionary<GitRepo, List<DockerfileInfo>> dockerfileInfos =
-                new Dictionary<GitRepo, List<DockerfileInfo>>
+            Dictionary<GitFile, List<DockerfileInfo>> dockerfileInfos =
+                new Dictionary<GitFile, List<DockerfileInfo>>
             {
                 {
-                    subscriptionInfos[0].Subscription.RepoInfo,
+                    subscriptionInfos[0].Subscription.Manifest,
                     new List<DockerfileInfo>
                     {
                         new DockerfileInfo(dockerfile1Path, new FromImageInfo("base1", "base1digest")),
@@ -1094,11 +1098,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 )
             };
 
-            Dictionary<GitRepo, List<DockerfileInfo>> dockerfileInfos =
-                new Dictionary<GitRepo, List<DockerfileInfo>>
+            Dictionary<GitFile, List<DockerfileInfo>> dockerfileInfos =
+                new Dictionary<GitFile, List<DockerfileInfo>>
             {
                 {
-                    subscriptionInfos[0].Subscription.RepoInfo,
+                    subscriptionInfos[0].Subscription.Manifest,
                     new List<DockerfileInfo>
                     {
                         new DockerfileInfo(dockerfile1Path, new FromImageInfo("base2", "base2digest")),
@@ -1174,11 +1178,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 )
             };
 
-            Dictionary<GitRepo, List<DockerfileInfo>> dockerfileInfos =
-                new Dictionary<GitRepo, List<DockerfileInfo>>
+            Dictionary<GitFile, List<DockerfileInfo>> dockerfileInfos =
+                new Dictionary<GitFile, List<DockerfileInfo>>
             {
                 {
-                    subscriptionInfos[0].Subscription.RepoInfo,
+                    subscriptionInfos[0].Subscription.Manifest,
                     new List<DockerfileInfo>
                     {
                         new DockerfileInfo(dockerfile1Path, new FromImageInfo(null, null, isInternal: true)),
@@ -1229,17 +1233,25 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         {
             return new Subscription
             {
-                ManifestPath = "testmanifest.json",
                 PipelineTrigger = new PipelineTrigger
                 {
                     Id = 1,
                     PathVariable = "--my-path"
                 },
-                RepoInfo = new GitRepo
+                Manifest = new GitFile
                 {
                     Branch = "testBranch" + index,
-                    Name = repoName,
-                    Owner = GetRepoOwner(testMethodName, index.ToString())
+                    RepoName = repoName,
+                    Owner = GetRepoOwner(testMethodName, index.ToString()),
+                    Path = "testmanifest.json"
+                },
+                ImageInfo = new GitFile
+                {
+
+                    Owner = GetStaleImagesCommandTests.GitHubOwner,
+                    RepoName = GetStaleImagesCommandTests.GitHubRepo,
+                    Branch = GetStaleImagesCommandTests.GitHubBranch,
+                    Path = "docker/image-info.json"
                 },
                 OsType = osType
             };
@@ -1261,10 +1273,6 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             private readonly IGitHubClientFactory gitHubClientFactory;
 
             private const string VariableName = "my-var";
-            private const string GitHubBranch = "my-branch";
-            private const string GitHubRepo = "my-repo";
-            private const string GitHubOwner = "my-owner";
-            private const string GitHubPath = "my-path";
 
             public Mock<IDockerService> DockerServiceMock { get; }
 
@@ -1276,7 +1284,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             /// <param name="osType">The OS type to filter the command with.</param>
             public TestContext(
                 SubscriptionInfo[] subscriptionInfos,
-                Dictionary<GitRepo, List<DockerfileInfo>> dockerfileInfos,
+                Dictionary<GitFile, List<DockerfileInfo>> dockerfileInfos,
                 string osType = "*")
             {
                 this.osType = osType;
@@ -1356,10 +1364,6 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 command.Options.SubscriptionsPath = this.subscriptionsPath;
                 command.Options.VariableName = VariableName;
                 command.Options.FilterOptions.OsType = this.osType;
-                command.Options.GitOptions.Branch = GitHubBranch;
-                command.Options.GitOptions.Owner = GitHubOwner;
-                command.Options.GitOptions.Repo = GitHubRepo;
-                command.Options.GitOptions.Path = GitHubPath;
                 command.Options.GitOptions.Email = "test";
                 command.Options.GitOptions.Username = "test";
                 command.Options.GitOptions.AuthToken = "test";
@@ -1404,17 +1408,17 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             /// <param name="dockerfileInfos">A mapping of Git repos to their associated set of Dockerfiles.</param>
             private IHttpClientFactory CreateHttpClientFactory(
                 SubscriptionInfo[] subscriptionInfos,
-                Dictionary<GitRepo, List<DockerfileInfo>> dockerfileInfos)
+                Dictionary<GitFile, List<DockerfileInfo>> dockerfileInfos)
             {
                 Dictionary<string, HttpResponseMessage> responses = new Dictionary<string, HttpResponseMessage>();
                 foreach (SubscriptionInfo subscriptionInfo in subscriptionInfos)
                 {
                     Subscription subscription = subscriptionInfo.Subscription;
-                    List<DockerfileInfo> repoDockerfileInfos = dockerfileInfos[subscription.RepoInfo];
+                    List<DockerfileInfo> repoDockerfileInfos = dockerfileInfos[subscription.Manifest];
                     string repoZipPath = GenerateRepoZipFile(subscription, subscriptionInfo.Manifest, repoDockerfileInfos);
 
                     responses.Add(
-                        $"https://github.com/{subscription.RepoInfo.Owner}/{subscription.RepoInfo.Name}/archive/{subscription.RepoInfo.Branch}.zip",
+                        $"https://github.com/{subscription.Manifest.Owner}/{subscription.Manifest.RepoName}/archive/{subscription.Manifest.Branch}.zip",
                         new HttpResponseMessage
                         {
                             StatusCode = HttpStatusCode.OK,
@@ -1451,10 +1455,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
                 // Create a sub-folder inside the temp folder that represents the repo contents.
                 string repoPath = Directory.CreateDirectory(
-                    Path.Combine(tempDir, $"{subscription.RepoInfo.Name}-{subscription.RepoInfo.Branch}")).FullName;
+                    Path.Combine(tempDir, $"{subscription.Manifest.RepoName}-{subscription.Manifest.Branch}")).FullName;
 
                 // Serialize the manifest model to a file in the repo folder.
-                string manifestPath = Path.Combine(repoPath, subscription.ManifestPath);
+                string manifestPath = Path.Combine(repoPath, subscription.Manifest.Path);
                 File.WriteAllText(manifestPath, JsonConvert.SerializeObject(manifest));
 
                 foreach (DockerfileInfo dockerfileInfo in repoDockerfileInfos)
@@ -1512,7 +1516,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             private static bool FilterBuildToSubscription(Build build, Subscription subscription, IList<string> expectedPaths)
             {
                 return build.Definition.Id == subscription.PipelineTrigger.Id &&
-                    build.SourceBranch == subscription.RepoInfo.Branch &&
+                    build.SourceBranch == subscription.Manifest.Branch &&
                     FilterBuildToParameters(build.Parameters, subscription.PipelineTrigger.PathVariable, expectedPaths);
             }
 

--- a/src/Microsoft.DotNet.ImageBuilder/tests/PublishImageInfoCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/PublishImageInfoCommandTests.cs
@@ -128,6 +128,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 PublishImageInfoCommand command = new PublishImageInfoCommand(gitHubClientFactoryMock.Object);
                 command.Options.ImageInfoPath = file;
                 command.Options.GitOptions.AuthToken = "token";
+                command.Options.GitOptions.Repo = "testRepo";
+                command.Options.GitOptions.Branch = "testBranch";
+                command.Options.GitOptions.Path = "imageinfo.json";
                 command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
 
                 File.WriteAllText(Path.Combine(tempFolderContext.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));

--- a/src/Microsoft.DotNet.ImageBuilder/tests/QueueBuildCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/QueueBuildCommandTests.cs
@@ -284,14 +284,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Manifest = new GitFile
                 {
                     Branch = "testBranch" + index,
-                    RepoName = repoName,
+                    Repo = repoName,
                     Owner = GetRepoOwner(testMethodName, index.ToString()),
                     Path = "testmanifest.json"
                 },
                 ImageInfo = new GitFile
                 {
                     Owner = "dotnetOwner",
-                    RepoName = "versionsRepo",
+                    Repo = "versionsRepo",
                     Branch = "masterBranch",
                     Path = "docker/image-info.json"
                 }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/QueueBuildCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/QueueBuildCommandTests.cs
@@ -276,17 +276,24 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         {
             return new Subscription
             {
-                ManifestPath = "testmanifest.json",
                 PipelineTrigger = new PipelineTrigger
                 {
                     Id = 1,
                     PathVariable = "--my-path"
                 },
-                RepoInfo = new GitRepo
+                Manifest = new GitFile
                 {
                     Branch = "testBranch" + index,
-                    Name = repoName,
-                    Owner = GetRepoOwner(testMethodName, index.ToString())
+                    RepoName = repoName,
+                    Owner = GetRepoOwner(testMethodName, index.ToString()),
+                    Path = "testmanifest.json"
+                },
+                ImageInfo = new GitFile
+                {
+                    Owner = "dotnetOwner",
+                    RepoName = "versionsRepo",
+                    Branch = "masterBranch",
+                    Path = "docker/image-info.json"
                 }
             };
         }
@@ -461,7 +468,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             private static bool FilterBuildToSubscription(Build build, Subscription subscription, IList<string> expectedPaths)
             {
                 return build.Definition.Id == subscription.PipelineTrigger.Id &&
-                    build.SourceBranch == subscription.RepoInfo.Branch &&
+                    build.SourceBranch == subscription.Manifest.Branch &&
                     FilterBuildToParameters(build.Parameters, subscription.PipelineTrigger.PathVariable, expectedPaths);
             }
 


### PR DESCRIPTION
The changes in https://github.com/dotnet/docker-tools/pull/478 provide the logic to remove any content in an image file that isn't represented in the manifest.  The problem is that sample images are contained in a separate manifest but have their image info contained in the same file as the product.  This would cause the clean-up logic for publishing sample images to blow away the product image info content because it doesn't exist in the sample's manifest file (and vice versa with publishing product images).

This can be solved by having separate image info files that each correspond to a single manifest.  There should be a 1:1 correspondence to avoid issues.  These changes update Image Builder to support this.  The previous implementation was never great because knowledge of the image info file name was spread across both pipeline-related files and Image Builder code.  That implementation makes things even worse now when considering the need to vary an image info file's name by manifest.

The new design removes all derivation of image info file names from Image Builder.  It's now stored in the subscriptions file so that it is explicitly paired with the appropriate manifest file.  The publish job still needs to have knowledge of the path as well.