### PR TITLE
Build caching logic for Build command

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public string ImageInfoOutputPath { get; set; }
         public string ImageInfoSourcePath { get; set; }
         public string SourceRepoUrl { get; set; }
-        public bool DisableCaching { get; set; }
+        public bool NoCache { get; set; }
 
         public BuildOptions() : base()
         {
@@ -53,9 +53,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             syntax.DefineOption("source-repo", ref sourceRepoUrl, "Repo URL of the Dockerfile sources");
             SourceRepoUrl = sourceRepoUrl;
 
-            bool disableCaching = false;
-            syntax.DefineOption("disable-caching", ref disableCaching, "Disables build cache feature");
-            DisableCaching = disableCaching;
+            bool noCache = false;
+            syntax.DefineOption("no-cache", ref noCache, "Disables build cache feature");
+            NoCache = noCache;
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
@@ -15,7 +15,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public bool IsRetryEnabled { get; set; }
         public bool IsSkipPullingEnabled { get; set; }
         public string ImageInfoOutputPath { get; set; }
+        public string ImageInfoSourcePath { get; set; }
         public string SourceRepoUrl { get; set; }
+        public bool DisableCaching { get; set; }
 
         public BuildOptions() : base()
         {
@@ -43,9 +45,17 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             syntax.DefineOption("image-info-output-path", ref imageInfoOutputPath, "Path to output image info");
             ImageInfoOutputPath = imageInfoOutputPath;
 
+            string imageInfoSourcePath = null;
+            syntax.DefineOption("image-info-source-path", ref imageInfoSourcePath, "Path to source image info");
+            ImageInfoSourcePath = imageInfoSourcePath;
+
             string sourceRepoUrl = null;
             syntax.DefineOption("source-repo", ref sourceRepoUrl, "Repo URL of the Dockerfile sources");
             SourceRepoUrl = sourceRepoUrl;
+
+            bool disableCaching = false;
+            syntax.DefineOption("disable-caching", ref disableCaching, "Disables build cache feature");
+            DisableCaching = disableCaching;
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestCommand.cs
@@ -96,7 +96,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 TagInfo sharedTag = image.Image.ManifestImage.SharedTags.First();
                 image.Image.Manifest.Digest = DockerHelper.GetDigestString(
                     image.RepoName,
-                    this.manifestToolService.GetImageDigest(sharedTag.FullyQualifiedName, Options.IsDryRun));
+                    this.manifestToolService.GetManifestListDigest(sharedTag.FullyQualifiedName, Options.IsDryRun));
             });
 
             // Strip out any platforms that are the result of pulling a cached version

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestCommand.cs
@@ -11,7 +11,6 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
@@ -21,8 +20,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private readonly IManifestToolService manifestToolService;
         private readonly IEnvironmentService environmentService;
         private readonly ILoggerService loggerService;
-
-        public const string ManifestListMediaType = "application/vnd.docker.distribution.manifest.list.v2+json";
 
         [ImportingConstructor]
         public PublishManifestCommand(
@@ -97,16 +94,47 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 image.Image.Manifest.Created = createdDate;
 
                 TagInfo sharedTag = image.Image.ManifestImage.SharedTags.First();
-                JArray tagManifest = this.manifestToolService.Inspect(sharedTag.FullyQualifiedName, Options.IsDryRun);
-                string digest = tagManifest?
-                    .OfType<JObject>()
-                    .First(manifestType => manifestType["MediaType"].Value<string>() == ManifestListMediaType)
-                    ["Digest"].Value<string>();
-                image.Image.Manifest.Digest = DockerHelper.GetDigestString(image.RepoName, digest);
+                image.Image.Manifest.Digest = DockerHelper.GetDigestString(
+                    image.RepoName,
+                    this.manifestToolService.GetImageDigest(sharedTag.FullyQualifiedName, Options.IsDryRun));
             });
+
+            // Strip out any platforms that are the result of pulling a cached version
+            RemoveCachedPlatforms(imageArtifactDetails);
 
             string imageInfoString = JsonHelper.SerializeObject(imageArtifactDetails);
             File.WriteAllText(Options.ImageInfoPath, imageInfoString);
