### PR TITLE
Upgrade ImageBuilder to .NET 5

### DIFF
--- a/eng/file-pusher/Dockerfile
+++ b/eng/file-pusher/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile is intended to be built at the root of the repo.
 
 # build image
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1-alpine AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine AS build-env
 
 WORKDIR /file-pusher
 
@@ -16,7 +16,7 @@ RUN dotnet publish -c Release -o out --no-restore
 
 
 # runtime image
-FROM mcr.microsoft.com/dotnet/core/runtime:3.1-alpine
+FROM mcr.microsoft.com/dotnet/runtime:5.0-alpine
 
 # copy file-pusher
 WORKDIR /file-pusher

--- a/eng/file-pusher/file-pusher.csproj
+++ b/eng/file-pusher/file-pusher.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>FilePusher</RootNamespace>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.ImageBuilder/Dockerfile.linux
+++ b/src/Microsoft.DotNet.ImageBuilder/Dockerfile.linux
@@ -5,7 +5,7 @@
 ARG ALPINE_TAG_SUFFIX=""
 
 # build Microsoft.DotNet.ImageBuilder
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build-env
 
 ARG RID_ARCH=x64
 
@@ -22,7 +22,7 @@ RUN dotnet publish ./src/Microsoft.DotNet.ImageBuilder.csproj -c Release -o out 
 
 
 # build runtime image
-FROM mcr.microsoft.com/dotnet/core/runtime-deps:5.0-alpine$ALPINE_TAG_SUFFIX
+FROM mcr.microsoft.com/dotnet/runtime-deps:5.0-alpine$ALPINE_TAG_SUFFIX
 
 ARG MANIFEST_TOOL_ARCH=amd64
 

--- a/src/Microsoft.DotNet.ImageBuilder/Dockerfile.linux
+++ b/src/Microsoft.DotNet.ImageBuilder/Dockerfile.linux
@@ -5,7 +5,7 @@
 ARG ALPINE_TAG_SUFFIX=""
 
 # build Microsoft.DotNet.ImageBuilder
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build-env
+FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build-env
 
 ARG RID_ARCH=x64
 
@@ -22,7 +22,7 @@ RUN dotnet publish ./src/Microsoft.DotNet.ImageBuilder.csproj -c Release -o out 
 
 
 # build runtime image
-FROM mcr.microsoft.com/dotnet/core/runtime-deps:3.1-alpine$ALPINE_TAG_SUFFIX
+FROM mcr.microsoft.com/dotnet/core/runtime-deps:5.0-alpine$ALPINE_TAG_SUFFIX
 
 ARG MANIFEST_TOOL_ARCH=amd64
 

--- a/src/Microsoft.DotNet.ImageBuilder/Dockerfile.windows
+++ b/src/Microsoft.DotNet.ImageBuilder/Dockerfile.windows
@@ -1,7 +1,7 @@
 # escape=`
 
 # build Microsoft.DotNet.ImageBuilder
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build-env
 WORKDIR /image-builder
 
 # restore packages before copying entire source - provides optimizations when rebuilding

--- a/src/Microsoft.DotNet.ImageBuilder/Dockerfile.windows
+++ b/src/Microsoft.DotNet.ImageBuilder/Dockerfile.windows
@@ -1,7 +1,7 @@
 # escape=`
 
 # build Microsoft.DotNet.ImageBuilder
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build-env
+FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build-env
 WORKDIR /image-builder
 
 # restore packages before copying entire source - provides optimizations when rebuilding

--- a/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <PublishTrimmed>False</PublishTrimmed>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Microsoft.DotNet.ImageBuilder</RootNamespace>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.ImageBuilder/tests/Microsoft.DotNet.ImageBuilder.Tests.csproj
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/Microsoft.DotNet.ImageBuilder.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>


### PR DESCRIPTION
Image Builder tests currently fail because the infra is configured to install .NET 5.0 on the machine running the tests: https://github.com/dotnet/docker-tools/blob/fb70fa59252fa72773f248afce37d4fbb4d7cb8a/eng/common/Install-DotNetSdk.ps1#L40

But the projects are still targeting .NET Core 3.1, so this ends up with a test failure because the required runtime framework version is not available.  

Fixes #691