### PR TITLE
Fix Windows build leg for image size validation

### DIFF
--- a/eng/common/templates/jobs/validate-image-sizes.yml
+++ b/eng/common/templates/jobs/validate-image-sizes.yml
@@ -35,12 +35,12 @@ jobs:
       dockerClientOS: linux
       validationMode: integrity
 - job: WindowsPerfTests
-  pool: # windows2004Amd64
+  pool:
     ${{ if eq(variables['System.TeamProject'], 'public') }}:
       name: DotNetCore-Docker-Public
     ${{ if eq(variables['System.TeamProject'], 'internal') }}:
       name: DotNetCore-Docker
-    demands: VSTS_OS -equals Windows-ServerDatacenter-2004
+    demands: VSTS_OS -equals Windows-ServerDatacenter-2009
   workspace:
     clean: all
   steps:


### PR DESCRIPTION
Now that Windows Server, version 2009 images have been published, the image size validation pipeline needs to be updated to use the latest version of Windows in order to pull those 2009 images.