### PR TITLE
Handle undocumented platform tag generation

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ShowImageStatsCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ShowImageStatsCommand.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
@@ -81,8 +82,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             TagInfo[] platformTags = Manifest.GetFilteredPlatformTags().ToArray();
             TagInfo[] sharedTags = Manifest.GetFilteredImages().SelectMany(image => image.SharedTags).ToArray();
-            TagInfo[] undocumentedPlatformTags = platformTags.Where(tag => tag.Model.IsUndocumented).ToArray();
-            TagInfo[] undocumentedSharedTags = sharedTags.Where(tag => tag.Model.IsUndocumented).ToArray();
+            TagInfo[] undocumentedPlatformTags = platformTags.Where(tag => tag.Model.DocType != TagDocumentationType.Undocumented).ToArray();
+            TagInfo[] undocumentedSharedTags = sharedTags.Where(tag => tag.Model.DocType != TagDocumentationType.Undocumented).ToArray();
 
             Logger.WriteMessage($"Total Unique Images:  {platforms.Length}");
             Logger.WriteMessage($"Total Simple Tags:  {platformTags.Length}");

--- a/src/Microsoft.DotNet.ImageBuilder/src/McrTagsMetadataGenerator.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/McrTagsMetadataGenerator.cs
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.ImageBuilder
             _imageDocInfos = _repo.FilteredImages
                 .SelectMany(image =>
                     image.AllPlatforms.SelectMany(platform => ImageDocumentationInfo.Create(image, platform)))
-                .Where(info => info.DocumentedTags.Any())
+                .Where(info => info.DocumentedPlatformTags.Any())
                 .ToList();
 
             StringBuilder yaml = new StringBuilder();
@@ -126,15 +126,19 @@ namespace Microsoft.DotNet.ImageBuilder
 
         private class ImageDocumentationInfo
         {
-            public IEnumerable<TagInfo> DocumentedTags { get; set; }
-            public string FormattedDocumentedTags { get; set; }
+            public IEnumerable<TagInfo> DocumentedSharedTags { get; }
+            public IEnumerable<TagInfo> DocumentedPlatformTags { get; }
+            public IEnumerable<TagInfo> DocumentedTags { get; }
+            public string FormattedDocumentedTags { get; }
             public PlatformInfo Platform { get; }
 
             private ImageDocumentationInfo(ImageInfo image, PlatformInfo platform, string documentationGroup)
             {
                 Platform = platform;
-                DocumentedTags = GetDocumentedTags(Platform.Tags, documentationGroup)
-                    .Concat(GetDocumentedTags(image.SharedTags, documentationGroup))
+                DocumentedSharedTags = GetDocumentedTags(image.SharedTags, documentationGroup).ToArray();
+                DocumentedPlatformTags = GetDocumentedTags(Platform.Tags, documentationGroup).ToArray();
+                DocumentedTags = DocumentedPlatformTags
+                    .Concat(DocumentedSharedTags)
                     .ToArray();
                 FormattedDocumentedTags = String.Join(
                     ", ",

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/Tag.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/Tag.cs
@@ -26,12 +26,13 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Manifest
         public bool IsLocal { get; set; }
 
         [Description(
-            "Indicates whether this tag should not be documented in the readme file. The " +
-            "image will still be tagged with this tag however and will still be published. " +
+            "Indicates how this tag should not be documented in the readme file. Regardless of the " +
+            "setting, the image will still be tagged with this tag and will still be published. " +
             "This is useful when deprecating a tag that still needs to be kept up-to-date " +
             "but not wanting it documented."
             )]
-        public bool IsUndocumented { get; set; }
+        [DefaultValue(TagDocumentationType.Documented)]
+        public TagDocumentationType DocType { get; set; }
 
         public Tag()
         {

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/TagDocumentationType.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/TagDocumentationType.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.ImageBuilder.Models.Manifest
+{
+    public enum TagDocumentationType
+    {
+        /// <summary>
+        /// The tag is always documented.
+        /// </summary>
+        Documented,
+
+        /// <summary>
+        /// The tag is never documented.
+        /// </summary>
+        Undocumented,
+
+        /// <summary>
+        /// The tag is only documented if there are corresponding platform tags that are documented.
+        /// </summary>
+        PlatformDocumented
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/tests/McrTagsMetadataGeneratorTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/McrTagsMetadataGeneratorTests.cs
@@ -99,8 +99,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// Verifies that <see cref="McrTagsMetadataGenerator"/> can be run against a platform that has no
         /// documented tags.
         /// </summary>
-        [Fact]
-        public void HandlesUndocumentedPlatform()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void HandlesUndocumentedPlatform(bool hasSharedTag)
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
 
@@ -129,12 +131,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
+            Image image;
+
             // Create manifest
             Manifest manifest = ManifestHelper.CreateManifest(
                 ManifestHelper.CreateRepo(RepoName,
                     new Image[]
                     {
-                        ManifestHelper.CreateImage(
+                        image = ManifestHelper.CreateImage(
                             platform,
                             ManifestHelper.CreatePlatform(
                                 DockerfileHelper.CreateDockerfile($"1.0/{RepoName}/os2", tempFolderContext),
@@ -142,6 +146,15 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     },
                     mcrTagsMetadataTemplatePath: Path.GetFileName(tagsMetadataTemplatePath))
             );
+
+            if (hasSharedTag)
+            {
+                image.SharedTags = new Dictionary<string, Tag>
+                {
+                    { "shared", new Tag() }
+                };
+            }
+
             string manifestPath = Path.Combine(tempFolderContext.Path, "manifest.json");
             File.WriteAllText(manifestPath, JsonConvert.SerializeObject(manifest));
 
@@ -166,7 +179,18 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Assert.Equal(
                 $"{SourceRepoUrl}/blob/{SourceBranch}/1.0/{RepoName}/os2/Dockerfile",
                 tagsMetadata.Repos[0].TagGroups[0].Dockerfile);
-            Assert.Equal(new string[] { "tag1a", "tag1b" }, tagsMetadata.Repos[0].TagGroups[0].Tags);
+
+            List<string> expectedTags = new List<string>
+            {
+                "tag1a",
+                "tag1b"
+            };
+            if (hasSharedTag)
+            {
+                expectedTags.Add("shared");
+            }
+
+            Assert.Equal(expectedTags, tagsMetadata.Repos[0].TagGroups[0].Tags);
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/McrTagsMetadataGeneratorTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/McrTagsMetadataGeneratorTests.cs
@@ -126,7 +126,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     "tag2",
                     new Tag
                     {
-                        IsUndocumented = true
+                        DocType = TagDocumentationType.Undocumented
                     }
                 }
             };
@@ -151,7 +151,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             {
                 image.SharedTags = new Dictionary<string, Tag>
                 {
-                    { "shared", new Tag() }
+                    { "shared", new Tag
+                        {
+                            DocType = TagDocumentationType.PlatformDocumented
+                        }
+                    }
                 };
             }
 


### PR DESCRIPTION
If a platform defined in the manifest has no documented tags of its own but is defined within an image that has shared tags, tag generation will fail here: https://github.com/dotnet/docker-tools/blob/92ef21737f934add62745a505a3d795e88313325/src/Microsoft.DotNet.ImageBuilder/src/McrTagsMetadataGenerator.cs#L62

This happens because the `ImageDocumentationInfo` objects that were generated include the platform that has no documented platform tags and it never gets removed from the set because there isn't a readme template that references one of its tags.

This is fixed by only generating an `ImageDocumentationInfo` object if a platform has any documented _platform_ tags.