### PR TITLE
Remove common testResultsDirectory variable

### DIFF
--- a/eng/common/templates/variables/common-paths.yml
+++ b/eng/common/templates/variables/common-paths.yml
@@ -3,4 +3,3 @@ variables:
   engCommonPath: $(Build.Repository.LocalPath)/$(engCommonRelativePath)
   engPath: $(Build.Repository.LocalPath)/eng
   testScriptPath: ./tests/run-tests.ps1
-  testResultsDirectory: tests/Microsoft.DotNet.Docker.Tests/TestResults/


### PR DESCRIPTION
This variable should not be defined in the comment set of variables because the path is specific to each consuming repo.