### PR TITLE
Pass manifest variables to waitForMcrImageIngestion cmd

### DIFF
--- a/eng/common/templates/steps/wait-for-mcr-image-ingestion.yml
+++ b/eng/common/templates/steps/wait-for-mcr-image-ingestion.yml
@@ -14,6 +14,7 @@ steps:
     --manifest '$(manifest)'
     --min-queue-time '${{ parameters.minQueueTime }}'
     --timeout '$(mcrImageIngestionTimeout)'
+    $(manifestVariables)
     ${{ parameters.dryRunArg }}
   displayName: Wait for Image Ingestion
   condition: and(${{ parameters.condition }}, eq(variables['waitForIngestionEnabled'], 'true'))


### PR DESCRIPTION
The `manifestVariables` variable needs to be passed to the `waitForMcrImageIngestion` since it's a manifest command.  This is needed in order to pass custom state.  An example that requires this is the build for Image Builder that needs to set the `UniqueId` state: https://github.com/dotnet/docker-tools/blob/92ef21737f934add62745a505a3d795e88313325/eng/pipelines/templates/variables/image-builder.yml#L8