### PR TITLE
Handle null digest value

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
@@ -129,16 +129,8 @@ namespace Microsoft.DotNet.ImageBuilder
                 "inspect", ".Created", "Failed to retrieve created date", image, isDryRun);
         }
 
-        public static string GetDigestSha(string digest)
-        {
-            if (digest is null)
-            {
-                return null;
-            }
-
-            return digest.Substring(digest.IndexOf("@") + 1);
-        }
-
+        public static string GetDigestSha(string digest) => digest?.Substring(digest.IndexOf("@") + 1);
+        
         public static string GetDigestString(string repo, string sha) => $"{repo}@{sha}";
 
         private static OS GetOS()

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
@@ -129,7 +129,15 @@ namespace Microsoft.DotNet.ImageBuilder
                 "inspect", ".Created", "Failed to retrieve created date", image, isDryRun);
         }
 
-        public static string GetDigestSha(string digest) => digest.Substring(digest.IndexOf("@") + 1);
+        public static string GetDigestSha(string digest)
+        {
+            if (digest is null)
+            {
+                return null;
+            }
+
+            return digest.Substring(digest.IndexOf("@") + 1);
+        }
 
         public static string GetDigestString(string repo, string sha) => $"{repo}@{sha}";
 


### PR DESCRIPTION
The changes from https://github.com/dotnet/docker-tools/pull/600 cause an issue when running dry-runs in the publish stage of PR builds.  The `ingestKustoImageInfo` command will encounter a NRE when attempting to extract the SHA from a digest value of the generated image info.  The digest value will be null in such a dry-run build because no image was pushed.  Fixed the code to gracefully handle a null digest value.