### PR TITLE
Fix build matrix generation for custom leg groupings

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
@@ -205,14 +205,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         CreateImage(
                             new Platform[]
                             {
-                                CreatePlatform(dockerfileRuntime2FullPath, new string[] { "tag" })
+                                CreatePlatform(dockerfileRuntime2FullPath, new string[] { "tag" }, osVersion: "buster")
                             },
                             productVersion: "2.0")),
                     CreateRepo("sdk2",
                         CreateImage(
                             new Platform[]
                             {
-                                CreatePlatform(dockerfileSdk2FullPath, new string[] { "tag" })
+                                CreatePlatform(dockerfileSdk2FullPath, new string[] { "tag" }, osVersion: "buster")
                             },
                             productVersion: "2.0"))
                 );
@@ -227,10 +227,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 BuildLegInfo leg_1_0 = matrixInfo.Legs.First();
                 string imageBuilderPaths = leg_1_0.Variables.First(variable => variable.Name == "imageBuilderPaths").Value;
                 Assert.Equal("--path 1.0/runtime-deps/os/Dockerfile --path 1.0/runtime/os/Dockerfile --path 2.0/sdk/os2/Dockerfile --path 2.0/runtime/os2/Dockerfile", imageBuilderPaths);
+                string osVersions = leg_1_0.Variables.First(variable => variable.Name == "osVersions").Value;
+                Assert.Equal("--os-version disco --os-version buster", osVersions);
 
                 BuildLegInfo leg_2_0 = matrixInfo.Legs.ElementAt(1);
                 imageBuilderPaths = leg_2_0.Variables.First(variable => variable.Name == "imageBuilderPaths").Value;
                 Assert.Equal("--path 2.0/runtime/os2/Dockerfile --path 2.0/sdk/os2/Dockerfile", imageBuilderPaths);
+                osVersions = leg_2_0.Variables.First(variable => variable.Name == "osVersions").Value;
+                Assert.Equal("--os-version buster", osVersions);
             }
         }
 


### PR DESCRIPTION
The changes made in https://github.com/dotnet/docker-tools/pull/546 didn't correctly handle custom leg grouping dependencies when the `platformVersionedOs` matrix type was being generated.  This would result in such dependencies not getting built in PR build jobs, where this matrix type is used, due to them being filtered out by the `os-version` option.