### PR TITLE
Add retry logic for ACR cleanup

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/AcrClient.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/AcrClient.cs
@@ -165,7 +165,12 @@ namespace Microsoft.DotNet.ImageBuilder
         {
             HttpResponseMessage response = await Policy
                 .HandleResult<HttpResponseMessage>(response => response.StatusCode == HttpStatusCode.TooManyRequests)
-                .WaitAndRetryAsync(RetryHelper.MaxRetries, RetryHelper.SleepDurationProvider,
+                .WaitAndRetryAsync(
+                    RetryHelper.MaxRetries,
+                    RetryHelper.ExponentialSleepDurationProvider
+                        .AddJitter(TimeSpan.FromSeconds(5))
+                        .AddOffset(TimeSpan.FromSeconds(5))
+                        .ToFunc(),
                     RetryHelper.GetOnRetryDelegate<HttpResponseMessage>(RetryHelper.MaxRetries, loggerService))
                 .ExecuteAsync(() => httpClient.SendAsync(createMessage()));
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/AcrClient.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/AcrClient.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -13,6 +14,7 @@ using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Models.Acr;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Newtonsoft.Json;
+using Polly;
 
 namespace Microsoft.DotNet.ImageBuilder
 {
@@ -25,13 +27,15 @@ namespace Microsoft.DotNet.ImageBuilder
             new Regex($"<(?<{LinkUrlGroup}>.+)>;\\s*rel=\"(?<{RelationshipTypeGroup}>.+)\"");
 
         private readonly HttpClient httpClient = new HttpClient();
+        private readonly ILoggerService loggerService;
         private readonly string baseUrl;
         private readonly string acrV1BaseUrl;
         private readonly string acrV2BaseUrl;
 
-        private AcrClient(HttpClient httpClient,string acrName)
+        private AcrClient(HttpClient httpClient,string acrName, ILoggerService loggerService)
         {
             this.httpClient = httpClient;
+            this.loggerService = loggerService;
             this.baseUrl = $"https://{acrName}";
             this.acrV1BaseUrl = $"{baseUrl}/acr/v1";
             this.acrV2BaseUrl = $"{baseUrl}/v2";
@@ -57,19 +61,15 @@ namespace Microsoft.DotNet.ImageBuilder
             return result;
         }
 
-        public async Task<Repository> GetRepositoryAsync(string name)
+        public Task<Repository> GetRepositoryAsync(string name)
         {
-            HttpResponseMessage response = await this.httpClient.GetAsync(
-                $"{this.acrV1BaseUrl}/{name}");
-            response.EnsureSuccessStatusCode();
-            return JsonConvert.DeserializeObject<Repository>(await response.Content.ReadAsStringAsync());
+            return SendGetRequestAsync<Repository>($"{this.acrV1BaseUrl}/{name}");
         }
 
         public async Task<DeleteRepositoryResponse> DeleteRepositoryAsync(string name)
         {
-            HttpResponseMessage response = await this.httpClient.DeleteAsync(
-                $"{this.acrV1BaseUrl}/{name}");
-            response.EnsureSuccessStatusCode();
+            HttpResponseMessage response = await SendRequestAsync(
+                () => new HttpRequestMessage(HttpMethod.Delete, $"{this.acrV1BaseUrl}/{name}"));
             return JsonConvert.DeserializeObject<DeleteRepositoryResponse>(await response.Content.ReadAsStringAsync());
         }
 
@@ -93,14 +93,14 @@ namespace Microsoft.DotNet.ImageBuilder
             return result;
         }
 
-        public async Task DeleteManifestAsync(string repositoryName, string digest)
+        public Task DeleteManifestAsync(string repositoryName, string digest)
         {
-            HttpResponseMessage response = await this.httpClient.DeleteAsync(
-                $"{this.acrV2BaseUrl}/{repositoryName}/manifests/{digest}");
-            response.EnsureSuccessStatusCode();
+            return SendRequestAsync(
+                () => new HttpRequestMessage(
+                    HttpMethod.Delete, $"{this.acrV2BaseUrl}/{repositoryName}/manifests/{digest}"));
         }
 
-        public static async Task<IAcrClient> CreateAsync(string acrName, string tenant, string username, string password)
+        public static async Task<IAcrClient> CreateAsync(string acrName, string tenant, string username, string password, ILoggerService loggerService)
         {
             string aadAccessToken = await GetAadAccessTokenAsync(tenant, username, password);
             
@@ -118,7 +118,7 @@ namespace Microsoft.DotNet.ImageBuilder
 
             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
 
-            return new AcrClient(httpClient, acrName);
+            return new AcrClient(httpClient, acrName, loggerService);
         }
 
         private async Task GetPagedResponseAsync<T>(string url, Action<T> onGetResults)
@@ -126,9 +126,9 @@ namespace Microsoft.DotNet.ImageBuilder
             string currentUrl = url;
             while (true)
             {
-                HttpResponseMessage response = await this.httpClient.GetAsync(
-                    currentUrl);
-                response.EnsureSuccessStatusCode();
+                HttpResponseMessage response = await SendRequestAsync(
+                    () => new HttpRequestMessage(HttpMethod.Get, currentUrl));
+                
                 T results = JsonConvert.DeserializeObject<T>(await response.Content.ReadAsStringAsync());
 
                 onGetResults(results);
@@ -152,6 +152,26 @@ namespace Microsoft.DotNet.ImageBuilder
                     return;
                 }
             }
+        }
+
+        private async Task<T> SendGetRequestAsync<T>(string url)
+        {
+            HttpResponseMessage response = await SendRequestAsync(
+                () => new HttpRequestMessage(HttpMethod.Get, url));
+            return JsonConvert.DeserializeObject<T>(await response.Content.ReadAsStringAsync());
+        }
+
+        private async Task<HttpResponseMessage> SendRequestAsync(Func<HttpRequestMessage> createMessage)
+        {
+            HttpResponseMessage response = await Policy
+                .HandleResult<HttpResponseMessage>(response => response.StatusCode == HttpStatusCode.TooManyRequests)
+                .WaitAndRetryAsync(RetryHelper.MaxRetries, RetryHelper.SleepDurationProvider,
+                    RetryHelper.GetRetryDelegate<HttpResponseMessage>(RetryHelper.MaxRetries, loggerService))
+                .ExecuteAsync(() => httpClient.SendAsync(createMessage()));
+
+            response.EnsureSuccessStatusCode();
+
+            return response;
         }
 
         private static async Task<string> GetAadAccessTokenAsync(string tenant, string username, string password)

