### PR TITLE
Disable image-info validation during build initialization

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -171,7 +171,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             ImageArtifactDetails? srcImageArtifactDetails = null;
             if (Options.ImageInfoSourcePath != null)
             {
-                srcImageArtifactDetails = ImageInfoHelper.LoadFromFile(Options.ImageInfoSourcePath, Manifest);
+                srcImageArtifactDetails = ImageInfoHelper.LoadFromFile(Options.ImageInfoSourcePath, Manifest, skipManifestValidation: true);
             }
 
             foreach (RepoInfo repoInfo in Manifest.FilteredRepos)

--- a/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
@@ -58,9 +58,9 @@ namespace Microsoft.DotNet.ImageBuilder
             return imageArtifactDetails;
         }
 
-        public static ImageArtifactDetails LoadFromFile(string path, ManifestInfo manifest)
+        public static ImageArtifactDetails LoadFromFile(string path, ManifestInfo manifest, bool skipManifestValidation = false)
         {
-            return LoadFromContent(File.ReadAllText(path), manifest);
+            return LoadFromContent(File.ReadAllText(path), manifest, skipManifestValidation);
         }
 
         public static void MergeImageArtifactDetails(ImageArtifactDetails src, ImageArtifactDetails target, ImageInfoMergeOptions options = null)


### PR DESCRIPTION
Fixes #639 

This is needed in order to unblock https://github.com/dotnet/dotnet-docker/pull/2226.