### PR TITLE
Fix tags metadata generator to handle undocumented platform

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/McrTagsMetadataGenerator.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/McrTagsMetadataGenerator.cs
@@ -136,9 +136,11 @@ namespace Microsoft.DotNet.ImageBuilder
                 DocumentedTags = GetDocumentedTags(Platform.Tags, documentationGroup)
                     .Concat(GetDocumentedTags(image.SharedTags, documentationGroup))
                     .ToArray();
-                FormattedDocumentedTags = DocumentedTags
-                    .Select(tag => tag.Name)
-                    .Aggregate((working, next) => $"{working}, {next}");
+                FormattedDocumentedTags = String.Join(
+                    ", ",
+                    DocumentedTags
+                        .Select(tag => tag.Name)
+                        .ToArray());
             }
 
             public static IEnumerable<ImageDocumentationInfo> Create(ImageInfo image, PlatformInfo platform)


### PR DESCRIPTION
If a platform defined in the manifest doesn't have any documented tags, it results in a "Sequence contains no elements" exception when attempting to call `McrTagsMetadataGenerator`.  This happens because the logic calls the Enumerable.Aggregate method which throws if the sequence is empty.  Fixed the code to use `String.Join` instead which results in an empty string return value if the array is empty.