### PR TITLE
Don't cache null image digests

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -150,7 +150,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             {
                 // Pushing the same image with different tags should result in the same digest being output
                 this.loggerService.WriteError(
-                    $"Tag '{tag}' was pushed with a resulting digest value that differs from the corresponding image's digest value of '{platform.Digest}'.");
+                    $"Tag '{tag}' was pushed with a resulting digest value that differs from the corresponding image's digest value." +
+                    Environment.NewLine +
+                    $"Digest value from image info: {platform.Digest}{Environment.NewLine}" +
+                    $"Digest value retrieved from query: {digest}");
                 this.environmentService.Exit(1);
             }
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerService.cs
@@ -35,6 +35,11 @@ namespace Microsoft.DotNet.ImageBuilder
 
             string digestSha = this.manifestToolService.GetManifestDigestSha(ManifestMediaType.Any, image, isDryRun);
 
+            if (digestSha is null)
+            {
+                return null;
+            }
+
             string digest = DockerHelper.GetDigestString(DockerHelper.GetRepo(image), digestSha);
 
             if (!digests.Contains(digest))
@@ -95,6 +100,11 @@ namespace Microsoft.DotNet.ImageBuilder
 
         public DateTime GetCreatedDate(string image, bool isDryRun)
         {
+            if (isDryRun)
+            {
+                return default;
+            }
+
             return DateTime.Parse(DockerHelper.GetCreatedDate(image, isDryRun));
         }
     }

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerServiceCache.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerServiceCache.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.ImageBuilder
     {
         private readonly IDockerService inner;
         private readonly ConcurrentDictionary<string, DateTime> createdDateCache = new ConcurrentDictionary<string, DateTime>();
-        private readonly ConcurrentDictionary<string, string> imageDigestCache = new ConcurrentDictionary<string, string>();
+        private readonly ImageDigestCache imageDigestCache;
         private readonly ConcurrentDictionary<string, long> imageSizeCache = new ConcurrentDictionary<string, long>();
         private readonly ConcurrentDictionary<string, bool> localImageExistsCache = new ConcurrentDictionary<string, bool>();
         private readonly ConcurrentDictionary<string, bool> pulledImages = new ConcurrentDictionary<string, bool>();
@@ -24,6 +24,7 @@ namespace Microsoft.DotNet.ImageBuilder
         public DockerServiceCache(IDockerService inner)
         {
             this.inner = inner;
+            this.imageDigestCache = new ImageDigestCache(inner);
         }
 
         public Architecture Architecture => inner.Architecture;
@@ -38,7 +39,7 @@ namespace Microsoft.DotNet.ImageBuilder
             createdDateCache.GetOrAdd(image, _ => inner.GetCreatedDate(image, isDryRun));
 
         public string GetImageDigest(string image, bool isDryRun) =>
-            imageDigestCache.GetOrAdd(image, _ => inner.GetImageDigest(image, isDryRun));
+            imageDigestCache.GetImageDigest(image, isDryRun);
 
         public long GetImageSize(string image, bool isDryRun) =>
             imageSizeCache.GetOrAdd(image, _ => inner.GetImageSize(image, isDryRun));

--- a/src/Microsoft.DotNet.ImageBuilder/src/ImageDigestCache.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ImageDigestCache.cs
@@ -31,6 +31,6 @@ namespace Microsoft.DotNet.ImageBuilder
                 // Don't allow null digests to be cached. A locally built image won't have a digest until
                 // it is pushed so if its digest is retrieved before pushing, we don't want that 
                 // null to be cached.
-                val => String.IsNullOrEmpty(val));
+                val => !String.IsNullOrEmpty(val));
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ImageDigestCache.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ImageDigestCache.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.ImageBuilder
+{
+    public class ImageDigestCache
+    {
+        private readonly IDockerService dockerService;
+        private readonly Dictionary<string, string> digestCache = new Dictionary<string, string>();
+
+        public ImageDigestCache(IDockerService dockerService)
+        {
+            this.dockerService = dockerService;
+        }
+
+        public void AddDigest(string tag, string digest)
+        {
+            lock(digestCache)
+            {
+                digestCache[tag] = digest;
+            }
+        }
+
+        public string GetImageDigest(string tag, bool isDryRun) =>
+            LockHelper.DoubleCheckedLockLookup(digestCache, digestCache, tag,
+                () => dockerService.GetImageDigest(tag, isDryRun),
+                // Don't allow null digests to be cached. A locally built image won't have a digest until
+                // it is pushed so if its digest is retrieved before pushing, we don't want that 
+                // null to be cached.
+                val => String.IsNullOrEmpty(val));
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/LockHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/LockHelper.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.ImageBuilder
         }
 
         public static TValue DoubleCheckedLockLookup<TKey, TValue>(
-            object lockObj, IDictionary<TKey, TValue> dictionary, TKey key, Func<TValue> getValue)
+            object lockObj, IDictionary<TKey, TValue> dictionary, TKey key, Func<TValue> getValue, Func<TValue, bool> addToDictionary = null)
         {
             if (!dictionary.TryGetValue(key, out TValue value))
             {
@@ -37,7 +37,10 @@ namespace Microsoft.DotNet.ImageBuilder
                     if (!dictionary.TryGetValue(key, out value))
                     {
                         value = getValue();
-                        dictionary.Add(key, value);
+                        if (addToDictionary is null || addToDictionary(value))
+                        {
+                            dictionary.Add(key, value);
+                        }
                     }
                 }
             }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ManifestToolServiceExtensions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ManifestToolServiceExtensions.cs
