### PR TITLE
Add Dockerfile path to exception message to give more context

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
@@ -228,7 +228,8 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             {
                 if (!BuildArgs.TryGetValue(match.Groups[ArgGroupName].Value, out string argValue))
                 {
-                    throw new InvalidOperationException($"A value was not found for the ARG '{match.Value}'");
+                    throw new InvalidOperationException(
+                        $"A value was not found for the ARG '{match.Value}' in `{DockerfilePath}`");
                 }
 
                 instruction = instruction.Replace(match.Value, argValue);


### PR DESCRIPTION
I encountered an issue when working on https://github.com/dotnet/dotnet-docker/issues/1820.  The following exception was thrown and had no idea which manifest entry was the source of the issue.  Adding the Dockerfile path to the message makes it easier to pinpoint the entry.

```
System.InvalidOperationException: A value was not found for the ARG '$REPO'
   at Microsoft.DotNet.ImageBuilder.ViewModel.PlatformInfo.SubstituteBuildArgs(String instruction) in /image-builder/src/ViewModel/PlatformInfo.cs:line 231
   at Microsoft.DotNet.ImageBuilder.ViewModel.PlatformInfo.<>c__DisplayClass66_0.<InitializeFromImages>b__2(String from) in /image-builder/src/ViewModel/PlatformInfo.cs:line 109
   at System.Linq.Utilities.<>c__DisplayClass2_0`3.<CombineSelectors>b__0(TSource x)
   at System.Linq.Enumerable.SelectIListIterator`2.MoveNext()
   at System.Linq.Enumerable.WhereEnumerableIterator`1.ToArray()
   at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
   at Microsoft.DotNet.ImageBuilder.ViewModel.PlatformInfo.InitializeFromImages() in /image-builder/src/ViewModel/PlatformInfo.cs:line 106
   at Microsoft.DotNet.ImageBuilder.ViewModel.PlatformInfo.Initialize(IEnumerable`1 internalRepos, String registry) in /image-builder/src/ViewModel/PlatformInfo.cs:line 71
   at Microsoft.DotNet.ImageBuilder.ViewModel.ManifestInfo.Create(String manifestPath, ManifestFilter manifestFilter, IManifestOptionsInfo options) in /image-builder/src/ViewModel/ManifestInfo.cs:line 82
   at Microsoft.DotNet.ImageBuilder.ViewModel.ManifestInfo.Load(IManifestOptionsInfo options) in /image-builder/src/ViewModel/ManifestInfo.cs:line 43
   at Microsoft.DotNet.ImageBuilder.Commands.ManifestCommand`1.LoadManifest() in /image-builder/src/Commands/ManifestCommand.cs:line 16
   at Microsoft.DotNet.ImageBuilder.ImageBuilder.Main(String[] args) in /image-builder/src/ImageBuilder.cs:line 66
```