### PR TITLE
Fix publishManifestCommand to handle dry run

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestCommand.cs
@@ -96,7 +96,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
                 TagInfo sharedTag = image.ManifestImage.SharedTags.First();
                 JArray tagManifest = this.manifestToolService.Inspect(sharedTag.FullyQualifiedName, Options.IsDryRun);
-                string digest = tagManifest
+                string digest = tagManifest?
                     .OfType<JObject>()
                     .First(manifestType => manifestType["MediaType"].Value<string>() == ManifestListMediaType)
                     ["Digest"].Value<string>();

--- a/src/Microsoft.DotNet.ImageBuilder/src/ManifestToolService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ManifestToolService.cs
@@ -21,6 +21,11 @@ namespace Microsoft.DotNet.ImageBuilder
         public JArray Inspect(string image, bool isDryRun)
         {
             string output = ExecuteHelper.ExecuteWithRetry("manifest-tool", $"inspect {image} --raw", isDryRun);
+            if (isDryRun)
+            {
+                return null;
+            }
+
             return JsonConvert.DeserializeObject<JArray>(output);
         }
     }


### PR DESCRIPTION
When executing a build with the `dry-run` option, the `publishManifest` command will fail with an `ArgumentNullException` when it attempts to inspect the image to get its digest value. Since it's a dry run, the output of the `manifest inspect` command returns null and the code tries to deserialize that as JSON.  This issue only occurs if the build is publishing manifest tags.

Fixed this to check for a dry run and not attempt to deserialize the value.