### PR TITLE
Store digests of internal FROM images in image info

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/IngestKustoImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/IngestKustoImageInfoCommand.cs
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     foreach (PlatformData platform in image.Platforms)
                     {
                         string timestamp = platform.Created.ToUniversalTime().ToString("yyyy'-'MM'-'dd' 'HH':'mm':'ss");
-                        builder.AppendLine(FormatCsv(platform.Digest, platform, image, repo, timestamp));
+                        builder.AppendLine(FormatCsv(DockerHelper.GetDigestSha(platform.Digest), platform, image, repo, timestamp));
 
                         foreach (string tag in platform.SimpleTags)
                         {

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
@@ -129,6 +129,10 @@ namespace Microsoft.DotNet.ImageBuilder
                 "inspect", ".Created", "Failed to retrieve created date", image, isDryRun);
         }
 
+        public static string GetDigestSha(string digest) => digest.Substring(digest.IndexOf("@") + 1);
+
+        public static string GetDigestString(string repo, string sha) => $"{repo}@{sha}";
+
         private static OS GetOS()
         {
             string osString = ExecuteCommandWithFormat("version", ".Server.Os", "Failed to detect Docker OS");

--- a/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
@@ -150,8 +150,18 @@ namespace Microsoft.DotNet.ImageBuilder
             }
         }
 
-        private static void ReplaceValue(PropertyInfo property, object srcObj, object targetObj) =>
-            property.SetValue(targetObj, property.GetValue(srcObj));
+        private static void ReplaceValue(PropertyInfo property, object srcObj, object targetObj)
+        {
+            object value = property.GetValue(srcObj);
+            if (value is IList<string> stringList)
+            {
+                value = stringList
+                    .OrderBy(item => item)
+                    .ToList<string>();
+            }
+
+            property.SetValue(targetObj, value);
+        }
 
         private static void MergeStringLists(PropertyInfo property, object srcObj, object targetObj)
         {

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
@@ -35,7 +35,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         public IEnumerable<string> InternalFromImages { get; private set; }
         public Platform Model { get; private set; }
         public IEnumerable<string> OverriddenFromImages { get => _overriddenFromImages; }
-        private string FullRepoModelName { get; set; }
+        public string FullRepoModelName { get; set; }
         private string RepoName { get; set; }
         public IEnumerable<TagInfo> Tags { get; private set; }
         public IDictionary<string, CustomBuildLegGroup> CustomLegGroups { get; private set; }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/ImageInfoHelperTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/ImageInfoHelperTests.cs
@@ -454,8 +454,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                             Dockerfile = "image1",
                                             SimpleTags =
                                             {
-                                                "tag1",
-                                                "tag3"
+                                                "tag3",
+                                                "tag1"
                                             }
                                         }
                                     }
@@ -464,7 +464,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                 {
                                     SharedTags =
                                     {
-                                        "sharedtag1",
+                                        "sharedtag1b",
+                                        "sharedtag1a",
                                     }
                                 }
                             }
@@ -543,14 +544,23 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             {
                                 Platforms =
                                 {
-                                    srcPlatform1,
+                                    new PlatformData
+                                    {
+                                        Dockerfile = "image1",
+                                        SimpleTags =
+                                        {
+                                            "tag1",
+                                            "tag3"
+                                        }
+                                    },
                                     targetPlatform2
                                 },
                                 Manifest = new ManifestData
                                 {
                                     SharedTags =
                                     {
-                                        "sharedtag1",
+                                        "sharedtag1a",
+                                        "sharedtag1b",
                                     }
                                 }
                             }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/PublishManifestCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/PublishManifestCommandTests.cs
@@ -156,9 +156,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Assert.True(actualCreatedDate > (DateTime.Now.ToUniversalTime() - TimeSpan.FromMinutes(1)));
             Assert.True(actualCreatedDate < (DateTime.Now.ToUniversalTime() + TimeSpan.FromMinutes(1)));
 
-            imageArtifactDetails.Repos[0].Images[0].Manifest.Digest = "digest1";
+            imageArtifactDetails.Repos[0].Images[0].Manifest.Digest = "repo1@digest1";
             imageArtifactDetails.Repos[0].Images[0].Manifest.Created = actualCreatedDate;
-            imageArtifactDetails.Repos[1].Images[0].Manifest.Digest = "digest2";
+            imageArtifactDetails.Repos[1].Images[0].Manifest.Digest = "repo2@digest2";
             imageArtifactDetails.Repos[1].Images[0].Manifest.Created = actualCreatedDate;
 
             string expectedOutput = JsonHelper.SerializeObject(imageArtifactDetails);


### PR DESCRIPTION
In order to be able to implement the build caching logic documented in #186, there needs to be a way to look up the digest of the base image for each of the published images.  Currently this is tracked in the image info file but only for base images that are external (those which we do not build); we don't track the digests of base images that have been built internally from our own Dockerfiles.  These changes add logic to be able to track these digests.

It's not as simple as getting the digest after having pushed the images because the images are pushed to a staging location and so the digest would be based off of that registry/repo name.  Instead, we need to manually construct what the eventual registry/repo name is and append it to the SHA value to get the digest value that we actually want to store.

For consistency, I've updated the logic for all digest values stored in the image info file to be based on this scheme instead of only storing the SHA value.

Related to #186