### PR TITLE
Fix caching info caused by multi-platform scenario

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -229,7 +229,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private bool CheckForCachedImage(
             ImageData? srcImageData, PlatformInfo platform, IEnumerable<string> allTags, PlatformData? platformData)
         {
-            if (platformData != null && _cachedDockerfilePaths.TryGetValue(GetBuildCacheKey(platform), out BuildCacheInfo? cacheInfo))
+            string cacheKey = GetBuildCacheKey(platform);
+            if (platformData != null && _cachedDockerfilePaths.TryGetValue(cacheKey, out BuildCacheInfo? cacheInfo))
             {
                 OnCacheHit(allTags, pullImage: false, cacheInfo.Digest);
                 platformData.BaseImageDigest = cacheInfo.BaseImageDigest;
@@ -254,7 +255,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         {
                             platformData.BaseImageDigest = srcPlatformData.BaseImageDigest;
 
-                            _cachedDockerfilePaths[GetBuildCacheKey(srcPlatformData.PlatformInfo)] =
+                            _cachedDockerfilePaths[cacheKey] =
                                 new BuildCacheInfo(srcPlatformData.Digest, platformData.BaseImageDigest);
                         }
                     }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/ImageInfoHelperTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/ImageInfoHelperTests.cs
@@ -3,16 +3,111 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
+using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
 using Moq;
 using Xunit;
+
+using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.DockerfileHelper;
+using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
     public class ImageInfoHelperTests
     {
+        [Fact]
+        public void LoadFromContent()
+        {
+            ImageArtifactDetails imageArtifactDetails = new ImageArtifactDetails
+            {
+                Repos =
+                {
+                    new RepoData
+                    {
+                        Repo = "runtime",
+                        Images =
+                        {
+                            new ImageData
+                            {
+                                Platforms =
+                                {
+                                    new PlatformData
+                                    {
+                                        Dockerfile = "1.0/runtime/linux/Dockerfile",
+                                        OsType = "Linux",
+                                        OsVersion = "Ubuntu 20.04",
+                                        Architecture = "amd64"
+                                    },
+                                    new PlatformData
+                                    {
+                                        Dockerfile = "1.0/runtime/windows/Dockerfile",
+                                        OsType = "Windows",
+                                        OsVersion = "Windows Server, version 2004",
+                                        Architecture = "amd64"
+                                    }
+                                },
+                                Manifest = new ManifestData
+                                {
+                                    SharedTags = new List<string>
+                                    {
+                                        "shared"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            using TempFolderContext tempFolderContext = new TempFolderContext();
+
+            Manifest manifest = CreateManifest(
+                CreateRepo("runtime",
+                    CreateImage(
+                        new Platform[]
+                        {
+                            CreatePlatform(
+                                CreateDockerfile("1.0/runtime/linux", tempFolderContext),
+                                new string[] { "linux" },
+                                OS.Linux,
+                                "focal"),
+                            CreatePlatform(
+                                CreateDockerfile("1.0/runtime/windows", tempFolderContext),
+                                new string[] { "windows" },
+                                OS.Windows,
+                                "nanoserver-2004")
+                        },
+                        new Dictionary<string, Tag>
+                        {
+                            { "shared", new Tag() }
+                        }))
+            );
+
+            string manifestPath = Path.Combine(tempFolderContext.Path, "manifest.json");
+            File.WriteAllText(manifestPath, JsonHelper.SerializeObject(manifest));
+
+            ManifestInfo manifestInfo = ManifestInfo.Load(new FakeManifestOptions(manifestPath));
+            string expected = JsonHelper.SerializeObject(imageArtifactDetails);
+
+            ImageArtifactDetails result = ImageInfoHelper.LoadFromContent(expected, manifestInfo);
+
+            Assert.Equal(expected, JsonHelper.SerializeObject(result));
+            RepoData repo = result.Repos.First();
+            ImageData image = repo.Images.First();
+            RepoInfo expectedRepo = manifestInfo.AllRepos.First();
+            ImageInfo expectedImage = expectedRepo.AllImages.First();
+            Assert.Same(expectedImage, image.ManifestImage);
+            Assert.Same(expectedRepo, image.ManifestRepo);
+
+            Assert.Same(expectedImage.AllPlatforms.First(), image.Platforms.First().PlatformInfo);
+            Assert.Same(expectedImage.AllPlatforms.Last(), image.Platforms.Last().PlatformInfo);
+        }
+
         [Fact]
         public void ImageInfoHelper_MergeRepos_ImageDigest()
         {
@@ -589,6 +684,30 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 new ManifestFilter(),
                 new VariableHelper(new Manifest(), Mock.Of<IManifestOptionsInfo>(), null),
                 "base");
+        }
+
+        private class FakeManifestOptions : IManifestOptionsInfo
+        {
+            public FakeManifestOptions(string manifestPath)
+            {
+                Manifest = manifestPath;
+            }
+
+            public string Manifest { get; }
+
+            public string RegistryOverride => null;
+
+            public string RepoPrefix => null;
+
+            public IDictionary<string, string> Variables { get; } = new Dictionary<string, string>();
+
+            public bool IsDryRun => false;
+
+            public bool IsVerbose => false;
+
+            public ManifestFilter GetManifestFilter() => new ManifestFilter();
+
+            public string GetOption(string name) => throw new NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
An issue was introduced by https://github.com/dotnet/docker-tools/pull/655 that caused the build to break when processing a manifest image that contained multiple platforms.  The new code that had been added made use of the `PlatformData.PlatformInfo` property which actually isn't being set correctly as part of the loading of an image info file.  It resulted in a null reference when trying to access that property in order to generate the cache key.  There had just not been any code path which exposed this null value before.

I've fixed the issue with the image info loading so that PlatformInfo is now set correctly across all platforms within an image.  I've also changed the caching code because it actually never even needed to make use of the `PlatformData.PlatformInfo` property at all, so that code is now simplified.