### PR TITLE
Fix manifest tool issues

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/Dockerfile.windows
+++ b/src/Microsoft.DotNet.ImageBuilder/Dockerfile.windows
@@ -1,3 +1,5 @@
+# escape=`
+
 # build Microsoft.DotNet.ImageBuilder
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build-env
 WORKDIR /image-builder
@@ -11,6 +13,13 @@ RUN dotnet restore ./src/Microsoft.DotNet.ImageBuilder.csproj
 COPY . ./
 RUN dotnet publish ./src/Microsoft.DotNet.ImageBuilder.csproj -c Release -o out -r win7-x64
 
+RUN pwsh -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri "https://github.com/estesp/manifest-tool/releases/download/v1.0.2/manifest-tool-windows-amd64.exe" `
+            -OutFile out/manifest-tool.exe;
 
 # build runtime image
 FROM mcr.microsoft.com/windows/nanoserver:sac2016

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -41,14 +41,19 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public override Task ExecuteAsync()
         {
             PullBaseImages();
-            BuildImages();
 
-            if (GetBuiltPlatforms().Any())
+            ExecuteWithUser(() =>
             {
-                PushImages();
-            }
+                BuildImages();
 
-            PublishImageInfo();
+                if (GetBuiltPlatforms().Any())
+                {
+                    PushImages();
+                }
+
+                PublishImageInfo();
+            });
+            
             WriteBuildSummary();
 
             return Task.CompletedTask;
@@ -499,13 +504,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             {
                 this.loggerService.WriteHeading("PUSHING IMAGES");
 
-                ExecuteWithUser(() =>
+                foreach (TagInfo tag in GetPushTags(GetBuiltTags()))
                 {
-                    foreach (TagInfo tag in GetPushTags(GetBuiltTags()))
-                    {
-                        this.dockerService.PushImage(tag.FullyQualifiedName, Options.IsDryRun);
-                    }
-                });
+                    this.dockerService.PushImage(tag.FullyQualifiedName, Options.IsDryRun);
+                }
             }
         }
 


### PR DESCRIPTION
Fixes a couple issues introduced from https://github.com/dotnet/docker-tools/pull/620.

Now that the manifest tool is called in Windows scenarios as well, the manifest tool needs to be contained in the Windows version of the Image Builder image.

And since the manifest tool is also being called for images that exist in the staging location, there needs to be an authenticated connection for those scenarios.  To fix that, I've updated `BuildCommand` to be logged into the Docker registry for more of its work.