+        }
+
+        private void RemoveCachedPlatforms(ImageArtifactDetails imageArtifactDetails)
+        {
+            for (int repoIndex = imageArtifactDetails.Repos.Count - 1; repoIndex >= 0; repoIndex--)
+            {
+                RepoData repo = imageArtifactDetails.Repos[repoIndex];
+                for (int imageIndex = repo.Images.Count - 1; imageIndex >= 0; imageIndex--)
+                {
+                    ImageData image = repo.Images[imageIndex];
+                    for (int i = image.Platforms.Count - 1; i >= 0; i--)
+                    {
+                        PlatformData platform = image.Platforms[i];
+                        if (platform.IsCached)
+                        {
+                            this.loggerService.WriteMessage($"Removing cached platform '{platform.GetIdentifier()}'");
+                            image.Platforms.Remove(platform);
+                        }
+                    }
+
+                    if (!image.Platforms.Any())
+                    {
+                        repo.Images.Remove(image);
+                    }
+                }
+
+                if (!repo.Images.Any())
+                {
+                    imageArtifactDetails.Repos.Remove(repo);
+                }
+            }
         }
 
         private string GenerateManifest(ImageInfo image)

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerService.cs
@@ -30,6 +30,11 @@ namespace Microsoft.DotNet.ImageBuilder
             ExecuteHelper.ExecuteWithRetry("docker", $"push {tag}", isDryRun);
         }
 
