### PR TITLE
Fix manifest publish for syndicated tags

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/tests/PublishManifestCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/PublishManifestCommandTests.cs
@@ -353,7 +353,7 @@ manifests:
 @"image: mcr.microsoft.com/repo2:sharedtag2a
 tags: [sharedtag2b]
 manifests:
-- image: mcr.microsoft.com/repo2:tag1
+- image: mcr.microsoft.com/repo2:tag2
   platform:
     architecture: amd64
     os: linux
@@ -430,17 +430,14 @@ manifests:
 
             const string syndicatedRepo2 = "repo2";
 
+            Platform platform;
+
             Manifest manifest = CreateManifest(
                 CreateRepo("repo",
                     CreateImage(
                         new Platform[]
                         {
-                            CreatePlatform(dockerfile,
-                                new string[]
-                                {
-                                    "tag1",
-                                    "tag2"
-                                })
+                            platform = CreatePlatform(dockerfile, Array.Empty<string>())
                         },
                         new Dictionary<string, Tag>
                         {
@@ -464,6 +461,22 @@ manifests:
             );
 
             manifest.Registry = "mcr.microsoft.com";
+            platform.Tags = new Dictionary<string, Tag>
+            {
+                { "tag1", new Tag() },
+                { "tag2", new Tag
+                    {
+                        Syndication = new TagSyndication
+                        {
+                            Repo = syndicatedRepo2,
+                            DestinationTags = new string[]
+                            {
+                                "tag2"
+                            }
+                        }
+                    }
+                },
+            };
 
             File.WriteAllText(command.Options.Manifest, JsonHelper.SerializeObject(manifest));
 


### PR DESCRIPTION
Manifest publishing doesn't correctly handle the new changes related to https://github.com/dotnet/dotnet-docker/pull/2405.  It ends up producing a manifest like the following in order to syndicate images to the old "core" repos.:

```
image: dotnetdocker.azurecr.io/public/dotnet/core-nightly/aspnet:3.1.10
tags: [3.1,latest]
manifests:
- image: dotnetdocker.azurecr.io/public/dotnet/core-nightly/aspnet:3.1.10-buster-slim
  platform:
    architecture: amd64
    os: linux
- image: dotnetdocker.azurecr.io/public/dotnet/core-nightly/aspnet:3.1.10-buster-slim-arm32v7
  platform:
    architecture: arm
    os: linux
    variant: v7
- image: dotnetdocker.azurecr.io/public/dotnet/core-nightly/aspnet:3.1.10-buster-slim-arm64v8
  platform:
    architecture: arm64
    os: linux
    variant: v8
- image: dotnetdocker.azurecr.io/public/dotnet/core-nightly/aspnet:3.1.10-nanoserver-1809
  platform:
    architecture: amd64
    os: windows
- image: dotnetdocker.azurecr.io/public/dotnet/core-nightly/aspnet:3.1.10-nanoserver-1903
  platform:
    architecture: amd64
    os: windows
- image: dotnetdocker.azurecr.io/public/dotnet/core-nightly/aspnet:3.1.10-nanoserver-1909
  platform:
    architecture: amd64
    os: windows
- image: dotnetdocker.azurecr.io/public/dotnet/core-nightly/aspnet:3.1.10-nanoserver-2004
  platform:
    architecture: amd64
    os: windows
- image: dotnetdocker.azurecr.io/public/dotnet/core-nightly/aspnet:3.1.10-nanoserver-20H2
```

The last line is incorrect.  It should be `2009`, not `20H2`.  It does this because 20H2 is the first tag listed in the tags array.  The logic just grabs the first one.  Instead, it should find the tag that matches the syndication target.