### PR TITLE
Fix runtime-deps sharing

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -254,7 +254,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private bool CheckForCachedImage(
             ImageData? srcImageData, RepoInfo repo, PlatformInfo platform, IEnumerable<string> allTags, PlatformData? platformData)
         {
-            PlatformData? srcPlatformData = srcImageData?.Platforms.FirstOrDefault(srcPlatform => srcPlatform.Equals(platform));
+            PlatformData? srcPlatformData = srcImageData?.Platforms.FirstOrDefault(srcPlatform => srcPlatform.PlatformInfo == platform);
 
             string cacheKey = GetBuildCacheKey(platform);
             if (platformData != null && _cachedDockerfilePaths.TryGetValue(cacheKey, out BuildCacheInfo? cacheInfo))

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
@@ -73,7 +73,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 {
                     PlatformData platformData = repoData.Images
                         .SelectMany(image => image.Platforms)
-                        .FirstOrDefault(platformData => platformData.Equals(platform));
+                        .FirstOrDefault(platformData => platformData.PlatformInfo == platform);
                     if (platformData != null)
                     {
                         foreach (string tag in platformData.SimpleTags)

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
@@ -155,7 +155,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             foreach (ImageData imageData in repoData.Images)
             {
                 PlatformData platformData = imageData.Platforms
-                    .FirstOrDefault(platformData => platformData.Equals(platform));
+                    .FirstOrDefault(platformData => platformData.PlatformInfo == platform);
                 if (platformData != null)
                 {
                     foundImageInfo = true;

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
@@ -198,7 +198,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     {
                         PlatformData platformData = imageData.Platforms[platformIndex];
                         PlatformInfo manifestPlatform = manifestImage.AllPlatforms
-                            .FirstOrDefault(manifestPlatform => platformData.Equals(manifestPlatform));
+                            .FirstOrDefault(manifestPlatform => platformData.PlatformInfo == manifestPlatform);
 
                         // If there doesn't exist a matching platform in the manifest, remove it from the image info
                         if (manifestPlatform is null)

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/TrimUnchangedPlatformsCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/TrimUnchangedPlatformsCommand.cs
@@ -51,7 +51,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         PlatformData platform = image.Platforms[i];
                         if (platform.IsUnchanged)
                         {
-                            _loggerService.WriteMessage($"Removing unchanged platform '{platform.GetIdentifier()}'");
+                            // Exclude the ProductVersion from the identifier because it requires the ImageInfo to be set on the platform.
+                            // But it's not set because we haven't used ImageInfoHelper to load it, we've just deserialized it directly.
+                            // Using ImageInfoHelper requires having the manifest but that seems unnecessary since it's not needed for the logic
+                            // of this command other than this simple logging statement.
+                            _loggerService.WriteMessage($"Removing unchanged platform '{platform.GetIdentifier(excludeProductVersion: true)}'");
                             image.Platforms.Remove(platform);
                         }
                     }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
@@ -38,9 +38,7 @@ namespace Microsoft.DotNet.ImageBuilder
                         foreach (ImageInfo manifestImage in manifestRepo.AllImages)
                         {
                             PlatformInfo matchingManifestPlatform = manifestImage.AllPlatforms
-                                .FirstOrDefault(platform =>
-                                    platformData.Equals(platform) &&
-                                    AreProductVersionsEquivalent(imageData.ProductVersion, manifestImage.ProductVersion));
+                                .FirstOrDefault(platform => ArePlatformsEqual(platformData, imageData, platform, manifestImage));
                             if (matchingManifestPlatform != null)
                             {
                                 if (imageData.ManifestImage is null)
@@ -81,6 +79,13 @@ namespace Microsoft.DotNet.ImageBuilder
 
             MergeData(src, target, options);
         }
+
+        private static bool ArePlatformsEqual(PlatformData platformData, ImageData imageData, PlatformInfo platform, ImageInfo manifestImage) =>
+            // We can't use PlatformData.CompareTo here because it relies on having its PlatformInfo and ImageInfo values fully populated
+            // which is what this class is trying to make happen.
+            platformData.GetIdentifier(excludeProductVersion: true) ==
+                PlatformData.FromPlatformInfo(platform, manifestImage).GetIdentifier(excludeProductVersion: true) &&
+            AreProductVersionsEquivalent(imageData.ProductVersion, manifestImage.ProductVersion);
 
         private static bool AreProductVersionsEquivalent(string productVersion1, string productVersion2)
         {

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/PlatformData.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/PlatformData.cs
@@ -79,10 +79,10 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Image
             return GetIdentifier().CompareTo(other.GetIdentifier());
         }
 
-        public bool Equals(PlatformInfo platformInfo) =>
-            CompareTo(FromPlatformInfo(platformInfo, null)) == 0;
-
-        public string GetIdentifier() => $"{Dockerfile}-{Architecture}-{OsType}-{OsVersion}";
+        // Product versions are considered equivalent if the major and minor segments are the same
+        // See https://github.com/dotnet/docker-tools/issues/688
+        public string GetIdentifier(bool excludeProductVersion = false) =>
+            $"{Dockerfile}-{Architecture}-{OsType}-{OsVersion}{(excludeProductVersion ? "" : "-" + new Version(ImageInfo.ProductVersion).ToString(2))}";
 
         public static PlatformData FromPlatformInfo(PlatformInfo platform, ImageInfo image) =>
             new PlatformData(image, platform)

--- a/src/Microsoft.DotNet.ImageBuilder/tests/ImageInfoHelperTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/ImageInfoHelperTests.cs
@@ -202,9 +202,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     new PlatformData
                                     {
                                         Dockerfile = "image1",
-                                        Digest = "digest"
+                                        Digest = "digest",
+                                        ImageInfo = imageInfo1
                                     }
-                                }
+                                },
+                                ProductVersion = "1.0"
                             }
                         }
                     }
@@ -227,9 +229,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                 {
                                     new PlatformData
                                     {
-                                        Dockerfile = "image1"
+                                        Dockerfile = "image1",
+                                        ImageInfo = imageInfo1
                                     }
-                                }
+                                },
+                                ProductVersion = "1.0"
                             }
                         }
                     }