+        public void CreateTag(string image, string tag, bool isDryRun)
+        {
+            DockerHelper.CreateTag(image, tag, isDryRun);
+        }
+
         public string BuildImage(string dockerfilePath, string buildContextPath, IEnumerable<string> tags, IDictionary<string, string> buildArgs, bool isRetryEnabled, bool isDryRun)
         {
             string tagArgs = $"-t {string.Join(" -t ", tags)}";

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerServiceCache.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerServiceCache.cs
@@ -1,0 +1,71 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.DotNet.ImageBuilder.Models.Manifest;
+
+namespace Microsoft.DotNet.ImageBuilder
+{
+    /// <summary>
+    /// Caches state returned from Docker commands.
+    /// </summary>
+    internal class DockerServiceCache : IDockerService
+    {
+        private readonly IDockerService inner;
+        private readonly Dictionary<string, DateTime> createdDateCache = new Dictionary<string, DateTime>();
+        private readonly Dictionary<string, string> imageDigestCache = new Dictionary<string, string>();
+        private readonly Dictionary<string, long> imageSizeCache = new Dictionary<string, long>();
+        private readonly Dictionary<string, bool> localImageExistsCache = new Dictionary<string, bool>();
+        private readonly HashSet<string> pulledImages = new HashSet<string>();
+
+        public DockerServiceCache(IDockerService inner)
+        {
+            this.inner = inner;
+        }
+
+        public Architecture Architecture => inner.Architecture;
+
+        public string BuildImage(string dockerfilePath, string buildContextPath, IEnumerable<string> tags, IDictionary<string, string> buildArgs, bool isRetryEnabled, bool isDryRun) =>
+            inner.BuildImage(dockerfilePath, buildContextPath, tags, buildArgs, isRetryEnabled, isDryRun);
+
+        public void CreateTag(string image, string tag, bool isDryRun) =>
+            inner.CreateTag(image, tag, isDryRun);
+
+        public DateTime GetCreatedDate(string image, bool isDryRun) =>
+            GetCachedValue(image, createdDateCache, () => inner.GetCreatedDate(image, isDryRun));
+
+        public string GetImageDigest(string image, bool isDryRun) =>
+            GetCachedValue(image, imageDigestCache, () => inner.GetImageDigest(image, isDryRun));
+
+        public long GetImageSize(string image, bool isDryRun) =>
+            GetCachedValue(image, imageSizeCache, () => inner.GetImageSize(image, isDryRun));
+        
+        public bool LocalImageExists(string tag, bool isDryRun) =>
+            GetCachedValue(tag, localImageExistsCache, () => inner.LocalImageExists(tag, isDryRun));
+        
+        public void PullImage(string image, bool isDryRun)
+        {
+            if (!pulledImages.Contains(image))
+            {
+                inner.PullImage(image, isDryRun);
+                pulledImages.Add(image);
+            }
+        }
+
+        public void PushImage(string tag, bool isDryRun) =>
+            inner.PushImage(tag, isDryRun);
+
+        private static TValue GetCachedValue<TKey, TValue>(TKey key, Dictionary<TKey, TValue> cache, Func<TValue> getValue)
+        {
+            if (!cache.TryGetValue(key, out TValue value))
+            {
+                value = getValue();
+                cache.Add(key, value);
+            }
+
+            return value;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/GitHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/GitHelper.cs
@@ -29,6 +29,11 @@ namespace Microsoft.DotNet.ImageBuilder
             while (!directory.GetDirectories(".git").Any())
             {
                 directory = directory.Parent;
+
+                if (directory is null)
+                {
+                    throw new InvalidOperationException($"File '{filePath}' is not contained within a Git repository.");
+                }
             }
 
             filePath = Path.GetRelativePath(directory.FullName, filePath);

--- a/src/Microsoft.DotNet.ImageBuilder/src/GitHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/GitHelper.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -22,10 +23,22 @@ namespace Microsoft.DotNet.ImageBuilder
 
         public static string GetCommitSha(string filePath, bool useFullHash = false)
         {
+            // Don't make the assumption that the current working directory is a Git repository
+            // Find the Git repo that contains the file being checked.
+            DirectoryInfo directory = new FileInfo(filePath).Directory;
+            while (!directory.GetDirectories(".git").Any())
+            {
+                directory = directory.Parent;
+            }
+
+            filePath = Path.GetRelativePath(directory.FullName, filePath);
+
             string format = useFullHash ? "H" : "h";
             return ExecuteHelper.Execute(
-                "git",
-                $"log -1 --format=format:%{format} {filePath}",
+                new ProcessStartInfo("git", $"log -1 --format=format:%{format} {filePath}")
+                {
+                    WorkingDirectory = directory.FullName
+                },
                 false,
                 $"Unable to retrieve the latest commit SHA for {filePath}");
         }

--- a/src/Microsoft.DotNet.ImageBuilder/src/IDockerService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/IDockerService.cs
@@ -18,6 +18,8 @@ namespace Microsoft.DotNet.ImageBuilder
 
         void PushImage(string tag, bool isDryRun);
 
+        void CreateTag(string image, string tag, bool isDryRun);
+
         string BuildImage(
             string dockerfilePath,
             string buildContextPath,

--- a/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
@@ -93,7 +93,9 @@ namespace Microsoft.DotNet.ImageBuilder
 
             foreach (PropertyInfo property in properties)
             {
-                if (property.PropertyType == typeof(string) || property.PropertyType == typeof(DateTime))
+                if (property.PropertyType == typeof(string) ||
+                    property.PropertyType == typeof(DateTime) ||
+                    property.PropertyType == typeof(bool))
                 {
                     property.SetValue(targetObj, property.GetValue(srcObj));
                 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ManifestToolService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ManifestToolService.cs
@@ -11,6 +11,9 @@ namespace Microsoft.DotNet.ImageBuilder
     [Export(typeof(IManifestToolService))]
     public class ManifestToolService : IManifestToolService
     {
+        public const string ManifestListMediaType = "application/vnd.docker.distribution.manifest.list.v2+json";
+        public const string ManifestMediaType = "application/vnd.docker.distribution.manifest.v2+json";
+
         public void PushFromSpec(string manifestFile, bool isDryRun)
         {
             // ExecuteWithRetry because the manifest-tool fails periodically while communicating

--- a/src/Microsoft.DotNet.ImageBuilder/src/ManifestToolServiceExtensions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ManifestToolServiceExtensions.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.DotNet.ImageBuilder
+{
+    public static class ManifestToolServiceExtensions
+    {
+        public static string GetImageDigest(this IManifestToolService manifestToolService, string tag, bool isDryRun)
+        {
+            JArray tagManifest = manifestToolService.Inspect(tag, isDryRun);
+            return tagManifest?
+                .OfType<JObject>()
+                .First(manifestType =>
+                {
+                    string mediaType = manifestType["MediaType"].Value<string>();
+                    return mediaType == ManifestToolService.ManifestListMediaType ||
+                        mediaType == ManifestToolService.ManifestMediaType;
+                })
+                ["Digest"].Value<string>();
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/ManifestToolServiceExtensions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ManifestToolServiceExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DotNet.ImageBuilder
 {
     public static class ManifestToolServiceExtensions
     {
-        public static string GetImageDigest(this IManifestToolService manifestToolService, string tag, bool isDryRun)
+        public static string GetManifestListDigest(this IManifestToolService manifestToolService, string tag, bool isDryRun)
         {
             JArray tagManifest = manifestToolService.Inspect(tag, isDryRun);
             return tagManifest?
@@ -17,8 +17,7 @@ namespace Microsoft.DotNet.ImageBuilder
                 .First(manifestType =>
                 {
                     string mediaType = manifestType["MediaType"].Value<string>();
-                    return mediaType == ManifestToolService.ManifestListMediaType ||
-                        mediaType == ManifestToolService.ManifestMediaType;
+                    return mediaType == ManifestToolService.ManifestListMediaType;
                 })
                 ["Digest"].Value<string>();
         }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/PlatformData.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/PlatformData.cs
@@ -31,6 +31,15 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Image
 
         public string CommitUrl { get; set; }
 
+        /// <summary>
+        /// Gets or sets whether the image was retrieved as a cached image.
+        /// </summary>
+        /// <remarks>
+        /// Items with this state should only be used internally within a build. Such items
+        /// should be stripped out of the published image info content.
+        /// </remarks>
+        public bool IsCached { get; set; }
+
         [JsonIgnore]
         public IEnumerable<string> FullyQualifiedSimpleTags { get; set; }
 

--- a/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
@@ -14,7 +14,6 @@ using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
 using Moq;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Abstractions;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;

--- a/src/Microsoft.DotNet.ImageBuilder/tests/PublishManifestCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/PublishManifestCommandTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 return new JArray(
                     new JObject
                     {
-                        { "MediaType", PublishManifestCommand.ManifestListMediaType },
+                        { "MediaType", ManifestToolService.ManifestListMediaType },
                         { "Digest", digest }
                     });
             }
@@ -56,6 +56,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             string dockerfile1 = CreateDockerfile("1.0/repo1/os", tempFolderContext);
             string dockerfile2 = CreateDockerfile("1.0/repo2/os", tempFolderContext);
+            string dockerfile3 = CreateDockerfile("1.0/repo3/os", tempFolderContext);
 
             ImageArtifactDetails imageArtifactDetails = new ImageArtifactDetails
             {
@@ -99,7 +100,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     CreatePlatform(dockerfile2),
                                     new PlatformData
                                     {
-
+                                        IsCached = true
                                     }
                                 },
                                 Manifest = new ManifestData
@@ -160,6 +161,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             imageArtifactDetails.Repos[0].Images[0].Manifest.Created = actualCreatedDate;
             imageArtifactDetails.Repos[1].Images[0].Manifest.Digest = "repo2@digest2";
             imageArtifactDetails.Repos[1].Images[0].Manifest.Created = actualCreatedDate;
+
+            // Remove cached platform
+            imageArtifactDetails.Repos[1].Images[0].Platforms.RemoveAt(1);
 
             string expectedOutput = JsonHelper.SerializeObject(imageArtifactDetails);
 


### PR DESCRIPTION
Adds caching logic to Image Builder's `build` command.  This helps to avoid building and publishing images that have not changed since they were last published.  The criteria for determining whether an image has changed is the following:
* The image it's based on has a current digest value that differs from the base image digest value from the previous publish.
* The Dockerfile's commit SHA is different than what it was when the image was previously published.

The published image info files contain the state that is used here for getting the information on the previous publishing of the image.  That file is passed as input for the `build` command.

In order to simplify testing logic, the image info output of a build job will contain data for images that were pulled from the cache.  They are marked accordingly with a flag.  This means that the image info output from the build now represents what images are contained in the staging location rather than which images were actually built.  At publish time any images marked as cached in the image info are stripped out before committing it to the dotnet/versions repo.

Related to #186