### PR TITLE
Update image size validation to use latest Windows version agent

### DIFF
--- a/eng/common/templates/jobs/validate-image-sizes.yml
+++ b/eng/common/templates/jobs/validate-image-sizes.yml
@@ -32,12 +32,12 @@ jobs:
       dockerClientOS: linux
       validationMode: integrity
 - job: WindowsPerfTests
-  pool: # windows1909Amd64
+  pool: # windows2004Amd64
     ${{ if eq(variables['System.TeamProject'], 'public') }}:
       name: DotNetCore-Docker-Public
     ${{ if eq(variables['System.TeamProject'], 'internal') }}:
       name: DotNetCore-Docker
-    demands: VSTS_OS -equals Windows-ServerDatacenter-1909
+    demands: VSTS_OS -equals Windows-ServerDatacenter-2004
   workspace:
     clean: all
   steps:


### PR DESCRIPTION
The image size validation tests require the Windows build agent to be the latest Windows version so that it can pull down all supported versions of Windows images.