### PR TITLE
Fix issue with digest renaming in caching logic

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -391,13 +391,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 // In that scenario, the digest that is retrieved will be based on the repo of the first repository
                 // encountered. For subsequent cache hits on different repositories, we need to prepopulate the digest
                 // cache with a digest value that would correspond to that repository, not the original repository.
-                sourceDigest = DockerHelper.GetImageName(
+                string newDigest = DockerHelper.GetImageName(
                     Manifest.Model.Registry, repo.Model.Name, digest: DockerHelper.GetDigestSha(sourceDigest));
 
                 // Populate the digest cache with the known digest value for the tags assigned to the image.
                 // This is needed in order to prevent a call to the manifest tool to get the digest for these tags
                 // because they haven't yet been pushed to staging by that time.
-                _imageDigestCache.AddDigest(tag, sourceDigest);
+                _imageDigestCache.AddDigest(tag, newDigest);
             });
         }
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
@@ -143,6 +143,26 @@ namespace Microsoft.DotNet.ImageBuilder
 
         public static string GetDigestString(string repo, string sha) => $"{repo}@{sha}";
 
+        public static string GetImageName(string registry, string repo, string tag = null, string digest = null)
+        {
+            if (tag != null && digest != null)
+            {
+                throw new InvalidOperationException($"Invalid to provide both the {nameof(tag)} and {nameof(digest)} arguments.");
+            }
+
+            string imageName = $"{registry}/{repo}";
+            if (tag != null)
+            {
+                return $"{imageName}:{tag}";
+            }
+            else if (digest != null)
+            {
+                return $"{imageName}@{digest}";
+            }
+
+            return imageName;
+        }
+
         /// <remarks>
         /// This method depends on the experimental Docker CLI `manifest` command.  As a result, this method
         /// should only used for developer usage scenarios.

--- a/src/Microsoft.DotNet.ImageBuilder/tests/ImageInfoHelperTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/ImageInfoHelperTests.cs
@@ -104,6 +104,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Assert.Same(expectedImage, image.ManifestImage);
             Assert.Same(expectedRepo, image.ManifestRepo);
 
+            Assert.Same(expectedImage, image.Platforms.First().ImageInfo);
             Assert.Same(expectedImage.AllPlatforms.First(), image.Platforms.First().PlatformInfo);
             Assert.Same(expectedImage.AllPlatforms.Last(), image.Platforms.Last().PlatformInfo);
         }


### PR DESCRIPTION
There was an issue with the changes from #655 in the logic which attempts to rewrite the image name of a digest to be based on a different repo.  This logic targeted the repo from the tag which is actually the overriden (staging) registry and repo location, rather than the MCR location.  This causes the incorrect image name to be stored in the image info file which messes things up.

I've fixed this by using the raw registry and repo names of the target repo in order to build up the correct image name.