### PR TITLE
Updates the repo name for the .NET Fx subscription

### DIFF
--- a/eng/check-base-image-subscriptions.json
+++ b/eng/check-base-image-subscriptions.json
@@ -66,7 +66,7 @@
       "owner": "dotnet",
       "repo": "versions",
       "branch": "master",
-      "path": "build-info/docker/image-info.Microsoft-dotnet-framework-docker-master-samples.json"
+      "path": "build-info/docker/image-info.microsoft-dotnet-framework-docker-master-samples.json"
     },
     "pipelineTrigger": {
       "id": 374,


### PR DESCRIPTION
Renames the image info files for the microsoft/dotnet-framework-docker repo so that the 'M' in Microsoft is lowercase. There are currently issues with the internal mirrored repo using capital M but the GitHub repo using lowercase. Getting this resolved to have consistent casing between the two.

