### PR TITLE
Don't cache null values

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerServiceCache.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerServiceCache.cs
@@ -62,7 +62,12 @@ namespace Microsoft.DotNet.ImageBuilder
             if (!cache.TryGetValue(key, out TValue value))
             {
                 value = getValue();
-                cache.Add(key, value);
+
+                // Don't cache null values
+                if (value != null)
+                {
+                    cache.Add(key, value);
+                }
             }
 
             return value;


### PR DESCRIPTION
Excludes null values from the caches maintained by `DockerServiceCache`.  This is important for a scenario like image digests where a locally built image will not have a digest value yet.  So an attempt to gets its digest would result in a null value being stored in the cache.  After pushing the image and attempting to retrieve the digest again, it would return the null value from the cache.