### PR TITLE
Include all osVersions in build matrix common Variables

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
@@ -138,7 +138,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             leg.Variables.Add(("architecture", platformGrouping.Key.Architecture.GetDockerName()));
 
             string[] osVersions = subgraph
-                .Select(platform => $"{ManifestFilterOptions.FormattedOsVersionOption} {platform.BaseOsVersion}")
+                .Select(platform => $"{ManifestFilterOptions.FormattedOsVersionOption} {platform.Model.OsVersion}")
                 .Distinct()
                 .ToArray();
             leg.Variables.Add(("osVersions", String.Join(" ", osVersions)));

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
@@ -228,13 +228,13 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 string imageBuilderPaths = leg_1_0.Variables.First(variable => variable.Name == "imageBuilderPaths").Value;
                 Assert.Equal("--path 1.0/runtime-deps/os/Dockerfile --path 1.0/runtime/os/Dockerfile --path 2.0/sdk/os2/Dockerfile --path 2.0/runtime/os2/Dockerfile", imageBuilderPaths);
                 string osVersions = leg_1_0.Variables.First(variable => variable.Name == "osVersions").Value;
-                Assert.Equal("--os-version disco --os-version buster", osVersions);
+                Assert.Equal("--os-version disco --os-version buster --os-version buster-slim", osVersions);
 
                 BuildLegInfo leg_2_0 = matrixInfo.Legs.ElementAt(1);
                 imageBuilderPaths = leg_2_0.Variables.First(variable => variable.Name == "imageBuilderPaths").Value;
                 Assert.Equal("--path 2.0/runtime/os2/Dockerfile --path 2.0/sdk/os2/Dockerfile", imageBuilderPaths);
                 osVersions = leg_2_0.Variables.First(variable => variable.Name == "osVersions").Value;
-                Assert.Equal("--os-version buster", osVersions);
+                Assert.Equal("--os-version buster-slim --os-version buster", osVersions);
             }
         }
 


### PR DESCRIPTION
I made a mistake with #566.  We need to include all osVersions in the build matrix generated variable so that the `-slim` variables do not get filtered out even though they are included in the `path` variables.