### PR TITLE
Refactor image-info logic to retrieve layers

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -104,10 +104,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     {
                         SetPlatformDataDigest(platform, tag.FullyQualifiedName);
                         SetPlatformDataBaseDigest(platform, platformDataByTag);
-                        SetPlatformDataLayers(platform);
                     }
 
                     SetPlatformDataCreatedDate(platform, tag.FullyQualifiedName);
+                    SetPlatformDataLayers(platform, tag.FullyQualifiedName);
                 }
 
                 if (!pushTags.Any())
@@ -169,16 +169,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             }
         }
 
-        private void SetPlatformDataLayers(PlatformData platform)
+        private void SetPlatformDataLayers(PlatformData platform, string tag)
         {
             if (platform.Layers == null || !platform.Layers.Any())
             {
-                if (platform.Digest == null)
-                {
-                    throw new InvalidOperationException($"Digest for platform '{platform.GetIdentifier()}' has not been calculated yet.");
-                }
-
-                platform.Layers = _dockerService.GetImageLayers(platform.Digest, Options.IsDryRun).ToList();
+                platform.Layers = _dockerService.GetImageLayers(tag, Options.IsDryRun).ToList();
             }
         }
 

--- a/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
@@ -75,15 +75,15 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     .Returns(baseImageDigest);
 
                 dockerServiceMock
-                    .Setup(o => o.GetImageLayers(runtimeDepsDigest, false))
+                    .Setup(o => o.GetImageLayers($"{runtimeDepsRepo}:{tag}", false))
                     .Returns(runtimeDepsLayers);
 
                 dockerServiceMock
-                    .Setup(o => o.GetImageLayers(runtimeDigest, false))
+                    .Setup(o => o.GetImageLayers($"{runtimeRepo}:{tag}", false))
                     .Returns(runtimeLayers);
 
                 dockerServiceMock
-                    .Setup(o => o.GetImageLayers(aspnetDigest, false))
+                    .Setup(o => o.GetImageLayers($"{aspnetRepo}:{tag}", false))
                     .Returns(aspnetLayers);
 
                 DateTime createdDate = DateTime.Now;
@@ -1222,9 +1222,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsLinuxDigest, $"{runtimeDeps2Repo}:{linuxTag}", false), Times.Once);
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsWindowsDigest, $"{runtimeDepsRepo}:{windowsTag}", false), Times.Once);
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsWindowsDigest, $"{runtimeDepsRepo}:shared", false), Times.Once);
-            dockerServiceMock.Verify(o => o.GetImageLayers(runtimeDepsLinuxDigest, false), Times.Once);
-            dockerServiceMock.Verify(o => o.GetImageLayers(runtimeDepsWindowsDigest, false), Times.Once);
-            dockerServiceMock.Verify(o => o.GetImageLayers(runtimeDeps2Digest, false), Times.Once);
+            dockerServiceMock.Verify(o => o.GetImageLayers($"{runtimeDepsRepo}:{linuxTag}", false), Times.Once);
+            dockerServiceMock.Verify(o => o.GetImageLayers($"{runtimeDepsRepo}:{windowsTag}", false), Times.Once);
+            dockerServiceMock.Verify(o => o.GetImageLayers($"{runtimeDeps2Repo}:{linuxTag}", false), Times.Once);
             dockerServiceMock.Verify(o => o.PushImage($"{runtimeDepsRepo}:{linuxTag}", false));
             dockerServiceMock.Verify(o => o.PushImage($"{runtimeDepsRepo}:{windowsTag}", false));
             dockerServiceMock.Verify(o => o.PushImage($"{runtimeDeps2Repo}:{linuxTag}", false));
@@ -1505,9 +1505,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             dockerServiceMock.Verify(o => o.PullImage(runtimeDepsDigest, false));
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsDigest, $"{runtimeDepsRepo}:{tag}", false));
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsDigest, $"{runtimeDeps2Repo}:{tag}", false));
-            dockerServiceMock.Verify(o => o.GetImageLayers(runtimeDepsDigest, false), Times.Once);
-            dockerServiceMock.Verify(o => o.GetImageLayers(runtimeDeps2Digest, false), Times.Once);
-            dockerServiceMock.Verify(o => o.GetImageLayers(runtimeDeps3Digest, false), Times.Once);
+            dockerServiceMock.Verify(o => o.GetImageLayers($"{runtimeDepsRepo}:{tag}", false), Times.Once);
+            dockerServiceMock.Verify(o => o.GetImageLayers($"{runtimeDeps2Repo}:{tag}", false), Times.Once);
+            dockerServiceMock.Verify(o => o.GetImageLayers($"{runtimeDeps3Repo}:{tag}", false), Times.Once);
             dockerServiceMock.Verify(o => o.PushImage($"{runtimeDepsRepo}:{tag}", false));
             dockerServiceMock.Verify(o => o.PushImage($"{runtimeDeps2Repo}:{tag}", false));
             dockerServiceMock.Verify(o => o.PushImage($"{runtimeDeps3Repo}:{tag}", false));
