### PR TITLE
Fix broken tests due to incompatible code changes

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
@@ -1254,11 +1254,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 )
             };
 
-            Dictionary<GitRepo, List<DockerfileInfo>> dockerfileInfos =
-                new Dictionary<GitRepo, List<DockerfileInfo>>
+            Dictionary<GitFile, List<DockerfileInfo>> dockerfileInfos =
+                new Dictionary<GitFile, List<DockerfileInfo>>
             {
                 {
-                    subscriptionInfos[0].Subscription.RepoInfo,
+                    subscriptionInfos[0].Subscription.Manifest,
                     new List<DockerfileInfo>
                     {
                         new DockerfileInfo(dockerfile1Path, new FromImageInfo("base1", "base1digest")),

--- a/src/Microsoft.DotNet.ImageBuilder/tests/PublishImageInfoCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/PublishImageInfoCommandTests.cs
@@ -285,6 +285,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 PublishImageInfoCommand command = new PublishImageInfoCommand(gitHubClientFactoryMock.Object);
                 command.Options.ImageInfoPath = file;
                 command.Options.GitOptions.AuthToken = "token";
+                command.Options.GitOptions.Repo = "repo";
+                command.Options.GitOptions.Owner = "owner";
+                command.Options.GitOptions.Path = "imageinfo.json";
+                command.Options.GitOptions.Branch = "branch";
                 command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
 
                 File.WriteAllText(Path.Combine(tempFolderContext.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));


### PR DESCRIPTION
The changes between #478, #482, and #484 were all merged without re-running the PR build.  These PRs all had changes that caused build errors when combined with the others.  Fixing those errors to get the build working again.