### PR TITLE
Fix IsLocal tag issues in BuildCommand

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -69,26 +69,26 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             Dictionary<string, PlatformData> platformDataByTag = new Dictionary<string, PlatformData>();
             foreach (PlatformData platformData in GetBuiltPlatforms())
             {
-                foreach (string tag in platformData.FullyQualifiedSimpleTags)
+                foreach (TagInfo tag in platformData.PlatformInfo.Tags)
                 {
-                    platformDataByTag.Add(tag, platformData);
+                    platformDataByTag.Add(tag.FullyQualifiedName, platformData);
                 }
             }
 
-            foreach (var platform in GetBuiltPlatforms())
+            foreach (PlatformData platform in GetBuiltPlatforms())
             {
                 PlatformInfo manifestPlatform = Manifest.GetFilteredPlatforms()
                    .First(manifestPlatform => platform.Equals(manifestPlatform));
 
-                foreach (string tag in platform.FullyQualifiedSimpleTags)
+                foreach (TagInfo tag in GetPushTags(platform.PlatformInfo.Tags))
                 {
                     if (Options.IsPushEnabled)
                     {
-                        SetPlatformDataDigest(platform, manifestPlatform, tag);
-                        SetPlatformDataBaseDigest(platform, manifestPlatform, platformDataByTag);
+                        SetPlatformDataDigest(platform, manifestPlatform, tag.FullyQualifiedName);
+                        SetPlatformDataBaseDigest(platform, platformDataByTag);
                     }
 
-                    SetPlatformDataCreatedDate(platform, tag);
+                    SetPlatformDataCreatedDate(platform, tag.FullyQualifiedName);
                     platform.CommitUrl = gitService.GetDockerfileCommitUrl(manifestPlatform, Options.SourceRepoUrl);
                 }
             }
@@ -111,14 +111,15 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             platform.Created = createdDate;
         }
 
-        private static void SetPlatformDataBaseDigest(PlatformData platform, PlatformInfo manifestPlatform, Dictionary<string, PlatformData> platformDataByTag)
+        private static void SetPlatformDataBaseDigest(PlatformData platform, Dictionary<string, PlatformData> platformDataByTag)
         {
-            if (platform.BaseImageDigest == null && manifestPlatform.FinalStageFromImage != null)
+            if (platform.BaseImageDigest == null && platform.PlatformInfo.FinalStageFromImage != null)
             {
-                if (!platformDataByTag.TryGetValue(manifestPlatform.FinalStageFromImage, out PlatformData basePlatformData))
+                platform.AllTags.FirstOrDefault(tag => tag.FullyQualifiedName == platform.PlatformInfo.FinalStageFromImage);
+                if (!platformDataByTag.TryGetValue(platform.PlatformInfo.FinalStageFromImage, out PlatformData basePlatformData))
                 {
                     throw new InvalidOperationException(
-                        $"Unable to find platform data for tag '{manifestPlatform.FinalStageFromImage}'. " +
+                        $"Unable to find platform data for tag '{platform.PlatformInfo.FinalStageFromImage}'. " +
                         "It's likely that the platforms are not ordered according to dependency.");
                 }
 
@@ -182,7 +183,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
                     foreach (PlatformInfo platform in image.FilteredPlatforms)
                     {
-                        PlatformData platformData = PlatformData.FromPlatformInfo(platform);
+                        PlatformData platformData = PlatformData.FromPlatformInfo(platform, image);
                         imageData.Platforms.Add(platformData);
 
                         bool createdPrivateDockerfile = UpdateDockerfileFromCommands(platform, out string dockerfilePath);
@@ -237,10 +238,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                             .Select(tag => tag.Name)
                             .OrderBy(name => name)
                             .ToList();
-                        platformData.FullyQualifiedSimpleTags = platformData.SimpleTags
-                            .Select(tag => TagInfo.GetFullyQualifiedName(repoInfo.QualifiedName, tag))
-                            .ToList();
-                        platformData.AllTags = allTags;
                     }
                 }
 
@@ -372,7 +369,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             .SelectMany(repoData => repoData.Images)
             .SelectMany(imageData => imageData.Platforms);
 
-        private IEnumerable<string> GetBuiltTags() =>
+        private IEnumerable<TagInfo> GetBuiltTags() =>
             GetBuiltPlatforms().SelectMany(platform => platform.AllTags);
 
         private void PushImages()
@@ -383,9 +380,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
                 ExecuteWithUser(() =>
                 {
-                    foreach (string tag in GetBuiltTags())
+                    foreach (TagInfo tag in GetPushTags(GetBuiltTags()))
                     {
-                        this.dockerService.PushImage(tag, Options.IsDryRun);
+                        this.dockerService.PushImage(tag.FullyQualifiedName, Options.IsDryRun);
                     }
                 });
             }
@@ -432,13 +429,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             this.loggerService.WriteHeading("IMAGES BUILT");
 
-            IEnumerable<string> builtTags = GetBuiltTags();
+            IEnumerable<TagInfo> builtTags = GetBuiltTags();
 
             if (builtTags.Any())
             {
-                foreach (string tag in builtTags)
+                foreach (TagInfo tag in builtTags)
                 {
-                    this.loggerService.WriteMessage(tag);
+                    this.loggerService.WriteMessage(tag.FullyQualifiedName);
                 }
             }
             else

--- a/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.ImageBuilder
                 RepoInfo manifestRepo = manifest.AllRepos.FirstOrDefault(repo => repo.Name == repoData.Repo);
                 if (manifestRepo == null)
                 {
-                    Console.WriteLine($"Image info repo not loaded:  {repoData.Repo}");
+                    Console.WriteLine($"Image info repo not loaded: {repoData.Repo}");
                     continue;
                 }
                 foreach (ImageData imageData in repoData.Images)
@@ -40,6 +40,8 @@ namespace Microsoft.DotNet.ImageBuilder
                             if (matchingManifestPlatform != null)
                             {
                                 imageData.ManifestImage = manifestImage;
+                                platformData.PlatformInfo = matchingManifestPlatform;
+                                platformData.ImageInfo = manifestImage;
                                 break;
                             }
                         }


### PR DESCRIPTION
Fixes two issues that were identified in how `BuildCommand` handles tags that are marked as `IsLocal`:

* Local tags were being pushed to the staging location but not actually being made public.  This was due to an issue in the `PushImages` method that was enumerating built tags but not filtering out those marked as local: https://github.com/dotnet/docker-tools/blob/8c270da5124f32ce1a407f977817e31c7bba113e/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs#L386

* Another issue was that an exception would be thrown when trying to find the digest of a tag that is marked as local: https://github.com/dotnet/docker-tools/blob/8c270da5124f32ce1a407f977817e31c7bba113e/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs#L120
  This occurred because when constructing the lookup data, it was actually filtering out tags marked as local.

These issues have been fixed by exposing the TagInfo objects rather than just the tag strings so that the appropriate metadata is available to determine whether the tag is local or not.  