### PR TITLE
Update readme generation of full tags section

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsCommand.cs
@@ -121,22 +121,26 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     .Distinct();
                 foreach (string productRepo in productRepoNames)
                 {
-                    readmes.Add(GetReadMeGitObject(productRepo, Manifest.ReadmePath));
+                    readmes.Add(GetReadMeGitObject(productRepo, Manifest.ReadmePath, containsTagListing: false));
                 }
             }
 
             foreach (RepoInfo repo in Manifest.FilteredRepos)
             {
-                readmes.Add(GetReadMeGitObject(GetProductRepoName(repo), repo.ReadmePath));
+                readmes.Add(GetReadMeGitObject(GetProductRepoName(repo), repo.ReadmePath, containsTagListing: true));
             }
 
             return readmes.ToArray();
         }
 
-        private GitObject GetReadMeGitObject(string productRepoName, string readmePath)
+        private GitObject GetReadMeGitObject(string productRepoName, string readmePath, bool containsTagListing)
         {
             string updatedReadMe = File.ReadAllText(readmePath);
-            updatedReadMe = ReadmeHelper.UpdateTagsListing(updatedReadMe, McrTagsPlaceholder);
+            if (containsTagListing)
+            {
+                updatedReadMe = ReadmeHelper.UpdateTagsListing(updatedReadMe, McrTagsPlaceholder);
+            }
+            
             return GetGitObject(productRepoName, readmePath, updatedReadMe);
         }
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.11" />
     <PackageReference Include="Polly" Version="7.2.0" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.0" />
+    <PackageReference Include="Sprache" Version="2.3.1" />
     <PackageReference Include="System.CommandLine" Version="0.1.0-e170603-2" />
     <PackageReference Include="System.ComponentModel.Composition" Version="4.5.0" />
     <PackageReference Include="YamlDotNet" Version="8.0.0" />

--- a/src/Microsoft.DotNet.ImageBuilder/src/ReadmeHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ReadmeHelper.cs
@@ -2,13 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Text.RegularExpressions;
+using Sprache;
 
 namespace Microsoft.DotNet.ImageBuilder
 {
     public static class ReadmeHelper
     {
         private const string TagsSectionHeader = "# Full Tag Listing";
+        private const string EndOfGeneratedTagsMarker = "<!--End of generated tags-->";
 
         public static string UpdateTagsListing(string readme, string tagsListing)
         {
@@ -16,11 +17,22 @@ namespace Microsoft.DotNet.ImageBuilder
             tagsListing = tagsListing.NormalizeLineEndings(readme);
 
             string targetLineEnding = readme.GetLineEndingFormat();
-            tagsListing = $"{TagsSectionHeader}{targetLineEnding}{targetLineEnding}{tagsListing}{targetLineEnding}";
 
-            // Regex to find the entire tags listing section including the header.
-            Regex regex = new Regex($"^{TagsSectionHeader}\\s*", RegexOptions.Multiline);
-            return regex.Replace(readme, tagsListing);
+            Parser<string> parser =
+                from leadingContent in Parse.AnyChar.Until(Parse.String(TagsSectionHeader + targetLineEnding)).Text()
+                from tagsContent in Parse.AnyChar.Until(Parse.String(EndOfGeneratedTagsMarker + targetLineEnding)).Text()
+                from trailingContent in Parse.AnyChar.Many().Text()
+                select string.Concat(
+                    leadingContent,
+                    TagsSectionHeader,
+                    targetLineEnding,
+                    targetLineEnding,
+                    tagsListing,
+                    EndOfGeneratedTagsMarker,
+                    targetLineEnding,
+                    trailingContent);
+
+            return parser.Parse(readme);
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ReadmeHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ReadmeHelper.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.ImageBuilder
             tagsListing = $"{TagsSectionHeader}{targetLineEnding}{targetLineEnding}{tagsListing}{targetLineEnding}";
 
             // Regex to find the entire tags listing section including the header.
-            Regex regex = new Regex($"^{TagsSectionHeader}\\s*(^(?!# ).*\\s)*", RegexOptions.Multiline);
+            Regex regex = new Regex($"^{TagsSectionHeader}\\s*", RegexOptions.Multiline);
             return regex.Replace(readme, tagsListing);
         }
     }


### PR DESCRIPTION
The logic to generate the `Full Tag Listing` section in the readme aggressively replaces all content between `# Full Tag Listing` and the next header.  Because of that it's not possible to include additional content to the `Full Tag Listing` section.  It will just be overridden by the replacement logic.  I've fixed this by only replacing the `# Full Tag Listing` header and any following whitespace.