### PR TITLE
Run publish stage in PR builds

### DIFF
--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -39,10 +39,9 @@ jobs:
       $(imageBuilderBuildArgs)
       $(imageBuilderImageInfoArg)
     displayName: Build Images
-  - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-    - publish: $(Build.ArtifactStagingDirectory)/$(legName)-image-info.json
-      artifact: $(legName)-image-info
-      displayName: Publish Image Info File Artifact
+  - publish: $(Build.ArtifactStagingDirectory)/$(legName)-image-info.json
+    artifact: $(legName)-image-info
+    displayName: Publish Image Info File Artifact
   - ${{ if eq(variables['System.TeamProject'], 'public') }}:
     - template: ${{ format('../steps/test-images-{0}-client.yml', parameters.dockerClientOS) }}
       parameters:

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -5,8 +5,8 @@ jobs:
   pool: ${{ parameters.pool }}
   variables:
     imageBuilder.commonCmdArgs: >
-      --manifest $(manifest)
-      --registry-override $(acr.server)
+      --manifest '$(manifest)'
+      --registry-override '$(acr.server)'
       $(imageBuilder.queueArgs)
     # publicSourceBranch is not necessarily the working branch, it is the branch referenced in the readme Dockerfile source links
     ${{ if contains(variables['Build.SourceBranchName'], 'nightly') }}:
@@ -34,26 +34,26 @@ jobs:
     displayName: Set Publish Variables
   - script: >
       $(runImageBuilderCmd) copyAcrImages
-      $(stagingRepoPrefix)
-      $(acr.servicePrincipalName)
-      $(app-dotnetdockerbuild-client-secret)
-      $(acr.servicePrincipalTenant)
-      $(acr.subscription)
-      $(acr.resourceGroup)
+      '$(stagingRepoPrefix)'
+      '$(acr.servicePrincipalName)'
+      '$(app-dotnetdockerbuild-client-secret)'
+      '$(acr.servicePrincipalTenant)'
+      '$(acr.subscription)'
+      '$(acr.resourceGroup)'
       --os-type '*'
       --architecture '*'
-      --repo-prefix $(publishRepoPrefix)
-      --image-info $(artifactsPath)/image-info.json
+      --repo-prefix '$(publishRepoPrefix)'
+      --image-info '$(artifactsPath)/image-info.json'
       $(dryRunArg)
       $(imageBuilder.pathArgs)
       $(imageBuilder.commonCmdArgs)
     displayName: Copy Images
   - script: >
       $(runImageBuilderCmd) publishManifest
-      $(artifactsPath)/image-info.json
-      --repo-prefix $(publishRepoPrefix)
-      --username $(acr.userName)
-      --password $(BotAccount-dotnet-docker-acr-bot-password)
+      '$(artifactsPath)/image-info.json'
+      --repo-prefix '$(publishRepoPrefix)'
+      --username '$(acr.userName)'
+      --password '$(BotAccount-dotnet-docker-acr-bot-password)'
       --os-type '*'
       --architecture '*'
       $(dryRunArg)
@@ -69,34 +69,31 @@ jobs:
       condition: and(succeeded(), eq(variables['publishReadme'], 'true'))
   - script: >
       $(runImageBuilderCmd) publishImageInfo
-      $(artifactsPath)/image-info.json
-      $(dotnetDockerBot.userName)
-      $(dotnetDockerBot.email)
-      $(BotAccount-dotnet-docker-bot-PAT)
-      --manifest $(manifest)
-      --git-owner dotnet
-      --git-repo versions
-      --git-branch master
-      --git-path build-info/docker/image-info.$(buildRepoName)-$(publicSourceBranch)$(imageInfoVariant).json
+      '$(artifactsPath)/image-info.json'
+      '$(dotnetDockerBot.userName)'
+      '$(dotnetDockerBot.email)'
+      '$(BotAccount-dotnet-docker-bot-PAT)'
+      --manifest '$(manifest)'
+      --git-owner 'dotnet'
+      --git-repo 'versions'
+      --git-branch 'master'
+      --git-path 'build-info/docker/image-info.$(buildRepoName)-$(publicSourceBranch)$(imageInfoVariant).json'
       $(dryRunArg)
     displayName: Publish Image Info
   - script: >
       $(runImageBuilderCmd) ingestKustoImageInfo
