### PR TITLE
Add 'main' branch to list of pipeline triggers

### DIFF
--- a/eng/pipelines/check-base-image-updates.yml
+++ b/eng/pipelines/check-base-image-updates.yml
@@ -6,6 +6,7 @@ schedules:
   displayName: Daily build
   branches:
     include:
+    - main
     - master
   always: true
 

--- a/eng/pipelines/cleanup-acr-images.yml
+++ b/eng/pipelines/cleanup-acr-images.yml
@@ -6,6 +6,7 @@ schedules:
   displayName: Nightly build
   branches:
     include:
+    - main
     - master
 
 variables:

--- a/eng/pipelines/dotnet-buildtools-image-builder-official.yml
+++ b/eng/pipelines/dotnet-buildtools-image-builder-official.yml
@@ -2,6 +2,7 @@ trigger:
   batch: true
   branches:
     include:
+    - main
     - master
   paths:
     include:

--- a/eng/pipelines/dotnet-buildtools-image-builder-pr.yml
+++ b/eng/pipelines/dotnet-buildtools-image-builder-pr.yml
@@ -1,6 +1,7 @@
 pr:
   branches:
     include:
+    - main
     - master
     - feature/*
   paths:

--- a/eng/pipelines/dotnet-docker-tools-eng-validation-pr.yml
+++ b/eng/pipelines/dotnet-docker-tools-eng-validation-pr.yml
@@ -1,6 +1,7 @@
 pr:
   branches:
     include:
+    - main
     - master
   paths:
     include:

--- a/eng/pipelines/dotnet-docker-tools-eng-validation.yml
+++ b/eng/pipelines/dotnet-docker-tools-eng-validation.yml
@@ -3,6 +3,7 @@ pr: none
 trigger:
   branches:
     include:
+    - main
     - master
   paths:
     include:

--- a/eng/pipelines/push-common-updates.yml
+++ b/eng/pipelines/push-common-updates.yml
@@ -2,6 +2,7 @@ trigger:
   batch: true
   branches:
     include:
+    - main
     - master
   paths:
     include:


### PR DESCRIPTION
This is the first stage in renaming `master` branch to `main`.  This is just adding `main` to the list of branches but doesn't remove `master` yet.

Related to https://github.com/dotnet/docker-tools/issues/742