### PR TITLE
Fix subscription branch for .NET Core samples

### DIFF
--- a/eng/check-base-image-subscriptions.json
+++ b/eng/check-base-image-subscriptions.json
@@ -41,7 +41,7 @@
     "manifest": {
       "owner": "dotnet",
       "repo": "dotnet-docker",
-      "branch": "nightly",
+      "branch": "master",
       "path": "manifest.samples.json"
     },
     "imageInfo": {


### PR DESCRIPTION
The branch for the .NET Core samples subscription was incorrectly defined to target the nightly branch.  Fixed it to target the master branch instead.