### PR TITLE
Fix matrix generation to walk graph for customBuildLegGrouping

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
@@ -10,6 +10,7 @@ using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
 using Newtonsoft.Json;
 using Xunit;
+using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
@@ -50,19 +51,19 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 string dockerfileRuntimePath = Path.Combine(runtimeDir.FullName, "Dockerfile");
                 File.WriteAllText(dockerfileRuntimePath, "FROM runtime-deps:tag");
 
-                Manifest manifest = ManifestHelper.CreateManifest(
-                    ManifestHelper.CreateRepo("runtime-deps",
-                        ManifestHelper.CreateImage(
+                Manifest manifest = CreateManifest(
+                    CreateRepo("runtime-deps",
+                        CreateImage(
                             new Platform[]
                             {
-                                ManifestHelper.CreatePlatform(runtimeDepsRelativeDir, new string[] { "tag" })
+                                CreatePlatform(runtimeDepsRelativeDir, new string[] { "tag" })
                             },
                             productVersion: "2.1.1")),
-                    ManifestHelper.CreateRepo("runtime",
-                        ManifestHelper.CreateImage(
+                    CreateRepo("runtime",
+                        CreateImage(
                             new Platform[]
                             {
-                                ManifestHelper.CreatePlatform(runtimeRelativeDir, new string[] { "runtime" })
+                                CreatePlatform(runtimeRelativeDir, new string[] { "runtime" })
                             },
                             productVersion: "2.2.3-preview"))
                 );
@@ -123,16 +124,16 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 string dockerfileSamplePath = Path.Combine(sampleDir.FullName, "Dockerfile");
                 File.WriteAllText(dockerfileSamplePath, "FROM sdk:tag");
 
-                Manifest manifest = ManifestHelper.CreateManifest(
-                    ManifestHelper.CreateRepo("runtime-deps",
-                        ManifestHelper.CreateImage(
-                            ManifestHelper.CreatePlatform(runtimeDepsRelativeDir, new string[] { "tag" }))),
-                    ManifestHelper.CreateRepo("sdk",
-                        ManifestHelper.CreateImage(
-                            ManifestHelper.CreatePlatform(sdkRelativeDir, new string[] { "tag" }))),
-                    ManifestHelper.CreateRepo("sample",
-                        ManifestHelper.CreateImage(
-                            ManifestHelper.CreatePlatform(sampleRelativeDir, new string[] { "tag" })))
+                Manifest manifest = CreateManifest(
+                    CreateRepo("runtime-deps",
+                        CreateImage(
+                            CreatePlatform(runtimeDepsRelativeDir, new string[] { "tag" }))),
+                    CreateRepo("sdk",
+                        CreateImage(
+                            CreatePlatform(sdkRelativeDir, new string[] { "tag" }))),
+                    CreateRepo("sample",
+                        CreateImage(
+                            CreatePlatform(sampleRelativeDir, new string[] { "tag" })))
                 );
 
                 File.WriteAllText(Path.Combine(tempFolderContext.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));
@@ -146,6 +147,90 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 string imageBuilderPaths = leg.Variables.First(variable => variable.Name == "imageBuilderPaths").Value;
 
                 Assert.Equal(expectedPaths, imageBuilderPaths);
+            }
+        }
+
+        /// <summary>
+        /// Verifies the platformVersionedOs matrix type is generated correctly when a 
+        /// custom build leg grouping is defined that has a parent graph.
+        /// </summary>
+        /// <remarks>
+        /// https://github.com/dotnet/docker-tools/issues/243
+        /// </remarks>
+        [Fact]
+        public void GenerateBuildMatrixCommand_CustomBuildLegGroupingParentGraph()
+        {
+            using (TempFolderContext tempFolderContext = TestHelper.UseTempFolder())
+            {
+                const string customBuildLegGrouping = "custom";
+                GenerateBuildMatrixCommand command = new GenerateBuildMatrixCommand();
+                command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
+                command.Options.MatrixType = MatrixType.PlatformVersionedOs;
+                command.Options.ProductVersionComponents = 2;
+                command.Options.CustomBuildLegGrouping = customBuildLegGrouping;
+
+                string dockerfileRuntimeDepsFullPath = DockerfileHelper.CreateDockerfile("1.0/runtime-deps/os", tempFolderContext);
+                string dockerfileRuntimePath = DockerfileHelper.CreateDockerfile("1.0/runtime/os", tempFolderContext, "runtime-deps:tag");
+
+                string dockerfileRuntime2FullPath = DockerfileHelper.CreateDockerfile("2.0/runtime/os2", tempFolderContext);
+                string dockerfileSdk2FullPath = DockerfileHelper.CreateDockerfile("2.0/sdk/os2", tempFolderContext, "runtime2:tag");
+
+                Manifest manifest = CreateManifest(
+                    CreateRepo("runtime-deps",
+                        CreateImage(
+                            new Platform[]
+                            {
+                                CreatePlatform(dockerfileRuntimeDepsFullPath, new string[] { "tag" })
+                            },
+                            productVersion: "1.0")),
+                    CreateRepo("runtime",
+                        CreateImage(
+                            new Platform[]
+                            {
+                                CreatePlatform(dockerfileRuntimePath, new string[] { "runtime" },
+                                    customBuildLegGroupings: new CustomBuildLegGrouping[]
+                                    {
+                                        new CustomBuildLegGrouping
+                                        {
+                                            Name = customBuildLegGrouping,
+                                            Dependencies = new string[]
+                                            {
+                                                "sdk2:tag"
+                                            }
+                                        }
+                                    })
+                            },
+                            productVersion: "1.0")),
+                    CreateRepo("runtime2",
+                        CreateImage(
+                            new Platform[]
+                            {
+                                CreatePlatform(dockerfileRuntime2FullPath, new string[] { "tag" })
+                            },
+                            productVersion: "2.0")),
+                    CreateRepo("sdk2",
+                        CreateImage(
+                            new Platform[]
+                            {
+                                CreatePlatform(dockerfileSdk2FullPath, new string[] { "tag" })
+                            },
+                            productVersion: "2.0"))
+                );
+
+                File.WriteAllText(Path.Combine(tempFolderContext.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));
+
+                command.LoadManifest();
+                IEnumerable<BuildMatrixInfo> matrixInfos = command.GenerateMatrixInfo();
+                Assert.Single(matrixInfos);
+
+                BuildMatrixInfo matrixInfo = matrixInfos.First();
+                BuildLegInfo leg_1_0 = matrixInfo.Legs.First();
+                string imageBuilderPaths = leg_1_0.Variables.First(variable => variable.Name == "imageBuilderPaths").Value;
+                Assert.Equal("--path 1.0/runtime-deps/os/Dockerfile --path 1.0/runtime/os/Dockerfile --path 2.0/sdk/os2/Dockerfile --path 2.0/runtime/os2/Dockerfile", imageBuilderPaths);
+
+                BuildLegInfo leg_2_0 = matrixInfo.Legs.ElementAt(1);
+                imageBuilderPaths = leg_2_0.Variables.First(variable => variable.Name == "imageBuilderPaths").Value;
+                Assert.Equal("--path 2.0/runtime/os2/Dockerfile --path 2.0/sdk/os2/Dockerfile", imageBuilderPaths);
             }
         }
     }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ManifestHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ManifestHelper.cs
@@ -48,7 +48,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests.Helpers
         }
 
         public static Platform CreatePlatform(
-            string dockerfilePath, string[] tags, OS os = OS.Linux, string osVersion = "disco", Architecture architecture = Architecture.AMD64)
+            string dockerfilePath, string[] tags, OS os = OS.Linux, string osVersion = "disco", Architecture architecture = Architecture.AMD64,
+            CustomBuildLegGrouping[] customBuildLegGroupings = null)
         {
             return new Platform
             {
@@ -56,7 +57,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests.Helpers
                 OsVersion = osVersion,
                 OS = os,
                 Tags = tags.ToDictionary(tag => tag, tag => new Tag()),
-                Architecture = architecture
+                Architecture = architecture,
+                CustomBuildLegGrouping = customBuildLegGroupings ?? Array.Empty<CustomBuildLegGrouping>()
             };
         }
     }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/IngestKustoImageInfoCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/IngestKustoImageInfoCommandTests.cs
