### PR TITLE
Support test job trimming from cached images

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixOptions.cs
@@ -17,6 +17,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public MatrixType MatrixType { get; set; }
         public IEnumerable<string> CustomBuildLegGroups { get; set; } = Enumerable.Empty<string>();
         public int ProductVersionComponents { get; set; }
+        public string ImageInfoPath { get; set; }
 
         public GenerateBuildMatrixOptions() : base()
         {
@@ -49,6 +50,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 ref productVersionComponents,
                 "Number of components of the product version considered to be significant");
             ProductVersionComponents = productVersionComponents;
+
+            string imageInfoPath = null;
+            syntax.DefineOption(
+                "image-info",
+                ref imageInfoPath,
+                "Path to image info file");
+            ImageInfoPath = imageInfoPath;
         }
     }
 }


### PR DESCRIPTION
Updates the `generateBuildMatrix` command to exclude any leg from the matrix that consists only of images that came from the cache.  An image info file would need to be passed to the command to provide this information.

Related to #632