### PR TITLE
Trim cached platforms

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
@@ -61,7 +61,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         private IEnumerable<string> GetDestinationTagNames(RepoInfo repo, PlatformInfo platform)
         {
-            IEnumerable<string> destTagNames = null;
+            List<string> destTagNames = new List<string>();
 
             // If an image info file was provided, use the tags defined there rather than the manifest. This is intended
             // to handle scenarios where the tag's value is dynamic, such as a timestamp, and we need to know the value
@@ -77,30 +77,27 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         .FirstOrDefault(platformData => platformData.Equals(platform));
                     if (platformData != null)
                     {
-                        destTagNames = platformData.SimpleTags
-                            .Select(tag => TagInfo.GetFullyQualifiedName(repo.QualifiedName, tag));
+                        destTagNames.AddRange(platformData.SimpleTags
+                            .Select(tag => TagInfo.GetFullyQualifiedName(repo.QualifiedName, tag)));
                     }
                     else
                     {
-                        this.LoggerService.WriteError($"Unable to find image info data for path '{platform.DockerfilePath}'.");
-                        this.environmentService.Exit(1);
+                        this.LoggerService.WriteMessage($"Unable to find image info data for path '{platform.DockerfilePath}'.");
                     }
                 }
                 else
                 {
-                    this.LoggerService.WriteError($"Unable to find image info data for repo '{repo.Name}'.");
-                    this.environmentService.Exit(1);
+                    this.LoggerService.WriteMessage($"Unable to find image info data for repo '{repo.Name}'.");
                 }
             }
             else
             {
-                destTagNames = platform.Tags
-                    .Select(tag => tag.FullyQualifiedName);
+                destTagNames.AddRange(platform.Tags
+                    .Select(tag => tag.FullyQualifiedName));
             }
 
-            destTagNames = destTagNames
+            return destTagNames
                 .Select(tag => tag.TrimStart($"{Manifest.Registry}/"));
-            return destTagNames;
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/IngestKustoImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/IngestKustoImageInfoCommand.cs
@@ -32,6 +32,12 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             string csv = GetImageInfoCsv();
             this.loggerService.WriteMessage($"Image Info to Ingest:{Environment.NewLine}{csv}");
 
+            if (String.IsNullOrEmpty(csv))
+            {
+                this.loggerService.WriteMessage("Skipping ingestion due to empty image info data.");
+                return;
+            }
+
             using MemoryStream stream = new MemoryStream();
             using StreamWriter writer = new StreamWriter(stream);
             writer.Write(csv);

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestCommand.cs
@@ -100,42 +100,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         ManifestMediaType.ManifestList, sharedTag.FullyQualifiedName, Options.IsDryRun));
             });
 
-            // Strip out any platforms that are the result of pulling a cached version
-            RemoveCachedPlatforms(imageArtifactDetails);
-
             string imageInfoString = JsonHelper.SerializeObject(imageArtifactDetails);
             File.WriteAllText(Options.ImageInfoPath, imageInfoString);