--- a/src/Microsoft.DotNet.ImageBuilder/src/AcrClient.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/AcrClient.cs
@@ -166,7 +166,7 @@ namespace Microsoft.DotNet.ImageBuilder
             HttpResponseMessage response = await Policy
                 .HandleResult<HttpResponseMessage>(response => response.StatusCode == HttpStatusCode.TooManyRequests)
                 .WaitAndRetryAsync(RetryHelper.MaxRetries, RetryHelper.SleepDurationProvider,
-                    RetryHelper.GetRetryDelegate<HttpResponseMessage>(RetryHelper.MaxRetries, loggerService))
+                    RetryHelper.GetOnRetryDelegate<HttpResponseMessage>(RetryHelper.MaxRetries, loggerService))
                 .ExecuteAsync(() => httpClient.SendAsync(createMessage()));
 
             response.EnsureSuccessStatusCode();

--- a/src/Microsoft.DotNet.ImageBuilder/src/AcrClientFactory.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/AcrClientFactory.cs
@@ -11,9 +11,17 @@ namespace Microsoft.DotNet.ImageBuilder
     [Export(typeof(IAcrClientFactory))]
     public class AcrClientFactory : IAcrClientFactory
     {
+        private readonly ILoggerService loggerService;
+
+        [ImportingConstructor]
+        public AcrClientFactory(ILoggerService loggerService)
+        {
+            this.loggerService = loggerService ?? throw new ArgumentNullException(nameof(loggerService));
+        }
+
         public Task<IAcrClient> CreateAsync(string acrName, string tenant, string username, string password)
         {
-            return AcrClient.CreateAsync(acrName, tenant, username, password);
+            return AcrClient.CreateAsync(acrName, tenant, username, password, loggerService);
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
@@ -147,7 +147,7 @@ namespace Microsoft.DotNet.ImageBuilder
             ProcessResult processResult = Policy
                 .HandleResult<ProcessResult>(result => result.Process.ExitCode != 0)
                 .WaitAndRetry(RetryHelper.MaxRetries, RetryHelper.SleepDurationProvider,
-                    RetryHelper.GetRetryDelegate<ProcessResult>(RetryHelper.MaxRetries, loggerService))
+                    RetryHelper.GetOnRetryDelegate<ProcessResult>(RetryHelper.MaxRetries, loggerService))
                 .Execute(() => executor(info));
 
             return processResult;

--- a/src/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
@@ -100,7 +100,7 @@ namespace Microsoft.DotNet.ImageBuilder
                 }
             }
 
-            return processResult.StandardOutput;
+            return processResult?.StandardOutput;
         }
 
         private static ProcessResult ExecuteProcess(ProcessStartInfo info, Action<Process> processStartedCallback = null)

--- a/src/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Text;
 using Polly;
