### PR TITLE
Trims test jobs consisting of only unchanged images

### DIFF
--- a/eng/common/templates/jobs/generate-matrix.yml
+++ b/eng/common/templates/jobs/generate-matrix.yml
@@ -2,6 +2,7 @@ parameters:
   matrixType: null
   name: null
   customBuildLegGroupArgs: ""
+  isTestStage: false
 
 jobs:
 - job: ${{ parameters.name }}
@@ -10,6 +11,13 @@ jobs:
   steps:
   - template: ../steps/validate-branch.yml
   - template: ../steps/init-docker-linux.yml
+  - ${{ if eq(parameters.isTestStage, true) }}:
+    - template: ../steps/download-build-artifact.yml
+      parameters:
+        targetPath: $(Build.ArtifactStagingDirectory)
+        artifactName: image-info
+    - script: echo "##vso[task.setvariable variable=additionalGenerateBuildMatrixOptions]--image-info $(artifactsPath)/image-info.json"
+      displayName: Set GenerateBuildMatrix Variables
   - script: >
       $(runImageBuilderCmd) generateBuildMatrix
       --manifest $(manifest)
@@ -20,6 +28,7 @@ jobs:
       ${{ parameters.customBuildLegGroupArgs }}
       $(imageBuilder.pathArgs)
       $(manifestVariables)
+      $(additionalGenerateBuildMatrixOptions)
     displayName: Generate ${{ parameters.matrixType }} Matrix
     name: matrix
   - template: ../steps/cleanup-docker-linux.yml

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -194,6 +194,7 @@ stages:
         matrixType: ${{ parameters.testMatrixType }}
         name: GenerateTestMatrix
         customBuildLegGroupArgs: ${{ parameters.testMatrixCustomBuildLegGroupArgs }}
+        isTestStage: true
 
     - template: ../jobs/test-images-linux-client.yml
       parameters:


### PR DESCRIPTION
When generating the matrix for the test stages, this passes the image info file produced by the build stage to the `generateBuildMatrix` command.  That command is already configured to filter out test legs for those legs consisting only of unchanged images.

Fixes #632