### PR TITLE
Handle non-matching tag names between manifest and image info file

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
@@ -82,8 +82,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                             string sourceTag = GetSourceTag(destinationTag);
                             tags.Add((sourceTag, destinationTag));
 
-                            TagInfo tagInfo = platformData.PlatformInfo.Tags.First(tagInfo => tagInfo.Name == tag);
-                            if (tagInfo.SyndicatedRepo != null)
+                            TagInfo tagInfo = platformData.PlatformInfo.Tags.FirstOrDefault(tagInfo => tagInfo.Name == tag);
+                            // There may not be a matching tag due to dynamic tag names. For now, we'll say that
+                            // syndication is not supported for dynamically named tags.
+                            // See https://github.com/dotnet/docker-tools/issues/686
+                            if (tagInfo?.SyndicatedRepo != null)
                             {
                                 foreach (string syndicatedDestinationTagName in tagInfo.SyndicatedDestinationTags)
                                 {


### PR DESCRIPTION
In cases where a dynamically named tag is defined in the manifest, such as with the use of `$(System:TimeStamp)`, there's likely to be discrepancies in the tag names between the manifest and the tag names defined in the image info file that was generated during the build.  The logic in `CopyAcrImagesCommand` doesn't handle this and explicitly expects there to be a matching tag name.  When it can't find one, an exception occurs.

I've updated the logic to gracefully handle this scenario by simply ignoring the fact that it couldn't find a match and not attempt to process the syndication data.  I think it's fine to say that, for now, syndication won't be supported for such dynamically named tags.  I do think this could eventually be supported with the [manifest redesign](https://github.com/dotnet/docker-tools/issues/664) by allowing tags to have statically defined identifiers.

Fixes #686