### PR TITLE
Remove osVersion parameter when building

### DIFF
--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -16,7 +16,6 @@ jobs:
     matrix: $[ ${{ parameters.matrix }} ]
   timeoutInMinutes: ${{ parameters.buildJobTimeout }}
   variables:
-    osVersion: ${{ parameters.osVersion }}
     ${{ if eq(variables['System.TeamProject'], 'internal') }}:
       imageBuilderBuildArgs: --registry-override $(acr.server) --repo-prefix $(stagingRepoPrefix) --push --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
     ${{ if eq(variables['System.TeamProject'], 'public') }}:
@@ -32,7 +31,6 @@ jobs:
       --manifest $(manifest)
       $(imageBuilderPaths)
       --os-type $(osType)
-      --os-version "$(osVersion)"
       --architecture $(architecture)
       --retry
       --source-repo $(publicGitRepoUri)


### PR DESCRIPTION
The [dotnet-buildtools-preqreqs-docker](https://github.com/dotnet/dotnet-buildtools-prereqs-docker) repo now builds both a Nano Server and Windows Server Core image in the same [pipeline](https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/master/eng/pipelines/dotnet-buildtools-prereqs-eng.yml).  There's an issue with this because the build leg that's supposed to build the Windows Server Core image ends up not being anything.  This is caused by the parameters used to invoke the Image Builder `build` command.  It's passed an `os-version` parameter that, in this case, is set to `nanoserver-1809` instead of `windowsservercore-ltsc2019`.  The reason for this is due to the need to treat those two OS versions as equivalent in that they require the same build agent version.  However, by setting the `os-version` parameter, it ends up filtering out the `windowsservercore-ltsc2019` Dockerfile paths.

Taking a step back, there's really no need to even have the build job pass an `os-version` parameter because it's already explicitly filtering what needs to be built by passing the `path` parameters.  I've updated the pipeline to remove that parameter as well as removing it from the build matrix generation output.