### PR TITLE
Fix platform comparison to handle duplicated platforms

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
@@ -80,12 +80,15 @@ namespace Microsoft.DotNet.ImageBuilder
             MergeData(src, target, options);
         }
 
-        private static bool ArePlatformsEqual(PlatformData platformData, ImageData imageData, PlatformInfo platform, ImageInfo manifestImage) =>
+        private static bool ArePlatformsEqual(PlatformData platformData, ImageData imageData, PlatformInfo platform, ImageInfo manifestImage)
+        {
+            PlatformData otherPlatform = PlatformData.FromPlatformInfo(platform, manifestImage);
             // We can't use PlatformData.CompareTo here because it relies on having its PlatformInfo and ImageInfo values fully populated
             // which is what this class is trying to make happen.
-            platformData.GetIdentifier(excludeProductVersion: true) ==
-                PlatformData.FromPlatformInfo(platform, manifestImage).GetIdentifier(excludeProductVersion: true) &&
-            AreProductVersionsEquivalent(imageData.ProductVersion, manifestImage.ProductVersion);
+            return !platformData.HasDifferentTagState(otherPlatform) &&
+                platformData.GetIdentifier(excludeProductVersion: true) == otherPlatform.GetIdentifier(excludeProductVersion: true) &&
+                AreProductVersionsEquivalent(imageData.ProductVersion, manifestImage.ProductVersion);
+        }
 
         private static bool AreProductVersionsEquivalent(string productVersion1, string productVersion2)
         {

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/PlatformData.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/PlatformData.cs
@@ -69,9 +69,8 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Image
                 return 1;
             }
 
-            // If either of the platforms has no simple tags while the other does have simple tags, they are not equal
-            if ((SimpleTags?.Count == 0 && other.SimpleTags?.Count > 0) ||
-                (SimpleTags?.Count > 0 && other.SimpleTags?.Count == 0))
+            
+            if (HasDifferentTagState(other))
             {
                 return 1;
             }
@@ -83,6 +82,11 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Image
         // See https://github.com/dotnet/docker-tools/issues/688
         public string GetIdentifier(bool excludeProductVersion = false) =>
             $"{Dockerfile}-{Architecture}-{OsType}-{OsVersion}{(excludeProductVersion ? "" : "-" + GetMajorMinorVersion())}";
+
+        public bool HasDifferentTagState(PlatformData other) =>
+            // If either of the platforms has no simple tags while the other does have simple tags, they are not equal
+            (SimpleTags?.Count == 0 && other.SimpleTags?.Count > 0) ||
+            (SimpleTags?.Count > 0 && other.SimpleTags?.Count == 0);
 
         public static PlatformData FromPlatformInfo(PlatformInfo platform, ImageInfo image) =>
             new PlatformData(image, platform)
@@ -96,6 +100,11 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Image
 
         private string GetMajorMinorVersion()
         {
+            if (ImageInfo is null)
+            {
+                return null;
+            }
+
             string fullVersion = ImageInfo.ProductVersion;
 
             // Remove any version suffix (like "-preview")


### PR DESCRIPTION
`ImageInfoHelper` was incorrectly setting the `ImageInfo` state on `ImageData` objects in cases of duplicated platforms (where a platform is defined multiple times but in different images).