@@ -50,7 +50,7 @@ namespace Microsoft.DotNet.ImageBuilder
             string digest = tagManifests?
                 .FirstOrDefault(manifestType => manifestType["MediaType"].Value<string>() == mediaType)
                 ?["Digest"].Value<string>();
-            if (digest is null)
+            if (String.IsNullOrEmpty(digest))
             {
                 if (throwIfNull)
                 {

--- a/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
@@ -103,7 +103,6 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 BuildCommand command = new BuildCommand(
                     dockerServiceMock.Object,
                     Mock.Of<ILoggerService>(),
-                    Mock.Of<IEnvironmentService>(),
                     gitServiceMock.Object);
                 command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
                 command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "image-info.json");
@@ -275,8 +274,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
             Mock<IDockerService> dockerServiceMock = CreateDockerServiceMock();
 
-            BuildCommand command = new BuildCommand(dockerServiceMock.Object, Mock.Of<ILoggerService>(), Mock.Of<IEnvironmentService>(),
-                Mock.Of<IGitService>());
+            BuildCommand command = new BuildCommand(dockerServiceMock.Object, Mock.Of<ILoggerService>(), Mock.Of<IGitService>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.IsPushEnabled = true;
 
@@ -354,8 +352,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     .Setup(o => o.GetCommitSha(dockerfileRelativePath, It.IsAny<bool>()))
                     .Returns(dockerfileCommitSha);
 
-                BuildCommand command = new BuildCommand(dockerServiceMock.Object, Mock.Of<ILoggerService>(), Mock.Of<IEnvironmentService>(),
-                    gitServiceMock.Object);
+                BuildCommand command = new BuildCommand(dockerServiceMock.Object, Mock.Of<ILoggerService>(), gitServiceMock.Object);
                 command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
                 command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "image-info.json");
                 command.Options.SourceRepoUrl = "https://source";
@@ -397,8 +394,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             string fullDockerfilePath = PathHelper.NormalizePath(Path.Combine(tempFolderContext.Path, dockerfileRelativePath));
             File.WriteAllText(fullDockerfilePath, $"FROM baserepo:basetag");
 
-            BuildCommand command = new BuildCommand(dockerServiceMock.Object, Mock.Of<ILoggerService>(), Mock.Of<IEnvironmentService>(),
-                Mock.Of<IGitService>());
+            BuildCommand command = new BuildCommand(dockerServiceMock.Object, Mock.Of<ILoggerService>(), Mock.Of<IGitService>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.IsSkipPullingEnabled = isSkipPullingEnabled;
 
@@ -549,7 +545,6 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             BuildCommand command = new BuildCommand(
                 dockerServiceMock.Object,
                 Mock.Of<ILoggerService>(),
-                Mock.Of<IEnvironmentService>(),
                 gitServiceMock.Object);
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "dest-image-info.json");


### PR DESCRIPTION
This is basically just a repeat of https://github.com/dotnet/docker-tools/pull/617 that had gotten broken again by further changes.  I've captured this logic in a single class to help avoid this happening again.