### PR TITLE
Add retry logic to copyAcrImages cmd

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/HttpPolicyBuilder.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/HttpPolicyBuilder.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.ImageBuilder
         public HttpPolicyBuilder WithMeteredRetryPolicy(ILoggerService loggerService)
         {
             policies.Add(Policy
-                .HandleResult<HttpResponseMessage>(response => response.StatusCode == HttpStatusCode.TooManyRequests)
+                .HandleResult<HttpResponseMessage>(response => response?.StatusCode == HttpStatusCode.TooManyRequests)
                 .Or<TaskCanceledException>(exception =>
                     exception.InnerException is IOException ioException &&
                     ioException.InnerException is SocketException)

--- a/src/Microsoft.DotNet.ImageBuilder/tests/CopyAcrImagesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/CopyAcrImagesCommandTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Mock<IEnvironmentService> environmentServiceMock = new Mock<IEnvironmentService>();
 
                 CopyAcrImagesCommand command = new CopyAcrImagesCommand(
-                    azureManagementFactoryMock.Object, environmentServiceMock.Object);
+                    azureManagementFactoryMock.Object, environmentServiceMock.Object, Mock.Of<ILoggerService>());
                 command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
                 command.Options.Subscription = subscriptionId;
                 command.Options.ResourceGroup = "my resource group";
@@ -137,7 +137,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Mock<IEnvironmentService> environmentServiceMock = new Mock<IEnvironmentService>();
 
                 CopyAcrImagesCommand command = new CopyAcrImagesCommand(
-                    azureManagementFactoryMock.Object, environmentServiceMock.Object);
+                    azureManagementFactoryMock.Object, environmentServiceMock.Object, Mock.Of<ILoggerService>());
                 command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
                 command.Options.Subscription = subscriptionId;
                 command.Options.ResourceGroup = "my resource group";


### PR DESCRIPTION
Fixes #563

While not ideal, I decided to keep things simple with `HttpPolicyBuilder`.  It is currently implemented to only handle `HttpResponseMessage` results.  In the case of the call to `ImportImageAsync`, there is no return object.  The Polly API is implemented in a way that there is not a reasonable common base type between `AsyncPolicy` and `AsyncPolicy<T>` that could be used in order to have shared logic between a policy that has a `HttpResponseMessage` return type and one that does not.  For that reason, I decided to just explicitly return null in the delegate that calls `ImportImageAsync` and have the policy gracefully handle nulls.