-        }
-
-        private void RemoveCachedPlatforms(ImageArtifactDetails imageArtifactDetails)
-        {
-            for (int repoIndex = imageArtifactDetails.Repos.Count - 1; repoIndex >= 0; repoIndex--)
-            {
-                RepoData repo = imageArtifactDetails.Repos[repoIndex];
-                for (int imageIndex = repo.Images.Count - 1; imageIndex >= 0; imageIndex--)
-                {
-                    ImageData image = repo.Images[imageIndex];
-                    for (int i = image.Platforms.Count - 1; i >= 0; i--)
-                    {
-                        PlatformData platform = image.Platforms[i];
-                        if (platform.IsCached)
-                        {
-                            this.loggerService.WriteMessage($"Removing cached platform '{platform.GetIdentifier()}'");
-                            image.Platforms.Remove(platform);
-                        }
-                    }
-
-                    if (!image.Platforms.Any())
-                    {
-                        repo.Images.Remove(image);
-                    }
-                }
-
-                if (!repo.Images.Any())
-                {
-                    imageArtifactDetails.Repos.Remove(repo);
-                }
-            }
         }
 
         private string GenerateManifest(ImageInfo image)

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/TrimCachedPlatformsCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/TrimCachedPlatformsCommand.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.DotNet.ImageBuilder.Models.Image;
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    [Export(typeof(ICommand))]
+    public class TrimCachedPlatformsCommand : Command<TrimCachedPlatformsOptions>
+    {
+        private readonly ILoggerService loggerService;
+
+        [ImportingConstructor]
+        public TrimCachedPlatformsCommand(ILoggerService loggerService)
+        {
+            this.loggerService = loggerService ?? throw new ArgumentNullException(nameof(loggerService));
+        }
+
+        public override async Task ExecuteAsync()
+        {
+            this.loggerService.WriteHeading("TRIMMING CACHED PLATFORMS");
+
+            string imageInfoContents = await File.ReadAllTextAsync(Options.ImageInfoPath);
+            ImageArtifactDetails imageArtifactDetails = JsonConvert.DeserializeObject<ImageArtifactDetails>(imageInfoContents);
+            RemoveCachedPlatforms(imageArtifactDetails);
+            imageInfoContents = JsonHelper.SerializeObject(imageArtifactDetails);
+
+            if (!Options.IsDryRun)
+            {
+                await File.WriteAllTextAsync(Options.ImageInfoPath, imageInfoContents);
+            }
+        }
+
+        private void RemoveCachedPlatforms(ImageArtifactDetails imageArtifactDetails)
+        {
+            for (int repoIndex = imageArtifactDetails.Repos.Count - 1; repoIndex >= 0; repoIndex--)
+            {
+                RepoData repo = imageArtifactDetails.Repos[repoIndex];
+                for (int imageIndex = repo.Images.Count - 1; imageIndex >= 0; imageIndex--)
+                {
+                    ImageData image = repo.Images[imageIndex];
+                    for (int i = image.Platforms.Count - 1; i >= 0; i--)
+                    {
+                        PlatformData platform = image.Platforms[i];
+                        if (platform.IsCached)
+                        {
+                            this.loggerService.WriteMessage($"Removing cached platform '{platform.GetIdentifier()}'");
+                            image.Platforms.Remove(platform);
+                        }
+                    }
+
+                    if (!image.Platforms.Any())
+                    {
+                        repo.Images.Remove(image);
+                    }
+                }
+
+                if (!repo.Images.Any())
+                {
+                    imageArtifactDetails.Repos.Remove(repo);
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/TrimCachedPlatformsOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/TrimCachedPlatformsOptions.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.CommandLine;
+
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    public class TrimCachedPlatformsOptions : Options
+    {
+        protected override string CommandHelp => "Trims platforms marked as cached from the image info file";
+
+        public string ImageInfoPath { get; set; }
+
+        public override void DefineParameters(ArgumentSyntax syntax)
+        {
+            base.DefineParameters(syntax);
+
+            string imageInfoPath = null;
+            syntax.DefineParameter("image-info", ref imageInfoPath, "Path to image info file");
+            ImageInfoPath = imageInfoPath;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/tests/PublishManifestCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/PublishManifestCommandTests.cs
@@ -86,11 +86,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             {
                                 Platforms =
                                 {
-                                    CreatePlatform(dockerfile2),
-                                    new PlatformData
-                                    {
-                                        IsCached = true
-                                    }
+                                    CreatePlatform(dockerfile2)
                                 },
                                 Manifest = new ManifestData
                                 {
@@ -150,9 +146,6 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             imageArtifactDetails.Repos[0].Images[0].Manifest.Created = actualCreatedDate;
             imageArtifactDetails.Repos[1].Images[0].Manifest.Digest = "repo2@digest2";
             imageArtifactDetails.Repos[1].Images[0].Manifest.Created = actualCreatedDate;
-
-            // Remove cached platform
-            imageArtifactDetails.Repos[1].Images[0].Platforms.RemoveAt(1);
 
             string expectedOutput = JsonHelper.SerializeObject(imageArtifactDetails);
 

--- a/src/Microsoft.DotNet.ImageBuilder/tests/TrimCachedPlatformsCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/TrimCachedPlatformsCommandTests.cs
@@ -1,0 +1,254 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.DotNet.ImageBuilder.Commands;
+using Microsoft.DotNet.ImageBuilder.Models.Image;
+using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
+using Moq;
+using Xunit;
+
+namespace Microsoft.DotNet.ImageBuilder.Tests
+{
+    public class TrimCachedPlatformsCommandTests
+    {
+        [Fact]
+        public async Task NoPlatforms()
+        {
+            await RunTestAsync(new ImageArtifactDetails(), new ImageArtifactDetails());
+        }
+
+        [Fact]
+        public async Task MixOfCachedPlatforms()
+        {
+            ImageArtifactDetails imageArtifactDetails = new ImageArtifactDetails
+            {
+                Repos = new List<RepoData>
+                {
+                    new RepoData
+                    {
+                        Repo = "repo1",
+                        Images = new List<ImageData>
+                        {
+                            new ImageData
+                            {
+                                Platforms = new List<PlatformData>
+                                {
+                                    new PlatformData(),
+                                    new PlatformData { IsCached = true },
+                                }
+                            },
+                            new ImageData
+                            {
+                                Platforms = new List<PlatformData>
+                                {
+                                    new PlatformData { IsCached = true },
+                                }
+                            },
+                            new ImageData
+                            {
+                                Platforms = new List<PlatformData>
+                                {
+                                    new PlatformData(),
+                                    new PlatformData(),
+                                }
+                            }
+                        }
+                    },
+                    new RepoData
+                    {
+                        Repo = "repo2",
+                        Images = new List<ImageData>
+                        {
+                            new ImageData
+                            {
+                                Platforms = new List<PlatformData>
+                                {
+                                    new PlatformData { IsCached = true },
+                                }
+                            },
+                            new ImageData
+                            {
+                                Platforms = new List<PlatformData>
+                                {
+                                    new PlatformData { IsCached = true },
+                                }
+                            }
+                        }
+                    },
+                    new RepoData
+                    {
+                        Repo = "repo3",
+                        Images = new List<ImageData>
+                        {
+                            new ImageData
+                            {
+                                Platforms = new List<PlatformData>
+                                {
+                                    new PlatformData()
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            ImageArtifactDetails expectedImageArtifactDetails = new ImageArtifactDetails
+            {
+                Repos = new List<RepoData>
+                {
+                    new RepoData
+                    {
+                        Repo = "repo1",
+                        Images = new List<ImageData>
+                        {
+                            new ImageData
+                            {
+                                Platforms = new List<PlatformData>
+                                {
+                                    new PlatformData(),
+                                }
+                            },
+                            new ImageData
+                            {
+                                Platforms = new List<PlatformData>
+                                {
+                                    new PlatformData(),
+                                    new PlatformData(),
+                                }
+                            }
+                        }
+                    },
+                    new RepoData
+                    {
+                        Repo = "repo3",
+                        Images = new List<ImageData>
+                        {
+                            new ImageData
+                            {
+                                Platforms = new List<PlatformData>
+                                {
+                                    new PlatformData()
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            await RunTestAsync(imageArtifactDetails, expectedImageArtifactDetails);
+        }
+
+        [Fact]
+        public async Task NoCachedPlatforms()
+        {
+            ImageArtifactDetails imageArtifactDetails = new ImageArtifactDetails
+            {
+                Repos = new List<RepoData>
+                {
+                    new RepoData
+                    {
+                        Repo = "repo1",
+                        Images = new List<ImageData>
+                        {
+                            new ImageData
+                            {
+                                Platforms = new List<PlatformData>
+                                {
+                                    new PlatformData(),
+                                }
+                            },
+                            new ImageData
+                            {
+                                Platforms = new List<PlatformData>
+                                {
+                                    new PlatformData(),
+                                    new PlatformData(),
+                                }
+                            }
+                        }
+                    },
+                    new RepoData
+                    {
+                        Repo = "repo2",
+                        Images = new List<ImageData>
+                        {
+                            new ImageData
+                            {
+                                Platforms = new List<PlatformData>
+                                {
+                                    new PlatformData()
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            ImageArtifactDetails expectedImageArtifactDetails = new ImageArtifactDetails
+            {
+                Repos = new List<RepoData>
+                {
+                    new RepoData
+                    {
+                        Repo = "repo1",
+                        Images = new List<ImageData>
+                        {
+                            new ImageData
+                            {
+                                Platforms = new List<PlatformData>
+                                {
+                                    new PlatformData(),
+                                }
+                            },
+                            new ImageData
+                            {
+                                Platforms = new List<PlatformData>
+                                {
+                                    new PlatformData(),
+                                    new PlatformData(),
+                                }
+                            }
+                        }
+                    },
+                    new RepoData
+                    {
+                        Repo = "repo2",
+                        Images = new List<ImageData>
+                        {
+                            new ImageData
+                            {
+                                Platforms = new List<PlatformData>
+                                {
+                                    new PlatformData()
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            await RunTestAsync(imageArtifactDetails, expectedImageArtifactDetails);
+        }
+
+        private async Task RunTestAsync(ImageArtifactDetails input, ImageArtifactDetails expectedOutput)
+        {
+            using TempFolderContext tempFolderContext = new TempFolderContext();
+
+            TrimCachedPlatformsCommand command = new TrimCachedPlatformsCommand(Mock.Of<ILoggerService>());
+            command.Options.ImageInfoPath = Path.Combine(tempFolderContext.Path, "imageinfo.json");
+
+            File.WriteAllText(command.Options.ImageInfoPath, JsonHelper.SerializeObject(input));
+
+            await command.ExecuteAsync();
+
+            string expectedContents = JsonHelper.SerializeObject(expectedOutput);
+            string actualContents = File.ReadAllText(command.Options.ImageInfoPath);
+
+            Assert.Equal(expectedContents, actualContents);
+        }
+    }
+}


### PR DESCRIPTION
The `copyAcrImages` command ends up publishing images that were retrieved from the cache which is unnecessary.  The problem is that the image info file that this command consumes has not had the cached platforms trimmed from it yet.  This gets done by the `publishManifest` command.  Rather than have the `copyAcrImages` ignore the cached platforms, I've instead added a new command that will trim out any cached platforms from the image info file.  This should be called before `copyAcrImages`.

In addition, the `ingestKustoImageInfo` command will result in an error if it is called in the scenario where no images have been built.  