### PR TITLE
Use Image Builder multi-arch tag

### DIFF
--- a/eng/common/Invoke-ImageBuilder.ps1
+++ b/eng/common/Invoke-ImageBuilder.ps1
@@ -70,7 +70,7 @@ try {
         # On Linux, ImageBuilder is run within a container.
         $imageBuilderImageName = "microsoft-dotnet-imagebuilder-withrepo"
         if ($ReuseImageBuilderImage -ne $True) {
-            ./eng/common/Invoke-WithRetry.ps1 "docker pull ${imageNames.imagebuilder.linux}"
+            ./eng/common/Invoke-WithRetry.ps1 "docker pull ${imageNames.imagebuilder}"
             Exec ("docker build -t $imageBuilderImageName --build-arg " `
                 + "IMAGE=${imageNames.imagebuilder.linux} -f eng/common/Dockerfile.WithRepo .")
         }
@@ -83,8 +83,8 @@ try {
         $imageBuilderFolder = ".Microsoft.DotNet.ImageBuilder"
         $imageBuilderCmd = [System.IO.Path]::Combine($imageBuilderFolder, "Microsoft.DotNet.ImageBuilder.exe")
         if (-not (Test-Path -Path "$imageBuilderCmd" -PathType Leaf)) {
-            ./eng/common/Invoke-WithRetry.ps1 "docker pull ${imageNames.imagebuilder.windows}"
-            Exec "docker create --name $imageBuilderContainerName ${imageNames.imagebuilder.windows}"
+            ./eng/common/Invoke-WithRetry.ps1 "docker pull ${imageNames.imagebuilder}"
+            Exec "docker create --name $imageBuilderContainerName ${imageNames.imagebuilder}"
             $containerCreated = $true
             if (Test-Path -Path $imageBuilderFolder)
             {

--- a/eng/common/templates/steps/init-docker-linux.yml
+++ b/eng/common/templates/steps/init-docker-linux.yml
@@ -36,12 +36,12 @@ steps:
   # Setup Image Builder (Optional)
   ################################################################################
 - ${{ if eq(parameters.setupImageBuilder, 'true') }}:
-  - script: $(engCommonPath)/pull-image.sh $(imageNames.imageBuilder.linux)
+  - script: $(engCommonPath)/pull-image.sh $(imageNames.imageBuilder)
     displayName: Pull Image Builder
   - script: >
       docker build
       -t $(imageNames.imageBuilder.withrepo)
-      --build-arg IMAGE=$(imageNames.imageBuilder.linux)
+      --build-arg IMAGE=$(imageNames.imageBuilder)
       -f $(engCommonPath)/Dockerfile.WithRepo .
     displayName: Build Image for Image Builder
   - script: >

--- a/eng/common/templates/steps/init-docker-windows.yml
+++ b/eng/common/templates/steps/init-docker-windows.yml
@@ -17,9 +17,9 @@ steps:
   # Setup Image Builder (Optional)
   ################################################################################
 - ${{ if eq(parameters.setupImageBuilder, 'true') }}:
-  - powershell: $(engCommonPath)/Invoke-WithRetry.ps1 "docker pull $(imageNames.imagebuilder.windows)"
+  - powershell: $(engCommonPath)/Invoke-WithRetry.ps1 "docker pull $(imageNames.imageBuilder)"
     displayName: Pull Image Builder
-  - script: docker create --name setupImageBuilder-$(Build.BuildId)-$(System.JobId) $(imageNames.imagebuilder.windows)
+  - script: docker create --name setupImageBuilder-$(Build.BuildId)-$(System.JobId) $(imageNames.imageBuilder)
     displayName: Create Setup Container
   - script: >
       docker cp

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,6 +1,5 @@
 variables:
-  imageNames.imageBuilder.linux: mcr.microsoft.com/dotnet-buildtools/image-builder:linux-20200610205920
-  imageNames.imageBuilder.windows: mcr.microsoft.com/dotnet-buildtools/image-builder:windows-20200610205920
+  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:688368
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch-slim-docker-testrunner-d61254f-20190807161111
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)


### PR DESCRIPTION
Updates the infra to reference the new multi-arch tag of Image Builder instead of platform-specific tags.