### PR TITLE
Fix matrix generation for duplicated platforms

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
@@ -211,10 +211,10 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         }
 
         public static bool AreMatchingPlatforms(ImageInfo image1, PlatformInfo platform1, ImageInfo image2, PlatformInfo platform2) =>
-            platform1.DockerfilePath == platform2.DockerfilePath &&
-            platform1.Model.OsVersion == platform2.Model.OsVersion &&
-            platform1.Model.Architecture == platform2.Model.Architecture &&
-            image1.ProductVersion == image2.ProductVersion;
+            platform1.GetUniqueKey(image1) == platform2.GetUniqueKey(image2);
+
+        public string GetUniqueKey(ImageInfo parentImageInfo) =>
+            $"{DockerfilePathRelativeToManifest}-{Model.OS}-{Model.OsVersion}-{Model.Architecture}-{parentImageInfo.ProductVersion}";
 
         private static bool IsStageReference(string fromImage, IList<Match> fromMatches)
         {


### PR DESCRIPTION
The `platformVersionedOs` matrix generation doesn't generate the correct matrix when a platform has been duplicated in the matrix.  It ends up generating one leg for each of those platforms, each having the same name.  What it should do is to combine things into one leg.

These changes refactor the matrix generating logic to reuse similar logic that exists for combining distinct platforms that share a Dockerfile into a single leg and repurposes it to be used for this scenario as well.