### PR TITLE
Update Clean ACR image pipelines

### DIFF
--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,6 +1,6 @@
 variables:
-  imageNames.imageBuilder.linux: mcr.microsoft.com/dotnet-buildtools/image-builder:linux-20200610205920
-  imageNames.imageBuilder.windows: mcr.microsoft.com/dotnet-buildtools/image-builder:windows-20200610205920
+  imageNames.imageBuilder.linux: mcr.microsoft.com/dotnet-buildtools/image-builder:linux-20200615140526
+  imageNames.imageBuilder.windows: mcr.microsoft.com/dotnet-buildtools/image-builder:windows-20200615140526
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch-slim-docker-testrunner-d61254f-20190807161111
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/eng/pipelines/cleanup-acr-images-custom.yml
+++ b/eng/pipelines/cleanup-acr-images-custom.yml
@@ -1,0 +1,18 @@
+trigger: none
+pr: none
+
+variables:
+- template: ../common/templates/variables/common.yml
+
+jobs:
+- job: Build
+  pool: Hosted Ubuntu 1604
+  steps:
+  - template: ../common/templates/steps/init-docker-linux.yml
+  - template: templates/steps/clean-acr-images.yml
+    parameters:
+      repo: $(repo)
+      action: $(action)
+      age: $(age)
+      customArgs: $(customArgs)
+  - template: ../common/templates/steps/cleanup-docker-linux.yml

--- a/eng/pipelines/cleanup-acr-images.yml
+++ b/eng/pipelines/cleanup-acr-images.yml
@@ -16,13 +16,19 @@ jobs:
   pool: Hosted Ubuntu 1604
   steps:
   - template: ../common/templates/steps/init-docker-linux.yml
-  - script: >
-      $(runImageBuilderCmd) cleanAcrImages
-      $(acr.servicePrincipalName)
-      $(app-dotnetdockerbuild-client-secret)
-      $(acr.servicePrincipalTenant)
-      $(acr.subscription)
-      $(acr.resourceGroup)
-      $(acr.server)
-    displayName: Clean ACR Images
+  - template: templates/steps/clean-acr-images.yml
+    parameters:
+      repo: "build-staging/*"
+      action: delete
+      age: 15
+  - template: templates/steps/clean-acr-images.yml
+    parameters:
+      repo: "public/dotnet/*nightly/*"
+      action: pruneDangling
+      age: 30
+  - template: templates/steps/clean-acr-images.yml
+    parameters:
+      repo: "test/*"
+      action: pruneAll
+      age: 7
   - template: ../common/templates/steps/cleanup-docker-linux.yml

--- a/eng/pipelines/templates/steps/clean-acr-images.yml
+++ b/eng/pipelines/templates/steps/clean-acr-images.yml
@@ -1,0 +1,19 @@
+parameters:
+  repo: null
+  action: null
+  age: null
+  customArgs: ""
+steps:
+  - script: >
+      $(runImageBuilderCmd) cleanAcrImages
+      ${{ parameters.repo }}
+      $(acr.servicePrincipalName)
+      $(app-dotnetdockerbuild-client-secret)
+      $(acr.servicePrincipalTenant)
+      $(acr.subscription)
+      $(acr.resourceGroup)
+      $(acr.server)
+      --action ${{ parameters.action }}
+      --age ${{ parameters.age }}
+      ${{ parameters.customArgs }}
+    displayName: Clean ACR Images - ${{ parameters.repo }}


### PR DESCRIPTION
Updates the pipelines that cleanup ACR images to consume the updated command API from https://github.com/dotnet/docker-tools/pull/541.  This requires defining which images are to be cleaned up through the command parameters instead of defined within the command logic itself.  In order to provide a means to cleanup images in an ad hoc fashion (such as Image Builder images, #504), an additional pipeline is added for executing custom cleanup operations where the parameters can be defined at queue time.

Fixes #504