### PR TITLE
Add uniqueness to artifact names to fix retry attempts

### DIFF
--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -40,7 +40,7 @@ jobs:
       $(imageBuilderImageInfoArg)
     displayName: Build Images
   - publish: $(Build.ArtifactStagingDirectory)/$(legName)-image-info.json
-    artifact: $(legName)-image-info
+    artifact: $(legName)-image-info-$(System.JobAttempt)
     displayName: Publish Image Info File Artifact
   - ${{ if eq(variables['System.TeamProject'], 'public') }}:
     - template: ${{ format('../steps/test-images-{0}-client.yml', parameters.dockerClientOS) }}

--- a/eng/common/templates/jobs/post-build.yml
+++ b/eng/common/templates/jobs/post-build.yml
@@ -7,6 +7,27 @@ jobs:
   - template: ../steps/download-build-artifact.yml
     parameters:
       targetPath: $(Build.ArtifactStagingDirectory)
+  - pwsh: |
+      # Deletes the artifacts from all the unsuccessful jobs
+      Get-ChildItem $(Build.ArtifactStagingDirectory) -Directory |
+          ForEach-Object {
+              [pscustomobject]@{
+                  # Parse the artifact filename to separate the base of the filename from the job attempt number 
+                  BaseName = $_.Name.Substring(0, $_.Name.LastIndexOf('-'));
+                  JobAttempt = $_.Name.Substring($_.Name.LastIndexOf('-') + 1)
+                  FullName = $_.FullName
+              }
+          } |
+          Group-Object BaseName |
+          # Delete all but the last artifact from each base filename
+          ForEach-Object {
+              $_.Group |
+                  Sort-Object JobAttempt |
+                  Select-Object -ExpandProperty FullName -SkipLast 1 |
+                  #Remove-Item -Recurse -Force
+                  Write-Host
+          }
+    displayName: Prune Publish Artifacts
   - script: >
       $(runImageBuilderCmd) mergeImageInfo
       --manifest $(manifest)

--- a/eng/common/templates/jobs/post-build.yml
+++ b/eng/common/templates/jobs/post-build.yml
@@ -24,8 +24,7 @@ jobs:
               $_.Group |
                   Sort-Object JobAttempt |
                   Select-Object -ExpandProperty FullName -SkipLast 1 |
-                  #Remove-Item -Recurse -Force
-                  Write-Host
+                  Remove-Item -Recurse -Force
           }
     displayName: Prune Publish Artifacts
   - script: >

--- a/eng/common/templates/jobs/post-build.yml
+++ b/eng/common/templates/jobs/post-build.yml
@@ -12,14 +12,14 @@ jobs:
       Get-ChildItem $(Build.ArtifactStagingDirectory) -Directory |
           ForEach-Object {
               [pscustomobject]@{
-                  # Parse the artifact filename to separate the base of the filename from the job attempt number 
+                  # Parse the artifact name to separate the base of the name from the job attempt number 
                   BaseName = $_.Name.Substring(0, $_.Name.LastIndexOf('-'));
                   JobAttempt = $_.Name.Substring($_.Name.LastIndexOf('-') + 1)
                   FullName = $_.FullName
               }
           } |
           Group-Object BaseName |
-          # Delete all but the last artifact from each base filename
+          # Delete all but the last artifact from each base name
           ForEach-Object {
               $_.Group |
                   Sort-Object JobAttempt |

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -66,7 +66,7 @@ jobs:
       $(imageBuilder.commonCmdArgs)
     displayName: Publish Manifest
   - publish: $(Build.ArtifactStagingDirectory)/image-info.json
-    artifact: image-info-final
+    artifact: image-info-final-$(System.JobAttempt)
     displayName: Publish Image Info File Artifact
   - template: ../steps/publish-readmes.yml
     parameters:


### PR DESCRIPTION
A retry of a job that has already published the image info artifact will result in a failure because an artifact with the same name already exists.  Pipeline artifacts cannot be overwritten or deleted.  So the only option is to use a unique name to prevent a conflict.  This is done by appending the `System.JobAttempt` variable to the artifact name.  In the post-build stage, we collect all the image info artifacts and combine them into one image info file.  There needs to be a way to ignore the image info artifacts that were published by failed jobs.  This is done by a script which deletes all the artifacts from those failed jobs.

Fixes #519 
