### PR TITLE
Split off PR-specific eng validation pipeline

### DIFF
--- a/eng/pipelines/dotnet-docker-tools-eng-validation-pr.yml
+++ b/eng/pipelines/dotnet-docker-tools-eng-validation-pr.yml
@@ -1,4 +1,4 @@
-trigger:
+pr:
   branches:
     include:
     - master

--- a/eng/pipelines/templates/variables/eng-validation.yml
+++ b/eng/pipelines/templates/variables/eng-validation.yml
@@ -1,0 +1,14 @@
+variables:
+- template: ../../../common/templates/variables/common.yml
+- name: manifest
+  value: eng/tests/pipeline-validation/test-manifest.json
+- name: testScriptPath
+  value: ./eng/tests/pipeline-validation/run-tests.ps1
+- name: testResultsDirectory
+  value: eng/tests/pipeline-validation/TestResults/
+- name: publicGitRepoUri
+  value: https://github.com/dotnet/dotnet-docker-test
+- name: publishRepoPrefix
+  value: test/
+- name: imageInfoVariant
+  value: "-test"


### PR DESCRIPTION
Define separate pipeline YAML file for eng validation: an internal one to trigger from commits and a public one to trigger from PRs.  There's not a way to define a single file with conditional logic around the `trigger` and `pr` keywords because AzDO doesn't support that.

Fixes #549 