### PR TITLE
Build support for shared Dockerfiles

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -229,7 +229,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private bool CheckForCachedImage(
             ImageData? srcImageData, PlatformInfo platform, IEnumerable<string> allTags, PlatformData? platformData)
         {
-            if (platformData != null && _cachedDockerfilePaths.TryGetValue(platformData.Dockerfile, out BuildCacheInfo? cacheInfo))
+            if (platformData != null && _cachedDockerfilePaths.TryGetValue(GetBuildCacheKey(platform), out BuildCacheInfo? cacheInfo))
             {
                 OnCacheHit(allTags, pullImage: false, cacheInfo.Digest);
                 platformData.BaseImageDigest = cacheInfo.BaseImageDigest;
@@ -254,7 +254,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         {
                             platformData.BaseImageDigest = srcPlatformData.BaseImageDigest;
 
-                            _cachedDockerfilePaths[platformData.Dockerfile] =
+                            _cachedDockerfilePaths[GetBuildCacheKey(srcPlatformData.PlatformInfo)] =
                                 new BuildCacheInfo(srcPlatformData.Digest, platformData.BaseImageDigest);
                         }
                     }
@@ -649,6 +649,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             _loggerService.WriteMessage();
         }
+
+        private static string GetBuildCacheKey(PlatformInfo platform) =>
+            $"{platform.DockerfilePathRelativeToManifest}-" +
+            string.Join('-', platform.BuildArgs.Select(kvp => $"{kvp.Key}={kvp.Value}").ToArray());
 
         private class BuildCacheInfo
         {

--- a/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
@@ -763,7 +763,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         {
             const string runtimeDepsRepo = "runtime-deps";
             const string runtimeDeps2Repo = "runtime-deps2";
-            string runtimeDepsDigest = $"{runtimeDepsRepo}@adc914a9f125ca612f9a67e4a0551937b7a37c82fabb46172c4867b73ed99227";
+            string runtimeDepsDigest = $"{runtimeDepsRepo}@sha1";
+            string runtimeDeps2Digest = $"{runtimeDeps2Repo}@sha1";
             const string tag = "tag";
             const string baseImageRepo = "baserepo";
             string baseImageTag = $"{baseImageRepo}:basetag";
@@ -780,7 +781,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             dockerServiceMock
                 .Setup(o => o.GetImageDigest($"{runtimeDeps2Repo}:{tag}", false))
-                .Returns(runtimeDepsDigest);
+                .Returns(runtimeDeps2Digest);
 
             dockerServiceMock
                 .Setup(o => o.GetImageDigest(baseImageTag, false))
@@ -929,7 +930,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         Architecture = "amd64",
                                         OsType = "Linux",
                                         OsVersion = "Ubuntu 19.04",
-                                        Digest = runtimeDepsDigest,
+                                        Digest = runtimeDeps2Digest,
                                         BaseImageDigest = runtimeDepsBaseImageDigest,
                                         Created = createdDate.ToUniversalTime(),
                                         SimpleTags =
@@ -972,7 +973,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         {
             const string runtimeDepsRepo = "runtime-deps";
             const string runtimeDeps2Repo = "runtime-deps2";
-            string runtimeDepsDigest = $"{runtimeDepsRepo}@adc914a9f125ca612f9a67e4a0551937b7a37c82fabb46172c4867b73ed99227";
+            string runtimeDepsDigest = $"{runtimeDepsRepo}@sha1";
+            string runtimeDeps2Digest = $"{runtimeDeps2Repo}@sha1";
             const string tag = "tag";
             const string baseImageRepo = "baserepo";
             string baseImageTag = $"{baseImageRepo}:basetag";
@@ -1106,7 +1108,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         Architecture = "amd64",
                                         OsType = "Linux",
                                         OsVersion = "Ubuntu 19.04",
-                                        Digest = runtimeDepsDigest,
+                                        Digest = runtimeDeps2Digest,
                                         BaseImageDigest = runtimeDepsBaseImageDigest,
                                         Created = createdDate.ToUniversalTime(),
                                         SimpleTags =

--- a/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
@@ -965,6 +965,293 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         }
 
         /// <summary>
+        /// Tests a caching scenario where multiple platforms are defined that share the same Dockerfile. One of the platforms
+        /// uses build args and has an entry defined in the source image info file which triggers a cache hit. Another platform
+        /// has the same build args but does not have an entry in the image info file. But because it shares the same Dockerfile,
+        /// it too should be a cache hit. The last platform again has no entry in the image info file and shares the same Dockerfile
+        /// but it uses different build args so it should be a cache miss.
+        /// </summary>
+        [Fact]
+        public async Task BuildCommand_Caching_SharedDockerfile_MissingSourceImageInfoEntry_DiffBuildArgs()
+        {
+            const string runtimeDepsRepo = "runtime-deps";
+            const string runtimeDeps2Repo = "runtime-deps2";
+            const string runtimeDeps3Repo = "runtime-deps3";
+            string runtimeDepsDigest = $"{runtimeDepsRepo}@sha1";
+            string runtimeDeps2Digest = $"{runtimeDeps2Repo}@sha1";
+            string runtimeDeps3Digest = $"{runtimeDeps3Repo}@sha2";
+            const string tag = "tag";
+            const string baseImageRepo = "baserepo";
+            string baseImageTag = $"{baseImageRepo}:basetag";
+            string runtimeDepsBaseImageDigest = $"{baseImageRepo}@sha-base";
+            const string currentRuntimeDepsCommitSha = "commit-sha";
+
+            using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
+
+            Mock<IDockerService> dockerServiceMock = CreateDockerServiceMock();
+
+            dockerServiceMock
+                .Setup(o => o.GetImageDigest($"{runtimeDepsRepo}:{tag}", false))
+                .Returns(runtimeDepsDigest);
+
+            dockerServiceMock
+                .Setup(o => o.GetImageDigest($"{runtimeDeps2Repo}:{tag}", false))
+                .Returns(runtimeDeps2Digest);
+
+            dockerServiceMock
+                .Setup(o => o.GetImageDigest($"{runtimeDeps3Repo}:{tag}", false))
+                .Returns(runtimeDeps3Digest);
+
+            dockerServiceMock
+                .Setup(o => o.GetImageDigest(baseImageTag, false))
+                .Returns(runtimeDepsBaseImageDigest);
+
+            DateTime createdDate = DateTime.Now;
+
+            dockerServiceMock
+                .Setup(o => o.GetCreatedDate($"{runtimeDepsRepo}:{tag}", false))
+                .Returns(createdDate);
+
+            dockerServiceMock
+                .Setup(o => o.GetCreatedDate($"{runtimeDeps2Repo}:{tag}", false))
+                .Returns(createdDate);
+
+            dockerServiceMock
+                .Setup(o => o.GetCreatedDate($"{runtimeDeps3Repo}:{tag}", false))
+                .Returns(createdDate);
+
+            string runtimeDepsDockerfileRelativePath = DockerfileHelper.CreateDockerfile(
+                "1.0/runtime-deps/os", tempFolderContext, baseImageTag);
+
+            Mock<IGitService> gitServiceMock = new Mock<IGitService>();
+            gitServiceMock
+                .Setup(o => o.GetCommitSha(PathHelper.NormalizePath(Path.Combine(tempFolderContext.Path, runtimeDepsDockerfileRelativePath)), It.IsAny<bool>()))
+                .Returns(currentRuntimeDepsCommitSha);
+
+            BuildCommand command = new BuildCommand(
+                dockerServiceMock.Object,
+                Mock.Of<ILoggerService>(),
+                gitServiceMock.Object);
+            command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
+            command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "dest-image-info.json");
+            command.Options.ImageInfoSourcePath = Path.Combine(tempFolderContext.Path, "src-image-info.json");
+            command.Options.IsPushEnabled = true;
+            command.Options.SourceRepoUrl = "https://github.com/dotnet/test";
+
+            const string ProductVersion = "1.0.1";
+
+            List<RepoData> sourceRepos = new List<RepoData>
+            {
+                new RepoData
+                {
+                    Repo = runtimeDepsRepo,
+                    Images =
+                    {
+                        new ImageData
+                        {
+                            ProductVersion = ProductVersion,
+                            Platforms =
+                            {
+                                new PlatformData
+                                {
+                                    Dockerfile = runtimeDepsDockerfileRelativePath,
+                                    Architecture = "amd64",
+                                    OsType = "Linux",
+                                    OsVersion = "Ubuntu 19.04",
+                                    Digest = runtimeDepsDigest,
+                                    BaseImageDigest = runtimeDepsBaseImageDigest,
+                                    Created = createdDate.ToUniversalTime(),
+                                    SimpleTags =
+                                    {
+                                        tag
+                                    },
+                                    CommitUrl = $"{command.Options.SourceRepoUrl}/blob/{currentRuntimeDepsCommitSha}/{runtimeDepsDockerfileRelativePath}"
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            ImageArtifactDetails sourceImageArtifactDetails = new ImageArtifactDetails
+            {
+                Repos = sourceRepos.ToList()
+            };
+
+            string sourceImageArtifactDetailsOutput = JsonHelper.SerializeObject(sourceImageArtifactDetails);
+            File.WriteAllText(command.Options.ImageInfoSourcePath, sourceImageArtifactDetailsOutput);
+
+            Platform runtimeDeps1Platform = CreatePlatform(runtimeDepsDockerfileRelativePath, new string[] { tag });
+            runtimeDeps1Platform.BuildArgs = new Dictionary<string, string>
+            {
+                { "ARG1", "val1" },
+                { "ARG2", "val2" }
+            };
+
+            Platform runtimeDeps2Platform = CreatePlatform(runtimeDepsDockerfileRelativePath, new string[] { tag });
+            runtimeDeps2Platform.BuildArgs = runtimeDeps1Platform.BuildArgs;
+
+            Platform runtimeDeps3Platform = CreatePlatform(runtimeDepsDockerfileRelativePath, new string[] { tag });
+            runtimeDeps3Platform.BuildArgs = new Dictionary<string, string>
+            {
+                { "ARG1", "val1" },
+                { "ARG2", "val2a" }
+            };
+
+            Manifest manifest = CreateManifest(
+                CreateRepo(runtimeDepsRepo,
+                    CreateImage(
+                        new Platform[]
+                        {
+                            runtimeDeps1Platform
+                        },
+                        productVersion: ProductVersion)),
+                CreateRepo(runtimeDeps2Repo,
+                    CreateImage(
+                        new Platform[]
+                        {
+                            runtimeDeps2Platform
+                        },
+                        productVersion: ProductVersion)),
+                CreateRepo(runtimeDeps3Repo,
+                    CreateImage(
+                        new Platform[]
+                        {
+                            runtimeDeps3Platform
+                        },
+                        productVersion: ProductVersion))
+            );
+
+            File.WriteAllText(Path.Combine(tempFolderContext.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));
+
+            command.LoadManifest();
+            await command.ExecuteAsync();
+
+            ImageArtifactDetails expectedOutputImageArtifactDetails = new ImageArtifactDetails
+            {
+                Repos = new List<RepoData>
+                {
+                    new RepoData
+                    {
+                        Repo = runtimeDepsRepo,
+                        Images =
+                        {
+                            new ImageData
+                            {
+                                ProductVersion = ProductVersion,
+                                Platforms =
+                                {
+                                    new PlatformData
+                                    {
+                                        Dockerfile = runtimeDepsDockerfileRelativePath,
+                                        Architecture = "amd64",
+                                        OsType = "Linux",
+                                        OsVersion = "Ubuntu 19.04",
+                                        Digest = runtimeDepsDigest,
+                                        BaseImageDigest = runtimeDepsBaseImageDigest,
+                                        Created = createdDate.ToUniversalTime(),
+                                        SimpleTags =
+                                        {
+                                            tag
+                                        },
+                                        CommitUrl = $"{command.Options.SourceRepoUrl}/blob/{currentRuntimeDepsCommitSha}/{runtimeDepsDockerfileRelativePath}",
+                                        IsCached = true
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    new RepoData
+                    {
+                        Repo = runtimeDeps2Repo,
+                        Images =
+                        {
+                            new ImageData
+                            {
+                                ProductVersion = ProductVersion,
+                                Platforms =
+                                {
+                                    new PlatformData
+                                    {
+                                        Dockerfile = runtimeDepsDockerfileRelativePath,
+                                        Architecture = "amd64",
+                                        OsType = "Linux",
+                                        OsVersion = "Ubuntu 19.04",
+                                        Digest = runtimeDeps2Digest,
+                                        BaseImageDigest = runtimeDepsBaseImageDigest,
+                                        Created = createdDate.ToUniversalTime(),
+                                        SimpleTags =
+                                        {
+                                            tag
+                                        },
+                                        CommitUrl = $"{command.Options.SourceRepoUrl}/blob/{currentRuntimeDepsCommitSha}/{runtimeDepsDockerfileRelativePath}",
+                                        IsCached = true
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    new RepoData
+                    {
+                        Repo = runtimeDeps3Repo,
+                        Images =
+                        {
+                            new ImageData
+                            {
+                                ProductVersion = ProductVersion,
+                                Platforms =
+                                {
+                                    new PlatformData
+                                    {
+                                        Dockerfile = runtimeDepsDockerfileRelativePath,
+                                        Architecture = "amd64",
+                                        OsType = "Linux",
+                                        OsVersion = "Ubuntu 19.04",
+                                        Digest = runtimeDeps3Digest,
+                                        BaseImageDigest = runtimeDepsBaseImageDigest,
+                                        Created = createdDate.ToUniversalTime(),
+                                        SimpleTags =
+                                        {
+                                            tag
+                                        },
+                                        CommitUrl = $"{command.Options.SourceRepoUrl}/blob/{currentRuntimeDepsCommitSha}/{runtimeDepsDockerfileRelativePath}"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            string expectedOutput = JsonHelper.SerializeObject(expectedOutputImageArtifactDetails);
+            string actualOutput = File.ReadAllText(command.Options.ImageInfoOutputPath);
+
+            Assert.Equal(expectedOutput, actualOutput);
+
+            dockerServiceMock.Verify(o => o.PullImage(runtimeDepsDigest, false));
+            dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsDigest, $"{runtimeDepsRepo}:{tag}", false));
+            dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsDigest, $"{runtimeDeps2Repo}:{tag}", false));
+            dockerServiceMock.Verify(o => o.PushImage($"{runtimeDepsRepo}:{tag}", false));
+            dockerServiceMock.Verify(o => o.PushImage($"{runtimeDeps2Repo}:{tag}", false));
+            dockerServiceMock.Verify(o => o.PushImage($"{runtimeDeps3Repo}:{tag}", false));
+            dockerServiceMock.Verify(o =>
+                o.BuildImage(
+                    PathHelper.NormalizePath(Path.Combine(tempFolderContext.Path, runtimeDepsDockerfileRelativePath)),
+                    It.IsAny<string>(),
+                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<IDictionary<string, string>>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>()));
+
+            dockerServiceMock.Verify(o => o.PullImage(baseImageTag, false));
+            dockerServiceMock.Verify(o => o.GetImageDigest(It.IsAny<string>(), false));
+            dockerServiceMock.Verify(o => o.Architecture);
+            dockerServiceMock.Verify(o => o.GetCreatedDate(It.IsAny<string>(), false));
+
+            dockerServiceMock.VerifyNoOtherCalls();
+        }
+
+        /// <summary>
         /// Tests a caching scenario where two platforms are defined that share the same Dockerfile and neither of them
         /// have a entry in the source image info file.
         /// </summary>


### PR DESCRIPTION
Related to https://github.com/dotnet/dotnet-docker/issues/2122

Fixes the issue described in this comment: https://github.com/dotnet/dotnet-docker/pull/2260#discussion_r492816689.

This is fixed by tracking info about the images that have been retrieved from the cache.  Regardless of whether an image has an entry in the image info file, it will get a cache hit if it shares the same Dockerfile path as an image that has been retrieved from the cache and tagged appropriately.

Note that this does not handle the scenario where there's a shared Dockerfile and neither of the platforms result in cache hits.  In that scenario, the first platform will end up having its image built as part of the normal cache miss processing.  The second platform will also get a cache miss even though technically its Dockerfile has already been built.  However, running a build won't produce a new image because the layers are already cached locally on the build machine.  This is a compromise so that we can rely on Docker for the caching behavior and keep our code simpler.  
