### PR TITLE
Fix various issues with waiting for MCR ingestion

### DIFF
--- a/eng/common/templates/jobs/wait-for-ingestion.yml
+++ b/eng/common/templates/jobs/wait-for-ingestion.yml
@@ -10,7 +10,7 @@ jobs:
       condition: and(succeeded(), ne(variables['sourceBuildId'], ''))
   - powershell: |
       # Get the last image info artifact that was published
-      $imageInfoDirName = $(dir $(Build.ArtifactStagingDirectory)/image-info-final-* | select -ExpandProperty Name)[-1]
+      $imageInfoDirName = @($(dir $(Build.ArtifactStagingDirectory)/image-info-final-* | select -ExpandProperty Name))[-1]
       $imageInfoPath = "$(artifactsPath)/$imageInfoDirName/image-info.json"
       echo "##vso[task.setvariable variable=imageInfoPath]$imageInfoPath"
     displayName: Get Image Info Path

--- a/eng/common/templates/steps/wait-for-mcr-doc-ingestion.yml
+++ b/eng/common/templates/steps/wait-for-mcr-doc-ingestion.yml
@@ -10,6 +10,7 @@ steps:
     '$(mcrStatus.servicePrincipalName)'
     '$(app-DotnetDockerMcrStatusApi-client-secret)'
     '$(mcrStatus.servicePrincipalTenant)'
+    --timeout '$(mcrDocIngestionTimeout)'
     ${{ parameters.dryRunArg }}
   displayName: Wait for MCR Doc Ingestion
   condition: and(${{ parameters.condition }}, eq(variables['waitForIngestionEnabled'], 'true'))

--- a/eng/common/templates/steps/wait-for-mcr-image-ingestion.yml
+++ b/eng/common/templates/steps/wait-for-mcr-image-ingestion.yml
@@ -13,6 +13,7 @@ steps:
     '$(mcrStatus.servicePrincipalTenant)'
     --manifest '$(manifest)'
     --min-queue-time '${{ parameters.minQueueTime }}'
+    --timeout '$(mcrImageIngestionTimeout)'
     ${{ parameters.dryRunArg }}
   displayName: Wait for Image Ingestion
   condition: and(${{ parameters.condition }}, eq(variables['waitForIngestionEnabled'], 'true'))

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -19,6 +19,10 @@ variables:
   value: ""
 - name: defaultLinuxAmd64PoolImage
   value: ubuntu-latest
+- name: mcrImageIngestionTimeout
+  value: "00:20:00"
+- name: mcrDocIngestionTimeout
+  value: "00:05:00"
 
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNet-Docker-Common

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/WaitForMcrDocIngestionOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/WaitForMcrDocIngestionOptions.cs
@@ -35,12 +35,14 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             base.DefineOptions(syntax);
 
             TimeSpan waitTimeout = TimeSpan.FromMinutes(5);
-            syntax.DefineOption("timeout", ref waitTimeout, val => TimeSpan.Parse(val),
+            syntax.DefineOption("timeout", ref waitTimeout,
+                val => String.IsNullOrEmpty(val) ? waitTimeout : TimeSpan.Parse(val),
                 $"Maximum time to wait for doc ingestion (default: {waitTimeout})");
             WaitTimeout = waitTimeout;
 
             TimeSpan requeryDelay = TimeSpan.FromSeconds(10);
-            syntax.DefineOption("requery-delay", ref requeryDelay, val => TimeSpan.Parse(val),
+            syntax.DefineOption("requery-delay", ref requeryDelay,
+                val => String.IsNullOrEmpty(val) ? requeryDelay : TimeSpan.Parse(val),
                 $"Amount of time to wait before requerying the status of the commit (default: {requeryDelay})");
             RequeryDelay = requeryDelay;
         }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/WaitForMcrImageIngestionCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/WaitForMcrImageIngestionCommand.cs
@@ -114,8 +114,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     this.loggerService.WriteMessage(GetQualifiedDigest(imageResult.DigestInfo.Repo.Repo, imageResult.DigestInfo.Digest));
                     string tags = String.Join(", ",
                         imageResult.ImageResult.Value
-                            .First(imageStatus => imageStatus.OverallStatus == StageStatus.Succeeded)
-                            .Tag);
+                            .Where(imageStatus => imageStatus.OverallStatus == StageStatus.Succeeded)
+                            .Select(imageStatus => imageStatus.Tag));
                     this.loggerService.WriteMessage($"\tTags: {tags}");
                     this.loggerService.WriteMessage();
                 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/WaitForMcrImageIngestionOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/WaitForMcrImageIngestionOptions.cs
@@ -39,17 +39,20 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             base.DefineOptions(syntax);
 
             DateTime minimumQueueTime = DateTime.MinValue;
-            syntax.DefineOption(MinimumQueueTimeOptionName, ref minimumQueueTime, val => DateTime.Parse(val),
+            syntax.DefineOption(MinimumQueueTimeOptionName, ref minimumQueueTime,
+                val => String.IsNullOrEmpty(val) ? minimumQueueTime : DateTime.Parse(val),
                 "Minimum queue time an image must have to be awaited");
             MinimumQueueTime = minimumQueueTime.ToUniversalTime();
 
             TimeSpan waitTimeout = TimeSpan.FromMinutes(20);
-            syntax.DefineOption("timeout", ref waitTimeout, val => TimeSpan.Parse(val),
+            syntax.DefineOption("timeout", ref waitTimeout,
+                val => String.IsNullOrEmpty(val) ? waitTimeout : TimeSpan.Parse(val),
                 $"Maximum time to wait for image ingestion (default: {waitTimeout})");
             WaitTimeout = waitTimeout;
 
             TimeSpan requeryDelay = TimeSpan.FromSeconds(10);
-            syntax.DefineOption("requery-delay", ref requeryDelay, val => TimeSpan.Parse(val),
+            syntax.DefineOption("requery-delay", ref requeryDelay,
+                val => String.IsNullOrEmpty(val) ? requeryDelay : TimeSpan.Parse(val),
                 $"Amount of time to wait before requerying the status of an image (default: {requeryDelay})");
             RequeryDelay = requeryDelay;
         }


### PR DESCRIPTION
* Logic to calculate image info directory name doesn't work if there's only one file matching the search pattern. This is because the result is a single value, not an array, and it's being dereferenced as an array.  Fixed to wrap it in an array (this works even if the returned value is an array; it doesn't create a nested array).
* Set the `timeout` option for the MCR image and doc ingestion commands so that pipelines can customize that value.
* Update the ingestion commands to allow empty timeout values to be passed for the options, which will cause the command to just use the default value.
* Fixed the summary output to list the image tags correctly.