### PR TITLE
Base manifest publishing on image info content

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
@@ -30,6 +30,8 @@ namespace Microsoft.DotNet.ImageBuilder
                 }
                 foreach (ImageData imageData in repoData.Images)
                 {
+                    imageData.ManifestRepo = manifestRepo;
+
                     PlatformData platformData = imageData.Platforms.FirstOrDefault();
                     if (platformData != null)
                     {

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/ImageData.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/ImageData.cs
@@ -31,6 +31,16 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Image
         [JsonIgnore]
         public ImageInfo ManifestImage { get; set; }
 
+        /// <summary>
+        /// Gets or sets a reference to the corresponding repo definition in the manifest.
+        /// </summary>
+        /// <remarks>
+        /// This can be null for an image info file that contains content for a platform that was once supported
+        /// but has since been removed from the manifest.
+        /// </remarks>
+        [JsonIgnore]
+        public RepoInfo ManifestRepo { get; set; }
+
         public int CompareTo([AllowNull] ImageData other)
         {
             if (other is null)


### PR DESCRIPTION
Fixes the `publishManifest` command to use the image info content for determining which manifests to publish.  Previously it was using the filtered manifest data.  But that is not representative of what needs to be published not that we have image caching functionality.