### PR TITLE
Support for multiple os-version options

### DIFF
--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -16,6 +16,7 @@ jobs:
     matrix: $[ ${{ parameters.matrix }} ]
   timeoutInMinutes: ${{ parameters.buildJobTimeout }}
   variables:
+    osVersion: ${{ parameters.osVersion }}
     ${{ if eq(variables['System.TeamProject'], 'internal') }}:
       imageBuilderBuildArgs: --registry-override $(acr.server) --repo-prefix $(stagingRepoPrefix) --push --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
     ${{ if eq(variables['System.TeamProject'], 'public') }}:
@@ -31,6 +32,7 @@ jobs:
       --manifest $(manifest)
       $(imageBuilderPaths)
       --os-type $(osType)
+      --os-version "$(osVersion)"
       --architecture $(architecture)
       --retry
       --source-repo $(publicGitRepoUri)

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestFilterOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestFilterOptions.cs
@@ -14,9 +14,12 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public const string PathOptionName = "path";
         public const string FormattedPathOption = "--" + PathOptionName;
 
+        public const string OsVersionOptionName = "os-version";
+        public const string FormattedOsVersionOption = "--" + OsVersionOptionName;
+
         public string Architecture { get; set; }
         public string OsType { get; set; }
-        public string OsVersion { get; set; }
+        public IEnumerable<string> OsVersions { get; set; }
         public IEnumerable<string> Paths { get; set; }
 
         public void DefineOptions(ArgumentSyntax syntax)
@@ -35,12 +38,12 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 "OS type (linux/windows) of the Dockerfiles to build - wildcard chars * and ? supported (default is the Docker OS)");
             OsType = osType;
 
-            string osVersion = null;
-            syntax.DefineOption(
-                "os-version",
-                ref osVersion,
-                "OS version of the Dockerfiles to build - wildcard chars * and ? supported (default is to build all)");
-            OsVersion = osVersion;
+            IReadOnlyList<string> osVersions = Array.Empty<string>();
+            syntax.DefineOptionList(
+                OsVersionOptionName,
+                ref osVersions,
+                "OS versions of the Dockerfiles to build - wildcard chars * and ? supported (default is to build all)");
+            OsVersions = osVersions;
 
             IReadOnlyList<string> paths = Array.Empty<string>();
             syntax.DefineOptionList(

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestOptions.cs
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 ManifestFilterOptions filterOptions = ((IFilterableOptions)this).FilterOptions;
                 filter.IncludeArchitecture = filterOptions.Architecture;
                 filter.IncludeOsType = filterOptions.OsType;
-                filter.IncludeOsVersion = filterOptions.OsVersion;
+                filter.IncludeOsVersions = filterOptions.OsVersions;
                 filter.IncludePaths = filterOptions.Paths;
             }
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestFilter.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestFilter.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         public string IncludeArchitecture { get; set; }
         public string IncludeOsType { get; set; }
         public string IncludeRepo { get; set; }
-        public string IncludeOsVersion { get; set; }
+        public IEnumerable<string> IncludeOsVersions { get; set; }
         public IEnumerable<string> IncludePaths { get; set; }
 
         public ManifestFilter()
@@ -54,9 +54,9 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
                     Regex.IsMatch(platform.Dockerfile, pathsRegexPattern, RegexOptions.IgnoreCase));
             }
 
-            if (IncludeOsVersion != null)
+            if (IncludeOsVersions?.Any() ?? false)
             {
-                string includeOsVersionPattern = GetFilterRegexPattern(IncludeOsVersion);
+                string includeOsVersionPattern = GetFilterRegexPattern(IncludeOsVersions.ToArray());
                 platforms = platforms.Where(platform =>
                     Regex.IsMatch(platform.OsVersion ?? string.Empty, includeOsVersionPattern, RegexOptions.IgnoreCase));
             }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
@@ -319,6 +319,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Assert.Equal(
                 "--path 1.0/runtime/nanoserver-1909/Dockerfile --path 1.0/aspnet/nanoserver-1909/Dockerfile --path 1.0/runtime/windowsservercore-1909/Dockerfile --path 1.0/aspnet/windowsservercore-1909/Dockerfile",
                 imageBuilderPaths);
+            string osVersions = leg.Variables.First(variable => variable.Name == "osVersions").Value;
+            Assert.Equal(
+                "--os-version nanoserver-1909 --os-version windowsservercore-1909",
+                osVersions);
         }
     }
 }


### PR DESCRIPTION
* Adds back the `os-version` parameter when running the `build` command.
* Fixes the value of the osVersion field in the build matrix to not be the normalized value.
* Adds support for multiple `os-version` options.  This supports cases where two different OS versions need to be built in the same job (e.g. Nano Server 1909 and Windows Server Core 1909).

Once a new version of Image Builder is available with these changes, another change will be made to consume that new version and update the pipeline to use the multiple `os-version` options.

Fixes #545