### PR TITLE
Update ACR cleanup to be driven from cmd options

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesCommand.cs
@@ -66,14 +66,14 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             {
                 case CleanAcrImagesAction.PruneDangling:
                     await ProcessManifestsAsync(acrClient, deletedImages, deletedRepos, repository,
-                        manifest => !manifest.Tags.Any() && IsExpired(manifest.LastUpdateTime, Options.DaysOld));
+                        manifest => !manifest.Tags.Any() && IsExpired(manifest.LastUpdateTime, Options.Age));
                     break;
                 case CleanAcrImagesAction.PruneAll:
                     await ProcessManifestsAsync(acrClient, deletedImages, deletedRepos, repository,
-                        manifest => IsExpired(manifest.LastUpdateTime, Options.DaysOld));
+                        manifest => IsExpired(manifest.LastUpdateTime, Options.Age));
                     break;
                 case CleanAcrImagesAction.Delete:
-                    if (IsExpired(repository.LastUpdateTime, Options.DaysOld))
+                    if (IsExpired(repository.LastUpdateTime, Options.Age))
                     {
                         await DeleteRepositoryAsync(acrClient, deletedRepos, repository);
                     }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesCommand.cs
@@ -7,8 +7,10 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Models.Acr;
+using Microsoft.DotNet.ImageBuilder.ViewModel;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
@@ -17,6 +19,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     {
         private readonly IAcrClientFactory acrClientFactory;
         private readonly ILoggerService loggerService;
+        private Regex repoNameFilterRegex;
 
         [ImportingConstructor]
         public CleanAcrImagesCommand(IAcrClientFactory acrClientFactory, ILoggerService loggerService)
@@ -27,6 +30,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         public override async Task ExecuteAsync()
         {
+            this.repoNameFilterRegex = new Regex(ManifestFilter.GetFilterRegexPattern(Options.RepoName));
+
             this.loggerService.WriteHeading("FINDING IMAGES TO CLEAN");
 
             this.loggerService.WriteSubheading($"Connecting to ACR '{Options.RegistryName}'");
@@ -42,7 +47,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             List<string> deletedImages = new List<string>();
 
             IEnumerable<Task> cleanupTasks = catalog.RepositoryNames
-                .Where(repoName => IsTestRepo(repoName) || IsStagingRepo(repoName) || IsPublicNightlyRepo(repoName))
+                .Where(repoName => this.repoNameFilterRegex.IsMatch(repoName))
                 .Select(repoName => acrClient.GetRepositoryAsync(repoName))
                 .Select(getRepoTask => ProcessRepoAsync(acrClient, getRepoTask, deletedRepos, deletedImages))
                 .ToArray();
@@ -56,21 +61,25 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             IAcrClient acrClient, Task<Repository> getRepoTask, List<string> deletedRepos, List<string> deletedImages)
         {
             Repository repository = await getRepoTask;
-            if (IsPublicNightlyRepo(repository.Name))
+
+            switch (Options.Action)
             {
-                await ProcessPublicNightlyRepoAsync(acrClient, deletedImages, repository);
-            }
-            else if (IsTestRepo(repository.Name))
-            {
-                await ProcessTestRepoAsync(acrClient, deletedImages, deletedRepos, repository);
-            }
-            else if (IsStagingRepo(repository.Name))
-            {
-                await ProcessStagingRepoAsync(acrClient, deletedRepos, repository);
-            }
-            else
-            {
-                throw new NotSupportedException($"Unexpected request to process repo '{repository.Name}'.");
+                case CleanAcrImagesAction.PruneDangling:
+                    await ProcessManifestsAsync(acrClient, deletedImages, deletedRepos, repository,
+                        manifest => !manifest.Tags.Any() && IsExpired(manifest.LastUpdateTime, Options.DaysOld));
+                    break;
+                case CleanAcrImagesAction.PruneAll:
+                    await ProcessManifestsAsync(acrClient, deletedImages, deletedRepos, repository,
+                        manifest => IsExpired(manifest.LastUpdateTime, Options.DaysOld));
+                    break;
+                case CleanAcrImagesAction.Delete:
+                    if (IsExpired(repository.LastUpdateTime, Options.DaysOld))
+                    {
+                        await DeleteRepositoryAsync(acrClient, deletedRepos, repository);
+                    }
+                    break;
+                default:
+                    throw new NotSupportedException($"Unsupported action: {Options.Action}");
             }
         }
 
@@ -108,8 +117,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         }
 