@@ -310,16 +314,19 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         {
                                             Dockerfile = "image1",
                                             BaseImageDigest = "base1digest-NEW",
-                                            Created = newCreatedDate
+                                            Created = newCreatedDate,
+                                            ImageInfo = imageInfo1
                                         }
                                     },
                                     {
                                         repo2Image3  = new PlatformData
                                         {
-                                            Dockerfile = "image3"
+                                            Dockerfile = "image3",
+                                            ImageInfo = imageInfo1
                                         }
                                     }
-                                }
+                                },
+                                ProductVersion = "1.0"
                             }
                         }
                     },
@@ -336,10 +343,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     {
                                         repo3Image1 = new PlatformData
                                         {
-                                            Dockerfile = "image1"
+                                            Dockerfile = "image1",
+                                            ImageInfo = imageInfo2
                                         }
                                     }
-                                }
+                                },
+                                ProductVersion = "1.0"
                             }
                         }
                     },
@@ -372,16 +381,19 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     {
                                         Dockerfile = "image1",
                                         BaseImageDigest = "base1digest",
-                                        Created = oldCreatedDate
+                                        Created = oldCreatedDate,
+                                        ImageInfo = imageInfo1
                                     },
                                     {
                                         repo2Image2 = new PlatformData
                                         {
                                             Dockerfile = "image2",
-                                            BaseImageDigest = "base2digest"
+                                            BaseImageDigest = "base2digest",
+                                            ImageInfo = imageInfo1
                                         }
                                     }
-                                }
+                                },
+                                ProductVersion = "1.0"
                             }
                         }
                     },
@@ -414,7 +426,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     repo2Image1,
                                     repo2Image2,
                                     repo2Image3
-                                }
+                                },
+                                ProductVersion = "1.0"
                             }
                         }
                     },
@@ -428,7 +441,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                 Platforms =
                                 {
                                     repo3Image1
-                                }
+                                },
+                                ProductVersion = "1.0"
                             }
                         }
                     },
