### PR TITLE
Set exit code within Invoke-ImageBuilder script

### DIFF
--- a/eng/common/Invoke-ImageBuilder.ps1
+++ b/eng/common/Invoke-ImageBuilder.ps1
@@ -48,6 +48,8 @@ function Exec {
     Log "Executing: '$Cmd'"
     Invoke-Expression $Cmd
     if ($LASTEXITCODE -ne 0) {
+        $host.SetShouldExit($LASTEXITCODE)
+        exit $LASTEXITCODE
         throw "Failed: '$Cmd'"
     }
 }


### PR DESCRIPTION
This is needed for dotnet/dotnet-docker#1933 so that a unit test can be created to ensure the Dockerfiles and templates are in sync.