### PR TITLE
Fix digest parsing

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
@@ -5,9 +5,10 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using Docker = Microsoft.DotNet.ImageBuilder.Models.Docker;
+using System.Linq;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 using Newtonsoft.Json;
+using Docker = Microsoft.DotNet.ImageBuilder.Models.Docker;
 
 namespace Microsoft.DotNet.ImageBuilder
 {
@@ -45,7 +46,13 @@ namespace Microsoft.DotNet.ImageBuilder
             string digests = ExecuteCommandWithFormat(
                 "inspect", "index .RepoDigests", "Failed to retrieve image digests", image, isDryRun);
 
-            return digests.TrimStart('[').TrimEnd(']').Split(' ');
+            string trimmedDigests = digests.TrimStart('[').TrimEnd(']');
+            if (trimmedDigests == String.Empty)
+            {
+                return Enumerable.Empty<string>();
+            }
+
+            return trimmedDigests.Split(' ');
         }
 
         public static long GetImageSize(string image, bool isDryRun)

--- a/src/Microsoft.DotNet.ImageBuilder/src/ManifestToolService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ManifestToolService.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.ImageBuilder
             string output = ExecuteHelper.ExecuteWithRetry("manifest-tool", $"inspect {image} --raw", isDryRun);
             if (isDryRun)
             {
-                return null;
+                return new JArray();
             }
 
             return JsonConvert.DeserializeObject<JArray>(output);

--- a/src/Microsoft.DotNet.ImageBuilder/src/ManifestToolServiceExtensions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ManifestToolServiceExtensions.cs
@@ -22,7 +22,8 @@ namespace Microsoft.DotNet.ImageBuilder
             if (hasSupportedMediaType |= mediaType.HasFlag(ManifestMediaType.ManifestList))
             {
                 digest = GetDigestOfMediaType(
-                    tag, tagManifests, ManifestToolService.ManifestListMediaType, throwIfNull: mediaType == ManifestMediaType.ManifestList);
+                    tag, tagManifests, ManifestToolService.ManifestListMediaType,
+                    throwIfNull: mediaType == ManifestMediaType.ManifestList && !isDryRun);
 
                 if (digest != null)
                 {
@@ -33,7 +34,7 @@ namespace Microsoft.DotNet.ImageBuilder
             if (hasSupportedMediaType |= mediaType.HasFlag(ManifestMediaType.Manifest))
             {
                 return GetDigestOfMediaType(
-                    tag, tagManifests, ManifestToolService.ManifestMediaType, throwIfNull: true);
+                    tag, tagManifests, ManifestToolService.ManifestMediaType, throwIfNull: !isDryRun);
             }
 
             if (!hasSupportedMediaType)


### PR DESCRIPTION
Fixes an issue with parsing the digests returned from the `docker inspect` command.  A locally built image will have an empty array returned for its `RepoDigests` field.  When trimming the array characters, it's left with an empty string.  Calling `Split` on an empty string produces an array with a single empty string rather than an empty array.  Fixed the code to return an empty enumerable in that case.

The namespaces were reordered according to Visual Studio's sorting.  Without fixing the sorting, it couldn't automatically place new namespaces in the correct order.