### PR TITLE
Add IngestImageInfoTelemetryCommand

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ImageInfoOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ImageInfoOptions.cs
@@ -16,6 +16,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         public override void DefineParameters(ArgumentSyntax syntax)
         {
+            base.DefineParameters(syntax);
+
             string imageInfoPath = null;
             syntax.DefineParameter("image-info-path", ref imageInfoPath, "Image info file path");
             ImageInfoPath = imageInfoPath;

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ImageInfoOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ImageInfoOptions.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.CommandLine;
+
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    public abstract class ImageInfoOptions : ManifestOptions
+    {
+        public string ImageInfoPath { get; set; }
+
+        protected ImageInfoOptions()
+        {
+        }
+
+        public override void DefineParameters(ArgumentSyntax syntax)
+        {
+            string imageInfoPath = null;
+            syntax.DefineParameter("image-info-path", ref imageInfoPath, "Image info file path");
+            ImageInfoPath = imageInfoPath;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/IngestKustImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/IngestKustImageInfoCommand.cs
@@ -1,0 +1,74 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.DotNet.ImageBuilder.Models.Image;
+using Microsoft.DotNet.ImageBuilder.Services;
+
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    [Export(typeof(ICommand))]
+    public class IngestKustoImageInfoCommand : ManifestCommand<IngestKustoImageInfoOptions>
+    {
+        private readonly IKustoClient kustoClient;
+        private readonly ILoggerService loggerService;
+
+        [ImportingConstructor]
+        public IngestKustoImageInfoCommand(ILoggerService loggerService, IKustoClient kustoClient)
+        {
+            this.loggerService = loggerService ?? throw new ArgumentNullException(nameof(loggerService));
+            this.kustoClient = kustoClient ?? throw new ArgumentNullException(nameof(kustoClient));
+        }
+
+        public override async Task ExecuteAsync()
+        {
+            this.loggerService.WriteHeading("INGESTING IMAGE INFO DATA INTO KUSTO");
+
+            string csv = GetImageInfoCSV();
+            this.loggerService.WriteMessage($"Image Info to Ingest:{Environment.NewLine}{csv}");
+
+            using MemoryStream stream = new MemoryStream();
+            using StreamWriter writer = new StreamWriter(stream);
+            writer.Write(csv);
+            writer.Flush();
+            stream.Seek(0, SeekOrigin.Begin);
+
+            await kustoClient.IngestFromCsvStreamAsync(stream, Options);
+        }
+
+        private string GetImageInfoCSV()
+        {
+            StringBuilder builder = new StringBuilder();
+
+            
+            foreach (RepoData repo in ImageInfoHelper.LoadFromFile(Options.ImageInfoPath, Manifest).Repos)
+            {
+                foreach (ImageData image in repo.Images)
+                {
+                    foreach (PlatformData platform in image.Platforms)
+                    {
+                        string timestamp = platform.Created.ToUniversalTime().ToString("yyyy'-'MM'-'dd' 'HH':'mm':'ss");
+                        builder.AppendLine(FormatCSV(platform.Digest, platform, image, repo, timestamp));
+
+                        foreach (string tag in platform.SimpleTags)
+                        {
+                            builder.AppendLine(FormatCSV(tag, platform, image, repo, timestamp));
+                        }
+                    }
+                }
+            }
+
+            // Kusto ingest API does not handle an empty line, therefore the last line must be trimmed.
+            return builder.ToString().TrimEnd(Environment.NewLine);
+        }
+
+        private string FormatCSV(string imageId, PlatformData platform, ImageData image, RepoData repo, string timestamp) =>
+            $"\"{imageId}\",\"{platform.Architecture}\",\"{platform.OsType}\",\"{platform.OsVersion}\","
+                + $"\"{image.ProductVersion}\",\"{platform.Dockerfile}\",\"{repo.Repo}\",\"{timestamp}\"";
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/IngestKustoImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/IngestKustoImageInfoCommand.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             this.loggerService.WriteHeading("INGESTING IMAGE INFO DATA INTO KUSTO");
 
-            string csv = GetImageInfoCSV();
+            string csv = GetImageInfoCsv();
             this.loggerService.WriteMessage($"Image Info to Ingest:{Environment.NewLine}{csv}");
 
             using MemoryStream stream = new MemoryStream();
@@ -41,11 +41,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             await kustoClient.IngestFromCsvStreamAsync(stream, Options);
         }
 
-        private string GetImageInfoCSV()
+        private string GetImageInfoCsv()
         {
             StringBuilder builder = new StringBuilder();
 
-            
             foreach (RepoData repo in ImageInfoHelper.LoadFromFile(Options.ImageInfoPath, Manifest).Repos)
             {
                 foreach (ImageData image in repo.Images)
@@ -53,11 +52,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     foreach (PlatformData platform in image.Platforms)
                     {
                         string timestamp = platform.Created.ToUniversalTime().ToString("yyyy'-'MM'-'dd' 'HH':'mm':'ss");
-                        builder.AppendLine(FormatCSV(platform.Digest, platform, image, repo, timestamp));
+                        builder.AppendLine(FormatCsv(platform.Digest, platform, image, repo, timestamp));
 
                         foreach (string tag in platform.SimpleTags)
                         {
-                            builder.AppendLine(FormatCSV(tag, platform, image, repo, timestamp));
+                            builder.AppendLine(FormatCsv(tag, platform, image, repo, timestamp));
                         }
                     }
                 }
@@ -67,7 +66,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             return builder.ToString().TrimEnd(Environment.NewLine);
         }
 
-        private string FormatCSV(string imageId, PlatformData platform, ImageData image, RepoData repo, string timestamp) =>
+        private string FormatCsv(string imageId, PlatformData platform, ImageData image, RepoData repo, string timestamp) =>
             $"\"{imageId}\",\"{platform.Architecture}\",\"{platform.OsType}\",\"{platform.OsVersion}\","
                 + $"\"{image.ProductVersion}\",\"{platform.Dockerfile}\",\"{repo.Repo}\",\"{timestamp}\"";
     }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/IngestKustoImageInfoOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/IngestKustoImageInfoOptions.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.CommandLine;
+
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    public class IngestKustoImageInfoOptions : ImageInfoOptions, IFilterableOptions
+    {
+        protected override string CommandHelp => "Ingests image info data into Kusto";
+
+        public ManifestFilterOptions FilterOptions { get; } = new ManifestFilterOptions();
+
+        public string ClientID { get; set; }
+        public string Cluster { get; set; }
+        public string Database { get; set; }
+        public string Secret { get; set; }
+        public string Table { get; set; }
+        public string Tenant { get; set; }
+
+        public override void DefineOptions(ArgumentSyntax syntax)
+        {
+            base.DefineOptions(syntax);
+
+            FilterOptions.DefineOptions(syntax);
+        }
+
+        public override void DefineParameters(ArgumentSyntax syntax)
+        {
+            base.DefineParameters(syntax);
+
+            string cluster = null;
+            syntax.DefineParameter("cluster", ref cluster, "The cluster to ingest the data to");
+            Cluster = cluster;
+
+            string database = null;
+            syntax.DefineParameter("database", ref database, "The database to ingest the data to");
+            Database = database;
+
+            string table = null;
+            syntax.DefineParameter("table", ref table, "The table to ingest the data to");
+            Table = table;
+
+            string clientID = null;
+            syntax.DefineParameter("client-id", ref clientID, "The URL or name associated with the service principal");
+            ClientID = clientID;
+
+            string secret = null;
+            syntax.DefineParameter("secret", ref secret, "The service principal password");
+            Secret = secret;
+
+            string tenant = null;
+            syntax.DefineParameter("tenant", ref tenant, "The tenant associated with the service principal");
+            Tenant = tenant;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoOptions.cs
@@ -6,13 +6,11 @@ using System.CommandLine;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
-    public class PublishImageInfoOptions : ManifestOptions, IGitOptionsHost
+    public class PublishImageInfoOptions : ImageInfoOptions, IGitOptionsHost
     {
         protected override string CommandHelp => "Publishes a build's merged image info.";
 
         public GitOptions GitOptions { get; } = new GitOptions();
-
-        public string ImageInfoPath { get; set; }
 
         public override void DefineOptions(ArgumentSyntax syntax)
         {
@@ -26,13 +24,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             base.DefineParameters(syntax);
 
             GitOptions.DefineParameters(syntax);
-
-            string imageInfoPath = null;
-            syntax.DefineParameter(
-                "image-info-path",
-                ref imageInfoPath,
-                "Image info file path");
-            ImageInfoPath = imageInfoPath;
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
@@ -25,6 +25,7 @@ namespace Microsoft.DotNet.ImageBuilder
                 RepoInfo manifestRepo = manifest.AllRepos.FirstOrDefault(repo => repo.Name == repoData.Repo);
                 if (manifestRepo == null)
                 {
+                    Console.WriteLine($"Image info repo not loaded:  {repoData.Repo}");
                     continue;
                 }
                 foreach (ImageData imageData in repoData.Images)

--- a/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
@@ -8,8 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Kusto.Ingest" Version="8.0.9" />
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.22.0" />
     <PackageReference Include="Microsoft.DotNet.VersionTools" Version="1.0.0-beta.19426.12" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.0" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.143.1" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.11" />
     <PackageReference Include="System.CommandLine" Version="0.1.0-e170603-2" />

--- a/src/Microsoft.DotNet.ImageBuilder/src/Services/IKustoClient.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Services/IKustoClient.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.DotNet.ImageBuilder.Commands;
+
+namespace Microsoft.DotNet.ImageBuilder.Services
+{
+    public interface IKustoClient
+    {
+        Task IngestFromCsvStreamAsync(Stream csv, IngestKustoImageInfoOptions Options);
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/Services/IKustoClient.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Services/IKustoClient.cs
@@ -10,6 +10,6 @@ namespace Microsoft.DotNet.ImageBuilder.Services
 {
     public interface IKustoClient
     {
-        Task IngestFromCsvStreamAsync(Stream csv, IngestKustoImageInfoOptions Options);
+        Task IngestFromCsvStreamAsync(Stream csv, IngestKustoImageInfoOptions options);
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Services/KustoClient.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Services/KustoClient.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Kusto.Data;
+using Kusto.Data.Common;
+using Kusto.Ingest;
+using Microsoft.DotNet.ImageBuilder.Commands;
+
+namespace Microsoft.DotNet.ImageBuilder.Services
+{
+    [Export(typeof(IKustoClient))]
+    internal class KustoClientWrapper : IKustoClient
+    {
+        public async Task IngestFromCsvStreamAsync(Stream csv, IngestKustoImageInfoOptions Options)
+        {
+            KustoConnectionStringBuilder connectionBuilder =
+                new KustoConnectionStringBuilder($"https://{Options.Cluster}.kusto.windows.net")
+                    .WithAadApplicationKeyAuthentication(Options.ClientID, Options.Secret, Options.Tenant);
+
+            using (IKustoIngestClient client = KustoIngestFactory.CreateDirectIngestClient(connectionBuilder))
+            {
+                KustoIngestionProperties properties =
+                    new KustoIngestionProperties(Options.Database, Options.Table) { Format = DataSourceFormat.csv };
+                StreamSourceOptions sourceOptions = new StreamSourceOptions() { SourceId = Guid.NewGuid() };
+
+                if (!Options.IsDryRun)
+                {
+                    IKustoIngestionResult result = await client.IngestFromStreamAsync(csv, properties, sourceOptions);
+
+                    IngestionStatus ingestionStatus = result.GetIngestionStatusBySourceId(sourceOptions.SourceId);
+                    while (ingestionStatus.Status == Status.Pending)
+                    {
+                        Thread.Sleep(TimeSpan.FromSeconds(30));
+                        ingestionStatus = result.GetIngestionStatusBySourceId(sourceOptions.SourceId);
+                    }
+
+                    if (ingestionStatus.Status != Status.Succeeded)
+                    {
+                        throw new InvalidOperationException(
+                            $"Failed to ingest Kusto data.{Environment.NewLine}{ingestionStatus.Details}");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ImageInfoHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ImageInfoHelper.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
 
@@ -10,10 +11,16 @@ namespace Microsoft.DotNet.ImageBuilder.Tests.Helpers
     public static class ImageInfoHelper
     {
         public static PlatformData CreatePlatform(
-            string dockerfile, string digest = null, string architecture = "amd64", string osType = "Linux", string osVersion = "Ubuntu 19.04",
-            List<string> simpleTags = null, string baseImageDigest = null)
+            string dockerfile,
+            string digest = null,
+            string architecture = "amd64",
+            string osType = "Linux",
+            string osVersion = "Ubuntu 19.04",
+            List<string> simpleTags = null,
+            string baseImageDigest = null,
+            DateTime? created = null)
         {
-            return new PlatformData
+            PlatformData platform = new PlatformData
             {
                 Dockerfile = dockerfile,
                 Digest = digest,
@@ -21,8 +28,15 @@ namespace Microsoft.DotNet.ImageBuilder.Tests.Helpers
                 OsType = osType,
                 OsVersion = osVersion,
                 SimpleTags = simpleTags,
-                BaseImageDigest = baseImageDigest
+                BaseImageDigest = baseImageDigest,
             };
+
+            if (created.HasValue)
+            {
+                platform.Created = created.Value;
+            }
+
+            return platform;
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/IngestKustoImageInfoCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/IngestKustoImageInfoCommandTests.cs
@@ -23,10 +23,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 {
     public class IngestKustoImageInfoCommandTests
     {
-        ITestOutputHelper _outputHelper;
+        private ITestOutputHelper _outputHelper;
 
         public IngestKustoImageInfoCommandTests(ITestOutputHelper outputHelper)
-
         {
             _outputHelper = outputHelper;
         }
@@ -37,7 +36,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         [Fact]
         public async Task IngestKustoImageInfoCommand_MultipleRepos()
         {
-            TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
+            using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
 
             string repo1Image1DockerfilePath = DockerfileHelper.CreateDockerfile("1.0/sdk/os", tempFolderContext);
             string repo2Image2DockerfilePath = DockerfileHelper.CreateDockerfile("2.0/sdk/os", tempFolderContext);

--- a/src/Microsoft.DotNet.ImageBuilder/tests/IngestKustoImageInfoCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/IngestKustoImageInfoCommandTests.cs
@@ -1,0 +1,164 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.DotNet.ImageBuilder.Commands;
+using Microsoft.DotNet.ImageBuilder.Models.Image;
+using Microsoft.DotNet.ImageBuilder.Models.Manifest;
+using Microsoft.DotNet.ImageBuilder.Services;
+using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
+using Microsoft.DotNet.VersionTools.Automation;
+using Microsoft.DotNet.VersionTools.Automation.GitHubApi;
+using Moq;
+using Newtonsoft.Json;
+using Xunit;
+using Xunit.Abstractions;
+using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
+
+namespace Microsoft.DotNet.ImageBuilder.Tests
+{
+    public class IngestKustoImageInfoCommandTests
+    {
+        ITestOutputHelper _outputHelper;
+
+        public IngestKustoImageInfoCommandTests(ITestOutputHelper outputHelper)
+
+        {
+            _outputHelper = outputHelper;
+        }
+
+        /// <summary>
+        /// Verifies the command will ingest multiple repos.
+        /// </summary>
+        [Fact]
+        public async Task IngestKustoImageInfoCommand_MultipleRepos()
+        {
+            TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
+
+            string repo1Image1DockerfilePath = DockerfileHelper.CreateDockerfile("1.0/sdk/os", tempFolderContext);
+            string repo2Image2DockerfilePath = DockerfileHelper.CreateDockerfile("2.0/sdk/os", tempFolderContext);
+            Manifest manifest = CreateManifest(
+                CreateRepo("repo1",
+                    CreateImage(
+                        CreatePlatform(repo1Image1DockerfilePath, new string[0]))),
+                CreateRepo("repo2",
+                    CreateImage(
+                        CreatePlatform(repo2Image2DockerfilePath, new string[0])))
+            );
+            string manifestPath = Path.Combine(tempFolderContext.Path, "manifest.json");
+            File.WriteAllText(manifestPath, JsonConvert.SerializeObject(manifest));
+
+            ImageArtifactDetails srcImageArtifactDetails = new ImageArtifactDetails
+            {
+                Repos =
+                {
+                    new RepoData
+                    {
+                        Repo = "r1",
+                        Images =
+                        {
+                            new ImageData
+                            {
+                                Manifest =
+                                new ManifestData
+                                {
+                                    Created = new DateTime(2020, 4, 20, 21, 57, 00, DateTimeKind.Utc),
+                                    Digest = "abc",
+                                    SharedTags = new List<string>
+                                    {
+                                        "st1"
+                                    }
+                                },
+                                Platforms =
+                                {
+                                    {
+                                        Helpers.ImageInfoHelper.CreatePlatform(
+                                            repo1Image1DockerfilePath,
+                                            created: new DateTime(2020, 4, 20, 21, 56, 50, DateTimeKind.Utc),
+                                            digest: "def",
+                                            simpleTags: new List<string>
+                                            {
+                                                "t1"
+                                            })
+                                    },
+                                    {
+                                        Helpers.ImageInfoHelper.CreatePlatform(
+                                            repo1Image1DockerfilePath,
+                                            created: new DateTime(2020, 4, 20, 21, 56, 56, DateTimeKind.Utc),
+                                            digest: "ghi",
+                                            simpleTags: new List<string>
+                                            {
+                                                "t2"
+                                            })
+                                    }
+                                },
+                                ProductVersion = "1.0.2",
+                            }
+                        }
+                    },
+                    new RepoData
+                    {
+                        Repo = "r2",
+                        Images =
+                        {
+                            new ImageData
+                            {
+                                Platforms =
+                                {
+                                    Helpers.ImageInfoHelper.CreatePlatform(
+                                        repo2Image2DockerfilePath,
+                                        created: new DateTime(2020, 4, 20, 21, 56, 58, DateTimeKind.Utc),
+                                        digest: "jkl",
+                                        simpleTags: new List<string>
+                                        {
+                                            "t3"
+                                        })
+                                },
+                                ProductVersion = "2.0.5"
+                            }
+                        }
+                    }
+                }
+            };
+
+            string expectedData =
+@"""def"",""amd64"",""Linux"",""Ubuntu 19.04"",""1.0.2"",""1.0/sdk/os/Dockerfile"",""r1"",""2020-04-20 21:56:50""
+""t1"",""amd64"",""Linux"",""Ubuntu 19.04"",""1.0.2"",""1.0/sdk/os/Dockerfile"",""r1"",""2020-04-20 21:56:50""
+""ghi"",""amd64"",""Linux"",""Ubuntu 19.04"",""1.0.2"",""1.0/sdk/os/Dockerfile"",""r1"",""2020-04-20 21:56:56""
+""t2"",""amd64"",""Linux"",""Ubuntu 19.04"",""1.0.2"",""1.0/sdk/os/Dockerfile"",""r1"",""2020-04-20 21:56:56""
+""jkl"",""amd64"",""Linux"",""Ubuntu 19.04"",""2.0.5"",""2.0/sdk/os/Dockerfile"",""r2"",""2020-04-20 21:56:58""
+""t3"",""amd64"",""Linux"",""Ubuntu 19.04"",""2.0.5"",""2.0/sdk/os/Dockerfile"",""r2"",""2020-04-20 21:56:58""";
+
+            string imageInfoPath = Path.Combine(tempFolderContext.Path, "image-info.json");
+            File.WriteAllText(imageInfoPath, JsonHelper.SerializeObject(srcImageArtifactDetails));
+
+            string ingestedData = null;
+
+            Mock<IKustoClient> kustoClientMock = new Mock<IKustoClient>();
+            kustoClientMock
+                .Setup(o => o.IngestFromCsvStreamAsync(It.IsAny<Stream>(), It.IsAny<IngestKustoImageInfoOptions>()))
+                .Callback<Stream, IngestKustoImageInfoOptions>((s, o) =>
+                {
+                    StreamReader reader = new StreamReader(s);
+                    ingestedData = reader.ReadToEnd();
+                });
+            IngestKustoImageInfoCommand command = new IngestKustoImageInfoCommand(
+                Mock.Of<ILoggerService>(), kustoClientMock.Object);
+            command.Options.ImageInfoPath = imageInfoPath;
+            command.Options.Manifest = manifestPath;
+
+            command.LoadManifest();
+            await command.ExecuteAsync();
+
+            _outputHelper.WriteLine($"Expected Data: {Environment.NewLine}{expectedData}");
+            _outputHelper.WriteLine($"Actual Data: {Environment.NewLine}{ingestedData}");
+
+            kustoClientMock.Verify(o => o.IngestFromCsvStreamAsync(It.IsAny<Stream>(), It.IsAny<IngestKustoImageInfoOptions>()));
+            Assert.Equal(expectedData, ingestedData);
+        }
+    }
+}


### PR DESCRIPTION
Add IngestImageInfoTelemetryCommand that is intended to ingest the image-info into Kusto for reporting purposes.  The data that gets imported is only for the concrete images.