### PR TITLE
Fix credscan issue with test file

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/tests/CleanAcrImagesCommandTest.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/CleanAcrImagesCommandTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             const string acrName = "myacr.azurecr.io";
             const string tenant = "mytenant";
             const string username = "fake user";
-            const string password = "fake password";
+            const string password = "PLACEHOLDER";
             const string subscription = "my sub";
             const string resourceGroup = "group";
 
@@ -122,7 +122,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             const string acrName = "myacr.azurecr.io";
             const string tenant = "mytenant";
             const string username = "fake user";
-            const string password = "fake password";
+            const string password = "PLACEHOLDER";
             const string subscription = "my sub";
             const string resourceGroup = "group";
 
@@ -260,7 +260,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             const string acrName = "myacr.azurecr.io";
             const string tenant = "mytenant";
             const string username = "fake user";
-            const string password = "fake password";
+            const string password = "PLACEHOLDER";
             const string subscription = "my sub";
             const string resourceGroup = "group";
 
@@ -348,7 +348,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             const string acrName = "myacr.azurecr.io";
             const string tenant = "mytenant";
             const string username = "fake user";
-            const string password = "fake password";
+            const string password = "PLACEHOLDER";
             const string subscription = "my sub";
             const string resourceGroup = "group";
 
@@ -427,7 +427,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             const string acrName = "myacr.azurecr.io";
             const string tenant = "mytenant";
             const string username = "fake user";
-            const string password = "fake password";
+            const string password = "PLACEHOLDER";
             const string subscription = "my sub";
             const string resourceGroup = "group";
 


### PR DESCRIPTION
CredScan incorrectly flagged this test file as containing secrets.  Updated the file to use the recommended value of `PLACEHOLDER` to avoid being flagged.