### PR TITLE
Fix image info merging of new or removed image manifest

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
@@ -80,6 +80,24 @@ namespace Microsoft.DotNet.ImageBuilder
             MergeData(src, target, options);
         }
 
+        private static void MergePropertyData(object srcObj, object targetObj, PropertyInfo property, ImageInfoMergeOptions options)
+        {
+            object srcResult = property.GetValue(srcObj);
+            object targetResult = property.GetValue(targetObj);
+            if (srcResult is null && targetResult != null)
+            {
+                property.SetValue(targetObj, null);
+            }
+            else if (srcResult != null && targetResult is null)
+            {
+                property.SetValue(targetObj, srcResult);
+            }
+            else
+            {
+                MergeData(srcResult, targetResult, options);
+            }
+        }
+
         private static void MergeData(object srcObj, object targetObj, ImageInfoMergeOptions options)
         {
             if (!((srcObj is null && targetObj is null) || (!(srcObj is null) && !(targetObj is null))))
@@ -152,7 +170,7 @@ namespace Microsoft.DotNet.ImageBuilder
                 }
                 else if (typeof(ManifestData).IsAssignableFrom(property.PropertyType))
                 {
-                    MergeData(property.GetValue(srcObj), property.GetValue(targetObj), options);
+                    MergePropertyData(srcObj, targetObj, property, options);
                 }
                 else
                 {

--- a/src/Microsoft.DotNet.ImageBuilder/tests/ImageInfoHelperTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/ImageInfoHelperTests.cs
@@ -769,6 +769,146 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             CompareImageArtifactDetails(expectedImageArtifactDetails, targetImageArtifactDetails);
         }
 
+        /// <summary>
+        /// Tests the scenario where a source image defines a manifest that the target doesn't have.
+        /// </summary>
+        [Fact]
+        public void ImageInfoHelper_MergeRepos_NewManifest()
+        {
+            ImageInfo imageInfo1 = CreateImageInfo();
+
+            ImageArtifactDetails srcImageArtifactDetails = new ImageArtifactDetails
+            {
+                Repos =
+                {
+                    new RepoData
+                    {
+                        Repo = "repo",
+                        Images =
+                        {
+                            new ImageData
+                            {
+                                ManifestImage = imageInfo1,
+                                Manifest = new ManifestData
+                                {
+                                    SharedTags = new List<string>
+                                    {
+                                        "shared"
+                                    }
+                                },
+                                Platforms =
+                                {
+                                    new PlatformData
+                                    {
+                                        Dockerfile = "image1",
+                                        Digest = "digest"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            ImageArtifactDetails targetImageArtifactDetails = new ImageArtifactDetails
+            {
+                Repos =
+                {
+                    new RepoData
+                    {
+                        Repo = "repo",
+                        Images =
+                        {
+                            new ImageData
+                            {
+                                ManifestImage = imageInfo1,
+                                Platforms =
+                                {
+                                    new PlatformData
+                                    {
+                                        Dockerfile = "image1"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            ImageInfoHelper.MergeImageArtifactDetails(srcImageArtifactDetails, targetImageArtifactDetails);
+            CompareImageArtifactDetails(srcImageArtifactDetails, targetImageArtifactDetails);
+        }
+
+        /// <summary>
+        /// Tests the scenario where a target image defines a manifest that the source doesn't have.
+        /// </summary>
+        [Fact]
+        public void ImageInfoHelper_MergeRepos_RemovedManifest()
+        {
+            ImageInfo imageInfo1 = CreateImageInfo();
+
+            ImageArtifactDetails srcImageArtifactDetails = new ImageArtifactDetails
+            {
+                Repos =
+                {
+                    new RepoData
+                    {
+                        Repo = "repo",
+                        Images =
+                        {
+                            new ImageData
+                            {
+                                ManifestImage = imageInfo1,
+                                Platforms =
+                                {
+                                    new PlatformData
+                                    {
+                                        Dockerfile = "image1",
+                                        Digest = "digest"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            ImageArtifactDetails targetImageArtifactDetails = new ImageArtifactDetails
+            {
+                Repos =
+                {
+                    new RepoData
+                    {
+                        Repo = "repo",
+                        Images =
+                        {
+                            new ImageData
+                            {
+                                ManifestImage = imageInfo1,
+                                Manifest = new ManifestData
+                                {
+                                    SharedTags = new List<string>
+                                    {
+                                        "shared"
+                                    }
+                                },
+                                Platforms =
+                                {
+                                    new PlatformData
+                                    {
+                                        Dockerfile = "image1"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            ImageInfoHelper.MergeImageArtifactDetails(srcImageArtifactDetails, targetImageArtifactDetails);
+            CompareImageArtifactDetails(srcImageArtifactDetails, targetImageArtifactDetails);
+        }
+
         public static void CompareImageArtifactDetails(ImageArtifactDetails expected, ImageArtifactDetails actual)
         {
             Assert.Equal(JsonHelper.SerializeObject(expected), JsonHelper.SerializeObject(actual));


### PR DESCRIPTION
The changes to add shared tags for each Linux distro end up exposing an issue in the image info merging logic.  The issue occurs when the image info file in the versions repo has an image without any manifest data (no shared tags) and the image info to be merged in does define manifest data for that same image.  It results in an [exception](https://github.com/dotnet/docker-tools/blob/5745c5c78a481ae76f3993b889114505989b595d/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs#L87) because the logic doesn't account for the scenario of merging a property value where the source and target have differing "nullness".

I've fixed the logic to handle this case as well as the reverse case where the image's manifest had been removed.