### PR TITLE
Fix commands to support dry-run option better

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
@@ -228,21 +228,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 string uniqueName = $"{sub.Manifest.Owner}-{sub.Manifest.Repo}-{sub.Manifest.Branch}";
                 if (!this.gitRepoIdToPathMapping.TryGetValue(uniqueName, out repoPath))
                 {
-                    string extractPath = Path.Combine(Path.GetTempPath(), uniqueName);
-                    Uri repoContentsUrl = GitHelper.GetArchiveUrl(sub.Manifest);
-                    string zipPath = Path.Combine(Path.GetTempPath(), $"{uniqueName}.zip");
-                    File.WriteAllBytes(zipPath, await this.httpClient.GetByteArrayAsync(repoContentsUrl));
-
-                    try
-                    {
-                        ZipFile.ExtractToDirectory(zipPath, extractPath);
-                    }
-                    finally
-                    {
-                        File.Delete(zipPath);
-                    }
-
-                    repoPath = Path.Combine(extractPath, $"{sub.Manifest.Repo}-{sub.Manifest.Branch}");
+                    repoPath = await GitHelper.DownloadAndExtractGitRepoArchiveAsync(httpClient, sub.Manifest);
                     this.gitRepoIdToPathMapping.Add(uniqueName, repoPath);
                 }
             }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GitOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GitOptions.cs
