### PR TITLE
Fix image info generation

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -123,7 +123,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             foreach (PlatformData platform in platformsWithNoPushTags)
             {
                 PlatformData matchingBuiltPlatform = builtPlatforms.First(builtPlatform =>
-                    builtPlatform.Digest != null &&
+                    GetPushTags(builtPlatform.PlatformInfo.Tags).Any() &&
                     PlatformInfo.AreMatchingPlatforms(platform.ImageInfo, platform.PlatformInfo, builtPlatform.ImageInfo, builtPlatform.PlatformInfo));
 
                 platform.Digest = matchingBuiltPlatform.Digest;


### PR DESCRIPTION
The changes in https://github.com/dotnet/docker-tools/pull/672 had an issue that caused the logic to not work in PR builds.  In PR builds, the image info is output but images are not pushed.  This messes up the logic which intends to find a matching platform that has its digest set because since the image wasn't pushed, it doesn't have its digest set.

Fixed the logic to not base its lookup on the state of the digest/created fields but rather whether it has tags which would imply that the state is set correctly.