### PR TITLE
Set TLS version when downloading .NET install script

### DIFF
--- a/eng/common/Install-DotNetSdk.ps1
+++ b/eng/common/Install-DotNetSdk.ps1
@@ -34,6 +34,7 @@ else {
 }
 
 if (!(Test-Path $DotnetInstallScript)) {
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
     Invoke-WebRequest "https://dot.net/v1/$DotnetInstallScript" -OutFile $InstallPath/$DotnetInstallScript
 }
 


### PR DESCRIPTION
Explicitly setting the TLS version to handle running this on machines that have a minimum TLS version configured.  See https://github.com/microsoft/dotnet-framework-docker/pull/488