### PR TITLE
Support custom destination tag names for syndication

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
@@ -85,10 +85,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                             TagInfo tagInfo = platformData.PlatformInfo.Tags.First(tagInfo => tagInfo.Name == tag);
                             if (tagInfo.SyndicatedRepo != null)
                             {
-                                destinationTag = TagInfo.GetFullyQualifiedName(
-                                    $"{Manifest.Registry}/{Options.RepoPrefix}{tagInfo.SyndicatedRepo}",
-                                    tag);
-                                tags.Add((sourceTag, destinationTag));
+                                foreach (string syndicatedDestinationTagName in tagInfo.SyndicatedDestinationTags)
+                                {
+                                    destinationTag = TagInfo.GetFullyQualifiedName(
+                                        $"{Manifest.Registry}/{Options.RepoPrefix}{tagInfo.SyndicatedRepo}",
+                                        syndicatedDestinationTagName);
+                                    tags.Add((sourceTag, destinationTag));
+                                }
                             }
                         }
                     }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/IngestKustoImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/IngestKustoImageInfoCommand.cs
@@ -88,8 +88,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
                             if (tag.SyndicatedRepo != null)
                             {
-                                builder.AppendLine(
-                                    FormatCsv(tag.Name, platform, image, tag.SyndicatedRepo, timestamp));
+                                foreach (string destinationTag in tag.SyndicatedDestinationTags)
+                                {
+                                    builder.AppendLine(
+                                       FormatCsv(destinationTag, platform, image, tag.SyndicatedRepo, timestamp));
+                                }
                             }
                         }
                     }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/WaitForMcrImageIngestionCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/WaitForMcrImageIngestionCommand.cs
@@ -73,16 +73,14 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 {
                     string syndicatedRepo = syndicatedTags.Key;
 
-                    string tag = syndicatedTags.First().FullyQualifiedName;
-                    tag = tag.Replace(
-                        DockerHelper.GetRepo(tag),
-                        Options.RepoPrefix + syndicatedRepo);
+                    string tag = syndicatedTags.First().SyndicatedDestinationTags.First();
+                    tag = DockerHelper.GetImageName(Manifest.Registry, Options.RepoPrefix + syndicatedRepo, tag);
                     string digest = _dockerService.GetImageDigest(tag, Options.IsDryRun);
 
                     yield return new DigestInfo(
                         DockerHelper.GetDigestSha(digest),
                         Options.RepoPrefix + syndicatedRepo,
-                        syndicatedTags.Select(tag => tag.Name));
+                        syndicatedTags.SelectMany(tag => tag.SyndicatedDestinationTags));
                 }
             }
 
@@ -103,7 +101,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     yield return new DigestInfo(
                         sha,
                         Options.RepoPrefix + syndicatedRepo,
-                        syndicatedTags.Select(tag => tag.Name));
+                        syndicatedTags.SelectMany(tag => tag.SyndicatedDestinationTags));
                 }
             }
         }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/Tag.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/Tag.cs
