### PR TITLE
Dockerfile generation support for amd64 tag suffix

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateDockerfilesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateDockerfilesCommand.cs
@@ -44,18 +44,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             symbols["ARCH_SHORT"] = platform.Model.Architecture.GetShortName();
             symbols["ARCH_NUPKG"] = platform.Model.Architecture.GetNupkgName();
             symbols["ARCH_VERSIONED"] = versionedArch;
+            symbols["ARCH_TAG_SUFFIX"] = $"-{versionedArch}";
             symbols["OS_VERSION"] = platform.Model.OsVersion;
             symbols["OS_VERSION_BASE"] = platform.BaseOsVersion;
             symbols["OS_VERSION_NUMBER"] = GetOsVersionNumber(platform);
             symbols["OS_ARCH_HYPHENATED"] = GetOsArchHyphenatedName(platform);
-
-            string archTagSuffix = $"-{versionedArch}";
-            if (Options.ArchTagSuffixExclusion != null)
-            {
-                archTagSuffix = platform.Model.Architecture != Options.ArchTagSuffixExclusion ? archTagSuffix : string.Empty;
-            }
-
-            symbols["ARCH_TAG_SUFFIX"] = archTagSuffix;
 
             return symbols;
         }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateDockerfilesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateDockerfilesCommand.cs
@@ -44,11 +44,18 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             symbols["ARCH_SHORT"] = platform.Model.Architecture.GetShortName();
             symbols["ARCH_NUPKG"] = platform.Model.Architecture.GetNupkgName();
             symbols["ARCH_VERSIONED"] = versionedArch;
-            symbols["ARCH_TAG_SUFFIX"] = platform.Model.Architecture != Architecture.AMD64 ? $"-{versionedArch}" : string.Empty;
             symbols["OS_VERSION"] = platform.Model.OsVersion;
             symbols["OS_VERSION_BASE"] = platform.BaseOsVersion;
             symbols["OS_VERSION_NUMBER"] = GetOsVersionNumber(platform);
             symbols["OS_ARCH_HYPHENATED"] = GetOsArchHyphenatedName(platform);
+
+            string archTagSuffix = $"-{versionedArch}";
+            if (Options.ArchTagSuffixExclusion != null)
+            {
+                archTagSuffix = platform.Model.Architecture != Options.ArchTagSuffixExclusion ? archTagSuffix : string.Empty;
+            }
+
+            symbols["ARCH_TAG_SUFFIX"] = archTagSuffix;
 
             return symbols;
         }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateDockerfilesOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateDockerfilesOptions.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.CommandLine;
+using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
@@ -11,6 +13,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public ManifestFilterOptions FilterOptions { get; } = new ManifestFilterOptions();
 
         protected override string CommandHelp => "Generates the Dockerfiles from Cottle based templates (http://r3c.github.io/cottle/)";
