### PR TITLE
Fix comparison of platforms in commands

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
@@ -107,7 +107,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 {
                     PlatformData platformData = repoData.Images
                         .SelectMany(image => image.Platforms)
-                        .FirstOrDefault(platformData => platformData.Dockerfile == platform.DockerfilePathRelativeToManifest);
+                        .FirstOrDefault(platformData => platformData.Equals(platform));
                     if (platformData != null)
                     {
                         destTagNames = platformData.SimpleTags

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
@@ -156,7 +156,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             foreach (ImageData imageData in repoData.Images)
             {
                 PlatformData platformData = imageData.Platforms
-                    .FirstOrDefault(platformData => platformData.Dockerfile == platform.DockerfilePathRelativeToManifest);
+                    .FirstOrDefault(platformData => platformData.Equals(platform));
                 if (platformData != null)
                 {
                     foundImageInfo = true;


### PR DESCRIPTION
An issue was identified where not all sample images are being published.  The issue occurs in the `CopyAcrImagesCommand` logic that attempts to find the associated image info's platform with a platform from the manifest.  This was only using the Dockerfile path for the comparison. But it should be comparing all the distinct aspects that make up a platform.  This is fixed by using the `PlatformData.Equals(PlatformInfo)` method which correctly encapsulates this logic.

I also searched for other other that was incorrectly making this comparison and found logic in `GetStaleImagesCommand` that also needed to be updated.
