### PR TITLE
Remove pipeline support for Windows Server 1903

### DIFF
--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -96,20 +96,6 @@ stages:
       noCache: ${{ parameters.noCache }}
   - template: ../jobs/build-images.yml
     parameters:
-      name: Windows1903_amd64
-      pool:
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: DotNetCore-Docker-Public
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: DotNetCore-Docker
-        demands: VSTS_OS -equals Windows_Server_2019_Data_Center_1903
-      matrix: dependencies.GenerateBuildMatrix.outputs['matrix.Windows1903Amd64']
-      dockerClientOS: windows
-      buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
-      customInitSteps: ${{ parameters.customBuildInitSteps }}
-      noCache: ${{ parameters.noCache }}
-  - template: ../jobs/build-images.yml
-    parameters:
       name: Windows1909_amd64
       pool:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
@@ -230,14 +216,6 @@ stages:
           name: DotNetCore-Docker
           demands: VSTS_OS -equals Windows_Server_2019_Data_Center_RS5
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.Windows1809Amd64']
-        testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
-    - template: ../jobs/test-images-windows-client.yml
-      parameters:
-        name: Windows1903_amd64
-        pool:
-          name: DotNetCore-Docker
-          demands: VSTS_OS -equals Windows_Server_2019_Data_Center_1903
-        matrix: dependencies.GenerateTestMatrix.outputs['matrix.Windows1903Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
     - template: ../jobs/test-images-windows-client.yml
       parameters:

--- a/eng/pipelines/check-base-image-updates.yml
+++ b/eng/pipelines/check-base-image-updates.yml
@@ -53,10 +53,9 @@ jobs:
       staleImagePathsVariableName: linux-arm64-stale-image-paths
 
 - job: Get_Stale_Images_Windows_AMD
-  # Use the most recent Windows version so we can pull all image versions of Windows
   pool:
     name: DotNetCore-Docker
-    demands: VSTS_OS -equals Windows_Server_2019_Data_Center_1903
+    demands: VSTS_OS -equals Windows_Server_2019_Data_Center_RS5
   steps:
   - template: templates/steps/get-stale-images.yml
     parameters:


### PR DESCRIPTION
For check-base-image-updates.yml, I decided to replace 1903 with 2019 LTSC instead of 20H2 because 2019 LTSC will be around a lot longer and not require updating for a long time.  It doesn't matter what version the agent pool is anymore because we no longer pull images, only use the manifest tool.