### PR TITLE
Publish image info to AzDO dotnet-versions repo

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GitOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GitOptions.cs
@@ -7,7 +7,7 @@ using Microsoft.DotNet.VersionTools.Automation;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
-    public class GitOptions : IGitFileRef
+    public class GitOptions : IGitHubFileRef
     {
         public string AuthToken { get; set; }
         public string Branch { get; set; }

--- a/src/Microsoft.DotNet.ImageBuilder/src/FileHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/FileHelper.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.ImageBuilder
+{
+    public static class FileHelper
+    {
+        public static void ForceDeleteDirectory(string path)
+        {
+            // Handles read-only dirs/files by forcing them to be writable
+
+            DirectoryInfo directory = new DirectoryInfo(path)
+            {
+                Attributes = FileAttributes.Normal
+            };
+
+            Parallel.ForEach(directory.GetFileSystemInfos("*", SearchOption.AllDirectories), fileInfo =>
+            {
+                fileInfo.Attributes = FileAttributes.Normal;
+            });
+
+            directory.Delete(true);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/GitHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/GitHelper.cs
@@ -48,13 +48,13 @@ namespace Microsoft.DotNet.ImageBuilder
                 $"Unable to retrieve the latest commit SHA for {filePath}");
         }
 
-        public static Uri GetArchiveUrl(IGitBranchRef branchRef) =>
+        public static Uri GetArchiveUrl(IGitHubBranchRef branchRef) =>
             new Uri($"https://github.com/{branchRef.Owner}/{branchRef.Repo}/archive/{branchRef.Branch}.zip");
 
-        public static Uri GetBlobUrl(IGitFileRef fileRef) =>
+        public static Uri GetBlobUrl(IGitHubFileRef fileRef) =>
             new Uri($"https://github.com/{fileRef.Owner}/{fileRef.Repo}/blob/{fileRef.Branch}/{fileRef.Path}");
 
-        public static Uri GetCommitUrl(IGitRepoRef repoRef, string sha) =>
+        public static Uri GetCommitUrl(IGitHubRepoRef repoRef, string sha) =>
             new Uri($"https://github.com/{repoRef.Owner}/{repoRef.Repo}/commit/{sha}");
 
         public static async Task<GitReference> PushChangesAsync(IGitHubClient client, IGitOptionsHost options, string commitMessage, Func<GitHubBranch, Task<IEnumerable<GitObject>>> getChanges)
@@ -118,7 +118,7 @@ namespace Microsoft.DotNet.ImageBuilder
             }
         }
 
-        public static async Task<string> DownloadAndExtractGitRepoArchiveAsync(HttpClient httpClient, IGitBranchRef branchRef)
+        public static async Task<string> DownloadAndExtractGitRepoArchiveAsync(HttpClient httpClient, IGitHubBranchRef branchRef)
         {
             string uniqueName = $"{branchRef.Owner}-{branchRef.Repo}-{branchRef.Branch}";
             string extractPath = Path.Combine(Path.GetTempPath(), uniqueName);

--- a/src/Microsoft.DotNet.ImageBuilder/src/GitService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/GitService.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel.Composition;
+using LibGit2Sharp;
 
 namespace Microsoft.DotNet.ImageBuilder
 {
@@ -12,6 +13,21 @@ namespace Microsoft.DotNet.ImageBuilder
         public string GetCommitSha(string filePath, bool useFullHash = false)
         {
             return GitHelper.GetCommitSha(filePath, useFullHash);
+        }
+
+        public IRepository CloneRepository(string sourceUrl, string workdirPath, CloneOptions options)
+        {
+            Repository.Clone(sourceUrl, workdirPath, options);
+            return new Repository(workdirPath);
+        }
+
+        public void Stage(IRepository repository, string path)
+        {
+            // The Stage method is encapsulated in this service in order for it to be mockable by unit tests.
+            // Due to the Stage method's dependency on the Diff class, it prevents it from being easily used
+            // with its default implementation due to https://github.com/libgit2/libgit2sharp/issues/1856.
+
+            LibGit2Sharp.Commands.Stage(repository, path);
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/IGitHubBranchRef.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/IGitHubBranchRef.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.DotNet.ImageBuilder
 {
-    public interface IGitBranchRef : IGitRepoRef
+    public interface IGitHubBranchRef : IGitHubRepoRef
     {
         public string Branch { get; set; }
     }

--- a/src/Microsoft.DotNet.ImageBuilder/src/IGitHubFileRef.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/IGitHubFileRef.cs
@@ -4,10 +4,8 @@
 
 namespace Microsoft.DotNet.ImageBuilder
 {
-    public interface IGitRepoRef
+    public interface IGitHubFileRef : IGitHubBranchRef
     {
-        public string Owner { get; set; }
-
-        public string Repo { get; set; }
+        string Path { get; }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/IGitHubRepoRef.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/IGitHubRepoRef.cs
@@ -4,8 +4,10 @@
 
 namespace Microsoft.DotNet.ImageBuilder
 {
-    public interface IGitFileRef : IGitBranchRef
+    public interface IGitHubRepoRef
     {
-        string Path { get; }
+        public string Owner { get; set; }
+
+        public string Repo { get; set; }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/IGitService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/IGitService.cs
@@ -2,10 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using LibGit2Sharp;
+
 namespace Microsoft.DotNet.ImageBuilder
 {
     public interface IGitService
     {
         string GetCommitSha(string filePath, bool useFullHash = false);
+
+        IRepository CloneRepository(string sourceUrl, string workdirPath, CloneOptions options);
+
+        void Stage(IRepository repository, string path);
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Cottle" Version="2.0.2" />
     <PackageReference Include="GiGraph.Dot" Version="1.1.0" />
+    <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
     <PackageReference Include="Microsoft.Azure.Kusto.Ingest" Version="8.0.9" />
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.22.0" />
     <PackageReference Include="Microsoft.DotNet.VersionTools" Version="1.0.0-beta.19426.12" />

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Subscription/GitFile.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Subscription/GitFile.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.ImageBuilder.Models.Subscription
 {
-    public class GitFile : IGitFileRef
+    public class GitFile : IGitHubFileRef
     {
         [JsonProperty(Required = Required.Always)]
         public string Owner { get; set; }


### PR DESCRIPTION
Due to the issue identified by https://github.com/dotnet/docker-tools/pull/705, `PublishImageInfoCommand` has been rewritten to correctly handle pushing the same commit to two git repositories (GitHub and AzDO).  To do this, it was necessary to remove the usage of the `Microsoft.DotNet.VersionTools` library for pushing changes because that is only capable of working with GitHub.  This has been replaced with an implementation that uses `LibGit2Sharp` which clones the GitHub repo, makes the necessary changes, and pushes that single commit to both the GitHub and AzDO repositories.  This ensures the same commit SHA exists between the two repositories, allowing code mirroring to not be interfered with.

Fixes #642