### PR TITLE
Fix bug in showImageStats related to counting undocumented tags

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ShowImageStatsCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ShowImageStatsCommand.cs
@@ -82,8 +82,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             TagInfo[] platformTags = Manifest.GetFilteredPlatformTags().ToArray();
             TagInfo[] sharedTags = Manifest.GetFilteredImages().SelectMany(image => image.SharedTags).ToArray();
-            TagInfo[] undocumentedPlatformTags = platformTags.Where(tag => tag.Model.DocType != TagDocumentationType.Undocumented).ToArray();
-            TagInfo[] undocumentedSharedTags = sharedTags.Where(tag => tag.Model.DocType != TagDocumentationType.Undocumented).ToArray();
+            TagInfo[] undocumentedPlatformTags = platformTags.Where(tag => tag.Model.DocType == TagDocumentationType.Undocumented).ToArray();
+            TagInfo[] undocumentedSharedTags = sharedTags.Where(tag => tag.Model.DocType == TagDocumentationType.Undocumented).ToArray();
 
             Logger.WriteMessage($"Total Unique Images:  {platforms.Length}");
             Logger.WriteMessage($"Total Simple Tags:  {platformTags.Length}");


### PR DESCRIPTION
This was introduced by https://github.com/dotnet/docker-tools/pull/584 when the documentation metadata was changed from a Boolean property to an enum.