### PR TITLE
Fix image info arg for build

### DIFF
--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -38,9 +38,9 @@ jobs:
       --architecture $(architecture)
       --retry
       --source-repo $(publicGitRepoUri)
-      $(imageBuilderImageInfoArg)
       $(manifestVariables)
       $(imageBuilderBuildArgs)
+      $(imageBuilderImageInfoArg)
     displayName: Build Images
   - publish: $(Build.ArtifactStagingDirectory)/$(legName)-image-info.json
     artifact: $(legName)-image-info-$(System.JobAttempt)


### PR DESCRIPTION
The changes in https://github.com/dotnet/docker-tools/pull/557 break internal build legs on a Windows agent.  I thought I had tested my changes on that, but I targeted the wrong branch when queueing the build.

The issue is that there is a difference between Linux and Windows in how handles variables that are defined in code.  So this [change](https://github.com/dotnet/docker-tools/pull/557/files#diff-db2f1628b602c431239729498ca85ec6) ends up producing a `"` at the end of the actual value of the variable.  This causes the rest of the arguments after it to get cut off and not used by the command which breaks things

This behavior occurs when using `script` on a Windows agent and can be fixed by not including the ending `"` character or by using PowerShell.  Both those solutions require a change that is Windows-specific and doesn't provide a single multi-platform solution.

To resolve the issue, I've moved the `imageBuilderImageInfoArg` variable to be the last in the list of arguments so that none of the args get cut eliminated from the parsing.