-      $(artifactsPath)/image-info.json
-      $(kusto.cluster)
-      $(kusto.database)
-      $(kusto.table)
-      $(kusto.servicePrincipalName)
-      $(app-DotnetDockerTelemetryIngestion-client-secret)
-      $(kusto.servicePrincipalTenant)
-      --manifest $(manifest)
+      '$(artifactsPath)/image-info.json'
+      '$(kusto.cluster)'
+      '$(kusto.database)'
+      '$(kusto.table)'
+      '$(kusto.servicePrincipalName)'
+      '$(app-DotnetDockerTelemetryIngestion-client-secret)'
+      '$(kusto.servicePrincipalTenant)'
+      --manifest '$(manifest)'
       --os-type '*'
       --architecture '*'
       $(dryRunArg)
     displayName: Ingest Kusto Image Info
-  - publish: $(Build.ArtifactStagingDirectory)/image-info.json
-    artifact: image-info-final
-    displayName: Publish Image Info File Artifact
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: Component Detection
   - template: ../steps/cleanup-docker-linux.yml

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -22,10 +22,15 @@ jobs:
     # Use dry-run option for certain publish operations if this is not a production build
   - script: |
       dryRunArg=""
-      if [ "$PUBLISHREPOPREFIX" != "public/" ]; then
+      if [[ "$PUBLISHREPOPREFIX" != "public/" || "$SYSTEM_TEAMPROJECT" == "public" ]]; then
         dryRunArg=" --dry-run"
       fi
+
+      # Replace '/' with '-'
+      buildRepoName=$(echo $BUILD_REPOSITORY_NAME | sed -e 's/\//-/g')
+      
       echo "##vso[task.setvariable variable=dryRunArg]$dryRunArg"
+      echo "##vso[task.setvariable variable=buildRepoName]$buildRepoName"
     displayName: Set Publish Variables
   - script: >
       $(runImageBuilderCmd) copyAcrImages
@@ -39,6 +44,7 @@ jobs:
       --architecture '*'
       --repo-prefix $(publishRepoPrefix)
       --image-info $(artifactsPath)/image-info.json
+      $(dryRunArg)
       $(imageBuilder.pathArgs)
       $(imageBuilder.commonCmdArgs)
     displayName: Copy Images
@@ -50,9 +56,13 @@ jobs:
       --password $(BotAccount-dotnet-docker-acr-bot-password)
       --os-type '*'
       --architecture '*'
+      $(dryRunArg)
       $(imageBuilder.pathArgs)
       $(imageBuilder.commonCmdArgs)
     displayName: Publish Manifest
+  - publish: $(Build.ArtifactStagingDirectory)/image-info.json
+    artifact: image-info-final
+    displayName: Publish Image Info File Artifact
   - template: ../steps/publish-readmes.yml
     parameters:
       dryRunArg: $(dryRunArg)
@@ -67,7 +77,7 @@ jobs:
       --git-owner dotnet
       --git-repo versions
       --git-branch master
-      --git-path build-info/docker/image-info.$(Build.Repository.Name)-$(publicSourceBranch)$(imageInfoVariant).json
+      --git-path build-info/docker/image-info.$(buildRepoName)-$(publicSourceBranch)$(imageInfoVariant).json
       $(dryRunArg)
     displayName: Publish Image Info
   - script: >

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -158,19 +158,19 @@ stages:
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
 
-- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-  ################################################################################
-  # Post-Build
-  ################################################################################
-  - stage: Post_Build
-    dependsOn: Build
-    condition: and(succeeded(), contains(variables['stages'], 'build'))
-    jobs:
-    - template: ../jobs/post-build.yml
+################################################################################
+# Post-Build
+################################################################################
+- stage: Post_Build
+  dependsOn: Build
+  condition: and(succeeded(), contains(variables['stages'], 'build'))
+  jobs:
+  - template: ../jobs/post-build.yml
 
