### PR TITLE
Manifest publishing support for duplicated platforms

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -101,8 +101,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     }
 
                     SetPlatformDataCreatedDate(platform, tag.FullyQualifiedName);
-                    platform.CommitUrl = _gitService.GetDockerfileCommitUrl(platform.PlatformInfo, Options.SourceRepoUrl);
                 }
+
+                platform.CommitUrl = _gitService.GetDockerfileCommitUrl(platform.PlatformInfo, Options.SourceRepoUrl);
             }
 
             string imageInfoString = JsonHelper.SerializeObject(_imageArtifactDetails);

--- a/src/Microsoft.DotNet.ImageBuilder/src/McrTagsMetadataGenerator.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/McrTagsMetadataGenerator.cs
@@ -140,10 +140,7 @@ namespace Microsoft.DotNet.ImageBuilder
                     // duplicated in another image in order to associate it within a distinct set of shared tags.
                     IEnumerable<ImageDocumentationInfo> matchingDocInfos = _imageDocInfos
                         .Where(docInfo => docInfo != info &&
-                            docInfo.Platform.DockerfilePath == info.Platform.DockerfilePath &&
-                            docInfo.Platform.Model.OsVersion == info.Platform.Model.OsVersion &&
-                            docInfo.Platform.Model.Architecture == info.Platform.Model.Architecture &&
-                            docInfo.Image.ProductVersion == info.Image.ProductVersion)
+                            PlatformInfo.AreMatchingPlatforms(docInfo.Image, docInfo.Platform, info.Image, info.Platform))
                         .Prepend(info)
                         .ToArray();
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/PlatformData.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/PlatformData.cs
@@ -69,25 +69,29 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Image
                 return 1;
             }
 
+            // If either of the platforms has no simple tags while the other does have simple tags, they are not equal
+            if ((SimpleTags?.Count == 0 && other.SimpleTags?.Count > 0) ||
+                (SimpleTags?.Count > 0 && other.SimpleTags?.Count == 0))
+            {
+                return 1;
+            }
+
             return GetIdentifier().CompareTo(other.GetIdentifier());
         }
 
-        public bool Equals(PlatformInfo platformInfo)
-        {
-            return GetIdentifier() == FromPlatformInfo(platformInfo, null).GetIdentifier();
-        }
+        public bool Equals(PlatformInfo platformInfo) =>
+            CompareTo(FromPlatformInfo(platformInfo, null)) == 0;
 
         public string GetIdentifier() => $"{Dockerfile}-{Architecture}-{OsType}-{OsVersion}";
 
-        public static PlatformData FromPlatformInfo(PlatformInfo platform, ImageInfo image)
-        {
-            return new PlatformData(image, platform)
+        public static PlatformData FromPlatformInfo(PlatformInfo platform, ImageInfo image) =>
+            new PlatformData(image, platform)
             {
                 Dockerfile = platform.DockerfilePathRelativeToManifest,
                 Architecture = platform.Model.Architecture.GetDisplayName(),
                 OsType = platform.Model.OS.ToString(),
-                OsVersion = platform.GetOSDisplayName()
+                OsVersion = platform.GetOSDisplayName(),
+                SimpleTags = platform.Tags.Select(tag => tag.Name).ToList()
             };
-        }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
@@ -210,6 +210,12 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             return displayName;
         }
 
+        public static bool AreMatchingPlatforms(ImageInfo image1, PlatformInfo platform1, ImageInfo image2, PlatformInfo platform2) =>
+            platform1.DockerfilePath == platform2.DockerfilePath &&
+            platform1.Model.OsVersion == platform2.Model.OsVersion &&
+            platform1.Model.Architecture == platform2.Model.Architecture &&
+            image1.ProductVersion == image2.ProductVersion;
+
         private static bool IsStageReference(string fromImage, IList<Match> fromMatches)
         {
             bool isStageReference = false;

--- a/src/Microsoft.DotNet.ImageBuilder/tests/ImageInfoHelperTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/ImageInfoHelperTests.cs
@@ -41,14 +41,16 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         Dockerfile = "1.0/runtime/linux/Dockerfile",
                                         OsType = "Linux",
                                         OsVersion = "Ubuntu 20.04",
-                                        Architecture = "amd64"
+                                        Architecture = "amd64",
+                                        SimpleTags = new List<string> { "linux" }
                                     },
                                     new PlatformData
                                     {
                                         Dockerfile = "1.0/runtime/windows/Dockerfile",
                                         OsType = "Windows",
                                         OsVersion = "Windows Server, version 2004",
-                                        Architecture = "amd64"
+                                        Architecture = "amd64",
+                                        SimpleTags = new List<string> { "windows" }
                                     }
                                 },
                                 Manifest = new ManifestData
@@ -666,6 +668,105 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             };
 
             CompareImageArtifactDetails(expected, targetImageArtifactDetails);
