### PR TITLE
Set buildRepoName variable to allow other build tasks to consume it

### DIFF
--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -50,6 +50,7 @@ jobs:
         $manifest = "$buildRepoName/$(manifest)"
         $testResultsDirectory = "$buildRepoName/$testResultsDirectory"
 
+        echo "##vso[task.setvariable variable=buildRepoName]$buildRepoName"
         echo "##vso[task.setvariable variable=manifest]$manifest"
         echo "##vso[task.setvariable variable=engCommonPath]$engCommonPath"
         echo "##vso[task.setvariable variable=engPath]$engPath"


### PR DESCRIPTION
Migrating the changes from https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/370.