-  ################################################################################
-  # Test Images
-  ################################################################################
+################################################################################
+# Test Images
+################################################################################
+- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - stage: Test
     dependsOn: Post_Build
     condition: "
@@ -271,40 +271,43 @@ stages:
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.WindowsLtsc2016Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
 
-  ################################################################################
-  # Publish Images
-  ################################################################################
-  - stage: Publish
+################################################################################
+# Publish Images
+################################################################################
+- stage: Publish
+  ${{ if eq(variables['System.TeamProject'], 'internal') }}:
     dependsOn: Test
-    condition: "
-      and(
-        contains(variables['stages'], 'publish'),
+  ${{ if eq(variables['System.TeamProject'], 'public') }}:
+    dependsOn: Post_Build
+  condition: "
+    and(
+      contains(variables['stages'], 'publish'),
+      or(
         or(
+          and(
+            and(
+              contains(variables['stages'], 'build'),
+              succeeded('Post_Build')),
+            and(
+              contains(variables['stages'], 'test'),
+              succeeded('Test'))),
           or(
             and(
-              and(
-                contains(variables['stages'], 'build'),
-                succeeded('Post_Build')),
+              not(contains(variables['stages'], 'build')),
               and(
                 contains(variables['stages'], 'test'),
                 succeeded('Test'))),
-            or(
+            and(
+              not(contains(variables['stages'], 'test')),
               and(
-                not(contains(variables['stages'], 'build')),
-                and(
-                  contains(variables['stages'], 'test'),
-                  succeeded('Test'))),
-              and(
-                not(contains(variables['stages'], 'test')),
-                and(
-                  contains(variables['stages'], 'build'),
-                  succeeded('Post_Build'))))),
-          not(
-            or(
-              contains(variables['stages'], 'build'),
-              contains(variables['stages'], 'test')))))"
-    jobs:
-    - template: ../jobs/publish.yml
-      parameters:
-        pool: # linuxAmd64Pool
-          name: Hosted Ubuntu 1604
+                contains(variables['stages'], 'build'),
+                succeeded('Post_Build'))))),
+        not(
+          or(
+            contains(variables['stages'], 'build'),
+            contains(variables['stages'], 'test')))))"
+  jobs:
+  - template: ../jobs/publish.yml
+    parameters:
+      pool: # linuxAmd64Pool
+        name: Hosted Ubuntu 1604

--- a/eng/common/templates/steps/init-docker-linux.yml
+++ b/eng/common/templates/steps/init-docker-linux.yml
@@ -8,12 +8,8 @@ steps:
 - script: echo "##vso[task.setvariable variable=artifactsPath]/artifacts"
   displayName: Define Artifacts Path Variable
 
-- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-  - script: echo '##vso[task.setvariable variable=imageBuilderImageInfoArg]--image-info-output-path $(artifactsPath)/$(legName)-image-info.json'
-    displayName: Set Image Info Arg for Image Builder
-- ${{ if eq(variables['System.TeamProject'], 'public') }}:
-  - script: echo '##vso[task.setvariable variable=imageBuilderImageInfoArg]'
-    displayName: Set Image Info Arg for Image Builder
+- script: echo '##vso[task.setvariable variable=imageBuilderImageInfoArg]--image-info-output-path $(artifactsPath)/$(legName)-image-info.json'
+  displayName: Set Image Info Arg for Image Builder
 
   ################################################################################
   # Cleanup Docker Resources

--- a/eng/common/templates/steps/init-docker-windows.yml
+++ b/eng/common/templates/steps/init-docker-windows.yml
@@ -5,12 +5,8 @@ steps:
 - script: echo "##vso[task.setvariable variable=artifactsPath]$(Build.ArtifactStagingDirectory)
   displayName: Define Artifacts Path Variable
 
-- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-  - script: echo '##vso[task.setvariable variable=imageBuilderImageInfoArg]--image-info-output-path $(artifactsPath)/$(legName)-image-info.json
-    displayName: Set Image Info Arg for Image Builder
-- ${{ if eq(variables['System.TeamProject'], 'public') }}:
-  - script: echo '##vso[task.setvariable variable=imageBuilderImageInfoArg]
-    displayName: Set Image Info Arg for Image Builder
+- script: echo '##vso[task.setvariable variable=imageBuilderImageInfoArg]--image-info-output-path $(artifactsPath)/$(legName)-image-info.json
+  displayName: Set Image Info Arg for Image Builder
 
   ################################################################################
   # Cleanup Docker Resources

