### PR TITLE
Support tag syndication

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
@@ -49,8 +49,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         .SelectMany(platform => GetTagInfos(repo, platform))
                         .Select(tagInfo =>
                             ImportImageAsync(
-                                TrimRegistry(tagInfo.DestinationTag),
-                                TrimRegistry(tagInfo.SourceTag),
+                                DockerHelper.TrimRegistry(tagInfo.DestinationTag, Manifest.Registry),
+                                DockerHelper.TrimRegistry(tagInfo.SourceTag, Manifest.Registry),
                                 srcResourceId: resourceId)))
                 .SelectMany(tasks => tasks);
 
@@ -110,8 +110,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             return tags;
         }
-
-        private string TrimRegistry(string tag) => tag.TrimStart($"{Manifest.Registry}/");
 
         private string GetSourceTag(string destinationTag) =>
             destinationTag.Replace(Options.RepoPrefix, Options.SourceRepoPrefix);

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateImageGraphCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateImageGraphCommand.cs
@@ -128,7 +128,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             if (Manifest.Registry != null)
             {
-                displayName = displayName.TrimStart(Manifest.Registry).TrimStart('/');
+                displayName = DockerHelper.TrimRegistry(displayName, Manifest.Registry);
             }
 
             if (trimParentRepos)

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
@@ -163,6 +163,8 @@ namespace Microsoft.DotNet.ImageBuilder
             return imageName;
         }
 
+        public static string TrimRegistry(string tag, string registry) => tag.TrimStart($"{registry}/");
+
         /// <remarks>
         /// This method depends on the experimental Docker CLI `manifest` command.  As a result, this method
         /// should only used for developer usage scenarios.