+        }
+
+        [Fact]
+        public void Merge_DuplicatedPlatforms()
+        {
+            ImageArtifactDetails imageArtifactDetails = new ImageArtifactDetails
+            {
+                Repos =
+                {
+                    new RepoData
+                    {
+                        Repo = "repo",
+                        Images =
+                        {
+                            new ImageData
+                            {
+                                ManifestImage = CreateImageInfo(),
+                                Platforms =
+                                {
+                                    new PlatformData
+                                    {
+                                        Dockerfile = "image1"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            ImageArtifactDetails targetImageArtifactDetails = new ImageArtifactDetails
+            {
+                Repos =
+                {
+                    new RepoData
+                    {
+                        Repo = "repo",
+                        Images =
+                        {
+                            new ImageData
+                            {
+                                ManifestImage = CreateImageInfo(),
+                                Platforms =
+                                {
+                                    new PlatformData
+                                    {
+                                        Dockerfile = "image1",
+                                        SimpleTags = new List<string>
+                                        {
+                                            "tag1"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            ImageArtifactDetails expectedImageArtifactDetails = new ImageArtifactDetails
+            {
+                Repos =
+                {
+                    new RepoData
+                    {
+                        Repo = "repo",
+                        Images =
+                        {
+                            new ImageData
+                            {
+                                Platforms =
+                                {
+                                    new PlatformData
+                                    {
+                                        Dockerfile = "image1"
+                                    }
+                                }
+                            },
+                            new ImageData
+                            {
+                                Platforms =
+                                {
+                                    new PlatformData
+                                    {
+                                        Dockerfile = "image1",
+                                        SimpleTags = new List<string>
+                                        {
+                                            "tag1"
+                                        }
+                                    }
+                                }
+                            },
+                        }
+                    }
+                }
+            };
+
+            ImageInfoHelper.MergeImageArtifactDetails(imageArtifactDetails, targetImageArtifactDetails);
+            CompareImageArtifactDetails(expectedImageArtifactDetails, targetImageArtifactDetails);
         }
 
         public static void CompareImageArtifactDetails(ImageArtifactDetails expected, ImageArtifactDetails actual)

--- a/src/Microsoft.DotNet.ImageBuilder/tests/MergeImageInfoFilesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/MergeImageInfoFilesCommandTests.cs
@@ -178,15 +178,15 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     CreateRepo("repo1"),
                     CreateRepo("repo2",
                         CreateImage(
-                            CreatePlatform(repo2Image1Dockerfile, new string[0])),
+                            CreatePlatform(repo2Image1Dockerfile, new string[] { "tag1" })),
                         CreateImage(
-                            CreatePlatform(repo2Image2Dockerfile, new string[0]))),
+                            CreatePlatform(repo2Image2Dockerfile, new string[] { "tag2" }))),
                     CreateRepo("repo3"),
                     CreateRepo("repo4",
                         CreateImage(
-                            CreatePlatform(repo4Image2Dockerfile, new string[0])),
+                            CreatePlatform(repo4Image2Dockerfile, new string[] { "tag1" })),
                         CreateImage(
-                            CreatePlatform(repo4Image3Dockerfile, new string[0])))
+                            CreatePlatform(repo4Image3Dockerfile, new string[] { "tag2" })))
                 );
                 File.WriteAllText(Path.Combine(context.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));
 
@@ -456,12 +456,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Manifest manifest = CreateManifest(
                     CreateRepo("repo1",
                         CreateImage(
-                            CreatePlatform(dockerfile1, new string[0], osVersion: Os1, architecture: Architecture.ARM),
-                            CreatePlatform(dockerfile1, new string[0], osVersion: Os1, architecture: Architecture.ARM64)),
+                            CreatePlatform(dockerfile1, new string[] { "tag1" }, osVersion: Os1, architecture: Architecture.ARM),
+                            CreatePlatform(dockerfile1, new string[] { "tag2" }, osVersion: Os1, architecture: Architecture.ARM64)),
                         CreateImage(
-                            CreatePlatform(dockerfile1, new string[0], osVersion: Os2, architecture: Architecture.ARM)),
+                            CreatePlatform(dockerfile1, new string[] { "tag3" }, osVersion: Os2, architecture: Architecture.ARM)),
                         CreateImage(
-                            CreatePlatform(dockerfile2, new string[0], osVersion: Os1)))
+                            CreatePlatform(dockerfile2, new string[] { "tag4" }, osVersion: Os1)))
                 );
                 File.WriteAllText(Path.Combine(context.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));
 

--- a/src/Microsoft.DotNet.ImageBuilder/tests/PublishImageInfoCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/PublishImageInfoCommandTests.cs
@@ -47,10 +47,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Manifest manifest = CreateManifest(
                     CreateRepo("repo1",
                         CreateImage(
-                            CreatePlatform(repo1Image1DockerfilePath, new string[0]))),
+                            CreatePlatform(repo1Image1DockerfilePath, new string[] { "tag1" }))),
                     CreateRepo("repo2",
                         CreateImage(
-                            CreatePlatform(repo2Image2DockerfilePath, new string[0])))
+                            CreatePlatform(repo2Image2DockerfilePath, new string[] { "tag1" })))
                 );
 
                 RepoData repo2;


### PR DESCRIPTION
With the changes being done for dotnet/dotnet-docker#2182, it will cause a platform to be defined multiple times in a manifest, contained in separate images. This requires changes to `PublishManfiestCommand` in order to correctly handle this scenario because it will otherwise throw an exception when it encounters a platform with no concrete platform tags.

This is solved by finding the matching platform that does contain a concrete tag and using that as the reference tag for the manifest creation.