-        private async Task ProcessTestRepoAsync(
-            IAcrClient acrClient, List<string> deletedImages, List<string> deletedRepos, Repository repository)
+        private async Task ProcessManifestsAsync(
+            IAcrClient acrClient, List<string> deletedImages, List<string> deletedRepos, Repository repository,
+            Func<ManifestAttributes, bool> canDeleteManifest)
         {
             RepositoryManifests repoManifests = await acrClient.GetRepositoryManifestsAsync(repository.Name);
             if (!repoManifests.Manifests.Any())
@@ -119,7 +129,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             }
 
             ManifestAttributes[] expiredTestImages = repoManifests.Manifests
-                .Where(manifest => IsExpired(manifest.LastUpdateTime, 7))
+                .Where(manifest => canDeleteManifest(manifest))
                 .ToArray();
 
             // If all the images in the repo are expired, delete the whole repo instead of 
@@ -131,15 +141,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             }
 
             await DeleteManifestsAsync(acrClient, deletedImages, repository, expiredTestImages);
-        }
-
-        private async Task ProcessPublicNightlyRepoAsync(
-            IAcrClient acrClient, List<string> deletedImages, Repository repository)
-        {
-            RepositoryManifests repoManifests = await acrClient.GetRepositoryManifestsAsync(repository.Name);
-            IEnumerable<ManifestAttributes> untaggedImages = repoManifests.Manifests
-                .Where(manifest => !manifest.Tags.Any() && IsExpired(manifest.LastUpdateTime, 30));
-            await DeleteManifestsAsync(acrClient, deletedImages, repository, untaggedImages);
         }
 
         private async Task DeleteManifestsAsync(
@@ -169,14 +170,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             lock (deletedImages)
             {
                 deletedImages.Add(imageId);
-            }
-        }
-
-        private async Task ProcessStagingRepoAsync(IAcrClient acrClient, List<string> deletedRepos, Repository repository)
-        {
-            if (IsExpired(repository.LastUpdateTime, 15))
-            {
-                await DeleteRepositoryAsync(acrClient, deletedRepos, repository);
             }
         }
 
@@ -229,10 +222,5 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         }
 
         private bool IsExpired(DateTime dateTime, int expirationDays) => dateTime.AddDays(expirationDays) < DateTime.Now;
-        private bool IsStagingRepo(string repoName) => repoName.StartsWith("build-staging/");
-        private bool IsPublicNightlyRepo(string repoName) =>
-            IsPublicRepo(repoName) && (repoName.Contains("/core-nightly/") || repoName.Contains("/nightly/"));
-        private bool IsTestRepo(string repoName) => repoName.StartsWith("test/");
-        private bool IsPublicRepo(string repoName) => repoName.StartsWith("public/");
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesOptions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.CommandLine;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
@@ -10,6 +11,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     {
         protected override string CommandHelp => "Removes unnecessary images from an ACR";
 
+        public string RepoName { get; set; }
+        public CleanAcrImagesAction Action { get; set; }
+        public int DaysOld { get; set; }
         public string Username { get; set; }
         public string Password { get; set; }
         public string Tenant { get; set; }
@@ -20,6 +24,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public override void DefineParameters(ArgumentSyntax syntax)
         {
             base.DefineParameters(syntax);
+
+            string repoName = null;
+            syntax.DefineParameter("repo", ref repoName, "Name of repo to target (wildcard chars * and ? supported)");
+            RepoName = repoName;
 
             string username = null;
             syntax.DefineParameter("username", ref username, "The URL or name associated with the service principal to use");
@@ -45,5 +53,38 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             syntax.DefineParameter("registry", ref registryName, "Name of the registry");
             RegistryName = registryName;
         }
+
+        public override void DefineOptions(ArgumentSyntax syntax)
+        {
+            base.DefineOptions(syntax);
+
+            const CleanAcrImagesAction defaultAction = CleanAcrImagesAction.PruneDangling;
+            string action = defaultAction.ToString().ToCamelCase();
+            syntax.DefineOption("action", ref action,
+                $"Type of delete action. {EnumHelper.GetHelpTextOptions(defaultAction)}");
+            Action = (CleanAcrImagesAction)Enum.Parse(typeof(CleanAcrImagesAction), action, ignoreCase: true);
+
+            int daysOld = 30;
+            syntax.DefineOption("days", ref action, "Number of days old to be considered for deletion");
+            DaysOld = daysOld;
+        }
+    }
+
+    public enum CleanAcrImagesAction
+    {
+        /// <summary>
+        /// Deletes untagged images in a repo.
+        /// </summary>
+        PruneDangling,
+
+        /// <summary>
+        /// Deletes all images in a repo.
+        /// </summary>
+        PruneAll,
+
+        /// <summary>
+        /// Deletes the repo.
+        /// </summary>
+        Delete
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesOptions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         public string RepoName { get; set; }
         public CleanAcrImagesAction Action { get; set; }
-        public int DaysOld { get; set; }
+        public int Age { get; set; }
         public string Username { get; set; }
         public string Password { get; set; }
         public string Tenant { get; set; }
@@ -58,15 +58,15 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             base.DefineOptions(syntax);
 
-            const CleanAcrImagesAction defaultAction = CleanAcrImagesAction.PruneDangling;
-            string action = defaultAction.ToString().ToCamelCase();
+            CleanAcrImagesAction action = CleanAcrImagesAction.PruneDangling;
             syntax.DefineOption("action", ref action,
-                $"Type of delete action. {EnumHelper.GetHelpTextOptions(defaultAction)}");
-            Action = (CleanAcrImagesAction)Enum.Parse(typeof(CleanAcrImagesAction), action, ignoreCase: true);
+                value => (CleanAcrImagesAction)Enum.Parse(typeof(CleanAcrImagesAction), value, true),
+                $"Type of delete action. {EnumHelper.GetHelpTextOptions(action)}");
+            Action = action;
 