@@ -35,8 +35,8 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Manifest
         public TagDocumentationType DocType { get; set; }
 
         [Description(
-            "Name of repository that the tag will be syndicated to.")]
-        public string SyndicatedRepo { get; set; }
+            "Description of where the tag should be syndicated to.")]
+        public TagSyndication Syndication { get; set; }
 
         public Tag()
         {

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/TagSyndication.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/TagSyndication.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
+
+using System.ComponentModel;
+
+namespace Microsoft.DotNet.ImageBuilder.Models.Manifest
+{
+    [Description(
+        "A description of where a tag should be syndicated to."
+        )]
+    public class TagSyndication
+    {
+        [Description(
+            "Name of the repo to syndicate the tag to."
+        )]
+        public string Repo { get; set; }
+
+        [Description(
+            "List of destination tag names to syndicate the tag to."
+        )]
+        public string[] DestinationTags { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/TagInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/TagInfo.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Linq;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 
 namespace Microsoft.DotNet.ImageBuilder.ViewModel
@@ -14,6 +15,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         public Tag Model { get; private set; }
         public string Name { get; private set; }
         public string SyndicatedRepo { get; private set; }
+        public string[] SyndicatedDestinationTags { get; private set; }
 
         private TagInfo()
         {
@@ -33,7 +35,18 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             };
             tagInfo.Name = variableHelper.SubstituteValues(name, tagInfo.GetVariableValue);
             tagInfo.FullyQualifiedName = GetFullyQualifiedName(repoName, tagInfo.Name);
-            tagInfo.SyndicatedRepo = variableHelper.SubstituteValues(model.SyndicatedRepo);
+
+            if (model.Syndication != null)
+            {
+                tagInfo.SyndicatedRepo = variableHelper.SubstituteValues(model.Syndication.Repo);
+                tagInfo.SyndicatedDestinationTags = model.Syndication.DestinationTags?
+                    .Select(tag => variableHelper.SubstituteValues(tag))
+                    .ToArray();
+                if (tagInfo.SyndicatedDestinationTags is null || !tagInfo.SyndicatedDestinationTags.Any())
+                {
+                    tagInfo.SyndicatedDestinationTags = new string[] { tagInfo.Name };
+                }
+            }
 
             return tagInfo;
         }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/CopyAcrImagesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/CopyAcrImagesCommandTests.cs
@@ -257,8 +257,19 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             const string syndicatedRepo3 = "runtime3";
 
             Platform platform = manifest.Repos.First().Images.First().Platforms.First();
-            platform.Tags["tag2"].SyndicatedRepo = syndicatedRepo2;
-            platform.Tags["tag3"].SyndicatedRepo = syndicatedRepo3;
+            platform.Tags["tag2"].Syndication = new TagSyndication
+            {
+                Repo = syndicatedRepo2,
+            };
+            platform.Tags["tag3"].Syndication = new TagSyndication
+            {
+                Repo = syndicatedRepo3,
+                DestinationTags = new string[]
+                {
+                    "tag3a",
+                    "tag3b"
+                }
+            };
 
             File.WriteAllText(Path.Combine(tempFolderContext.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));
 
@@ -305,7 +316,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 $"{command.Options.RepoPrefix}{runtimeRepo.Repo}:tag2",
                 $"{command.Options.RepoPrefix}{runtimeRepo.Repo}:tag3",
                 $"{command.Options.RepoPrefix}{syndicatedRepo2}:tag2",
-                $"{command.Options.RepoPrefix}{syndicatedRepo3}:tag3"
+                $"{command.Options.RepoPrefix}{syndicatedRepo3}:tag3a",
+                $"{command.Options.RepoPrefix}{syndicatedRepo3}:tag3b"
             };
 
             foreach (string expectedTag in expectedTags)

--- a/src/Microsoft.DotNet.ImageBuilder/tests/IngestKustoImageInfoCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/IngestKustoImageInfoCommandTests.cs
@@ -196,8 +196,19 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             const string syndicatedRepository = "repo2";
             Platform platform = manifest.Repos.First().Images.First().Platforms.First();
-            platform.Tags["t1"].SyndicatedRepo = syndicatedRepository;
-            platform.Tags["t2"].SyndicatedRepo = syndicatedRepository;
+            platform.Tags["t1"].Syndication = new TagSyndication
+            {
+                Repo = syndicatedRepository
+            };
+            platform.Tags["t2"].Syndication = new TagSyndication
+            {
+                Repo = syndicatedRepository,
+                DestinationTags = new string[]
+                {
+                    "t2a",
+                    "t2b"
+                }
+            };
 
             string manifestPath = Path.Combine(tempFolderContext.Path, "manifest.json");
             File.WriteAllText(manifestPath, JsonConvert.SerializeObject(manifest));
@@ -239,7 +250,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 ""t1"",""amd64"",""Linux"",""Ubuntu 19.04"",""1.0.5"",""1.0/sdk/os/Dockerfile"",""repo1"",""2020-04-20 21:56:58""
 ""t1"",""amd64"",""Linux"",""Ubuntu 19.04"",""1.0.5"",""1.0/sdk/os/Dockerfile"",""repo2"",""2020-04-20 21:56:58""
 ""t2"",""amd64"",""Linux"",""Ubuntu 19.04"",""1.0.5"",""1.0/sdk/os/Dockerfile"",""repo1"",""2020-04-20 21:56:58""
-""t2"",""amd64"",""Linux"",""Ubuntu 19.04"",""1.0.5"",""1.0/sdk/os/Dockerfile"",""repo2"",""2020-04-20 21:56:58""
+""t2a"",""amd64"",""Linux"",""Ubuntu 19.04"",""1.0.5"",""1.0/sdk/os/Dockerfile"",""repo2"",""2020-04-20 21:56:58""
+""t2b"",""amd64"",""Linux"",""Ubuntu 19.04"",""1.0.5"",""1.0/sdk/os/Dockerfile"",""repo2"",""2020-04-20 21:56:58""
 ""t3"",""amd64"",""Linux"",""Ubuntu 19.04"",""1.0.5"",""1.0/sdk/os/Dockerfile"",""repo1"",""2020-04-20 21:56:58""";
             expectedData = expectedData.NormalizeLineEndings(Environment.NewLine).Trim();
 

--- a/src/Microsoft.DotNet.ImageBuilder/tests/PublishManifestCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/PublishManifestCommandTests.cs
@@ -193,19 +193,19 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         public async Task DuplicatePlatform()
         {
             string expectedManifest1 =
-@"image: repo1:sharedtag2
+@"image: mcr.microsoft.com/repo1:sharedtag2
 tags: [sharedtag1]
 manifests:
-- image: repo1:tag1
+- image: mcr.microsoft.com/repo1:tag1
   platform:
     architecture: amd64
     os: linux
 ";
 
             string expectedManifest2 =
-@"image: repo1:sharedtag3
+@"image: mcr.microsoft.com/repo1:sharedtag3
 manifests:
-- image: repo1:tag1
+- image: mcr.microsoft.com/repo1:tag1
   platform:
     architecture: amd64
     os: linux
@@ -321,6 +321,7 @@ manifests:
                             { "sharedtag3", new Tag() }
                         }))
             );
+            manifest.Registry = "mcr.microsoft.com";
             File.WriteAllText(command.Options.Manifest, JsonHelper.SerializeObject(manifest));
 
             command.LoadManifest();
@@ -349,7 +350,8 @@ manifests:
 ";
 
             string expectedManifest2 =
-@"image: mcr.microsoft.com/repo2:sharedtag2
+@"image: mcr.microsoft.com/repo2:sharedtag2a
+tags: [sharedtag2b]
 manifests:
 - image: mcr.microsoft.com/repo2:tag1
   platform:
@@ -442,7 +444,21 @@ manifests:
                         },
                         new Dictionary<string, Tag>
                         {
-                            { "sharedtag2", new Tag { SyndicatedRepo = syndicatedRepo2 } },
+                            {
+                                "sharedtag2",
+                                new Tag
+                                {
+                                    Syndication = new TagSyndication
+                                    {
+                                        Repo = syndicatedRepo2,
+                                        DestinationTags = new string[]
+                                        {
+                                            "sharedtag2a",
+                                            "sharedtag2b"
+                                        }
+                                    }
+                                }
+                            },
                             { "sharedtag1", new Tag() }
                         }))
             );


### PR DESCRIPTION
In order to syndicate the 2.1 and 3.1 images to the original "core" repos, we must handle the case of the `latest` tag (see https://github.com/dotnet/dotnet-docker/pull/2340#pullrequestreview-517090038).  In the new repos, 5.0 should be latest but in the original "core" repos, 3.1 should be latest.  That means we can't simply syndicate the `latest` tag with the same name.  To handle this, I've updated the manifest model to include a `destinationTags` concept for syndication that allows custom tag names to be defined for the syndicated destination.  For example, this allows the `dotnet/runtime:3.1` tag to be syndicated as both `dotnet/core/runtime:3.1` and `dotnet/core/runtime:latest` with a definition like the following:

```
"3.1": {
  "syndication": {
    "repo": "$(syndicatedRuntimeRepo)",
    "destinationTags": [
      "3.1",
      "latest"
    ]
  }
}
```