### PR TITLE
Ref the new image info variant for docker-tools test builds

### DIFF
--- a/eng/pipelines/dotnet-docker-tools-eng-validation.yml
+++ b/eng/pipelines/dotnet-docker-tools-eng-validation.yml
@@ -27,6 +27,8 @@ variables:
   value: https://github.com/dotnet/dotnet-docker-test
 - name: publishRepoPrefix
   value: test/
+- name: imageInfoVariant
+  value: "-test"
 
 stages:
 - template: ../common/templates/stages/build-test-publish-repo.yml


### PR DESCRIPTION
Reference the new filename of the image info file (see https://github.com/dotnet/versions/pull/610).