-            int daysOld = 30;
-            syntax.DefineOption("days", ref action, "Number of days old to be considered for deletion");
-            DaysOld = daysOld;
+            int age = 30;
+            syntax.DefineOption("age", ref age, $"Minimum age (days) of repo or images to be deleted (default: {age})");
+            Age = age;
         }
     }
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixOptions.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 "type",
                 ref matrixType,
                 value => (MatrixType)Enum.Parse(typeof(MatrixType), value, true),
-                $"Type of matrix to generate - {Enum.GetNames(typeof(MatrixType)).Aggregate((s1, s2) => $"{s1}, {s2}")}");
+                $"Type of matrix to generate. {EnumHelper.GetHelpTextOptions(matrixType)}");
             MatrixType = matrixType;
 
             string customBuildLegGrouping = null;

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ValidateImageSizeOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ValidateImageSizeOptions.cs
@@ -21,11 +21,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             base.DefineOptions(syntax);
 
-            ImageSizeValidationMode defaultValidationMode = ImageSizeValidationMode.All;
-            string mode = defaultValidationMode.ToString().ToLowerInvariant();
+            ImageSizeValidationMode mode = ImageSizeValidationMode.All;
             syntax.DefineOption("mode", ref mode,
-                $"Mode of validation. {EnumHelper.GetHelpTextOptions(defaultValidationMode)}");
-            Mode = (ImageSizeValidationMode)Enum.Parse(typeof(ImageSizeValidationMode), mode, ignoreCase: true);
+                value => (ImageSizeValidationMode)Enum.Parse(typeof(ImageSizeValidationMode), value, true),
+                $"Mode of validation. {EnumHelper.GetHelpTextOptions(mode)}");
+            Mode = mode;
         }
     }
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ValidateImageSizeOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ValidateImageSizeOptions.cs
@@ -21,8 +21,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             base.DefineOptions(syntax);
 
-            string mode = ImageSizeValidationMode.All.ToString().ToLowerInvariant();
-            syntax.DefineOption("mode", ref mode, "Mode of validation. Options: all (default), size, integrity");
+            ImageSizeValidationMode defaultValidationMode = ImageSizeValidationMode.All;
+            string mode = defaultValidationMode.ToString().ToLowerInvariant();
+            syntax.DefineOption("mode", ref mode,
+                $"Mode of validation. {EnumHelper.GetHelpTextOptions(defaultValidationMode)}");
             Mode = (ImageSizeValidationMode)Enum.Parse(typeof(ImageSizeValidationMode), mode, ignoreCase: true);
         }
     }

