### PR TITLE
Fix help output for Image Builder

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/ImageBuilder.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ImageBuilder.cs
@@ -51,6 +51,7 @@ namespace Microsoft.DotNet.ImageBuilder
                 }
 
                 Parser parser = new CommandLineBuilder(rootCliCommand)
+                    .UseDefaults()
                     .UseMiddleware(context =>
                     {
                         if (context.ParseResult.CommandResult.Command != rootCliCommand)


### PR DESCRIPTION
This fixes the issue of the help info not being output when running Image Builder.  The problem was the configuration of `System.CommandLine.Builder.CommandLineBuilder`.  The builder is used in order to setup some middleware.  But when using a builder, you're starting from scratch and need to build up all functionality that the CLI should use, including the help.  This is easily accomplished by calling the `UseDefaults` extension method which is what is implicitly used when a CommandLineBuilder is not explicitly created.  This sets up all the functionality that we'd want, including other functionality like tab suggestion support.

Fixes #731