### PR TITLE
Disallow official builds from non-official branches

### DIFF
--- a/eng/common/templates/jobs/generate-matrix.yml
+++ b/eng/common/templates/jobs/generate-matrix.yml
@@ -8,6 +8,7 @@ jobs:
   pool:
     vmImage: $(defaultLinuxAmd64PoolImage)
   steps:
+  - template: ../steps/validate-branch.yml
   - template: ../steps/init-docker-linux.yml
   - script: >
       $(runImageBuilderCmd) generateBuildMatrix

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -10,6 +10,7 @@ jobs:
       $(manifestVariables)
       $(imageBuilder.queueArgs)
   steps:
+  - template: ../steps/validate-branch.yml
   - template: ../steps/init-docker-linux.yml
   - template: ../steps/download-build-artifact.yml
     parameters:

--- a/eng/common/templates/steps/validate-branch.yml
+++ b/eng/common/templates/steps/validate-branch.yml
@@ -1,0 +1,10 @@
+steps:
+- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+  - script: |
+      if [[ "$OFFICIALBRANCHES" != *\'$BUILD_SOURCEBRANCHNAME\'* && \
+            "$PUBLISHREPOPREFIX" == "public/" && \
+            "$OVERRIDEOFFICIALBRANCHVALIDATION" != "true" ]]; then
+          echo "##vso[task.logissue type=error]Official builds must be done from an official branch: $OFFICIALBRANCHES"
+          exit 1
+      fi
+    displayName: Validate Branch

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -23,6 +23,9 @@ variables:
   value: "00:20:00"
 - name: mcrDocIngestionTimeout
   value: "00:05:00"
+- name: officialBranches
+  # list multiple branches as "'branch1', 'branch2', etc."
+  value: "'master'"
 
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNet-Docker-Common


### PR DESCRIPTION
Adds a validation step that would get executed in all stages of the build.  This validates that the build is running on an official branch if it's an official build.  Official branches are defined in a common variable that each pipeline can override if necessary.

I also added a variable that would allow this validation to be overriden.  This variable is intended as an escape hatch for now and would need to be explicitly added to a build run.

Fixes #605