### PR TITLE
Add 'import' concept to manifests

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
@@ -125,14 +125,14 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
                 foreach (PlatformInfo platform in platforms)
                 {
-                    pathsToRebuild.AddRange(await GetPathsToRebuildAsync(allPlatforms, platform, repoData));
+                    pathsToRebuild.AddRange(GetPathsToRebuild(allPlatforms, platform, repoData));
                 }
             }
 
             return pathsToRebuild.Distinct().ToList();
         }
 
-        private async Task<List<string>> GetPathsToRebuildAsync(
+        private List<string> GetPathsToRebuild(
             IEnumerable<PlatformInfo> allPlatforms, PlatformInfo platform, RepoData repoData)
         {
             bool foundImageInfo = false;

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/Manifest.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/Manifest.cs
@@ -18,6 +18,12 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Manifest
     public class Manifest
     {
         [Description(
+            "Additional json files to be loaded with this manifest.  This is a convienent" +
+            "way to split the manifest apart into logical parts."
+            )]
+        public string[] Includes { get; set; }
+
+        [Description(
             "Relative path to the GitHub readme Markdown file associated with the manifest. " +
             "This readme file documents the overall set of Docker repositories described by " +
             "the manifest.")]
@@ -31,7 +37,6 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Manifest
         [Description(
             "The set of Docker repositories described by this manifest."
             )]
-        [JsonProperty(Required = Required.Always)]
         public Repo[] Repos { get; set; }
 
         [Description(

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
@@ -175,6 +175,11 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 
             if (model.Includes != null)
             {
+                if (model.Variables == null)
+                {
+                    model.Variables = new Dictionary<string, string>();
+                }
+
                 // Limitation:  Includes only support variables at this time based on usage needs.
                 // There is nothing that prevents expanding this to support other metadata.
                 foreach (string includePath in model.Includes)

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ModelExtensions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ModelExtensions.cs
@@ -40,6 +40,11 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 
         public static void Validate(this Manifest manifest, string manifestDirectory)
         {
+            if (manifest.Repos == null)
+            {
+                throw new ValidationException($"The manifest must contain at least one repo.");
+            }
+
             foreach (Repo repo in manifest.Repos)
             {
                 ValidateRepo(repo, manifestDirectory);
@@ -63,7 +68,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             }
         }
 
-        private static void ValidateFileReference(string path, string manifestDirectory)
+        public static void ValidateFileReference(string path, string manifestDirectory)
         {
             ValidatePathIsRelative(path);
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ModelExtensions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ModelExtensions.cs
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 
         public static void Validate(this Manifest manifest, string manifestDirectory)
         {
-            if (manifest.Repos == null)
+            if (manifest.Repos == null || !manifest.Repos.Any())
             {
                 throw new ValidationException($"The manifest must contain at least one repo.");
             }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ManifestHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ManifestHelper.cs
@@ -6,6 +6,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
+using Microsoft.DotNet.ImageBuilder.ViewModel;
+using Moq;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests.Helpers
 {
@@ -60,6 +62,21 @@ namespace Microsoft.DotNet.ImageBuilder.Tests.Helpers
                 Architecture = architecture,
                 CustomBuildLegGrouping = customBuildLegGroupings ?? Array.Empty<CustomBuildLegGrouping>()
             };
+        }
+
+        public static IManifestOptionsInfo GetManifestOptions(string manifestPath)
+        {
+            Mock<IManifestOptionsInfo> manifestOptionsMock = new Mock<IManifestOptionsInfo>();
+
+            manifestOptionsMock
+                .SetupGet(o => o.Manifest)
+                .Returns(manifestPath);
+
+            manifestOptionsMock
+                .Setup(o => o.GetManifestFilter())
+                .Returns(new ManifestFilter());
+
+            return manifestOptionsMock.Object;
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/ManifestInfoTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/ManifestInfoTests.cs
@@ -1,0 +1,133 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
+using Microsoft.DotNet.ImageBuilder.ViewModel;
+using Xunit;
+
+namespace Microsoft.DotNet.ImageBuilder.Tests
+{
+    public class ManifestInfoTests
+    {
+        private static string s_dockerfilePath = "testDockerfile";
+        private static string s_repoJson = 
+$@"
+  ""repos"": [
+    {{
+      ""name"": ""testRepo"",
+      ""images"": [
+        {{
+          ""platforms"": [
+            {{
+              ""dockerfile"": ""{s_dockerfilePath}"",
+              ""os"": ""linux"",
+              ""osVersion"": ""stretch"",
+              ""tags"": {{
+                  ""testTag"": {{}}
+              }}
+            }}
+          ]
+        }}
+      ]
+    }}
+  ]
+";
+
+        [Fact]
+        public void Load_Import_Variables()
+        {
+            string includeManifestPath = "manifest.variables.json";
+            string variableOneName = "variable1";
+            string variableOneValue = "value1";
+            string variableTwoName = "variable2";
+            string variableTwoValue = "value2";
+            string manifest =
+$@"
+{{
+  ""includes"": [
+    ""{includeManifestPath}""
+  ],
+  ""variables"": {{
+      ""{variableOneName}"": ""{variableOneValue}""
+  }},
+{s_repoJson}
+}}";
+            string includeManifest =
+$@"
+{{
+  ""variables"": {{
+      ""{variableTwoName}"": ""{variableTwoValue}""
+  }}
+}}";
+
+            ManifestInfo manifestInfo = LoadManifestInfo(manifest, includeManifestPath, includeManifest);
+            Assert.Equal(2, manifestInfo.Model.Variables.Count);
+            Assert.Equal(variableOneValue, manifestInfo.Model.Variables[variableOneName]);
+            Assert.Equal(variableTwoValue, manifestInfo.Model.Variables[variableTwoName]);
+        }
+
+        [Fact]
+        public void Load_Import_InvalidPath()
+        {
+            string manifest =
+$@"
+{{
+  ""includes"": [
+    ""invalid.json""
+  ],
+{s_repoJson}
+}}";
+
+            Assert.Throws<FileNotFoundException>(() => LoadManifestInfo(manifest));
+        }
+
+        [Fact]
+        public void Load_Import_DuplicateVariables()
+        {
+            string includeManifestPath = "manifest.variables.json";
+            string duplicateVariable = "\"variable1\": \"value1\"";
+            string manifest =
+$@"
+{{
+  ""includes"": [
+    ""{includeManifestPath}""
+  ],
+  ""variables"": {{
+      {duplicateVariable}
+  }},
+{s_repoJson}
+}}";
+            string includeManifest =
+$@"
+{{
+  ""variables"": {{
+      {duplicateVariable}
+  }}
+}}";
+
+            Assert.Throws<InvalidOperationException>(() => LoadManifestInfo(manifest, includeManifestPath, includeManifest));
+        }
+
+        private static ManifestInfo LoadManifestInfo(string manifest, string includeManifestPath = null, string includeManifest = null)
+        {
+            using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
+
+            string manifestPath = Path.Combine(tempFolderContext.Path, "manifest.json");
+            File.WriteAllText(manifestPath, manifest);
+
+            if (includeManifestPath != null)
+            {
+                string fullIncludeManifestPath = Path.Combine(tempFolderContext.Path, includeManifestPath);
+                File.WriteAllText(fullIncludeManifestPath, includeManifest);
+            }
+
+            DockerfileHelper.CreateDockerfile(s_dockerfilePath, tempFolderContext);
+
+            IManifestOptionsInfo manifestOptions = ManifestHelper.GetManifestOptions(manifestPath);
+            return ManifestInfo.Load(manifestOptions);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/tests/McrTagsMetadataGeneratorTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/McrTagsMetadataGeneratorTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             File.WriteAllText(manifestPath, JsonConvert.SerializeObject(manifest));
 
             // Load manifest
-            IManifestOptionsInfo manifestOptions = GetManifestOptions(manifestPath);
+            IManifestOptionsInfo manifestOptions = ManifestHelper.GetManifestOptions(manifestPath);
             ManifestInfo manifestInfo = ManifestInfo.Load(manifestOptions);
             RepoInfo repo = manifestInfo.AllRepos.First();
 
@@ -145,7 +145,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             File.WriteAllText(manifestPath, JsonConvert.SerializeObject(manifest));
 
             // Load manifest
-            IManifestOptionsInfo manifestOptions = GetManifestOptions(manifestPath);
+            IManifestOptionsInfo manifestOptions = ManifestHelper.GetManifestOptions(manifestPath);
             ManifestInfo manifestInfo = ManifestInfo.Load(manifestOptions);
             RepoInfo repo = manifestInfo.AllRepos.First();
 
@@ -166,21 +166,6 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 $"{SourceRepoUrl}/blob/{SourceBranch}/1.0/{RepoName}/os2/Dockerfile",
                 tagsMetadata.Repos[0].TagGroups[0].Dockerfile);
             Assert.Equal(new string[] { "tag1a", "tag1b" }, tagsMetadata.Repos[0].TagGroups[0].Tags);
-        }
-        
-        private static IManifestOptionsInfo GetManifestOptions(string manifestPath)
-        {
-            Mock<IManifestOptionsInfo> manifestOptionsMock = new Mock<IManifestOptionsInfo>();
-
-            manifestOptionsMock
-                .SetupGet(o => o.Manifest)
-                .Returns(manifestPath);
-
-            manifestOptionsMock
-                .Setup(o => o.GetManifestFilter())
-                .Returns(new ManifestFilter());
-
-            return manifestOptionsMock.Object;
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/Microsoft.DotNet.ImageBuilder.Tests.csproj
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/Microsoft.DotNet.ImageBuilder.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR adds an `import' concept to the manifest.  This allows the manifest.json to be split across multiple files.  This is being added to support the [Dockerfile templates feature](https://github.com/dotnet/dotnet-docker/issues/1933).

The initial implementation only supports variables.  This is a scoping decision based on what is currently required.  There is nothing that prevents future expansion to support other model types.