### PR TITLE
Add GenerateImageGraph command

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateImageGraphCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateImageGraphCommand.cs
@@ -1,0 +1,156 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using GiGraph.Dot.Entities.Attributes.Enums;
+using GiGraph.Dot.Entities.Edges;
+using GiGraph.Dot.Entities.Graphs;
+using GiGraph.Dot.Entities.Nodes;
+using GiGraph.Dot.Extensions;
+using Microsoft.DotNet.ImageBuilder.Models.Docker;
+using Microsoft.DotNet.ImageBuilder.ViewModel;
+
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    [Export(typeof(ICommand))]
+    public class GenerateImageGraphCommand : ManifestCommand<GenerateImageGraphOptions>
+    {
+        private Dictionary<string, Manifest> _imageManifestCache = new Dictionary<string, Manifest>();
+        private Dictionary<string, DotNode> _nodeCache = new Dictionary<string, DotNode>();
+
+        public GenerateImageGraphCommand() : base()
+        {
+        }
+
+        public override Task ExecuteAsync()
+        {
+            Logger.WriteHeading("GENERATING IMAGE GRAPH");
+
+            DotGraph graph = new DotGraph("ImageGraph", true);
+            graph.Attributes.LayoutDirection = DotRankDirection.BottomToTop;
+            graph.Attributes.FontColor = Color.Black;
+            graph.Attributes.Style = DotStyle.Solid;
+
+            PlatformInfo[] platforms = Manifest.GetFilteredPlatforms().ToArray();
+            AddBaseImages(graph, platforms);
+            AddModeledImages(graph, platforms);
+
+            graph.SaveToFile(Options.OutputPath);
+            Logger.WriteMessage($"Graph saved to `{Options.OutputPath}`");
+
+            if (Options.IsVerbose)
+            {
+                Logger.WriteMessage("Graph:");
+                Logger.WriteMessage(File.ReadAllText(Options.OutputPath));
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private void AddBaseImages(DotGraph graph, PlatformInfo[] platforms)
+        {
+            IEnumerable<string> externalBaseImages = platforms
+                .Where(platform => !platform.IsInternalFromImage(platform.FinalStageFromImage))
+                .Select(platform => platform.FinalStageFromImage)
+                .Distinct()
+                .OrderBy(name => name)
+                .ToArray();
+
+            LoadImageManifests(externalBaseImages.Select(image => new[] { image }));
+
+            foreach (string externalBaseImage in externalBaseImages)
+            {
+                AddImageNode(graph, new[] { externalBaseImage }, Color.Crimson);
+            }
+        }
+
+        private DotNode AddImageNode(DotGraph graph, IEnumerable<string> tags, Color color, string fromImage = null)
+        {
+            string primaryTag = tags.First();
+            Manifest manifest = _imageManifestCache[primaryTag];
+            long totalSize = manifest.SchemaV2Manifest.Config.Size + manifest.SchemaV2Manifest.Layers.Select(layer => layer.Size).Sum();
+            string recordBody = $"{GetImageDisplayName(primaryTag, fromImage != null)}| Size: {ConvertToMB(totalSize):#,#.0}";
+
+            if (fromImage != null)
+            {
+                Manifest fromManifest = _imageManifestCache[fromImage];
+                long ownedSize = manifest.SchemaV2Manifest.Config.Size +
+                    manifest.SchemaV2Manifest.Layers.Except(fromManifest.SchemaV2Manifest.Layers).Select(layer => layer.Size).Sum();
+
+                recordBody += $"| Owned: {ConvertToMB(ownedSize):#,#.0} ({ownedSize / Convert.ToDecimal(totalSize) * 100:.0}%)";
+            }
+
+            DotNode imageNode = new DotNode(primaryTag);
+            imageNode.Attributes.Shape = DotNodeShape.Record;
+            imageNode.Attributes.Color = color;
+            imageNode.Attributes.Label = $"{{{recordBody}}}";
+
+            graph.Nodes.Add(imageNode);
+            foreach (string tag in tags)
+            {
+                _nodeCache.Add(tag, imageNode);
+            }
+
+            return imageNode;
+        }
+
+        private void AddModeledImages(DotGraph graph, PlatformInfo[] platforms)
+        {
+            IEnumerable<IEnumerable<string>> images = platforms.Select(platform => platform.Tags.Select(tag => tag.FullyQualifiedName));
+            LoadImageManifests(images);
+
+            foreach (PlatformInfo platform in platforms)
+            {
+                IEnumerable<string> tags = platform.Tags.Select(tag => tag.FullyQualifiedName);
+                DotNode imageNode = AddImageNode(graph, tags, Color.Navy, platform.FinalStageFromImage);
+
+                var myEdge = new DotEdge(imageNode.Id, _nodeCache[platform.FinalStageFromImage].Id);
+                myEdge.Attributes.ArrowHead = DotArrowType.Normal;
+                myEdge.Attributes.ArrowTail = DotArrowType.None;
+                myEdge.Attributes.Color = Color.Black;
+                myEdge.Attributes.Style = DotStyle.Dashed;
+                graph.Edges.Add(myEdge);
+            }
+        }
+
+        private decimal ConvertToMB(long bytes) => bytes / 1048576m;
+
+        private static string GetImageDisplayName(string tag, bool trimParentRepos)
+        {
+            string displayName = tag.TrimStart("mcr.microsoft.com/");
+            if (trimParentRepos)
+            {
+                // Strip off any parent product repos for brevity
+                int lastSlash = displayName.LastIndexOf('/');
+                if (lastSlash != -1)
+                {
+                    displayName = displayName.Substring(lastSlash + 1);
+                }
+            }
+
+            return displayName;
+        }
+
+        private void LoadImageManifests(IEnumerable<IEnumerable<string>> images)
+        {
+            Parallel.ForEach(images, tagList =>
+            {
+                Manifest manifest = DockerHelper.InspectManifest(tagList.First(), Options.IsDryRun);
+                lock (_imageManifestCache)
+                {
+                    foreach (string tag in tagList)
+                    {
+                        _imageManifestCache.Add(tag, manifest);
+                    }
+                }
+            });
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateImageGraphCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateImageGraphCommand.cs
@@ -124,7 +124,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         private string GetImageDisplayName(string tag, bool trimParentRepos)
         {
-            string displayName = tag.TrimStart(Manifest.Registry).TrimStart('/');
+            string displayName = tag;
+
+            if (Manifest.Registry != null)
+            {
+                displayName = displayName.TrimStart(Manifest.Registry).TrimStart('/');
+            }
+
             if (trimParentRepos)
             {
                 // Strip off any parent product repos for brevity

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateImageGraphCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateImageGraphCommand.cs
@@ -122,9 +122,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         private decimal ConvertToMB(long bytes) => bytes / 1048576m;
 
-        private static string GetImageDisplayName(string tag, bool trimParentRepos)
+        private string GetImageDisplayName(string tag, bool trimParentRepos)
         {
-            string displayName = tag.TrimStart("mcr.microsoft.com/");
+            string displayName = tag.TrimStart(Manifest.Registry).TrimStart('/');
             if (trimParentRepos)
             {
                 // Strip off any parent product repos for brevity

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateImageGraphOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateImageGraphOptions.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.CommandLine;
+
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    public class GenerateImageGraphOptions : ManifestOptions, IFilterableOptions
+    {
+        protected override string CommandHelp => "Generate a DOT (graph description language) file illustrating the image and layer hierarchy";
+
+        public ManifestFilterOptions FilterOptions { get; } = new ManifestFilterOptions();
+
+        public string OutputPath { get; set; }
+
+        public override void DefineOptions(ArgumentSyntax syntax)
+        {
+            base.DefineOptions(syntax);
+
+            FilterOptions.DefineOptions(syntax);
+        }
+
+        public override void DefineParameters(ArgumentSyntax syntax)
+        {
+            base.DefineParameters(syntax);
+
+            string outputPath = null;
+            syntax.DefineParameter("output-path", ref outputPath, "The path to write the graph to");
+            OutputPath = outputPath;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
@@ -4,7 +4,9 @@
 
 using System;
 using System.Diagnostics;
+using Docker = Microsoft.DotNet.ImageBuilder.Models.Docker;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
+using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.ImageBuilder
 {
@@ -130,8 +132,19 @@ namespace Microsoft.DotNet.ImageBuilder
         }
 
         public static string GetDigestSha(string digest) => digest?.Substring(digest.IndexOf("@") + 1);
-        
+
         public static string GetDigestString(string repo, string sha) => $"{repo}@{sha}";
+
+        /// <remarks>
+        /// This method depends on the experimental Docker CLI `manifest` command.  As a result, this method
+        /// should only used for developer usage scenarios.
+        /// </remarks>
+        public static Docker.Manifest InspectManifest(string image, bool isDryRun)
+        {
+            string manifest = ExecuteCommand(
+                "manifest inspect", "Failed to inspect manifest", $"{image} --verbose", isDryRun);
+            return JsonConvert.DeserializeObject<Docker.Manifest>(manifest);
+        }
 
         private static OS GetOS()
         {

--- a/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Cottle" Version="2.0.2" />
+    <PackageReference Include="GiGraph.Dot" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.Kusto.Ingest" Version="8.0.9" />
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.22.0" />
     <PackageReference Include="Microsoft.DotNet.VersionTools" Version="1.0.0-beta.19426.12" />

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Docker/Descriptor.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Docker/Descriptor.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.ImageBuilder.Models.Docker
+{
+    public partial class Descriptor : IEquatable<Descriptor>
+    {
+        public string MediaType { get; set; }
+
+        public string Digest { get; set; }
+
+        public long Size { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public Platform Platform { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public Uri[] Urls { get; set; }
+
+        public bool Equals(Descriptor other)
+        {
+            return other != null && Digest == other.Digest;
+        }
+
+        public override bool Equals(object obj) => Equals(obj as Descriptor);
+
+        public override int GetHashCode() => Digest.GetHashCode();
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Docker/Manifest.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Docker/Manifest.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.ImageBuilder.Models.Docker
+{
+    public partial class Manifest
+    {
+        public string Ref { get; set; }
+
+        public Descriptor Descriptor { get; set; }
+
+        public SchemaV2Manifest SchemaV2Manifest { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Docker/Platform.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Docker/Platform.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.ImageBuilder.Models.Docker
+{
+    public partial class Platform
+    {
+        public string Architecture { get; set; }
+
+        public string Os { get; set; }
+
+        [JsonProperty("os.version")]
+        public string OsVersion { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Docker/SchemaV2Manifest.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Docker/SchemaV2Manifest.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.ImageBuilder.Models.Docker
+{
+    public partial class SchemaV2Manifest
+    {
+        public long SchemaVersion { get; set; }
+
+        public string MediaType { get; set; }
+
+        public Descriptor Config { get; set; }
+
+        public Descriptor[] Layers { get; set; }
+    }
+}


### PR DESCRIPTION
This command generates a DOT (graph description language) file illustrating the image and layer hierarchy.  This command is not intended for any production scenarios it is intended for local desktop usages to generate visualizations of the images within a manifest.