### PR TITLE
Prevent default value of IsCached property from being serialized

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/PlatformData.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/PlatformData.cs
@@ -49,6 +49,7 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Image
         /// Items with this state should only be used internally within a build. Such items
         /// should be stripped out of the published image info content.
         /// </remarks>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool IsCached { get; set; }
 
         [JsonIgnore]


### PR DESCRIPTION
We don't want the image info files published to the dotnet/versions repo to include a bunch of `"isCached": false` lines because they will all have that value.