### PR TITLE
Fix sdk install script

### DIFF
--- a/eng/common/Install-DotNetSdk.ps1
+++ b/eng/common/Install-DotNetSdk.ps1
@@ -40,12 +40,15 @@ if (!(Test-Path $DotnetInstallScript)) {
 
 $DotnetChannel = "5.0"
 
+$InstallFailed = $false
 if ($IsRunningOnUnix) {
     & chmod +x $InstallPath/$DotnetInstallScript
     & $InstallPath/$DotnetInstallScript --channel $DotnetChannel --version "latest" --install-dir $InstallPath
+    $InstallFailed = ($LASTEXITCODE -ne 0)
 }
 else {
     & $InstallPath/$DotnetInstallScript -Channel $DotnetChannel -Version "latest" -InstallDir $InstallPath
+    $InstallFailed = (-not $?)
 }
 
-if ($LASTEXITCODE -ne 0) { throw "Failed to install the .NET Core SDK" }
+if ($InstallFailed) { throw "Failed to install the .NET Core SDK" }


### PR DESCRIPTION
The SDK install script is failing on the Windows build agents. It fails with the error: `The variable '$LASTEXITCODE' cannot be retrieved because it has not been set.`.  This happens because the script has `Set-StrictMode` and apparently the built-in `LASTEXITCODE` variable isn't set.

It's not completely clear why this started happening.  It works on some build machines but fails on others. I did find that updating the build agent to latest causes the script to start failing on the same machine that it was previously working on.  So it seems related to the build agent version which could have a different version of PowerShell associated with it.

After further [reading up](https://devblogs.microsoft.com/scripting/powershell-error-handling-and-why-you-should-care/) on the `LASTEXITCODE` variable, it seems that we shouldn't be using it in the case of Windows because for Windows it ends up calling a PS script which shouldn't, in theory, affect the `LASTEXITCODE` variable.  We should be using `$?` instead to check for success or failure.  The same is not true when calling the `dotnet-install.sh` script.  For that we, should continue to check `LASTEXITCODE` since that's an external command.