@@ -475,7 +489,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                             {
                                                 "tag1",
                                                 "tag3"
-                                            }
+                                            },
+                                            ImageInfo = imageInfo1
                                         }
                                     }
                                 },
@@ -486,7 +501,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         "shared1",
                                         "shared2"
                                     }
-                                }
+                                },
+                                ProductVersion = "1.0"
                             }
                         }
                     }
@@ -515,7 +531,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                             "tag1",
                                             "tag2",
                                             "tag4"
-                                        }
+                                        },
+                                        ImageInfo = imageInfo1
                                     },
                                     {
                                         targetImage2 = new PlatformData
@@ -524,7 +541,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                             SimpleTags =
                                             {
                                                 "a"
-                                            }
+                                            },
+                                            ImageInfo = imageInfo1
                                         }
                                     }
                                 },
@@ -535,7 +553,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         "shared2",
                                         "shared3"
                                     }
-                                }
+                                },
+                                ProductVersion = "1.0"
                             }
                         }
                     }
@@ -578,7 +597,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         "shared2",
                                         "shared3"
                                     }
-                                }
+                                },
+                                ProductVersion = "1.0"
                             }
                         }
                     }
@@ -623,7 +643,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                             {
                                                 "tag3",
                                                 "tag1"
-                                            }
+                                            },
+                                            ImageInfo = imageInfo1
                                         }
                                     }
                                 },
@@ -634,7 +655,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         "sharedtag1b",
                                         "sharedtag1a",
                                     }
-                                }
+                                },
+                                ProductVersion = "1.0"
                             }
                         }
                     }
@@ -664,7 +686,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                                 "tag1",
                                                 "tag2",
                                                 "tag4"
-                                            }
+                                            },
+                                            ImageInfo = imageInfo1
                                         }
                                     },
                                     {
@@ -674,7 +697,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                             SimpleTags =
                                             {
                                                 "a"
-                                            }
+                                            },
+                                            ImageInfo = imageInfo1
                                         }
                                     }
                                 },
@@ -684,7 +708,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     {
                                         "sharedtag2",
                                     }
-                                }
+                                },
+                                ProductVersion = "1.0"
                             }
                         }
                     }
@@ -729,7 +754,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         "sharedtag1a",
                                         "sharedtag1b",
                                     }
-                                }
+                                },
+                                ProductVersion = "1.0"
                             }
                         }
                     }
@@ -1018,9 +1044,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     new PlatformData
                                     {
                                         Dockerfile = "image1",
-                                        Digest = "digest"
+                                        Digest = "digest",
+                                        ImageInfo = imageInfo1
                                     }
-                                }
+                                },
+                                ProductVersion = "1.0"
                             }
                         }
                     }
@@ -1043,9 +1071,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                 {
                                     new PlatformData
                                     {
-                                        Dockerfile = "image1"
+                                        Dockerfile = "image1",
+                                        ImageInfo = imageInfo1
                                     }
-                                }
+                                },
+                                ProductVersion = "1.0"
                             }
                         }
                     }
@@ -1081,9 +1111,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     new PlatformData
                                     {
                                         Dockerfile = "image1",
-                                        Digest = "digest"
+                                        Digest = "digest",
+                                        ImageInfo = imageInfo1
                                     }
-                                }
+                                },
+                                ProductVersion = "1.0"
                             }
                         }
                     }
@@ -1113,9 +1145,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                 {
                                     new PlatformData
                                     {
-                                        Dockerfile = "image1"
+                                        Dockerfile = "image1",
+                                        ImageInfo = imageInfo1
                                     }
-                                }
+                                },
+                                ProductVersion = "1.0"
                             }
                         }
                     }
@@ -1131,19 +1165,18 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Assert.Equal(JsonHelper.SerializeObject(expected), JsonHelper.SerializeObject(actual));
         }
 