--- a/src/Microsoft.DotNet.ImageBuilder/src/EnumHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/EnumHelper.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+
+namespace Microsoft.DotNet.ImageBuilder
+{
+    public static class EnumHelper
+    {
+        public static string GetHelpTextOptions<T>(T defaultValue)
+            where T : Enum
+        {
+            string nonDefaultValueOptions = String.Join(", ",
+                Enum.GetValues(typeof(T))
+                    .Cast<T>()
+                    .Where(enumVal => !enumVal.Equals(defaultValue))
+                    .Select(enumVal => enumVal.ToString().ToCamelCase()));
+            return $"Options: {defaultValue.ToString().ToCamelCase()} (default), {nonDefaultValueOptions}";
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/tests/CleanAcrImagesCommandTest.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/CleanAcrImagesCommandTest.cs
@@ -109,6 +109,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             command.Options.Tenant = tenant;
             command.Options.ResourceGroup = resourceGroup;
             command.Options.RegistryName = acrName;
+            command.Options.RepoName = "build-staging/*";
+            command.Options.Action = CleanAcrImagesAction.Delete;
+            command.Options.DaysOld = 15;
 
             await command.ExecuteAsync();
 
@@ -226,6 +229,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             acrClientMock
                 .Setup(o => o.GetRepositoryManifestsAsync(publicRepo4Name))
                 .ReturnsAsync(repo4Manifests);
+            acrClientMock
+                .Setup(o => o.DeleteRepositoryAsync(publicRepo4Name))
+                .ReturnsAsync(new DeleteRepositoryResponse());
 
             Mock<IAcrClientFactory> acrClientFactoryMock = new Mock<IAcrClientFactory>();
             acrClientFactoryMock
@@ -240,6 +246,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             command.Options.Tenant = tenant;
             command.Options.ResourceGroup = resourceGroup;
             command.Options.RegistryName = acrName;
+            command.Options.RepoName = "public/dotnet/*nightly/*";
+            command.Options.Action = CleanAcrImagesAction.PruneDangling;
+            command.Options.DaysOld = 30;
 
             await command.ExecuteAsync();
 
@@ -248,7 +257,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             acrClientMock.Verify(o => o.DeleteManifestAsync(publicRepo2Name, It.IsAny<string>()), Times.Never);
             acrClientMock.Verify(o => o.DeleteManifestAsync(publicRepo3Name, repo3Digest1), Times.Never);
             acrClientMock.Verify(o => o.DeleteManifestAsync(publicRepo3Name, repo3Digest2));
-            acrClientMock.Verify(o => o.DeleteManifestAsync(publicRepo4Name, repo4Digest1));
+            acrClientMock.Verify(o => o.DeleteRepositoryAsync(publicRepo4Name));
         }
 
         /// <summary>
@@ -331,6 +340,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             command.Options.Tenant = tenant;
             command.Options.ResourceGroup = resourceGroup;
             command.Options.RegistryName = acrName;
+            command.Options.RepoName = "test/*";
+            command.Options.Action = CleanAcrImagesAction.PruneAll;
+            command.Options.DaysOld = 7;
 
             await command.ExecuteAsync();
 
@@ -414,6 +426,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             command.Options.Tenant = tenant;
             command.Options.ResourceGroup = resourceGroup;
             command.Options.RegistryName = acrName;
+            command.Options.RepoName = "test/*";
+            command.Options.Action = CleanAcrImagesAction.PruneAll;
+            command.Options.DaysOld = 7;
 
             await command.ExecuteAsync();
 
@@ -515,6 +530,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             command.Options.Tenant = tenant;
             command.Options.ResourceGroup = resourceGroup;
             command.Options.RegistryName = acrName;
+            command.Options.RepoName = "test/*";
+            command.Options.Action = CleanAcrImagesAction.PruneAll;
+            command.Options.DaysOld = 7;
 
             await command.ExecuteAsync();
 

--- a/src/Microsoft.DotNet.ImageBuilder/tests/CleanAcrImagesCommandTest.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/CleanAcrImagesCommandTest.cs
@@ -111,7 +111,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             command.Options.RegistryName = acrName;
             command.Options.RepoName = "build-staging/*";
             command.Options.Action = CleanAcrImagesAction.Delete;
-            command.Options.DaysOld = 15;
+            command.Options.Age = 15;
 
             await command.ExecuteAsync();
 
@@ -248,7 +248,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             command.Options.RegistryName = acrName;
             command.Options.RepoName = "public/dotnet/*nightly/*";
             command.Options.Action = CleanAcrImagesAction.PruneDangling;
-            command.Options.DaysOld = 30;
+            command.Options.Age = 30;
 
             await command.ExecuteAsync();
 
@@ -342,7 +342,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             command.Options.RegistryName = acrName;
             command.Options.RepoName = "test/*";
             command.Options.Action = CleanAcrImagesAction.PruneAll;
-            command.Options.DaysOld = 7;
+            command.Options.Age = 7;
 
             await command.ExecuteAsync();
 
@@ -428,7 +428,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             command.Options.RegistryName = acrName;
             command.Options.RepoName = "test/*";
             command.Options.Action = CleanAcrImagesAction.PruneAll;
-            command.Options.DaysOld = 7;
+            command.Options.Age = 7;
 
             await command.ExecuteAsync();
 
@@ -532,7 +532,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             command.Options.RegistryName = acrName;
             command.Options.RepoName = "test/*";
             command.Options.Action = CleanAcrImagesAction.PruneAll;
-            command.Options.DaysOld = 7;
+            command.Options.Age = 7;
 
             await command.ExecuteAsync();
 


### PR DESCRIPTION
In order to better allow for more ad-hoc deletion of images in ACR, these changes update the `cleanAcrImages` command to specify what and how the deletions should be made by using the command parameters instead of having repo-specific logic embedded in the command.

Related to #504