### PR TITLE
Wait for MCR image/doc ingestion in pipeline

### DIFF
--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -37,6 +37,7 @@ jobs:
       echo "##vso[task.setvariable variable=dryRunArg]$dryRunArg"
       echo "##vso[task.setvariable variable=buildRepoName]$buildRepoName"
       echo "##vso[task.setvariable variable=publicSourceBranch]$publicSourceBranch"
+      echo "##vso[task.setvariable variable=imageQueueTime]$(date --rfc-2822)"
     displayName: Set Publish Variables
   - script: >
       $(runImageBuilderCmd) copyAcrImages
@@ -69,6 +70,10 @@ jobs:
   - publish: $(Build.ArtifactStagingDirectory)/image-info.json
     artifact: image-info-final-$(System.JobAttempt)
     displayName: Publish Image Info File Artifact
+  - template: ../steps/wait-for-mcr-image-ingestion.yml
+    parameters:
+      imageInfoPath: '$(artifactsPath)/image-info.json'
+      minQueueTime: $(imageQueueTime)
   - template: ../steps/publish-readmes.yml
     parameters:
       dryRunArg: $(dryRunArg)

--- a/eng/common/templates/jobs/wait-for-ingestion.yml
+++ b/eng/common/templates/jobs/wait-for-ingestion.yml
@@ -1,5 +1,5 @@
 jobs:
-- job: Build
+- job: WaitForIngestion
   pool:
     vmImage: $(defaultLinuxAmd64PoolImage)
   steps:

--- a/eng/common/templates/jobs/wait-for-ingestion.yml
+++ b/eng/common/templates/jobs/wait-for-ingestion.yml
@@ -1,0 +1,27 @@
+jobs:
+- job: Build
+  pool:
+    vmImage: $(defaultLinuxAmd64PoolImage)
+  steps:
+  - template: ../steps/init-docker-linux.yml
+  - template: ../steps/download-build-artifact.yml
+    parameters:
+      targetPath: $(Build.ArtifactStagingDirectory)
+      condition: and(succeeded(), ne(variables['sourceBuildId'], ''))
+  - powershell: |
+      # Get the last image info artifact that was published
+      $imageInfoDirName = $(dir $(Build.ArtifactStagingDirectory)/image-info-final-* | select -ExpandProperty Name)[-1]
+      $imageInfoPath = "$(artifactsPath)/$imageInfoDirName/image-info.json"
+      echo "##vso[task.setvariable variable=imageInfoPath]$imageInfoPath"
+    displayName: Get Image Info Path
+    condition: and(succeeded(), ne(variables['sourceBuildId'], ''))
+  - template: ../steps/wait-for-mcr-image-ingestion.yml
+    parameters:
+      imageInfoPath: $(imageInfoPath)
+      minQueueTime: $(minQueueTime)
+      condition: and(succeeded(), ne(variables['sourceBuildId'], ''))
+  - template: ../steps/wait-for-mcr-doc-ingestion.yml
+    parameters:
+      commitDigest: $(readmeCommitDigest)
+      condition: and(succeeded(), ne(variables['readmeCommitDigest'], ''))
+  - template: ../steps/cleanup-docker-linux.yml

--- a/eng/common/templates/steps/download-build-artifact.yml
+++ b/eng/common/templates/steps/download-build-artifact.yml
@@ -1,7 +1,7 @@
 parameters:
   targetPath: ""
   artifactName: ""
-  requiresPublicRepoPrefix: false
+  condition: true
 
 steps:
 - task: DownloadPipelineArtifact@1
@@ -14,5 +14,4 @@ steps:
     targetPath: ${{ parameters.targetPath }}
     artifactName: ${{ parameters.artifactName }}
   displayName: Download Build Artifact(s)
-  ${{ if eq(parameters.requiresPublicRepoPrefix, true) }}:
-    condition: and(succeeded(), eq(variables['publishRepoPrefix'], 'public/'))
+  condition: ${{ parameters.condition }}

--- a/eng/common/templates/steps/publish-readmes.yml
+++ b/eng/common/templates/steps/publish-readmes.yml
@@ -1,6 +1,6 @@
 parameters:
   dryRunArg: ""
-  condition:  true
+  condition: true
 
 steps:
 - script: >
@@ -14,5 +14,10 @@ steps:
     ${{ parameters.dryRunArg }}
     $(manifestVariables)
     $(imageBuilder.queueArgs)
+  name: PublishReadmes
   displayName: Publish Readmes
   condition: ${{ parameters.condition }}
+- template: wait-for-mcr-doc-ingestion.yml
+  parameters:
+    commitDigest: $(PublishReadmes.readmeCommitDigest)
+    condition: and(${{ parameters.condition }}, ne(variables['PublishReadmes.readmeCommitDigest'], ''))

--- a/eng/common/templates/steps/wait-for-mcr-doc-ingestion.yml
+++ b/eng/common/templates/steps/wait-for-mcr-doc-ingestion.yml
@@ -1,0 +1,13 @@
+parameters:
+  commitDigest: null
+  condition: true
+
+steps:
+- script: >
+    $(runImageBuilderCmd) waitForMcrDocIngestion
+    '${{ parameters.commitDigest }}'
+    '$(mcrStatus.servicePrincipalName)'
+    '$(app-DotnetDockerMcrStatusApi-client-secret)'
+    '$(mcrStatus.servicePrincipalTenant)'
+  displayName: Wait for MCR Doc Ingestion
+  condition: and(${{ parameters.condition }}, eq(variables['waitForIngestionEnabled'], 'true'))

--- a/eng/common/templates/steps/wait-for-mcr-image-ingestion.yml
+++ b/eng/common/templates/steps/wait-for-mcr-image-ingestion.yml
@@ -1,0 +1,16 @@
+parameters:
+  imageInfoPath: null
+  minQueueTime: null
+  condition: true
+
+steps:
+- script: >
+    $(runImageBuilderCmd) waitForMcrImageIngestion
+    '${{ parameters.imageInfoPath }}'
+    '$(mcrStatus.servicePrincipalName)'
+    '$(app-DotnetDockerMcrStatusApi-client-secret)'
+    '$(mcrStatus.servicePrincipalTenant)'
+    --manifest '$(manifest)'
+    --min-queue-time '${{ parameters.minQueueTime }}'
+  displayName: Wait for Image Ingestion
+  condition: and(${{ parameters.condition }}, eq(variables['waitForIngestionEnabled'], 'true'))

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:722813
+  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:723323
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch-slim-docker-testrunner-690072
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:704299
+  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:722813
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch-slim-docker-testrunner-690072
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)


### PR DESCRIPTION
Updates the publish stage of the pipeline to wait for MCR image and doc ingestion after they've been published.  This is an opt-in model that will be enabled by setting the `waitForIngestionEnabled` variable to `true`.  Also included is a job template that can be used by each repo to wait for ingestion as a standalone pipeline.

Related to #547