### PR TITLE
Fix image info publishing

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/Dockerfile.linux
+++ b/src/Microsoft.DotNet.ImageBuilder/Dockerfile.linux
@@ -14,11 +14,11 @@ WORKDIR /image-builder
 # restore packages before copying entire source - provides optimizations when rebuilding
 COPY NuGet.config ./
 COPY src/Microsoft.DotNet.ImageBuilder.csproj ./src/
-RUN dotnet restore ./src/Microsoft.DotNet.ImageBuilder.csproj
+RUN dotnet restore -r alpine.3.9-$RID_ARCH ./src/Microsoft.DotNet.ImageBuilder.csproj
 
 # copy everything else and publish
 COPY . ./
-RUN dotnet publish ./src/Microsoft.DotNet.ImageBuilder.csproj -c Release -o out -r linux-musl-$RID_ARCH /p:ShowLinkerSizeComparison=true
+RUN dotnet publish ./src/Microsoft.DotNet.ImageBuilder.csproj -c Release -o out -r alpine.3.9-$RID_ARCH --no-restore /p:ShowLinkerSizeComparison=true
 
 
 # build runtime image

--- a/src/Microsoft.DotNet.ImageBuilder/Dockerfile.windows
+++ b/src/Microsoft.DotNet.ImageBuilder/Dockerfile.windows
@@ -7,11 +7,11 @@ WORKDIR /image-builder
 # restore packages before copying entire source - provides optimizations when rebuilding
 COPY NuGet.config ./
 COPY src/Microsoft.DotNet.ImageBuilder.csproj ./src/
-RUN dotnet restore ./src/Microsoft.DotNet.ImageBuilder.csproj
+RUN dotnet restore -r win7-x64 ./src/Microsoft.DotNet.ImageBuilder.csproj
 
 # copy everything else and publish
 COPY . ./
-RUN dotnet publish ./src/Microsoft.DotNet.ImageBuilder.csproj -c Release -o out -r win7-x64
+RUN dotnet publish ./src/Microsoft.DotNet.ImageBuilder.csproj -c Release -o out -r win7-x64 --no-restore
 
 RUN pwsh -Command `
         $ErrorActionPreference = 'Stop'; `

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
@@ -77,7 +77,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             }
             finally
             {
-                FileHelper.ForceDeleteDirectory(repoPath);
+                if (Directory.Exists(repoPath))
+                {
+                    FileHelper.ForceDeleteDirectory(repoPath);
+                }
             }
 
             return Task.CompletedTask;
@@ -180,7 +183,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
                 // Since the registry name is not represented in the image info, make sure to compare the repo name with the
                 // manifest's repo model name which isn't registry-qualified.
-                RepoInfo manifestRepo = Manifest.AllRepos.FirstOrDefault(manifestRepo => manifestRepo.Name == repoData.Repo);
+                RepoInfo? manifestRepo = Manifest.AllRepos.FirstOrDefault(manifestRepo => manifestRepo.Name == repoData.Repo);
 
                 // If there doesn't exist a matching repo in the manifest, remove it from the image info
                 if (manifestRepo is null)
@@ -204,7 +207,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     for (int platformIndex = imageData.Platforms.Count - 1; platformIndex >= 0; platformIndex--)
                     {
                         PlatformData platformData = imageData.Platforms[platformIndex];
-                        PlatformInfo manifestPlatform = manifestImage.AllPlatforms
+                        PlatformInfo? manifestPlatform = manifestImage.AllPlatforms
                             .FirstOrDefault(manifestPlatform => platformData.PlatformInfo == manifestPlatform);
 
                         // If there doesn't exist a matching platform in the manifest, remove it from the image info


### PR DESCRIPTION
The `publishImageInfo` command does not work when executing Image Builder in a container.  It runs into the same problem described by https://github.com/dotnet/dotnet-docker/pull/2111.  To resolve this, the alpine rid needs to be used when publishing.

Also fixed an issue in the command itself which prevented the error being surfaced because an exception was happening in a `finally` block.