+using Polly.Contrib.WaitAndRetry;
 
 namespace Microsoft.DotNet.ImageBuilder
 {
@@ -146,7 +147,8 @@ namespace Microsoft.DotNet.ImageBuilder
         {
             ProcessResult processResult = Policy
                 .HandleResult<ProcessResult>(result => result.Process.ExitCode != 0)
-                .WaitAndRetry(RetryHelper.MaxRetries, RetryHelper.ExponentialSleepDurationProviderFunc,
+                .WaitAndRetry(
+                    Backoff.ExponentialBackoff(TimeSpan.FromSeconds(1), RetryHelper.MaxRetries, RetryHelper.WaitFactor),
                     RetryHelper.GetOnRetryDelegate<ProcessResult>(RetryHelper.MaxRetries, loggerService))
                 .Execute(() => executor(info));
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
@@ -146,7 +146,7 @@ namespace Microsoft.DotNet.ImageBuilder
         {
             ProcessResult processResult = Policy
                 .HandleResult<ProcessResult>(result => result.Process.ExitCode != 0)
-                .WaitAndRetry(RetryHelper.MaxRetries, RetryHelper.SleepDurationProvider,
+                .WaitAndRetry(RetryHelper.MaxRetries, RetryHelper.ExponentialSleepDurationProviderFunc,
                     RetryHelper.GetOnRetryDelegate<ProcessResult>(RetryHelper.MaxRetries, loggerService))
                 .Execute(() => executor(info));
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.143.1" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.11" />
     <PackageReference Include="Polly" Version="7.2.0" />
+    <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.0" />
     <PackageReference Include="System.CommandLine" Version="0.1.0-e170603-2" />
     <PackageReference Include="System.ComponentModel.Composition" Version="4.5.0" />
     <PackageReference Include="YamlDotNet" Version="8.0.0" />

--- a/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.0" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.143.1" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.11" />
+    <PackageReference Include="Polly" Version="7.2.0" />
     <PackageReference Include="System.CommandLine" Version="0.1.0-e170603-2" />
     <PackageReference Include="System.ComponentModel.Composition" Version="4.5.0" />
     <PackageReference Include="YamlDotNet" Version="8.0.0" />

--- a/src/Microsoft.DotNet.ImageBuilder/src/RetryHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/RetryHelper.cs
@@ -7,13 +7,34 @@ using Polly;
 
 namespace Microsoft.DotNet.ImageBuilder
 {
+    public delegate TimeSpan SleepDurationProvider(int retryAttempt);
+
     public static class RetryHelper
     {
         private const int waitFactor = 5;
         public const int MaxRetries = 5;
 
-        public static readonly Func<int, TimeSpan> SleepDurationProvider =
+        private static readonly Random jitterer = new Random();
+
+        public static SleepDurationProvider ExponentialSleepDurationProvider =
             retryAttempt => TimeSpan.FromSeconds(Math.Pow(waitFactor, retryAttempt - 1));
+
+        public static Func<int, TimeSpan> ExponentialSleepDurationProviderFunc =
+            ExponentialSleepDurationProvider.ToFunc();
+
+        public static SleepDurationProvider AddJitter(this SleepDurationProvider sleepDurationProvider, TimeSpan maxJitterTime = default)
+        {
+            TimeSpan jitterOffset = maxJitterTime != default ?
+                TimeSpan.FromMilliseconds(jitterer.Next(0, (int)maxJitterTime.TotalMilliseconds)) : TimeSpan.Zero;
+            return retryAttempt => sleepDurationProvider(retryAttempt) + jitterOffset;
+        }
+
+        public static SleepDurationProvider AddOffset(
+            this SleepDurationProvider sleepDurationProvider, TimeSpan timeOffset = default) =>
+                retryAttempt => sleepDurationProvider(retryAttempt) + timeOffset;
+
+        public static Func<int, TimeSpan> ToFunc(this SleepDurationProvider sleepDurationProvider) =>
+            retryAttempt => sleepDurationProvider(retryAttempt);
 
         public static Action<DelegateResult<T>, TimeSpan, int, Context> GetOnRetryDelegate<T>(
             int maxRetries, ILoggerService loggerService)

--- a/src/Microsoft.DotNet.ImageBuilder/src/RetryHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/RetryHelper.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Polly;
+
+namespace Microsoft.DotNet.ImageBuilder
+{
+    public static class RetryHelper
+    {
+        private const int waitFactor = 5;
+        public const int MaxRetries = 5;
+
+        public static readonly Func<int, TimeSpan> SleepDurationProvider =
+            retryAttempt => TimeSpan.FromSeconds(Math.Pow(waitFactor, retryAttempt - 1));
+
+        public static Action<DelegateResult<T>, TimeSpan, int, Context> GetRetryDelegate<T>(
+            int maxRetries, ILoggerService loggerService)
+        {
+            return (delegateResult, timeSpan, retryCount, context) => loggerService.WriteMessage(
+                $"Retry {retryCount}/{maxRetries}, retrying in {timeSpan.TotalSeconds} seconds...");
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/RetryHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/RetryHelper.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.ImageBuilder
         public static readonly Func<int, TimeSpan> SleepDurationProvider =
             retryAttempt => TimeSpan.FromSeconds(Math.Pow(waitFactor, retryAttempt - 1));
 
-        public static Action<DelegateResult<T>, TimeSpan, int, Context> GetRetryDelegate<T>(
+        public static Action<DelegateResult<T>, TimeSpan, int, Context> GetOnRetryDelegate<T>(
             int maxRetries, ILoggerService loggerService)
         {
             return (delegateResult, timeSpan, retryCount, context) => loggerService.WriteMessage(

--- a/src/Microsoft.DotNet.ImageBuilder/src/RetryHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/RetryHelper.cs
@@ -7,33 +7,10 @@ using Polly;
 
 namespace Microsoft.DotNet.ImageBuilder
 {
-    public delegate TimeSpan SleepDurationProvider(int retryAttempt);
-
     public static class RetryHelper
     {
-        private const int waitFactor = 5;
+        public const int WaitFactor = 5;
         public const int MaxRetries = 5;
-
-        private static readonly Random jitterer = new Random();
-
-        public static SleepDurationProvider ExponentialSleepDurationProvider =
-            retryAttempt => TimeSpan.FromSeconds(Math.Pow(waitFactor, retryAttempt - 1));
-
-        public static Func<int, TimeSpan> ExponentialSleepDurationProviderFunc =
-            ExponentialSleepDurationProvider.ToFunc();
-
-        public static SleepDurationProvider AddJitter(this SleepDurationProvider sleepDurationProvider, TimeSpan maxJitterTime)
-        {
-            TimeSpan jitterOffset = TimeSpan.FromMilliseconds(jitterer.Next(0, (int)maxJitterTime.TotalMilliseconds));
-            return retryAttempt => sleepDurationProvider(retryAttempt) + jitterOffset;
-        }
-
-        public static SleepDurationProvider AddOffset(
-            this SleepDurationProvider sleepDurationProvider, TimeSpan timeOffset) =>
-                retryAttempt => sleepDurationProvider(retryAttempt) + timeOffset;
-
-        public static Func<int, TimeSpan> ToFunc(this SleepDurationProvider sleepDurationProvider) =>
-            retryAttempt => sleepDurationProvider(retryAttempt);
 
         public static Action<DelegateResult<T>, TimeSpan, int, Context> GetOnRetryDelegate<T>(
             int maxRetries, ILoggerService loggerService)

--- a/src/Microsoft.DotNet.ImageBuilder/src/RetryHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/RetryHelper.cs
@@ -22,15 +22,14 @@ namespace Microsoft.DotNet.ImageBuilder
         public static Func<int, TimeSpan> ExponentialSleepDurationProviderFunc =
             ExponentialSleepDurationProvider.ToFunc();
 
-        public static SleepDurationProvider AddJitter(this SleepDurationProvider sleepDurationProvider, TimeSpan maxJitterTime = default)
+        public static SleepDurationProvider AddJitter(this SleepDurationProvider sleepDurationProvider, TimeSpan maxJitterTime)
         {
-            TimeSpan jitterOffset = maxJitterTime != default ?
-                TimeSpan.FromMilliseconds(jitterer.Next(0, (int)maxJitterTime.TotalMilliseconds)) : TimeSpan.Zero;
+            TimeSpan jitterOffset = TimeSpan.FromMilliseconds(jitterer.Next(0, (int)maxJitterTime.TotalMilliseconds));
             return retryAttempt => sleepDurationProvider(retryAttempt) + jitterOffset;
         }
 
         public static SleepDurationProvider AddOffset(
-            this SleepDurationProvider sleepDurationProvider, TimeSpan timeOffset = default) =>
+            this SleepDurationProvider sleepDurationProvider, TimeSpan timeOffset) =>
                 retryAttempt => sleepDurationProvider(retryAttempt) + timeOffset;
 
         public static Func<int, TimeSpan> ToFunc(this SleepDurationProvider sleepDurationProvider) =>


### PR DESCRIPTION
When running the `cleanAcrImages` command, it can result in there being too many requests to the ACR REST endpoint, resulting in HTTP status 429 errors.  This occurs because there are so many requests occurring in parallel.  To mitigate this, I've added retry logic to attempt retries if this error is encountered.  I've refactored things to make use of the Polly library since it is well-suited for retry logic.