@@ -131,6 +131,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 ""t2"",""amd64"",""Linux"",""Ubuntu 19.04"",""1.0.2"",""1.0/sdk/os/Dockerfile"",""r1"",""2020-04-20 21:56:56""
 ""jkl"",""amd64"",""Linux"",""Ubuntu 19.04"",""2.0.5"",""2.0/sdk/os/Dockerfile"",""r2"",""2020-04-20 21:56:58""
 ""t3"",""amd64"",""Linux"",""Ubuntu 19.04"",""2.0.5"",""2.0/sdk/os/Dockerfile"",""r2"",""2020-04-20 21:56:58""";
+            expectedData = expectedData.NormalizeLineEndings(Environment.NewLine).Trim();
 
             string imageInfoPath = Path.Combine(tempFolderContext.Path, "image-info.json");
             File.WriteAllText(imageInfoPath, JsonHelper.SerializeObject(srcImageArtifactDetails));


### PR DESCRIPTION
An issue exists with the matrix generation logic that consumes the customBuildLegGrouping from the manifest.  It doesn't walk the parent graph to produce the full set of images that should be built.

An example is with 5.0 Alpine on ARM where there exists no SDK image.  The manifest is defined in a way such that the 5.0 Alpine on ARM platform depends on the buster-slim ARM SDK image: https://github.com/dotnet/dotnet-docker/blob/402a1591e224b681015be628986eefa5012e940e/manifest.json#L1495.  The error in the logic causes the SDK image's parent dependencies to not be included in the imageBuilderPaths output.  

Fixed this by walking the parent graph and collecting all parents to be included in the imageBuilderPaths.