--- a/eng/common/templates/steps/publish-readmes.yml
+++ b/eng/common/templates/steps/publish-readmes.yml
@@ -5,12 +5,12 @@ parameters:
 steps:
 - script: >
     $(runImageBuilderCmd) publishMcrDocs
-    --manifest $(manifest)
-    --registry-override $(acr.server)
-    $(dotnetDockerBot.userName)
-    $(dotnetDockerBot.email)
-    $(BotAccount-dotnet-docker-bot-PAT)
-    $(publicGitRepoUri)
+    --manifest '$(manifest)'
+    --registry-override '$(acr.server)'
+    '$(dotnetDockerBot.userName)'
+    '$(dotnetDockerBot.email)'
+    '$(BotAccount-dotnet-docker-bot-PAT)'
+    '$(publicGitRepoUri)'
     ${{ parameters.dryRunArg }}
     $(imageBuilder.queueArgs)
   displayName: Publish Readmes

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -15,6 +15,45 @@ variables:
   value: 2
 - name: imageInfoVariant
   value: ""
+
+  # Default values for variables defined in variable groups
+- name: acr.resourceGroup
+  value: "''"
+- name: acr.server
+  value: "''"
+- name: acr.servicePrincipalName
+  value: "''"
+- name: acr.servicePrincipalTenant
+  value: "''"
+- name: acr.subscription
+  value: "''"
+- name: acr.userName
+  value: "''"
+- name: app-dotnetdockerbuild-client-secret
+  value: "''"
+- name: app-DotnetDockerTelemetryIngestion-client-secret
+  value: PLACEHOLDER
+- name: BotAccount-dotnet-docker-acr-bot-password
+  value: "''"
+- name: BotAccount-dotnet-docker-bot-PAT
+  value: "''"
+- name: dotnetDockerBot.email
+  value: "''"
+- name: dotnetDockerBot.userName
+  value: "''"
+- name: kusto.cluster
+  value: "''"
+- name: kusto.database
+  value: "''"
+- name: kusto.table
+  value: "''"
+- name: kusto.servicePrincipalName
+  value: PLACEHOLDER
+- name: kusto.servicePrincipalTenant
+  value: PLACEHOLDER
+- name: publishRepoPrefix
+  value: "test/"
+
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNet-Docker-Common
   - group: DotNet-Docker-Secrets

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -15,42 +15,6 @@ variables:
   value: 2
 - name: imageInfoVariant
   value: ""
-
-  # Default values for variables defined in variable groups
-- name: acr.resourceGroup
-  value: "''"
-- name: acr.server
-  value: "''"
-- name: acr.servicePrincipalName
-  value: "''"
-- name: acr.servicePrincipalTenant
-  value: "''"
-- name: acr.subscription
-  value: "''"
-- name: acr.userName
-  value: "''"
-- name: app-dotnetdockerbuild-client-secret
-  value: "''"
-- name: app-DotnetDockerTelemetryIngestion-client-secret
-  value: PLACEHOLDER
-- name: BotAccount-dotnet-docker-acr-bot-password
-  value: "''"
-- name: BotAccount-dotnet-docker-bot-PAT
-  value: "''"
-- name: dotnetDockerBot.email
-  value: "''"
-- name: dotnetDockerBot.userName
-  value: "''"
-- name: kusto.cluster
-  value: "''"
-- name: kusto.database
-  value: "''"
-- name: kusto.table
-  value: "''"
-- name: kusto.servicePrincipalName
-  value: PLACEHOLDER
-- name: kusto.servicePrincipalTenant
-  value: PLACEHOLDER
 - name: publishRepoPrefix
   value: "test/"
 


### PR DESCRIPTION
Updates the pipeline workflow to execute the Post_Build and Publish stages as part of PR builds.  This provides more coverage of the pipeline when validating PRs and should help to expose issues that have otherwise gotten through to internal builds.  

Fixes #474