-        private static ImageInfo CreateImageInfo()
-        {
-            return ImageInfo.Create(
+        private static ImageInfo CreateImageInfo() =>
+            ImageInfo.Create(
                 new Image
                 {
-                    Platforms = Array.Empty<Platform>()
+                    Platforms = Array.Empty<Platform>(),
+                    ProductVersion = "1.0"
                 },
                 "fullrepo",
                 "repo",
                 new ManifestFilter(),
                 new VariableHelper(new Manifest(), Mock.Of<IManifestOptionsInfo>(), null),
                 "base");
-        }
 
         private class FakeManifestOptions : IManifestOptionsInfo
         {

--- a/src/Microsoft.DotNet.ImageBuilder/tests/MergeImageInfoFilesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/MergeImageInfoFilesCommandTests.cs
@@ -55,14 +55,16 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                                 {
                                                     "tag3"
                                                 })
-                                        }
+                                        },
+                                        ProductVersion = "1.0"
                                     },
                                     new ImageData
                                     {
                                         Platforms =
                                         {
                                             CreatePlatform(repo2Image2Dockerfile)
-                                        }
+                                        },
+                                        ProductVersion = "1.0"
                                     }
                                 }
                             },
@@ -81,7 +83,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                                 {
                                                     "tag1"
                                                 })
-                                        }
+                                        },
+                                        ProductVersion = "1.0"
                                     }
                                 }
                             }
@@ -107,7 +110,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                                     "tag1"
                                                 },
                                                 baseImageDigest: "base1hash")
-                                        }
+                                        },
+                                        ProductVersion = "1.0"
                                     },
                                     new ImageData
                                     {
@@ -119,7 +123,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                                 {
                                                     "tag2"
                                                 })
-                                        }
+                                        },
+                                        ProductVersion = "1.0"
                                     }
                                 }
                             },
@@ -142,7 +147,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                                 {
                                                     "tag2"
                                                 })
-                                        }
+                                        },
+                                        ProductVersion = "1.0"
                                     },
                                     new ImageData
                                     {
@@ -154,7 +160,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                                 {
                                                     "tag1"
                                                 })
-                                        }
+                                        },
+                                        ProductVersion = "1.0"
                                     }
                                 }
                             }
@@ -178,15 +185,31 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     CreateRepo("repo1"),
                     CreateRepo("repo2",
                         CreateImage(
-                            CreatePlatform(repo2Image1Dockerfile, new string[] { "tag1" })),
+                            new Platform[]
+                            {
+                                CreatePlatform(repo2Image1Dockerfile, new string[] { "tag1" })
+                            },
+                            productVersion: "1.0"),
                         CreateImage(
-                            CreatePlatform(repo2Image2Dockerfile, new string[] { "tag2" }))),
+                            new Platform[]
+                            {
+                                CreatePlatform(repo2Image2Dockerfile, new string[] { "tag2" })
+                            },
+                            productVersion: "1.0")),
                     CreateRepo("repo3"),
                     CreateRepo("repo4",
                         CreateImage(
-                            CreatePlatform(repo4Image2Dockerfile, new string[] { "tag1" })),
+                            new Platform[]
+                            {
+                                CreatePlatform(repo4Image2Dockerfile, new string[] { "tag1" })
+                            },
+                            productVersion: "1.0"),
                         CreateImage(
-                            CreatePlatform(repo4Image3Dockerfile, new string[] { "tag2" })))
+                            new Platform[]
+                            {
+                                CreatePlatform(repo4Image3Dockerfile, new string[] { "tag2" })
+                            },
+                            productVersion: "1.0"))
                 );
                 File.WriteAllText(Path.Combine(context.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));
 
@@ -221,7 +244,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                                 "tag3"
                                             },
                                             baseImageDigest: "base1hash")
-                                    }
+                                    },
+                                    ProductVersion = "1.0"
                                 },
                                 new ImageData
                                 {
@@ -233,7 +257,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                             {
                                                 "tag2"
                                             })
-                                    }
+                                    },
+                                    ProductVersion = "1.0"
                                 }
                             }
                         },
@@ -257,7 +282,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                                 "tag1",
                                                 "tag2"
                                             })
