### PR TITLE
Support ARM-based Linux build agents

### DIFF
--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -45,34 +45,42 @@ stages:
       pool: # linuxArm64v8Pool
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: DotNetCore-Docker-Public
+          demands:
+          - Agent.OS -equals linux
+          - Agent.OSArchitecture -equals ARM64
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: DotNetCore-Docker
-        demands:
-        - agent.os -equals linux
-        - RemoteDockerServerOS -equals linux
-        - RemoteDockerServerArch -equals aarch64
+          demands:
+          - Agent.OS -equals linux
+          - RemoteDockerServerOS -equals linux
+          - RemoteDockerServerArch -equals aarch64
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.LinuxArm64v8']
-      useRemoteDockerServer: true
       dockerClientOS: linux
       buildJobTimeout: ${{ parameters.linuxArmBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        useRemoteDockerServer: true
   - template: ../jobs/build-images.yml
     parameters:
       name: Linux_arm32v7
       pool: # linuxArm32v7Pool
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: DotNetCore-Docker-Public
+          demands:
+          - Agent.OS -equals linux
+          - Agent.OSArchitecture -equals ARM64
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: DotNetCore-Docker
-        demands:
-        - agent.os -equals linux
-        - RemoteDockerServerOS -equals linux
-        - RemoteDockerServerArch -equals aarch64
+          demands:
+          - Agent.OS -equals linux
+          - RemoteDockerServerOS -equals linux
+          - RemoteDockerServerArch -equals aarch64
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.LinuxArm32v7']
-      useRemoteDockerServer: true
       dockerClientOS: linux
       buildJobTimeout: ${{ parameters.linuxArmBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        useRemoteDockerServer: true
   - template: ../jobs/build-images.yml
     parameters:
       name: Windows1809_amd64
@@ -181,7 +189,7 @@ stages:
         pool: # linuxArm64v8Pool
           name: DotNetCore-Docker
           demands:
-          - agent.os -equals linux
+          - Agent.OS -equals linux
           - RemoteDockerServerOS -equals linux
           - RemoteDockerServerArch -equals aarch64
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.LinuxArm64v8']
@@ -193,7 +201,7 @@ stages:
         pool: # linuxArm32v7Pool
           name: DotNetCore-Docker
           demands:
-          - agent.os -equals linux
+          - Agent.OS -equals linux
           - RemoteDockerServerOS -equals linux
           - RemoteDockerServerArch -equals aarch64
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.LinuxArm32v7']


### PR DESCRIPTION
These changes allow the pipeline to make use of ARM-based Linux machines that are directly running as build agents.  This is a change compared to how things worked in the past when AzDO didn't have support for the agent software to run on an aarch64 machine.  It was necessary to use a AMD64 proxy machine that sent Docker commands remotely to the aarch64 machine.  But now the agent software is capable of running on this architecture (https://github.com/microsoft/azure-pipelines-agent/issues/1911).

This implementation is using a staged approach to only have this hardware configuration done within the Dotnet-Docker-Public agent pool.

These changes won't be merged until the hardware has been updated appropriately.

Related to https://github.com/dotnet/docker-tools/issues/486