+
+        public Architecture? ArchTagSuffixExclusion { get; set; }
 
         public GenerateDockerfilesOptions() : base()
         {
@@ -21,6 +25,12 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             base.DefineOptions(syntax);
 
             FilterOptions.DefineOptions(syntax);
+
+            Architecture? archTagSuffixExclusion = null;
+            syntax.DefineOption("arch-tag-suffix-exclusion", ref archTagSuffixExclusion,
+                value => (Architecture)Enum.Parse(typeof(Architecture), value, true),
+                "Architecture that should be excluded as a tag suffix");
+            ArchTagSuffixExclusion = archTagSuffixExclusion;
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateDockerfilesOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateDockerfilesOptions.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.CommandLine;
-using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
@@ -13,8 +11,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public ManifestFilterOptions FilterOptions { get; } = new ManifestFilterOptions();
 
         protected override string CommandHelp => "Generates the Dockerfiles from Cottle based templates (http://r3c.github.io/cottle/)";
-
-        public Architecture? ArchTagSuffixExclusion { get; set; }
 
         public GenerateDockerfilesOptions() : base()
         {
@@ -25,12 +21,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             base.DefineOptions(syntax);
 
             FilterOptions.DefineOptions(syntax);
-
-            Architecture? archTagSuffixExclusion = null;
-            syntax.DefineOption("arch-tag-suffix-exclusion", ref archTagSuffixExclusion,
-                value => (Architecture)Enum.Parse(typeof(Architecture), value, true),
-                "Architecture that should be excluded as a tag suffix");
-            ArchTagSuffixExclusion = archTagSuffixExclusion;
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateDockerfilesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateDockerfilesCommandTests.cs
@@ -104,7 +104,7 @@ ENV TEST2 Value1";
         [InlineData("repo1:tag2", "ARCH_VERSIONED", "amd64")]
         [InlineData("repo1:tag3", "ARCH_VERSIONED", "amd64")]
         [InlineData("repo1:tag1", "ARCH_TAG_SUFFIX", "-arm32v7")]
-        [InlineData("repo1:tag2", "ARCH_TAG_SUFFIX", "", false, Architecture.AMD64)]
+        [InlineData("repo1:tag2", "ARCH_TAG_SUFFIX", "-amd64")]
         [InlineData("repo1:tag3", "ARCH_TAG_SUFFIX", "-amd64")]
         [InlineData("repo1:tag1", "OS_VERSION", "buster-slim")]
         [InlineData("repo1:tag2", "OS_VERSION", "nanoserver-1903")]
@@ -122,11 +122,10 @@ ENV TEST2 Value1";
         [InlineData("repo1:tag4", "OS_ARCH_HYPHENATED", "WindowsServerCore-ltsc2019")]
         [InlineData("repo1:tag5", "OS_ARCH_HYPHENATED", "Alpine-3.12")]
         [InlineData("repo1:tag1", "Variable1", "Value1", true)]
-        public void GenerateDockerfilesCommand_SupportedSymbols(string tag, string symbol, string expectedValue, bool isVariable = false,
-            Architecture? archTagSuffixExclusion = null)
+        public void GenerateDockerfilesCommand_SupportedSymbols(string tag, string symbol, string expectedValue, bool isVariable = false)
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
-            GenerateDockerfilesCommand command = InitializeCommand(tempFolderContext, archTagSuffixExclusion: archTagSuffixExclusion);
+            GenerateDockerfilesCommand command = InitializeCommand(tempFolderContext);
 
             IReadOnlyDictionary<Value, Value> symbols = command.GetSymbols(command.Manifest.GetPlatformByTag(tag));
 
@@ -148,8 +147,7 @@ ENV TEST2 Value1";
             string dockerfileTemplate = DefaultDockerfileTemplate,
             string dockerfile = DefaultDockerfile,
             bool allowOptionalTemplates = true,
-            bool validate = false,
-            Architecture? archTagSuffixExclusion = null)
+            bool validate = false)
         {
             DockerfileHelper.CreateFile(DockerfilePath, tempFolderContext, dockerfile);
 
@@ -206,7 +204,6 @@ ENV TEST2 Value1";
             command.Options.Manifest = manifestPath;
             command.Options.AllowOptionalTemplates = allowOptionalTemplates;
             command.Options.Validate = validate;
-            command.Options.ArchTagSuffixExclusion = archTagSuffixExclusion;
             command.LoadManifest();
 
             return command;

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateDockerfilesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateDockerfilesCommandTests.cs
@@ -104,8 +104,8 @@ ENV TEST2 Value1";
         [InlineData("repo1:tag2", "ARCH_VERSIONED", "amd64")]
         [InlineData("repo1:tag3", "ARCH_VERSIONED", "amd64")]
         [InlineData("repo1:tag1", "ARCH_TAG_SUFFIX", "-arm32v7")]
-        [InlineData("repo1:tag2", "ARCH_TAG_SUFFIX", "")]
-        [InlineData("repo1:tag3", "ARCH_TAG_SUFFIX", "")]
+        [InlineData("repo1:tag2", "ARCH_TAG_SUFFIX", "", false, Architecture.AMD64)]
+        [InlineData("repo1:tag3", "ARCH_TAG_SUFFIX", "-amd64")]
         [InlineData("repo1:tag1", "OS_VERSION", "buster-slim")]
         [InlineData("repo1:tag2", "OS_VERSION", "nanoserver-1903")]
         [InlineData("repo1:tag3", "OS_VERSION", "windowsservercore-1903")]
@@ -122,10 +122,11 @@ ENV TEST2 Value1";
         [InlineData("repo1:tag4", "OS_ARCH_HYPHENATED", "WindowsServerCore-ltsc2019")]
         [InlineData("repo1:tag5", "OS_ARCH_HYPHENATED", "Alpine-3.12")]
         [InlineData("repo1:tag1", "Variable1", "Value1", true)]
-        public void GenerateDockerfilesCommand_SupportedSymbols(string tag, string symbol, string expectedValue, bool isVariable = false)
+        public void GenerateDockerfilesCommand_SupportedSymbols(string tag, string symbol, string expectedValue, bool isVariable = false,
+            Architecture? archTagSuffixExclusion = null)
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
-            GenerateDockerfilesCommand command = InitializeCommand(tempFolderContext);
+            GenerateDockerfilesCommand command = InitializeCommand(tempFolderContext, archTagSuffixExclusion: archTagSuffixExclusion);
 
             IReadOnlyDictionary<Value, Value> symbols = command.GetSymbols(command.Manifest.GetPlatformByTag(tag));
 
@@ -147,7 +148,8 @@ ENV TEST2 Value1";
             string dockerfileTemplate = DefaultDockerfileTemplate,
             string dockerfile = DefaultDockerfile,
             bool allowOptionalTemplates = true,
-            bool validate = false)
+            bool validate = false,
+            Architecture? archTagSuffixExclusion = null)
         {
             DockerfileHelper.CreateFile(DockerfilePath, tempFolderContext, dockerfile);
 
@@ -204,6 +206,7 @@ ENV TEST2 Value1";
             command.Options.Manifest = manifestPath;
             command.Options.AllowOptionalTemplates = allowOptionalTemplates;
             command.Options.Validate = validate;
+            command.Options.ArchTagSuffixExclusion = archTagSuffixExclusion;
             command.LoadManifest();
 
             return command;


### PR DESCRIPTION
For the changes being made for #2182, there needs to be a way to generate Dockerfiles from a template that makes use of the `ARCH_TAG_SUFFIX` variable which is always populated.  Currently, it defaults to an empty value if the architecture is AMD64.

This is fixed by including an option to set the default architecture that, if set, will be excluded as a tag suffix.  For 2.1/3.1 Dockerfile templates, this will be set to "AMD64".  For 5.0, this option will not be set.

Related to https://github.com/dotnet/dotnet-docker/issues/2182