### PR TITLE
Fix MCR ingestion wait logic for syndicated tags

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/tests/WaitForMcrImageIngestionCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/WaitForMcrImageIngestionCommandTests.cs
@@ -204,8 +204,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             WaitForMcrImageIngestionCommand command = new WaitForMcrImageIngestionCommand(
                 Mock.Of<ILoggerService>(),
                 CreateMcrStatusClientFactory(tenant, clientId, clientSecret, statusClientMock.Object),
-                environmentServiceMock.Object,
-                Mock.Of<IDockerService>());
+                environmentServiceMock.Object);
 
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
 
@@ -454,8 +453,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             WaitForMcrImageIngestionCommand command = new WaitForMcrImageIngestionCommand(
                 Mock.Of<ILoggerService>(),
                 CreateMcrStatusClientFactory(tenant, clientId, clientSecret, statusClientMock.Object),
-                environmentServiceMock.Object,
-                Mock.Of<IDockerService>());
+                environmentServiceMock.Object);
 
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
 
@@ -611,8 +609,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             WaitForMcrImageIngestionCommand command = new WaitForMcrImageIngestionCommand(
                 Mock.Of<ILoggerService>(),
                 CreateMcrStatusClientFactory(tenant, clientId, clientSecret, statusClientMock.Object),
-                environmentServiceMock.Object,
-                Mock.Of<IDockerService>());
+                environmentServiceMock.Object);
 
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
 
@@ -792,8 +789,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             WaitForMcrImageIngestionCommand command = new WaitForMcrImageIngestionCommand(
                 Mock.Of<ILoggerService>(),
                 CreateMcrStatusClientFactory(tenant, clientId, clientSecret, statusClientMock.Object),
-                environmentServiceMock.Object,
-                Mock.Of<IDockerService>());
+                environmentServiceMock.Object);
 
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
 
@@ -897,8 +893,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             WaitForMcrImageIngestionCommand command = new WaitForMcrImageIngestionCommand(
                 Mock.Of<ILoggerService>(),
                 CreateMcrStatusClientFactory(tenant, clientId, clientSecret, statusClientMock.Object),
-                environmentServiceMock.Object,
-                Mock.Of<IDockerService>());
+                environmentServiceMock.Object);
 
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
 
@@ -1084,25 +1079,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             Mock<IEnvironmentService> environmentServiceMock = new Mock<IEnvironmentService>();
 
-            Mock<IDockerService> dockerServiceMock = new Mock<IDockerService>();
-            dockerServiceMock
-                .Setup(o => o.GetImageDigest($"{registry}/repo1:sharedTag1", false))
-                .Returns(repo1ManifestDigest1);
-            dockerServiceMock
-                .Setup(o => o.GetImageDigest($"{registry}/repo2:sharedTag1", false))
-                .Returns(repo2ManifestDigest1);
-            dockerServiceMock
-                .Setup(o => o.GetImageDigest($"{registry}/repo1:platformTag1", false))
-                .Returns(repo1PlatformDigest1);
-            dockerServiceMock
-                .Setup(o => o.GetImageDigest($"{registry}/repo2:platformTag1a", false))
-                .Returns(repo2PlatformDigest1);
-
             WaitForMcrImageIngestionCommand command = new WaitForMcrImageIngestionCommand(
                 Mock.Of<ILoggerService>(),
                 CreateMcrStatusClientFactory(tenant, clientId, clientSecret, statusClientMock.Object),
-                environmentServiceMock.Object,
-                dockerServiceMock.Object);
+                environmentServiceMock.Object);
 
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
 


### PR DESCRIPTION
I'm not sure what I was thinking for the logic to wait for MCR ingestion in https://github.com/dotnet/docker-tools/pull/682.  It attempts to query the image digest of a syndicated tag in order to get the SHA it needs to query MCR for.  It's completely unnecessary (and incorrect because of publishing latency) to query for it because the digest is already known.  The digest will be the same as the digest of the corresponding manifest tag pushed to the primary repo.  For example, the digest for the `dotnet/runtime:3.1` tag will be the same as the digest for the `dotnet/core/runtime:3.1` tag.  Since the digest for the `dotnet/runtime:3.1` tag is known from the image info file, there's no need to query for it.  