### PR TITLE
Fix up issues in wait for MCR ingestion logic

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/McrStatus/StageStatus.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/McrStatus/StageStatus.cs
@@ -6,6 +6,7 @@ namespace Microsoft.DotNet.ImageBuilder.Models.McrStatus
 {
     public enum StageStatus
     {
+        Unknown,
         Processing,
         Failed,
         NotApplicable,


### PR DESCRIPTION
Fixing up a couple issues that were identified with the logic to wait for MCR ingestion:
* StageStatus enum should include an Unknown value since that is a valid case.
* When reporting on the details of failed status, the image statuses being enumerated weren't correctly filtered.  They should be filtered in the same way as they are when waiting for the result.