### PR TITLE
Fix image size validation to handle tagless platforms

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ImageSizeCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ImageSizeCommand.cs
@@ -28,7 +28,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             foreach (RepoInfo repo in Manifest.FilteredRepos.Where(platform => platform.FilteredImages.Any()))
             {
                 IEnumerable<PlatformInfo> platforms = repo.FilteredImages
-                    .SelectMany(image => image.FilteredPlatforms);
+                    .SelectMany(image => image.FilteredPlatforms)
+                    .Where(platform => platform.Tags.Any());
 
                 foreach (PlatformInfo platform in platforms)
                 {


### PR DESCRIPTION
The changes being made for dotnet/dotnet-docker#2182 require defining platforms in the manifest that do not contain any simple tags.  This breaks the `ImageSizeCommand` class because it's always expecting at least one tag in a platform.  I've fixed the logic to ignore such platforms.