@@ -1722,8 +1722,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             dockerServiceMock.Verify(o => o.GetImageDigest(baseImageTag, false));
             dockerServiceMock.Verify(o => o.GetImageDigest($"{runtimeDepsRepo}:{tag}", false));
             dockerServiceMock.Verify(o => o.GetImageDigest($"{runtimeDeps2Repo}:{tag}", false));
-            dockerServiceMock.Verify(o => o.GetImageLayers(runtimeDepsDigest, false), Times.Once);
-            dockerServiceMock.Verify(o => o.GetImageLayers(runtimeDeps2Digest, false), Times.Once);
+            dockerServiceMock.Verify(o => o.GetImageLayers($"{runtimeDepsRepo}:{tag}", false), Times.Once);
+            dockerServiceMock.Verify(o => o.GetImageLayers($"{runtimeDeps2Repo}:{tag}", false), Times.Once);
             dockerServiceMock.Verify(o => o.GetCreatedDate(It.IsAny<string>(), false));
 
             dockerServiceMock.VerifyNoOtherCalls();
@@ -1910,7 +1910,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsDigest, $"{runtimeDepsRepo}:{tag}", false), Times.Once);
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsDigest, $"{runtimeDepsRepo}:{newTag}", false), Times.Once);
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsDigest, $"{runtimeDepsRepo}:shared", false), Times.Once);
-            dockerServiceMock.Verify(o => o.GetImageLayers(runtimeDepsDigest, false), Times.Once);
+            dockerServiceMock.Verify(o => o.GetImageLayers($"{runtimeDepsRepo}:{tag}", false), Times.Once);
+            dockerServiceMock.Verify(o => o.GetImageLayers($"{runtimeDepsRepo}:{newTag}", false), Times.Once);
             dockerServiceMock.Verify(o => o.PushImage($"{runtimeDepsRepo}:{tag}", false));
             dockerServiceMock.Verify(o => o.PushImage($"{runtimeDepsRepo}:{newTag}", false));
             dockerServiceMock.Verify(o => o.PushImage($"{runtimeDepsRepo}:shared", false));
@@ -2152,8 +2153,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsLinuxDigest, $"{runtimeDepsRepo}:shared", false), Times.Once);
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsLinuxDigest, $"{runtimeDeps2Repo}:{tag}", false), Times.Once);
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsLinuxDigest, $"{runtimeDeps2Repo}:{newTag}", false), Times.Once);
-            dockerServiceMock.Verify(o => o.GetImageLayers(runtimeDepsLinuxDigest, false), Times.Once);
-            dockerServiceMock.Verify(o => o.GetImageLayers(runtimeDeps2Digest, false), Times.Once);
+            dockerServiceMock.Verify(o => o.GetImageLayers($"{runtimeDepsRepo}:{tag}", false), Times.Once);
+            dockerServiceMock.Verify(o => o.GetImageLayers($"{runtimeDeps2Repo}:{tag}", false), Times.Once);
+            dockerServiceMock.Verify(o => o.GetImageLayers($"{runtimeDeps2Repo}:{newTag}", false), Times.Once);
             dockerServiceMock.Verify(o => o.PushImage($"{runtimeDepsRepo}:{tag}", false));
             dockerServiceMock.Verify(o => o.PushImage($"{runtimeDeps2Repo}:{tag}", false));
             dockerServiceMock.Verify(o => o.PushImage($"{runtimeDeps2Repo}:{newTag}", false));


### PR DESCRIPTION
Related to #719

The original fix in https://github.com/dotnet/docker-tools/pull/729 does not work properly in our production builds.  The image digest from the image info was used to retrieve layers.  In production builds the image digest is set to the destination repo - e.g. MCR.  The local image digests are in terms of the staging repos.  To correct this, a tag must be used to retrieve the layer info.