### PR TITLE
Fix field name used in subscriptions file

### DIFF
--- a/eng/check-base-image-subscriptions.json
+++ b/eng/check-base-image-subscriptions.json
@@ -2,13 +2,13 @@
   {
     "manifest": {
       "owner": "dotnet",
-      "repoName": "dotnet-docker",
+      "repo": "dotnet-docker",
       "branch": "master",
       "path": "manifest.json"
     },
     "imageInfo": {
       "owner": "dotnet",
-      "repoName": "versions",
+      "repo": "versions",
       "branch": "master",
       "path": "build-info/docker/image-info.dotnet-dotnet-docker-master.json"
     },
@@ -21,13 +21,13 @@
   {
     "manifest": {
       "owner": "dotnet",
-      "repoName": "dotnet-docker",
+      "repo": "dotnet-docker",
       "branch": "nightly",
       "path": "manifest.json"
     },
     "imageInfo": {
       "owner": "dotnet",
-      "repoName": "versions",
+      "repo": "versions",
       "branch": "master",
       "path": "build-info/docker/image-info.dotnet-dotnet-docker-nightly.json"
     },
@@ -40,13 +40,13 @@
   {
     "manifest": {
       "owner": "dotnet",
-      "repoName": "dotnet-docker",
+      "repo": "dotnet-docker",
       "branch": "nightly",
       "path": "manifest.samples.json"
     },
     "imageInfo": {
       "owner": "dotnet",
-      "repoName": "versions",
+      "repo": "versions",
       "branch": "master",
       "path": "build-info/docker/image-info.dotnet-dotnet-docker-master-samples.json"
     },
@@ -58,13 +58,13 @@
   {
     "manifest": {
       "owner": "Microsoft",
-      "repoName": "dotnet-framework-docker",
+      "repo": "dotnet-framework-docker",
       "branch": "master",
       "path": "manifest.samples.json"
     },
     "imageInfo": {
       "owner": "dotnet",
-      "repoName": "versions",
+      "repo": "versions",
       "branch": "master",
       "path": "build-info/docker/image-info.Microsoft-dotnet-framework-docker-master-samples.json"
     },


### PR DESCRIPTION
The schema for the subscriptions file was updated in https://github.com/dotnet/docker-tools/pull/482.  During the PR review process, the name of the `GitFile.RepoName` property was renamed to `GitFile.Repo`.  But the subscriptions file wasn't updated to reflect that change.  Updating that here.