### PR TITLE
Don't connect to Kusto on dry runs

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/IngestKustoImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/IngestKustoImageInfoCommand.cs
@@ -38,7 +38,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             writer.Flush();
             stream.Seek(0, SeekOrigin.Begin);
 
-            await kustoClient.IngestFromCsvStreamAsync(stream, Options);
+            if (!Options.IsDryRun)
+            {
+                await kustoClient.IngestFromCsvStreamAsync(stream, Options);
+            }
         }
 
         private string GetImageInfoCsv()


### PR DESCRIPTION
These changes are in support of https://github.com/dotnet/docker-tools/issues/474 to allow commands executed in the publish stage to be done so with the `dry-run` option and not require authenticated connections.

The issue is that `KustoClient` currently will attempt to connect to a Kusto service even if the `dry-run` option is set, although it doesn't end up executing any write operations.  But since we're not able to provide any credentials in this scenario, the connection attempt to the Kusto service will never work.  

To fix this, the call to ingest from the CSV is completely skipped in the `dry-run` scenario to avoid any Kusto connection attempt.