### PR TITLE
Fix order of copyAcrImages params

### DIFF
--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -28,12 +28,12 @@ jobs:
     displayName: Set Publish Variables
   - script: >
       $(runImageBuilderCmd) copyAcrImages
-      '$(stagingRepoPrefix)'
       '$(acr.servicePrincipalName)'
       '$(app-dotnetdockerbuild-client-secret)'
       '$(acr.servicePrincipalTenant)'
       '$(acr.subscription)'
       '$(acr.resourceGroup)'
+      '$(stagingRepoPrefix)'
       --os-type '*'
       --architecture '*'
       --repo-prefix '$(publishRepoPrefix)'


### PR DESCRIPTION
The changes in https://github.com/dotnet/docker-tools/pull/629 caused there to be a change in the order of parameters for the copyAcrImages command that needs to be fixed in the pipeline.