-                                    }
+                                    },
+                                    ProductVersion = "1.0"
                                 },
                                 new ImageData
                                 {
@@ -269,7 +295,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                             {
                                                 "tag1"
                                             })
-                                    }
+                                    },
+                                    ProductVersion = "1.0"
                                 }
                             }
                         }
@@ -332,7 +359,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                                     "tag2"
                                                 }
                                             }
-                                        }
+                                        },
+                                        ProductVersion = "1.0"
                                     },
                                     new ImageData
                                     {
@@ -350,7 +378,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                                     "tagA"
                                                 }
                                             }
-                                        }
+                                        },
+                                        ProductVersion = "1.0"
                                     }
                                 }
                             }
@@ -382,7 +411,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                                     "tag2"
                                                 }
                                             }
-                                        }
+                                        },
+                                        ProductVersion = "1.0"
                                     }
                                 }
                             }
@@ -413,7 +443,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                                     "tag1"
                                                 }
                                             }
-                                        }
+                                        },
+                                        ProductVersion = "1.0"
                                     },
                                     new ImageData
                                     {
@@ -431,7 +462,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                                     "tagB"
                                                 }
                                             }
-                                        }
+                                        },
+                                        ProductVersion = "1.0"
                                     }
                                 }
                             }
@@ -454,12 +486,24 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Manifest manifest = CreateManifest(
                     CreateRepo("repo1",
                         CreateImage(
-                            CreatePlatform(dockerfile1, new string[] { "tag1" }, osVersion: Os1, architecture: Architecture.ARM),
-                            CreatePlatform(dockerfile1, new string[] { "tag2" }, osVersion: Os1, architecture: Architecture.ARM64)),
+                            new Platform[]
+                            {
+                                CreatePlatform(dockerfile1, new string[] { "tag1" }, osVersion: Os1, architecture: Architecture.ARM),
+                                CreatePlatform(dockerfile1, new string[] { "tag2" }, osVersion: Os1, architecture: Architecture.ARM64)
+                            },
+                            productVersion: "1.0"),
                         CreateImage(
-                            CreatePlatform(dockerfile1, new string[] { "tag3" }, osVersion: Os2, architecture: Architecture.ARM)),
+                            new Platform[]
+                            {
+                                CreatePlatform(dockerfile1, new string[] { "tag3" }, osVersion: Os2, architecture: Architecture.ARM)
+                            },
+                            productVersion: "1.0"),
                         CreateImage(
-                            CreatePlatform(dockerfile2, new string[] { "tag4" }, osVersion: Os1)))
+                            new Platform[]
+                            {
+                                CreatePlatform(dockerfile2, new string[] { "tag4" }, osVersion: Os1)
+                            },
+                            productVersion: "1.0"))
                 );
                 File.WriteAllText(Path.Combine(context.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));
 
@@ -508,7 +552,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                                 "tag3"
                                             }
                                         }
-                                    }
+                                    },
+                                    ProductVersion = "1.0"
                                 },
                                 new ImageData
                                 {
@@ -527,7 +572,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                                 "tagB"
                                             }
                                         }
-                                    }
+                                    },
+                                    ProductVersion = "1.0"
                                 },
                                 new ImageData
                                 {
@@ -545,7 +591,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                                 "tag1"
                                             }
                                         }
-                                    }
+                                    },
+                                    ProductVersion = "1.0"
                                 }
                             }
                         }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/PublishImageInfoCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/PublishImageInfoCommandTests.cs
@@ -52,10 +52,18 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Manifest manifest = CreateManifest(
                     CreateRepo("repo1",
                         CreateImage(
-                            CreatePlatform(repo1Image1DockerfilePath, new string[] { "tag1" }))),
+                            new Platform[]
+                            {
+                                CreatePlatform(repo1Image1DockerfilePath, new string[] { "tag1" })
+                            },
+                            productVersion: "1.0")),
                     CreateRepo("repo2",
                         CreateImage(
-                            CreatePlatform(repo2Image2DockerfilePath, new string[] { "tag1" })))
+                            new Platform[]
+                            {
+                                CreatePlatform(repo2Image2DockerfilePath, new string[] { "tag1" })
+                            },
+                            productVersion: "2.0"))
                 );
 
                 RepoData repo2;
