### PR TITLE
Support test job trimming from cached images

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixOptions.cs
@@ -17,6 +17,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public MatrixType MatrixType { get; set; }
         public IEnumerable<string> CustomBuildLegGroups { get; set; } = Enumerable.Empty<string>();
         public int ProductVersionComponents { get; set; }
+        public string ImageInfoPath { get; set; }
+        public IDictionary<string, string> DockerfileTestCategories { get; set; } = new Dictionary<string, string>();
 
         public GenerateBuildMatrixOptions() : base()
         {
@@ -49,6 +51,22 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 ref productVersionComponents,
                 "Number of components of the product version considered to be significant");
             ProductVersionComponents = productVersionComponents;
+
+            string imageInfoPath = null;
+            syntax.DefineOption(
+                "image-info",
+                ref imageInfoPath,
+                "Path to image info file");
+            ImageInfoPath = imageInfoPath;
+
+            IReadOnlyList<string> dockerfileTestCategories = Array.Empty<string>();
+            syntax.DefineOptionList(
+                "dockerfile-test-category",
+                ref dockerfileTestCategories,
+                "Mapping of a test category to a Dockerfile path (syntax: <category>=<path>) (wildcards in path are supported)");
+            DockerfileTestCategories = dockerfileTestCategories
+                .Select(mapping => mapping.Split('='))
+                .ToDictionary(mapping => mapping[0], mapping => mapping[1]);
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/CustomBuildLegDependencyType.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/CustomBuildLegDependencyType.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Manifest
     public enum CustomBuildLegDependencyType
     {
         [Description(
-            "Indicates the dependency is considered to be integral to the depending image." +
+            "Indicates the dependency is considered to be integral to the depending image. " +
             "This means the dependent image will not have its own dependency graph considered for build leg " +
             "generation. An example of this is when a custom build leg dependency is defined from sdk to " +
             "aspnet; in that case, aspnet and sdk will be included in a leg together but the sdk will not " +
@@ -21,11 +21,11 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Manifest
         Integral,
 
         [Description(
-            "Indicates the dependency is considered to be a supplemental companion to the depending image." +
+            "Indicates the dependency is considered to be a supplemental companion to the depending image. " +
             "This means the dependent image will have its own dependency graph considered for build leg " +
             "generation. An example of this is when a custom build leg dependency is defined to " +
             "include an SDK image supported on a particular architecture in order to test a runtime OS " +
-            "that doesn't its own SDK on that architecture (Buster ARM SDK to test Alpine ARM runtime); " +
+            "that doesn't have its own SDK on that architecture (Buster ARM SDK to test Alpine ARM runtime); " +
             "in that case, the SDK will be included in a leg together with the runtime and the SDK will " +
             "still have have its own leg."
             )]


### PR DESCRIPTION
Updates the `generateBuildMatrix` command to output a `testCategories` field that defines which test categories should be run in a test job.  Which test categories to include is determined by whether the image was built or retrieved from the cache.  Images from the cache do not need to be tested.  If a test leg doesn't have any test categories, it is excluded from the matrix in order to prevent any test job from running.

Related to #632