### PR TITLE
Temporarily disable publishing image info to AzDO repo

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             if (!Options.IsDryRun)
             {
                 await UpdateGitHubAsync(imageInfoContent, imageInfoPathIdentifier);
-                await UpdateAzdoAsync(imageInfoContent, imageInfoPathIdentifier);
+                //await UpdateAzdoAsync(imageInfoContent, imageInfoPathIdentifier);
             }
         }
 

--- a/src/Microsoft.DotNet.ImageBuilder/tests/PublishImageInfoCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/PublishImageInfoCommandTests.cs
@@ -405,9 +405,6 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
                 return true;
             };
-
-            azdoGitHttpClientMock.Verify(
-                o => o.CreatePushAsync(It.Is<GitPush>(push => verifyGitPush(push)), It.IsAny<Guid>()));
         }
 
         private static Mock<IAzdoGitHttpClient> GetAzdoGitHttpClient(AzdoOptions azdoOptions)


### PR DESCRIPTION
The changes made in https://github.com/dotnet/docker-tools/pull/698 aren't going to work.  While the same changes will be made to each repo, the way in which the changes are made will result in different commit SHAs.  This will then break the code-mirror pipeline that runs when attempting to mirror the changes from GitHub to AzDO.  The changes need to have identical commit SHAs in order for the code mirroring to execute successfully.

I'm temporarily disabling this functionality until a new implementation can be made.