@@ -78,7 +86,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         {
                                             "newtag"
                                         })
-                                    }
+                                    },
+                                    ProductVersion = "1.0"
                                 }
                             }
                         },
@@ -97,7 +106,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                             {
                                                 "tag1"
                                             })
-                                        }
+                                        },
+                                        ProductVersion = "2.0"
                                     }
                                 }
                             }
@@ -126,7 +136,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                             {
                                                 "oldtag"
                                             })
-                                    }
+                                    },
+                                    ProductVersion = "1.0"
                                 }
                             }
                         }
@@ -196,7 +207,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                             {
                                                 "newtag"
                                             })
-                                    }
+                                    },
+                                    ProductVersion = "1.0"
                                 }
                             }
                         },
@@ -222,10 +234,18 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Manifest manifest = CreateManifest(
                     CreateRepo("repo1",
                         CreateImage(
-                            CreatePlatform(repo1Image1DockerfilePath, new string[0]))),
+                            new Platform[]
+                            {
+                                CreatePlatform(repo1Image1DockerfilePath, new string[0])
+                            },
+                            productVersion: "1.0")),
                     CreateRepo("repo2",
                         CreateImage(
-                            CreatePlatform(repo2Image2DockerfilePath, new string[0])))
+                            new Platform[]
+                            {
+                                CreatePlatform(repo2Image2DockerfilePath, new string[0])
+                            },
+                            productVersion: "2.0"))
                 );
                 manifest.Registry = "mcr.microsoft.com";
 
@@ -245,7 +265,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     Platforms =
                                     {
                                         Helpers.ImageInfoHelper.CreatePlatform(repo1Image1DockerfilePath)
-                                    }
+                                    },
+                                    ProductVersion = "1.0"
                                 }
                             }
                         },
@@ -260,7 +281,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         Platforms =
                                         {
                                             Helpers.ImageInfoHelper.CreatePlatform(repo2Image2DockerfilePath)
-                                        }
+                                        },
+                                        ProductVersion = "2.0"
                                     }
                                 }
                             }
@@ -285,7 +307,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     Platforms =
                                     {
                                         Helpers.ImageInfoHelper.CreatePlatform(repo1Image1DockerfilePath)
-                                    }
+                                    },
+                                    ProductVersion = "1.0"
                                 },
                                 new ImageData
                                 {
@@ -293,7 +316,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     {
                                         Helpers.ImageInfoHelper.CreatePlatform(
                                             DockerfileHelper.CreateDockerfile("1.0/runtime2/os", tempFolderContext))
-                                    }
+                                    },
+                                    ProductVersion = "1.0"
                                 }
                             }
                         },
@@ -364,7 +388,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     Platforms =
                                     {
                                         Helpers.ImageInfoHelper.CreatePlatform(repo1Image1DockerfilePath)
-                                    }
+                                    },
+                                    ProductVersion = "1.0"
                                 }
                             }
                         },


### PR DESCRIPTION
Publishing of images that share runtime-deps between different product versions is currently broken.  As an example, for the sharing of 3.1 and 5.0 runtime-deps for Focal, it results in the 3.1 images being published but not the 5.0 images.  This happens because the comparison logic of the `PlatformData` class doesn't take into account the product version of the image that it's contained within.  This leads to two different platforms (3.1 vs 5.0) as being considered equal when they are not.  Because of that `CopyAcrImagesCommand` ends up publishing runtime-deps 3.1 tags twice rather than the 3.1 tags followed by the 5.0 tags.

This has been broken since the release of 5.0.  It wasn't known at that time because of a specific scenario where this issue doesn't occur.  For the 5.0 release, the build cache trimmed out 3.1 changes but left 5.0 to be published because of the tag update.  So 5.0 runtime-deps published fine in that case.  It's the scenario where both 3.1 and 5.0 runtime-deps tags are being published that leads to the issue.