### PR TITLE
Support manifest-specific image infos in pipeline

### DIFF
--- a/eng/check-base-image-subscriptions.json
+++ b/eng/check-base-image-subscriptions.json
@@ -1,11 +1,17 @@
 [
   {
-    "repoInfo": {
+    "manifest": {
       "owner": "dotnet",
-      "name": "dotnet-docker",
-      "branch": "master"
+      "repoName": "dotnet-docker",
+      "branch": "master",
+      "path": "manifest.json"
     },
-    "manifestPath": "manifest.json",
+    "imageInfo": {
+      "owner": "dotnet",
+      "repoName": "versions",
+      "branch": "dev/mthalman/image-info-test",
+      "path": "build-info/docker/image-info.dotnet-dotnet-docker-master.json"
+    },
     "pipelineTrigger": {
       "id": 373,
       "pathVariable": "imageBuilder.pathArgs"
@@ -13,12 +19,18 @@
     "osType": "linux"
   },
   {
-    "repoInfo": {
+    "manifest": {
       "owner": "dotnet",
-      "name": "dotnet-docker",
-      "branch": "nightly"
+      "repoName": "dotnet-docker",
+      "branch": "nightly",
+      "path": "manifest.json"
     },
-    "manifestPath": "manifest.json",
+    "imageInfo": {
+      "owner": "dotnet",
+      "repoName": "versions",
+      "branch": "dev/mthalman/image-info-test",
+      "path": "build-info/docker/image-info.dotnet-dotnet-docker-nightly.json"
+    },
     "pipelineTrigger": {
       "id": 359,
       "pathVariable": "imageBuilder.pathArgs"
@@ -26,24 +38,36 @@
     "osType": "linux"
   },
   {
-    "repoInfo": {
+    "manifest": {
       "owner": "dotnet",
-      "name": "dotnet-docker",
-      "branch": "master"
+      "repoName": "dotnet-docker",
+      "branch": "nightly",
+      "path": "manifest.samples.json"
     },
-    "manifestPath": "manifest.samples.json",
+    "imageInfo": {
+      "owner": "dotnet",
+      "repoName": "versions",
+      "branch": "dev/mthalman/image-info-test",
+      "path": "build-info/docker/image-info.dotnet-dotnet-docker-master-samples.json"
+    },
     "pipelineTrigger": {
       "id": 376,
       "pathVariable": "imageBuilder.pathArgs"
     }
   },
   {
-    "repoInfo": {
+    "manifest": {
       "owner": "Microsoft",
-      "name": "dotnet-framework-docker",
-      "branch": "master"
+      "repoName": "dotnet-framework-docker",
+      "branch": "master",
+      "path": "manifest.samples.json"
     },
-    "manifestPath": "manifest.samples.json",
+    "imageInfo": {
+      "owner": "dotnet",
+      "repoName": "versions",
+      "branch": "dev/mthalman/image-info-test",
+      "path": "build-info/docker/image-info.Microsoft-dotnet-framework-docker-master-samples.json"
+    },
     "pipelineTrigger": {
       "id": 374,
       "pathVariable": "imageBuilder.pathArgs"

--- a/eng/check-base-image-subscriptions.json
+++ b/eng/check-base-image-subscriptions.json
@@ -9,7 +9,7 @@
     "imageInfo": {
       "owner": "dotnet",
       "repoName": "versions",
-      "branch": "dev/mthalman/image-info-test",
+      "branch": "master",
       "path": "build-info/docker/image-info.dotnet-dotnet-docker-master.json"
     },
     "pipelineTrigger": {
@@ -28,7 +28,7 @@
     "imageInfo": {
       "owner": "dotnet",
       "repoName": "versions",
-      "branch": "dev/mthalman/image-info-test",
+      "branch": "master",
       "path": "build-info/docker/image-info.dotnet-dotnet-docker-nightly.json"
     },
     "pipelineTrigger": {
@@ -47,7 +47,7 @@
     "imageInfo": {
       "owner": "dotnet",
       "repoName": "versions",
-      "branch": "dev/mthalman/image-info-test",
+      "branch": "master",
       "path": "build-info/docker/image-info.dotnet-dotnet-docker-master-samples.json"
     },
     "pipelineTrigger": {
@@ -65,7 +65,7 @@
     "imageInfo": {
       "owner": "dotnet",
       "repoName": "versions",
-      "branch": "dev/mthalman/image-info-test",
+      "branch": "master",
       "path": "build-info/docker/image-info.Microsoft-dotnet-framework-docker-master-samples.json"
     },
     "pipelineTrigger": {

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -67,7 +67,7 @@ jobs:
       --git-owner dotnet
       --git-repo versions
       --git-branch master
-      --git-path build-info/docker/image-info.$(Build.Repository.Name)-$(publicSourceBranch).json
+      --git-path build-info/docker/image-info.$(Build.Repository.Name)-$(publicSourceBranch)$(imageInfoVariant).json
       $(dryRunArg)
     displayName: Publish Image Info
   - publish: $(Build.ArtifactStagingDirectory)/image-info.json

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -13,6 +13,8 @@ variables:
   value: ""
 - name: productVersionComponents
   value: 2
+- name: imageInfoVariant
+  value: ""
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNet-Docker-Common
   - group: DotNet-Docker-Secrets

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,6 +1,6 @@
 variables:
-  imageNames.imageBuilder.linux: mcr.microsoft.com/dotnet-buildtools/image-builder:debian-20200409184943
-  imageNames.imageBuilder.windows: mcr.microsoft.com/dotnet-buildtools/image-builder:nanoserver-20200409184943
+  imageNames.imageBuilder.linux: mcr.microsoft.com/dotnet-buildtools/image-builder:debian-20200416172807
+  imageNames.imageBuilder.windows: mcr.microsoft.com/dotnet-buildtools/image-builder:nanoserver-20200416172807
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch-slim-docker-testrunner-d61254f-20190807161111
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/eng/pipelines/templates/steps/get-stale-images.yml
+++ b/eng/pipelines/templates/steps/get-stale-images.yml
@@ -18,10 +18,6 @@ steps:
       --subscriptions-path $(checkBaseImageSubscriptionsPath)
       --os-type ${{ parameters.osType }}
       --architecture ${{ parameters.architecture }}
-      --git-owner dotnet
-      --git-repo versions
-      --git-branch master
-      --git-path build-info/docker
     displayName: Get Stale Images
     name: GetStaleImages
   - template: ${{ format('../../../common/templates/steps/cleanup-docker-{0}.yml', parameters.dockerClientOS) }}


### PR DESCRIPTION
Updates pipeline-related files to support the manifest-specific image info design defined by Image Builder in #482.