--- a/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
@@ -38,7 +38,9 @@ namespace Microsoft.DotNet.ImageBuilder
                         foreach (ImageInfo manifestImage in manifestRepo.AllImages)
                         {
                             PlatformInfo matchingManifestPlatform = manifestImage.AllPlatforms
-                                .FirstOrDefault(platform => platformData.Equals(platform));
+                                .FirstOrDefault(platform =>
+                                    platformData.Equals(platform) &&
+                                    imageData.ProductVersion == manifestImage.ProductVersion);
                             if (matchingManifestPlatform != null)
                             {
                                 if (imageData.ManifestImage is null)

--- a/src/Microsoft.DotNet.ImageBuilder/src/McrTagsMetadataGenerator.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/McrTagsMetadataGenerator.cs
@@ -139,7 +139,7 @@ namespace Microsoft.DotNet.ImageBuilder
                     // Find all other doc infos that match this one. This accounts for scenarios where a platform is
                     // duplicated in another image in order to associate it within a distinct set of shared tags.
                     IEnumerable<ImageDocumentationInfo> matchingDocInfos = _imageDocInfos
-                        .Where(docInfo => docInfo != info &&
+                        .Where(docInfo => docInfo.Platform != info.Platform &&
                             PlatformInfo.AreMatchingPlatforms(docInfo.Image, docInfo.Platform, info.Image, info.Platform))
                         .Prepend(info)
                         .ToArray();

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/ImageData.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/ImageData.cs
@@ -58,6 +58,11 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Image
                 return 0;
             }
 
+            if (ManifestImage.ProductVersion != other.ProductVersion)
+            {
+                return ManifestImage.ProductVersion?.CompareTo(other.ProductVersion) ?? 1;
+            }
+
             // If we're comparing two different image items, compare them by the first Platform to
             // provide deterministic ordering.
             PlatformData thisFirstPlatform = Platforms

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/Tag.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/Tag.cs
@@ -34,6 +34,10 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Manifest
         [DefaultValue(TagDocumentationType.Documented)]
         public TagDocumentationType DocType { get; set; }
 
+        [Description(
+            "Name of repository that the tag will be syndicated to.")]
+        public string SyndicatedRepo { get; set; }
+
         public Tag()
         {
         }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/TagInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/TagInfo.cs
@@ -13,6 +13,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         public string FullyQualifiedName { get; private set; }
         public Tag Model { get; private set; }
         public string Name { get; private set; }
+        public string SyndicatedRepo { get; private set; }
 
         private TagInfo()
         {
@@ -32,6 +33,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             };
             tagInfo.Name = variableHelper.SubstituteValues(name, tagInfo.GetVariableValue);
             tagInfo.FullyQualifiedName = GetFullyQualifiedName(repoName, tagInfo.Name);
+            tagInfo.SyndicatedRepo = variableHelper.SubstituteValues(model.SyndicatedRepo);
 
             return tagInfo;
         }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
@@ -584,6 +584,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             new ImageData
                             {
+                                ProductVersion = "1.0",
                                 Platforms =
                                 {
                                     CreateSimplePlatformData(runtimeDockerfilePath, isCached: isRuntimeCached)
@@ -598,6 +599,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             new ImageData
                             {
+                                ProductVersion = "1.0",
                                 Platforms =
                                 {
                                     CreateSimplePlatformData(aspnetDockerfilePath, isCached: isAspnetCached)
@@ -612,6 +614,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             new ImageData
                             {
+                                ProductVersion = "1.0",
                                 Platforms =
                                 {
                                     CreateSimplePlatformData(sdkDockerfilePath, isCached: isSdkCached)

--- a/src/Microsoft.DotNet.ImageBuilder/tests/IngestKustoImageInfoCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/IngestKustoImageInfoCommandTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Commands;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
@@ -39,14 +40,28 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
 
             string repo1Image1DockerfilePath = DockerfileHelper.CreateDockerfile("1.0/sdk/os", tempFolderContext);
+            string repo1Image2DockerfilePath = DockerfileHelper.CreateDockerfile("1.0/sdk/os2", tempFolderContext);
             string repo2Image2DockerfilePath = DockerfileHelper.CreateDockerfile("2.0/sdk/os", tempFolderContext);
             Manifest manifest = CreateManifest(
-                CreateRepo("repo1",
+                CreateRepo("r1",
                     CreateImage(
-                        CreatePlatform(repo1Image1DockerfilePath, new string[0]))),
-                CreateRepo("repo2",
+                        new Platform[]
+                        {
+                            CreatePlatform(repo1Image1DockerfilePath, new string[] { "t1" }),
+                            CreatePlatform(repo1Image2DockerfilePath, new string[] { "t2" })
+                        },
+                        productVersion: "1.0.2",
+                        sharedTags: new Dictionary<string, Tag>
+                        {
+                            { "st1", new Tag() }
+                        })),
+                CreateRepo("r2",
                     CreateImage(
-                        CreatePlatform(repo2Image2DockerfilePath, new string[0])))
+                        new Platform[]
+                        {
+                            CreatePlatform(repo2Image2DockerfilePath, new string[] { "t3" })
+                        },
+                        productVersion: "2.0.5"))
             );
             string manifestPath = Path.Combine(tempFolderContext.Path, "manifest.json");
             File.WriteAllText(manifestPath, JsonConvert.SerializeObject(manifest));
@@ -62,8 +77,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             new ImageData
                             {
-                                Manifest =
-                                new ManifestData
+                                Manifest = new ManifestData
                                 {
                                     Created = new DateTime(2020, 4, 20, 21, 57, 00, DateTimeKind.Utc),
                                     Digest = "abc",
@@ -86,7 +100,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     },
                                     {
                                         Helpers.ImageInfoHelper.CreatePlatform(
-                                            repo1Image1DockerfilePath,
+                                            repo1Image2DockerfilePath,
                                             created: new DateTime(2020, 4, 20, 21, 56, 56, DateTimeKind.Utc),
                                             digest: "ghi",
                                             simpleTags: new List<string>
@@ -127,10 +141,106 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             string expectedData =
 @"""def"",""amd64"",""Linux"",""Ubuntu 19.04"",""1.0.2"",""1.0/sdk/os/Dockerfile"",""r1"",""2020-04-20 21:56:50""
 ""t1"",""amd64"",""Linux"",""Ubuntu 19.04"",""1.0.2"",""1.0/sdk/os/Dockerfile"",""r1"",""2020-04-20 21:56:50""
-""ghi"",""amd64"",""Linux"",""Ubuntu 19.04"",""1.0.2"",""1.0/sdk/os/Dockerfile"",""r1"",""2020-04-20 21:56:56""
-""t2"",""amd64"",""Linux"",""Ubuntu 19.04"",""1.0.2"",""1.0/sdk/os/Dockerfile"",""r1"",""2020-04-20 21:56:56""
+""ghi"",""amd64"",""Linux"",""Ubuntu 19.04"",""1.0.2"",""1.0/sdk/os2/Dockerfile"",""r1"",""2020-04-20 21:56:56""
+""t2"",""amd64"",""Linux"",""Ubuntu 19.04"",""1.0.2"",""1.0/sdk/os2/Dockerfile"",""r1"",""2020-04-20 21:56:56""
 ""jkl"",""amd64"",""Linux"",""Ubuntu 19.04"",""2.0.5"",""2.0/sdk/os/Dockerfile"",""r2"",""2020-04-20 21:56:58""
 ""t3"",""amd64"",""Linux"",""Ubuntu 19.04"",""2.0.5"",""2.0/sdk/os/Dockerfile"",""r2"",""2020-04-20 21:56:58""";
+            expectedData = expectedData.NormalizeLineEndings(Environment.NewLine).Trim();
+
+            string imageInfoPath = Path.Combine(tempFolderContext.Path, "image-info.json");
+            File.WriteAllText(imageInfoPath, JsonHelper.SerializeObject(srcImageArtifactDetails));
+
+            string ingestedData = null;
+
+            Mock<IKustoClient> kustoClientMock = new Mock<IKustoClient>();
+            kustoClientMock
+                .Setup(o => o.IngestFromCsvStreamAsync(It.IsAny<Stream>(), It.IsAny<IngestKustoImageInfoOptions>()))
+                .Callback<Stream, IngestKustoImageInfoOptions>((s, o) =>
+                {
+                    StreamReader reader = new StreamReader(s);
+                    ingestedData = reader.ReadToEnd();
+                });
+            IngestKustoImageInfoCommand command = new IngestKustoImageInfoCommand(
+                Mock.Of<ILoggerService>(), kustoClientMock.Object);
+            command.Options.ImageInfoPath = imageInfoPath;
+            command.Options.Manifest = manifestPath;
+
+            command.LoadManifest();
+            await command.ExecuteAsync();
+
+            _outputHelper.WriteLine($"Expected Data: {Environment.NewLine}{expectedData}");
+            _outputHelper.WriteLine($"Actual Data: {Environment.NewLine}{ingestedData}");
+
+            kustoClientMock.Verify(o => o.IngestFromCsvStreamAsync(It.IsAny<Stream>(), It.IsAny<IngestKustoImageInfoOptions>()));
+            Assert.Equal(expectedData, ingestedData);
+        }
+
+        /// <summary>
+        /// Verifies the command will ingest syndicated tags to another repo.
+        /// </summary>
+        [Fact]
+        public async Task SyndicatedTag()
+        {
+            using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
+
+            string repo1Image1DockerfilePath = DockerfileHelper.CreateDockerfile("1.0/sdk/os", tempFolderContext);
+            Manifest manifest = CreateManifest(
+                CreateRepo("repo1",
+                    CreateImage(
+                        new Platform[]
+                        {
+                            CreatePlatform(repo1Image1DockerfilePath, new string[] { "t1", "t2", "t3" } )
+                        },
+                        productVersion: "1.0.5"))
+            );
+
+            const string syndicatedRepository = "repo2";
+            Platform platform = manifest.Repos.First().Images.First().Platforms.First();
+            platform.Tags["t1"].SyndicatedRepo = syndicatedRepository;
+            platform.Tags["t2"].SyndicatedRepo = syndicatedRepository;
+
+            string manifestPath = Path.Combine(tempFolderContext.Path, "manifest.json");
+            File.WriteAllText(manifestPath, JsonConvert.SerializeObject(manifest));
+
+            ImageArtifactDetails srcImageArtifactDetails = new ImageArtifactDetails
+            {
+                Repos =
+                {
+                    new RepoData
+                    {
+                        Repo = "repo1",
+                        Images =
+                        {
+                            new ImageData
+                            {
+                                Platforms =
+                                {
+                                    Helpers.ImageInfoHelper.CreatePlatform(
+                                        repo1Image1DockerfilePath,
+                                        created: new DateTime(2020, 4, 20, 21, 56, 58, DateTimeKind.Utc),
+                                        digest: "jkl",
+                                        simpleTags: new List<string>
+                                        {
+                                            "t1",
+                                            "t2",
+                                            "t3"
+                                        })
+                                },
+                                ProductVersion = "1.0.5"
+                            }
+                        }
+                    }
+                }
+            };
+
+            string expectedData =
+@"""jkl"",""amd64"",""Linux"",""Ubuntu 19.04"",""1.0.5"",""1.0/sdk/os/Dockerfile"",""repo1"",""2020-04-20 21:56:58""
+""jkl"",""amd64"",""Linux"",""Ubuntu 19.04"",""1.0.5"",""1.0/sdk/os/Dockerfile"",""repo2"",""2020-04-20 21:56:58""
+""t1"",""amd64"",""Linux"",""Ubuntu 19.04"",""1.0.5"",""1.0/sdk/os/Dockerfile"",""repo1"",""2020-04-20 21:56:58""
+""t1"",""amd64"",""Linux"",""Ubuntu 19.04"",""1.0.5"",""1.0/sdk/os/Dockerfile"",""repo2"",""2020-04-20 21:56:58""
+""t2"",""amd64"",""Linux"",""Ubuntu 19.04"",""1.0.5"",""1.0/sdk/os/Dockerfile"",""repo1"",""2020-04-20 21:56:58""
+""t2"",""amd64"",""Linux"",""Ubuntu 19.04"",""1.0.5"",""1.0/sdk/os/Dockerfile"",""repo2"",""2020-04-20 21:56:58""
+""t3"",""amd64"",""Linux"",""Ubuntu 19.04"",""1.0.5"",""1.0/sdk/os/Dockerfile"",""repo1"",""2020-04-20 21:56:58""";
             expectedData = expectedData.NormalizeLineEndings(Environment.NewLine).Trim();
 
             string imageInfoPath = Path.Combine(tempFolderContext.Path, "image-info.json");


### PR DESCRIPTION
Updates the manifest schema to allow each tag to be syndicated to an additional repository.  That means the tag will be published both to the repository in which it's contained as well as the repository that it's configured to be syndicated to.  This supports dotnet/dotnet-docker#2317 by allowing, for example, the `2.1` tag to be published to both the `dotnet/core/runtime` and `dotnet/runtime` repositories.

This syndicated repository only applies to the publish logic.  Images are not tagged with these syndicated repositories at build time.  Specifically, it impacts the following commands:
* `copyAcrImages`
* `ingestKustoImageInfo`
* `publishManifest`
* `waitForMcrImageIngestion`