### PR TITLE
Sub-options need setters

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesOptions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public string RepoName { get; set; }
         public CleanAcrImagesAction Action { get; set; }
         public int Age { get; set; }
-        public ServicePrincipalOptions ServicePrincipal { get; } = new ServicePrincipalOptions();
+        public ServicePrincipalOptions ServicePrincipal { get; set; } = new ServicePrincipalOptions();
         public string Subscription { get; set; }
         public string ResourceGroup { get; set; }
         public string RegistryName { get; set; }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyImagesOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyImagesOptions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     public class CopyImagesOptions : ManifestOptions, IFilterableOptions
     {
-        public ManifestFilterOptions FilterOptions { get; } = new ManifestFilterOptions();
+        public ManifestFilterOptions FilterOptions { get; set; } = new ManifestFilterOptions();
 
         public string ResourceGroup { get; set; } = string.Empty;
         public string Subscription { get; set; } = string.Empty;

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixOptions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     public class GenerateBuildMatrixOptions : ManifestOptions, IFilterableOptions
     {
-        public ManifestFilterOptions FilterOptions { get; } = new ManifestFilterOptions();
+        public ManifestFilterOptions FilterOptions { get; set; } = new ManifestFilterOptions();
         public MatrixType MatrixType { get; set; }
         public IEnumerable<string> CustomBuildLegGroups { get; set; } = Enumerable.Empty<string>();
         public int ProductVersionComponents { get; set; }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateDockerfilesOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateDockerfilesOptions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     public class GenerateDockerfilesOptions : GenerateArtifactsOptions, IFilterableOptions
     {
-        public ManifestFilterOptions FilterOptions { get; } = new ManifestFilterOptions();
+        public ManifestFilterOptions FilterOptions { get; set; } = new ManifestFilterOptions();
 
         public GenerateDockerfilesOptions() : base()
         {

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateImageGraphOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateImageGraphOptions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     public class GenerateImageGraphOptions : ManifestOptions, IFilterableOptions
     {
-        public ManifestFilterOptions FilterOptions { get; } = new ManifestFilterOptions();
+        public ManifestFilterOptions FilterOptions { get; set; } = new ManifestFilterOptions();
 
         public string OutputPath { get; set; } = string.Empty;
     }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetBaseImageStatusOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetBaseImageStatusOptions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     public class GetBaseImageStatusOptions : ManifestOptions, IFilterableOptions
     {
-        public ManifestFilterOptions FilterOptions { get; } = new ManifestFilterOptions();
+        public ManifestFilterOptions FilterOptions { get; set; } = new ManifestFilterOptions();
 
         public bool ContinuousMode { get; set; }
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesOptions.cs
@@ -12,9 +12,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     public class GetStaleImagesOptions : Options, IFilterableOptions, IGitOptionsHost
     {
-        public ManifestFilterOptions FilterOptions { get; } = new ManifestFilterOptions();
+        public ManifestFilterOptions FilterOptions { get; set; } = new ManifestFilterOptions();
 
-        public GitOptions GitOptions { get; } = new GitOptions();
+        public GitOptions GitOptions { get; set; } = new GitOptions();
 
         public string SubscriptionsPath { get; set; } = string.Empty;
         public string VariableName { get; set; } = string.Empty;

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ImageSizeOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ImageSizeOptions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     public abstract class ImageSizeOptions : ManifestOptions, IFilterableOptions
     {
-        public ManifestFilterOptions FilterOptions { get; } = new ManifestFilterOptions();
+        public ManifestFilterOptions FilterOptions { get; set; } = new ManifestFilterOptions();
 
         public int AllowedVariance { get; set; }
         public string BaselinePath { get; set; }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/IngestKustoImageInfoOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/IngestKustoImageInfoOptions.cs
@@ -11,11 +11,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     public class IngestKustoImageInfoOptions : ImageInfoOptions, IFilterableOptions
     {
-        public ManifestFilterOptions FilterOptions { get; } = new ManifestFilterOptions();
+        public ManifestFilterOptions FilterOptions { get; set; } = new ManifestFilterOptions();
 
         public string Cluster { get; set; } = string.Empty;
         public string Database { get; set; } = string.Empty;
-        public ServicePrincipalOptions ServicePrincipal { get; } = new ServicePrincipalOptions();
+        public ServicePrincipalOptions ServicePrincipal { get; set; } = new ServicePrincipalOptions();
         public string Table { get; set; } = string.Empty;
     }
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestOptions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     public class PublishManifestOptions : DockerRegistryOptions, IFilterableOptions
     {
-        public ManifestFilterOptions FilterOptions { get; } = new ManifestFilterOptions();
+        public ManifestFilterOptions FilterOptions { get; set; } = new ManifestFilterOptions();
 
         public string ImageInfoPath { get; set; } = string.Empty;
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsOptions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     public class PublishMcrDocsOptions : ManifestOptions, IGitOptionsHost
     {
-        public GitOptions GitOptions { get; } = new GitOptions();
+        public GitOptions GitOptions { get; set; } = new GitOptions();
 
         public string SourceRepoUrl { get; set; } = string.Empty;
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ShowImageStatsOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ShowImageStatsOptions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     public class ShowImageStatsOptions : ManifestOptions, IFilterableOptions
     {
-        public ManifestFilterOptions FilterOptions { get; } = new ManifestFilterOptions();
+        public ManifestFilterOptions FilterOptions { get; set; } = new ManifestFilterOptions();
 
         public ShowImageStatsOptions() : base()
         {

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/WaitForMcrDocIngestionOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/WaitForMcrDocIngestionOptions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         public TimeSpan RequeryDelay { get; set; }
 
-        public ServicePrincipalOptions ServicePrincipal { get; } = new ServicePrincipalOptions();
+        public ServicePrincipalOptions ServicePrincipal { get; set; } = new ServicePrincipalOptions();
     }
 
     public class WaitForMcrDocIngestionOptionsBuilder : CliOptionsBuilder

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/WaitForMcrImageIngestionOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/WaitForMcrImageIngestionOptions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         public TimeSpan RequeryDelay { get; set; }
 
-        public ServicePrincipalOptions ServicePrincipal { get; } = new ServicePrincipalOptions();
+        public ServicePrincipalOptions ServicePrincipal { get; set; } = new ServicePrincipalOptions();
     }
 
     public class WaitForMcrImageIngestionOptionsBuilder : ManifestOptionsBuilder


### PR DESCRIPTION
All the options classes that compose sub-options need to have setters defined for those properties.  Without the setter, the binding logic is unable to set them and the properties are left to their default values instead of the ones provided via command line.