### PR TITLE
Fix ACR querying issue

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesCommand.cs
@@ -121,7 +121,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             IAcrClient acrClient, List<string> deletedImages, List<string> deletedRepos, Repository repository,
             Func<ManifestAttributes, bool> canDeleteManifest)
         {
+            this.loggerService.WriteMessage($"Querying manifests for repo '{repository.Name}'");
             RepositoryManifests repoManifests = await acrClient.GetRepositoryManifestsAsync(repository.Name);
+            this.loggerService.WriteMessage($"Finished querying manifests for repo '{repository.Name}'. Manifest count: {repoManifests.Manifests.Count}");
+
             if (!repoManifests.Manifests.Any())
             {
                 await DeleteRepositoryAsync(acrClient, deletedRepos, repository);


### PR DESCRIPTION
Fixes an issue where querying for ACR repo manifests would sometimes result in a `SocketException`.  It's not exactly clear why this happens but it's definitely related to the amount of records that are being requested as defined by the URL.  This is done in order to page through the results.  The max value, 999, was being used which has been problematic.  I've moved this down to 500 and consistently seen good results.  I've also added some code to the retry logic to handle the case where a `SocketException` gets thrown.  My testing found that retries would work if a SocketException was ever thrown.