### PR TITLE
Support arbitrary number of custom-build-leg-group args

### DIFF
--- a/eng/common/templates/jobs/generate-matrix.yml
+++ b/eng/common/templates/jobs/generate-matrix.yml
@@ -1,7 +1,7 @@
 parameters:
   matrixType: null
   name: null
-  customBuildLegGroup: ""
+  customBuildLegGroupArgs: ""
 
 jobs:
 - job: ${{ parameters.name }}
@@ -15,8 +15,8 @@ jobs:
       --type ${{ parameters.matrixType }}
       --os-type '*'
       --architecture '*'
-      --custom-build-leg-group "${{ parameters.customBuildLegGroup }}"
       --product-version-components $(productVersionComponents)
+      ${{ parameters.customBuildLegGroupArgs }}
       $(imageBuilder.pathArgs)
       $(manifestVariables)
     displayName: Generate ${{ parameters.matrixType }} Matrix

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -1,7 +1,8 @@
 parameters:
   buildMatrixType: platformDependencyGraph
   testMatrixType: platformVersionedOs
-  customBuildLegGroupArgs: ""
+  buildMatrixCustomBuildLegGroupArgs: ""
+  testMatrixCustomBuildLegGroupArgs: ""
   customBuildInitSteps: []
   
   linuxAmdBuildJobTimeout: 60
@@ -35,7 +36,7 @@ stages:
     parameters:
       matrixType: ${{ parameters.buildMatrixType }}
       name: GenerateBuildMatrix
-      customBuildLegGroupArgs: ${{ parameters.customBuildLegGroupArgs }}
+      customBuildLegGroupArgs: ${{ parameters.buildMatrixCustomBuildLegGroupArgs }}
 
   - template: ../jobs/build-images.yml
     parameters:
@@ -169,6 +170,7 @@ stages:
       parameters:
         matrixType: ${{ parameters.testMatrixType }}
         name: GenerateTestMatrix
+        customBuildLegGroupArgs: ${{ parameters.testMatrixCustomBuildLegGroupArgs }}
 
     - template: ../jobs/test-images-linux-client.yml
       parameters:

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -1,7 +1,7 @@
 parameters:
   buildMatrixType: platformDependencyGraph
   testMatrixType: platformVersionedOs
-  customBuildLegGroup: ""
+  customBuildLegGroupArgs: ""
   customBuildInitSteps: []
   
   linuxAmdBuildJobTimeout: 60
@@ -35,7 +35,7 @@ stages:
     parameters:
       matrixType: ${{ parameters.buildMatrixType }}
       name: GenerateBuildMatrix
-      customBuildLegGroup: ${{ parameters.customBuildLegGroup }}
+      customBuildLegGroupArgs: ${{ parameters.customBuildLegGroupArgs }}
 
   - template: ../jobs/build-images.yml
     parameters:


### PR DESCRIPTION
When calling the `generateBuildMatrix` command, we need to be able to pass in an arbitrary number of custom-build-leg-group args now that the arg has changed to an option list from https://github.com/dotnet/docker-tools/pull/594.