### PR TITLE
Add main branch to list of official branches

### DIFF
--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -25,7 +25,7 @@ variables:
   value: "00:05:00"
 - name: officialBranches
   # list multiple branches as "'branch1', 'branch2', etc."
-  value: "'master'"
+  value: "'master', 'main'"
 
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNet-Docker-Common


### PR DESCRIPTION
This variable is used by all repos which now have a mix of both `master` and `main` branches.  So the list of official branches should now include both of them until all the repos have transitioned.

Related to https://github.com/dotnet/docker-tools/issues/742.