### PR TITLE
Update PAT used for accessing dotnet-versions repo

### DIFF
--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -4,7 +4,10 @@ jobs:
 - job: Publish
   pool: ${{ parameters.pool }}
   variables:
-    imageBuilder.commonCmdArgs: >
+  - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+    - group: DotNet-AllOrgs-Darc-Pats
+  - name: imageBuilder.commonCmdArgs
+    value: >
       --manifest '$(manifest)'
       --registry-override '$(acr.server)'
       $(manifestVariables)
@@ -78,7 +81,7 @@ jobs:
       '$(dotnetDockerBot.userName)'
       '$(dotnetDockerBot.email)'
       '$(BotAccount-dotnet-docker-bot-PAT)'
-      '$(BotAccount-dotnet-docker-dnceng-code-rw)'
+      '$(dn-bot-devdiv-dnceng-rw-code-pat)'
       'dnceng'
       'internal'
       --manifest '$(manifest)'


### PR DESCRIPTION
I had originally created the `BotAccount-dotnet-docker-dnceng-code-rw` secret but I then I realized that PAT was associated with my domain account when it should be a bot.  Eng Services has an existing bot domain account that can be used for these purposes and has a PAT for it at `dn-bot-devdiv-dnceng-rw-code-pat`.