### PR TITLE
Add missing run-tests parameters

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/run-tests.ps1
+++ b/src/Microsoft.DotNet.ImageBuilder/run-tests.ps1
@@ -9,6 +9,11 @@ param(
     [string]$Version,
     [string]$Architecture,
     [string]$OS,
+    [string]$Registry,
+    [string]$RepoPrefix,
+    [switch]$DisableHttpVerification,
+    [switch]$PullImages,
+    [string]$ImageInfoPath,
     [ValidateSet("functional", "pre-build")]
     [string[]]$TestCategories = @("functional")
 )


### PR DESCRIPTION
This is a follow up change to https://github.com/dotnet/docker-tools/pull/590.  Those changes broke the official build.  The reason this was passing before is because this script declared no parameters and no parameter validation was performed.  The build as always passing parameters to the script but they were silently ignored.