### PR TITLE
Override testResultsDirectory in case of multiple repos

### DIFF
--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -48,11 +48,13 @@ jobs:
         $engPath = "$(Build.Repository.LocalPath)/$buildRepoName/eng"
         $testScriptPath = "$buildRepoName/$(testScriptPath)"
         $manifest = "$buildRepoName/$(manifest)"
+        $testResultsDirectory = "$buildRepoName/$testResultsDirectory"
 
         echo "##vso[task.setvariable variable=manifest]$manifest"
         echo "##vso[task.setvariable variable=engCommonPath]$engCommonPath"
         echo "##vso[task.setvariable variable=engPath]$engPath"
         echo "##vso[task.setvariable variable=testScriptPath]$testScriptPath"
+        echo "##vso[task.setvariable variable=testResultsDirectory]$testResultsDirectory"
       displayName: Override Common Paths
   - template: ${{ format('../steps/init-docker-{0}.yml', parameters.dockerClientOS) }}
   - ${{ parameters.customInitSteps }}

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:787681
+  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:791077
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch-slim-docker-testrunner-690072
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)


### PR DESCRIPTION
Fixes an issue from https://github.com/dotnet/docker-tools/pull/618 because it didn't override the `testResultsDirectory` variable causing the tests to be unable to copy test results for the pipeline.

Related to #186