@@ -8,7 +8,7 @@ using Microsoft.DotNet.VersionTools.Automation;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
-    public class GitOptions
+    public class GitOptions : IGitFileRef
     {
         public string AuthToken { get; set; }
         public string Branch { get; set; }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
@@ -20,12 +20,20 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     {
         private readonly IGitHubClientFactory gitHubClientFactory;
         private readonly ILoggerService loggerService;
+        private readonly HttpClient httpClient;
 
         [ImportingConstructor]
-        public PublishImageInfoCommand(IGitHubClientFactory gitHubClientFactory, ILoggerService loggerService)
+        public PublishImageInfoCommand(IGitHubClientFactory gitHubClientFactory, ILoggerService loggerService, IHttpClientFactory httpClientFactory)
         {
+            if (httpClientFactory is null)
+            {
+                throw new ArgumentNullException(nameof(httpClientFactory));
+            }
+
             this.gitHubClientFactory = gitHubClientFactory ?? throw new ArgumentNullException(nameof(gitHubClientFactory));
             this.loggerService = loggerService ?? throw new ArgumentNullException(nameof(loggerService));
+
+            this.httpClient = httpClientFactory.GetClient();
         }
 
         public override async Task ExecuteAsync()
@@ -64,7 +72,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             ImageArtifactDetails srcImageArtifactDetails = ImageInfoHelper.LoadFromFile(Options.ImageInfoPath, Manifest);
 
-            string repoPath = await GitHelper.DownloadAndExtractGitRepoArchiveAsync(new HttpClient(), Options.GitOptions);
+            string repoPath = await GitHelper.DownloadAndExtractGitRepoArchiveAsync(httpClient, Options.GitOptions);
             try
             {
                 string repoImageInfoPath = Path.Combine(repoPath, Options.GitOptions.Path);

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
@@ -3,8 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
@@ -16,91 +19,103 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     public class PublishImageInfoCommand : ManifestCommand<PublishImageInfoOptions>
     {
         private readonly IGitHubClientFactory gitHubClientFactory;
+        private readonly ILoggerService loggerService;
 
         [ImportingConstructor]
-        public PublishImageInfoCommand(IGitHubClientFactory gitHubClientFactory)
+        public PublishImageInfoCommand(IGitHubClientFactory gitHubClientFactory, ILoggerService loggerService)
         {
             this.gitHubClientFactory = gitHubClientFactory ?? throw new ArgumentNullException(nameof(gitHubClientFactory));
+            this.loggerService = loggerService ?? throw new ArgumentNullException(nameof(loggerService));
         }
 
         public override async Task ExecuteAsync()
         {
-            ImageArtifactDetails srcImageArtifactDetails = ImageInfoHelper.LoadFromFile(Options.ImageInfoPath, Manifest);
+            Uri imageInfoPathIdentifier = GitHelper.GetBlobUrl(Options.GitOptions);
+            GitObject imageInfoGitObject = await GetUpdatedImageInfoGitObjectAsync();
 
-            using (IGitHubClient gitHubClient = this.gitHubClientFactory.GetClient(Options.GitOptions.ToGitHubAuth(), Options.IsDryRun))
+            if (imageInfoGitObject is null)
             {
+                loggerService.WriteMessage($"No changes to the '{imageInfoPathIdentifier}' file were needed.");
+                return;
+            }
+
+            if (Options.IsDryRun)
+            {
+                loggerService.WriteMessage(
+                    $"The '{imageInfoPathIdentifier}' file would have been updated with the following content:" +
+                        Environment.NewLine + imageInfoGitObject.Content + Environment.NewLine);
+            }
+            else
+            {
+                using IGitHubClient gitHubClient = this.gitHubClientFactory.GetClient(Options.GitOptions.ToGitHubAuth(), Options.IsDryRun);
                 await GitHelper.ExecuteGitOperationsWithRetryAsync(async () =>
                 {
-                    bool hasChanges = false;
-                    GitReference gitRef = await GitHelper.PushChangesAsync(gitHubClient, Options, "Merging image info updates from build.", async branch =>
-                    {
-                        string originalTargetImageInfoContents = await gitHubClient.GetGitHubFileContentsAsync(Options.GitOptions.Path, branch);
-                        ImageArtifactDetails newImageArtifactDetails;
+                    GitReference gitRef = await GitHelper.PushChangesAsync(
+                        gitHubClient, Options, "Merging image info updates from build.",
+                        branch => Task.FromResult<IEnumerable<GitObject>>(new GitObject[] { imageInfoGitObject }));
 
-                        if (originalTargetImageInfoContents != null)
-                        {
-                            ImageArtifactDetails targetImageArtifactDetails = ImageInfoHelper.LoadFromContent(
-                                originalTargetImageInfoContents, Manifest, skipManifestValidation: true);
-
-                            RemoveOutOfDateContent(targetImageArtifactDetails);
-
-                            ImageInfoMergeOptions options = new ImageInfoMergeOptions
-                            {
-                                ReplaceTags = true
-                            };
-
-                            ImageInfoHelper.MergeImageArtifactDetails(srcImageArtifactDetails, targetImageArtifactDetails, options);
-
-                            newImageArtifactDetails = targetImageArtifactDetails;
-                        }
-                        else
-                        {
-                            // If there is no existing file to update, there's nothing to merge with so the source data
-                            // becomes the target data.
-                            newImageArtifactDetails = srcImageArtifactDetails;
-                        }
-
-                        string newTargetImageInfoContents =
-                            JsonHelper.SerializeObject(newImageArtifactDetails) + Environment.NewLine;
-
-                        if (originalTargetImageInfoContents != newTargetImageInfoContents)
-                        {
-                            GitObject imageInfoGitObject = new GitObject
-                            {
-                                Path = Options.GitOptions.Path,
-                                Type = GitObject.TypeBlob,
-                                Mode = GitObject.ModeFile,
-                                Content = newTargetImageInfoContents
-                            };
-
-                            hasChanges = true;
-                            return new GitObject[] { imageInfoGitObject };
-                        }
-                        else
-                        {
-                            return Enumerable.Empty<GitObject>();
-                        }
-                    });
-
-                    Uri imageInfoPathIdentifier = GitHelper.GetBlobUrl(Options.GitOptions);
-
-                    if (hasChanges)
-                    {
-                        if (!Options.IsDryRun)
-                        {
-                            Uri commitUrl = GitHelper.GetCommitUrl(Options.GitOptions, gitRef.Object.Sha);
-                            Logger.WriteMessage($"The '{imageInfoPathIdentifier}' file was updated ({commitUrl}).");
-                        }
-                        else
-                        {
-                            Logger.WriteMessage($"The '{imageInfoPathIdentifier}' file would have been updated.");
-                        }
-                    }
-                    else
-                    {
-                        Logger.WriteMessage($"No changes to the '{imageInfoPathIdentifier}' file were needed.");
-                    }
+                    Uri commitUrl = GitHelper.GetCommitUrl(Options.GitOptions, gitRef.Object.Sha);
+                    loggerService.WriteMessage($"The '{imageInfoPathIdentifier}' file was updated ({commitUrl}).");
                 });
+            }
+        }
+
+        private async Task<GitObject> GetUpdatedImageInfoGitObjectAsync()
+        {
+            ImageArtifactDetails srcImageArtifactDetails = ImageInfoHelper.LoadFromFile(Options.ImageInfoPath, Manifest);
+
+            string repoPath = await GitHelper.DownloadAndExtractGitRepoArchiveAsync(new HttpClient(), Options.GitOptions);
+            try
+            {
+                string repoImageInfoPath = Path.Combine(repoPath, Options.GitOptions.Path);
+                string originalTargetImageInfoContents = File.ReadAllText(repoImageInfoPath);
+
+                ImageArtifactDetails newImageArtifactDetails;
+
+                if (originalTargetImageInfoContents != null)
+                {
+                    ImageArtifactDetails targetImageArtifactDetails = ImageInfoHelper.LoadFromContent(
+                        originalTargetImageInfoContents, Manifest, skipManifestValidation: true);
+
+                    RemoveOutOfDateContent(targetImageArtifactDetails);
+
+                    ImageInfoMergeOptions options = new ImageInfoMergeOptions
+                    {
+                        ReplaceTags = true
+                    };
+
+                    ImageInfoHelper.MergeImageArtifactDetails(srcImageArtifactDetails, targetImageArtifactDetails, options);
+
+                    newImageArtifactDetails = targetImageArtifactDetails;
+                }
+                else
+                {
+                    // If there is no existing file to update, there's nothing to merge with so the source data
+                    // becomes the target data.
+                    newImageArtifactDetails = srcImageArtifactDetails;
+                }
+
+                string newTargetImageInfoContents =
+                    JsonHelper.SerializeObject(newImageArtifactDetails) + Environment.NewLine;
+
+                if (originalTargetImageInfoContents != newTargetImageInfoContents)
+                {
+                    return new GitObject
+                    {
+                        Path = Options.GitOptions.Path,
+                        Type = GitObject.TypeBlob,
+                        Mode = GitObject.ModeFile,
+                        Content = newTargetImageInfoContents
+                    };
+                }
+                else
+                {
+                    return null;
+                }
+            }
+            finally
+            {
+                Directory.Delete(repoPath, recursive: true);
             }
         }
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
@@ -47,13 +47,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 return;
             }
 
-            if (Options.IsDryRun)
-            {
-                loggerService.WriteMessage(
-                    $"The '{imageInfoPathIdentifier}' file would have been updated with the following content:" +
-                        Environment.NewLine + imageInfoGitObject.Content + Environment.NewLine);
-            }
-            else
+            loggerService.WriteMessage(
+                $"The '{imageInfoPathIdentifier}' file has been updated with the following content:" +
+                    Environment.NewLine + imageInfoGitObject.Content + Environment.NewLine);
+
+            if (!Options.IsDryRun)
             {
                 using IGitHubClient gitHubClient = this.gitHubClientFactory.GetClient(Options.GitOptions.ToGitHubAuth(), Options.IsDryRun);
                 await GitHelper.ExecuteGitOperationsWithRetryAsync(async () =>

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoOptions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     {
         protected override string CommandHelp => "Publishes a build's merged image info.";
 
-        public GitOptions GitOptions { get; } = new GitOptions();
+        public GitOptions GitOptions { get; set; } = new GitOptions();
 
         public override void DefineOptions(ArgumentSyntax syntax)
         {

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsCommand.cs
@@ -45,15 +45,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 GetUpdatedReadmes(productRepo)
                 .Concat(GetUpdatedTagsMetadata(productRepo));
 
-            if (Options.IsDryRun)
+            foreach (GitObject gitObject in gitObjects)
             {
-                foreach (GitObject gitObject in gitObjects)
-                {
-                    this.loggerService.WriteMessage(
-                        $"Updated file '{gitObject.Path}' with contents:{Environment.NewLine}{gitObject.Content}{Environment.NewLine}");
-                }
+                this.loggerService.WriteMessage(
+                    $"Updated file '{gitObject.Path}' with contents:{Environment.NewLine}{gitObject.Content}{Environment.NewLine}");
             }
-            else
+
+            if (!Options.IsDryRun)
             {
                 using IGitHubClient gitHubClient = this.gitHubClientFactory.GetClient(Options.GitOptions.ToGitHubAuth(), Options.IsDryRun);
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/IGitBranchRef.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/IGitBranchRef.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.ImageBuilder
+{
+    public interface IGitBranchRef : IGitRepoRef
+    {
+        public string Branch { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/IGitFileRef.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/IGitFileRef.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.ImageBuilder
+{
+    public interface IGitFileRef : IGitBranchRef
+    {
+        string Path { get; }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/IGitRepoRef.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/IGitRepoRef.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.ImageBuilder
+{
+    public interface IGitRepoRef
+    {
+        public string Owner { get; set; }
+
+        public string Repo { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Subscription/GitFile.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Subscription/GitFile.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.ImageBuilder.Models.Subscription
 {
-    public class GitFile
+    public class GitFile : IGitFileRef
     {
         [JsonProperty(Required = Required.Always)]
         public string Owner { get; set; }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/PublishImageInfoCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/PublishImageInfoCommandTests.cs
@@ -125,7 +125,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     .Setup(o => o.GetClient(It.IsAny<GitHubAuth>(), false))
                     .Returns(gitHubClientMock.Object);
 
-                PublishImageInfoCommand command = new PublishImageInfoCommand(gitHubClientFactoryMock.Object);
+                PublishImageInfoCommand command = new PublishImageInfoCommand(gitHubClientFactoryMock.Object, Mock.Of<ILoggerService>());
                 command.Options.ImageInfoPath = file;
                 command.Options.GitOptions.AuthToken = "token";
                 command.Options.GitOptions.Repo = "testRepo";
@@ -282,7 +282,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     .Setup(o => o.GetClient(It.IsAny<GitHubAuth>(), false))
                     .Returns(gitHubClientMock.Object);
 
-                PublishImageInfoCommand command = new PublishImageInfoCommand(gitHubClientFactoryMock.Object);
+                PublishImageInfoCommand command = new PublishImageInfoCommand(gitHubClientFactoryMock.Object, Mock.Of<ILoggerService>());
                 command.Options.ImageInfoPath = file;
                 command.Options.GitOptions.AuthToken = "token";
                 command.Options.GitOptions.Repo = "repo";

--- a/src/Microsoft.DotNet.ImageBuilder/tests/PublishImageInfoCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/PublishImageInfoCommandTests.cs
@@ -5,6 +5,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
+using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Commands;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
@@ -19,8 +22,15 @@ using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
-    public class PublishImageInfoCommandTests
+    public class PublishImageInfoCommandTests : IDisposable
     {
+        private readonly List<string> foldersToDelete = new List<string>();
+
+        public void Dispose()
+        {
+            foldersToDelete.ForEach(folder => Directory.Delete(folder, recursive: true));
+        }
+
         /// <summary>
         /// Verifies the command will replace any existing tags of a merged image.
         /// </summary>
@@ -118,19 +128,26 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     }
                 };
 
-                Mock<IGitHubClient> gitHubClientMock = GetGitHubClientMock(targetImageArtifactDetails);
+                Mock<IGitHubClient> gitHubClientMock = GetGitHubClientMock();
 
                 Mock<IGitHubClientFactory> gitHubClientFactoryMock = new Mock<IGitHubClientFactory>();
                 gitHubClientFactoryMock
                     .Setup(o => o.GetClient(It.IsAny<GitHubAuth>(), false))
                     .Returns(gitHubClientMock.Object);
 
-                PublishImageInfoCommand command = new PublishImageInfoCommand(gitHubClientFactoryMock.Object, Mock.Of<ILoggerService>());
+                GitOptions gitOptions = new GitOptions
+                {
+                    AuthToken = "token",
+                    Repo = "testRepo",
+                    Branch = "testBranch",
+                    Path = "imageinfo.json"
+                };
+
+                PublishImageInfoCommand command = new PublishImageInfoCommand(
+                    gitHubClientFactoryMock.Object, Mock.Of<ILoggerService>(),
+                    CreateHttpClientFactory(gitOptions, targetImageArtifactDetails));
                 command.Options.ImageInfoPath = file;
-                command.Options.GitOptions.AuthToken = "token";
-                command.Options.GitOptions.Repo = "testRepo";
-                command.Options.GitOptions.Branch = "testBranch";
-                command.Options.GitOptions.Path = "imageinfo.json";
+                command.Options.GitOptions = gitOptions;
                 command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
 
                 File.WriteAllText(Path.Combine(tempFolderContext.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));
@@ -275,20 +292,27 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     }
                 };
 
-                Mock<IGitHubClient> gitHubClientMock = GetGitHubClientMock(targetImageArtifactDetails);
+                Mock<IGitHubClient> gitHubClientMock = GetGitHubClientMock();
 
                 Mock<IGitHubClientFactory> gitHubClientFactoryMock = new Mock<IGitHubClientFactory>();
                 gitHubClientFactoryMock
                     .Setup(o => o.GetClient(It.IsAny<GitHubAuth>(), false))
                     .Returns(gitHubClientMock.Object);
 
-                PublishImageInfoCommand command = new PublishImageInfoCommand(gitHubClientFactoryMock.Object, Mock.Of<ILoggerService>());
+                GitOptions gitOptions = new GitOptions
+                {
+                    AuthToken = "token",
+                    Repo = "repo",
+                    Owner = "owner",
+                    Path = "imageinfo.json",
+                    Branch = "branch"
+                };
+
+                PublishImageInfoCommand command = new PublishImageInfoCommand(
+                    gitHubClientFactoryMock.Object, Mock.Of<ILoggerService>(),
+                    CreateHttpClientFactory(gitOptions, targetImageArtifactDetails));
                 command.Options.ImageInfoPath = file;
-                command.Options.GitOptions.AuthToken = "token";
-                command.Options.GitOptions.Repo = "repo";
-                command.Options.GitOptions.Owner = "owner";
-                command.Options.GitOptions.Path = "imageinfo.json";
-                command.Options.GitOptions.Branch = "branch";
+                command.Options.GitOptions = gitOptions;
                 command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
 
                 File.WriteAllText(Path.Combine(tempFolderContext.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));
@@ -333,12 +357,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             }
         }
 
-        private static Mock<IGitHubClient> GetGitHubClientMock(ImageArtifactDetails imageArtifactDetails)
+        private static Mock<IGitHubClient> GetGitHubClientMock()
         {
             Mock<IGitHubClient> gitHubClientMock = new Mock<IGitHubClient>();
-            gitHubClientMock
-                .Setup(o => o.GetGitHubFileContentsAsync(It.IsAny<string>(), It.IsAny<GitHubBranch>()))
-                .ReturnsAsync(JsonHelper.SerializeObject(imageArtifactDetails));
 
             gitHubClientMock
                 .Setup(o => o.GetReferenceAsync(It.IsAny<GitHubProject>(), It.IsAny<string>()))
@@ -371,6 +392,43 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 });
 
             return gitHubClientMock;
+        }
+
+        private IHttpClientFactory CreateHttpClientFactory(IGitFileRef imageOptionsFileRef, ImageArtifactDetails imageArtifactDetails)
+        {
+            string tempDir = Directory.CreateDirectory(
+                    Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())).FullName;
+            this.foldersToDelete.Add(tempDir);
+
+            string repoPath = Directory.CreateDirectory(
+                   Path.Combine(tempDir, $"{imageOptionsFileRef.Repo}-{imageOptionsFileRef.Branch}")).FullName;
+
+            string imageInfoPath = Path.Combine(repoPath, imageOptionsFileRef.Path);
+            File.WriteAllText(imageInfoPath, JsonConvert.SerializeObject(imageArtifactDetails));
+
+            string repoZipPath = Path.Combine(tempDir, "repo.zip");
+            ZipFile.CreateFromDirectory(repoPath, repoZipPath, CompressionLevel.Fastest, true);
+
+            Dictionary<string, HttpResponseMessage> responses = new Dictionary<string, HttpResponseMessage>
+            {
+                {
+                    GitHelper.GetArchiveUrl(imageOptionsFileRef).ToString(),
+                    new HttpResponseMessage
+                    {
+                        StatusCode = HttpStatusCode.OK,
+                        Content = new ByteArrayContent(File.ReadAllBytes(repoZipPath))
+                    }
+                }
+            };
+
+            HttpClient client = new HttpClient(new TestHttpMessageHandler(responses));
+
+            Mock<IHttpClientFactory> httpClientFactoryMock = new Mock<IHttpClientFactory>();
+            httpClientFactoryMock
+                .Setup(o => o.GetClient())
+                .Returns(client);
+
+            return httpClientFactoryMock.Object;
         }
     }
 }


### PR DESCRIPTION
The `publishImageInfo` and `publicMcrDocs` commands did not support the `dry-run` option very well because they required GitHub credentials in order to read some files.  This is problematic as part of the work to support #474 because no credentials will be available in such a scenario.  So in order to still exercise these commands in that scenario, the commands need to be updated.

I've refactored the commands so that they now do all of their processing logic that generates the file content to be pushed before accessing GitHub.  