### PR TITLE
Image Builder: use Docker creds when pulling from Docker Hub

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         protected override string Description => "Builds Dockerfiles";
 
-        public override Task ExecuteAsync()
+        protected override Task ExecuteCoreAsync()
         {
             if (Options.ImageInfoOutputPath != null)
             {

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
@@ -10,9 +10,10 @@ using static Microsoft.DotNet.ImageBuilder.Commands.CliHelper;
 #nullable enable
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
-    public class BuildOptions : DockerRegistryOptions, IFilterableOptions
+    public class BuildOptions : DockerRegistryOptions, IFilterableOptions, IDockerCredsOptionsHost
     {
         public ManifestFilterOptions FilterOptions { get; set; } = new ManifestFilterOptions();
+        public DockerCredsOptions DockerCredsOptions { get; set; } = new DockerCredsOptions();
 
         public bool IsPushEnabled { get; set; }
         public bool IsRetryEnabled { get; set; }
@@ -28,9 +29,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private readonly ManifestFilterOptionsBuilder _manifestFilterOptionsBuilder =
             new ManifestFilterOptionsBuilder();
 
+        private readonly DockerCredsOptionsBuilder _dockerCredsOptionsBuilder =
+            new DockerCredsOptionsBuilder();
+
         public override IEnumerable<Option> GetCliOptions() =>
             base.GetCliOptions()
                 .Concat(_manifestFilterOptionsBuilder.GetCliOptions())
+                .Concat(_dockerCredsOptionsBuilder.GetCliOptions())
                 .Concat(
                     new Option[]
                     {
@@ -52,7 +57,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         public override IEnumerable<Argument> GetCliArguments() =>
             base.GetCliArguments()
-                .Concat(_manifestFilterOptionsBuilder.GetCliArguments());
+                .Concat(_manifestFilterOptionsBuilder.GetCliArguments())
+                .Concat(_dockerCredsOptionsBuilder.GetCliArguments());
     }
 }
 #nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesCommand.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         protected override string Description => "Removes unnecessary images from an ACR";
 
-        public override async Task ExecuteAsync()
+        protected override async Task ExecuteCoreAsync()
         {
             _repoNameFilterRegex = new Regex(ManifestFilter.GetFilterRegexPattern(Options.RepoName));
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesCommand.cs
@@ -23,7 +23,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private Regex _repoNameFilterRegex;
 
         [ImportingConstructor]
-        public CleanAcrImagesCommand(IAcrClientFactory acrClientFactory, ILoggerService loggerService)
+        public CleanAcrImagesCommand(IDockerService dockerService, IAcrClientFactory acrClientFactory, ILoggerService loggerService)
+            : base(dockerService)
         {
             _acrClientFactory = acrClientFactory ?? throw new ArgumentNullException(nameof(acrClientFactory));
             _loggerService = loggerService ?? throw new ArgumentNullException(nameof(loggerService));

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/Command.TOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/Command.TOptions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Threading.Tasks;
@@ -19,9 +20,12 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         protected abstract string Description { get; }
 
-        public Command()
+        protected IDockerService DockerService { get; }
+
+        public Command(IDockerService dockerService)
         {
             Options = new TOptions();
+            DockerService = dockerService ?? throw new ArgumentNullException(nameof(dockerService));
         }
 
         public Command GetCliCommand()
@@ -43,7 +47,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             cmd.Handler = CommandHandler.Create<TOptions>(options =>
             {
                 Initialize(options);
-                return ExecuteCoreAsync();
+                return ExecuteAsync();
+
+                
             });
 
             return cmd;
@@ -54,7 +60,26 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             Options = options;
         }
 
-        public Task ExecuteAsync() => ExecuteCoreAsync();
+        public async Task ExecuteAsync()
+        {
+            if (Options is IDockerCredsOptionsHost dockerCredsOptionsHost)
+            {
+                DockerService.IsAnonymousAccessAllowed = dockerCredsOptionsHost.DockerCredsOptions.AllowAnonymousAccess;
+
+                if (dockerCredsOptionsHost.DockerCredsOptions.DockerUsername is not null)
+                {
+                    await DockerService.ExecuteWithUserAsync(
+                        ExecuteCoreAsync,
+                        dockerCredsOptionsHost.DockerCredsOptions.DockerUsername,
+                        dockerCredsOptionsHost.DockerCredsOptions.DockerPassword,
+                        server: null,
+                        isDryRun: Options.IsDryRun);
+                    return;
+                }
+            }
+
+            await ExecuteCoreAsync();
+        }
 
         protected abstract Task ExecuteCoreAsync();
     }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/Command.TOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/Command.TOptions.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             cmd.Handler = CommandHandler.Create<TOptions>(options =>
             {
                 Initialize(options);
-                return ExecuteAsync();
+                return ExecuteCoreAsync();
             });
 
             return cmd;
@@ -54,7 +54,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             Options = options;
         }
 
-        public abstract Task ExecuteAsync();
+        public Task ExecuteAsync() => ExecuteCoreAsync();
+
+        protected abstract Task ExecuteCoreAsync();
     }
 }
 #nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
@@ -20,8 +20,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         [ImportingConstructor]
         public CopyAcrImagesCommand(
-            IAzureManagementFactory azureManagementFactory, ILoggerService loggerService)
-            : base(azureManagementFactory, loggerService)
+            IDockerService dockerService, IAzureManagementFactory azureManagementFactory, ILoggerService loggerService)
+            : base(dockerService, azureManagementFactory, loggerService)
         {
             _imageArtifactDetails = new Lazy<ImageArtifactDetails>(() =>
             {

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         protected override string Description => "Copies the platform images as specified in the manifest between repositories of an ACR";
 
-        public override async Task ExecuteAsync()
+        protected override async Task ExecuteCoreAsync()
         {
             LoggerService.WriteHeading("COPYING IMAGES");
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyDockerHubBaseImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyDockerHubBaseImagesCommand.cs
@@ -15,8 +15,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     {
         [ImportingConstructor]
         public CopyDockerHubBaseImagesCommand(
-            IAzureManagementFactory azureManagementFactory, ILoggerService loggerService)
-            : base(azureManagementFactory, loggerService)
+            IDockerService dockerService, IAzureManagementFactory azureManagementFactory, ILoggerService loggerService)
+            : base(dockerService, azureManagementFactory, loggerService)
         {
         }
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyDockerHubBaseImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyDockerHubBaseImagesCommand.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         protected override string Description => "Copies external base images from Docker Hub to ACR";
 
-        public override async Task ExecuteAsync()
+        protected override async Task ExecuteCoreAsync()
         {
             LoggerService.WriteHeading("COPYING IMAGES");
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyImagesCommand.cs
@@ -22,7 +22,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     {
         private readonly Lazy<string> _registryName;
 
-        public CopyImagesCommand(IAzureManagementFactory azureManagementFactory, ILoggerService loggerService)
+        public CopyImagesCommand(IDockerService dockerService, IAzureManagementFactory azureManagementFactory, ILoggerService loggerService)
+            : base(dockerService)
         {
             AzureManagementFactory = azureManagementFactory;
             LoggerService = loggerService;

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/DockerCredsOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/DockerCredsOptions.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.CommandLine;
+using System.Linq;
+using static Microsoft.DotNet.ImageBuilder.Commands.CliHelper;
+
+#nullable enable
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    public class DockerCredsOptions
+    {
+        public string? DockerUsername { get; set; }
+        public string? DockerPassword { get; set; }
+        public bool AllowAnonymousAccess { get; set; }
+    }
+
+    public class DockerCredsOptionsBuilder
+    {
+        public IEnumerable<Option> GetCliOptions() =>
+            new Option[]
+            {
+                CreateOption<string>("docker-user", nameof(DockerCredsOptions.DockerUsername),
+                    "Username of the Docker Hub account"),
+                CreateOption<string>("docker-password", nameof(DockerCredsOptions.DockerPassword),
+                    "Password of the Docker Hub account"),
+                CreateOption<bool>("allow-anon-docker-access", nameof(DockerCredsOptions.AllowAnonymousAccess),
+                    "Explicitly allows anonymous access to the Docker Hub registry")
+            };
+
+        public IEnumerable<Argument> GetCliArguments() => Enumerable.Empty<Argument>();
+    }
+}
+#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/DockerRegistryCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/DockerRegistryCommand.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
@@ -10,9 +11,12 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         where TOptions : DockerRegistryOptions, new()
         where TOptionsBuilder : DockerRegistryOptionsBuilder, new()
     {
-        protected void ExecuteWithUser(Action action)
+        public DockerRegistryCommand(IDockerService dockerService)
+            : base(dockerService)
         {
-            DockerHelper.ExecuteWithUser(action, Options.Username, Options.Password, Manifest.Registry, Options.IsDryRun);
         }
+
+        protected Task ExecuteWithUserAsync(Func<Task> action) =>
+            DockerService.ExecuteWithUserAsync(action, Options.Username, Options.Password, Manifest.Registry, Options.IsDryRun);
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateArtifactsCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateArtifactsCommand.cs
@@ -29,7 +29,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private readonly List<string> _invalidTemplates = new List<string>();
         private readonly List<string> _outOfSyncArtifacts = new List<string>();
 
-        protected GenerateArtifactsCommand(IEnvironmentService environmentService) : base()
+        protected GenerateArtifactsCommand(IDockerService dockerService, IEnvironmentService environmentService)
+            : base(dockerService)
         {
             _environmentService = environmentService ?? throw new ArgumentNullException(nameof(environmentService));
         }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
@@ -23,7 +23,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private static readonly char[] s_pathSeparators = { '/', '\\' };
         private static readonly Regex s_versionRegex = new Regex(@$"^(?<{VersionRegGroupName}>(\d|\.)+).*$");
 
-        public GenerateBuildMatrixCommand() : base()
+        [ImportingConstructor]
+        public GenerateBuildMatrixCommand(IDockerService dockerService)
+            : base(dockerService)
         {
             _imageArtifactDetails = new Lazy<ImageArtifactDetails>(() =>
             {

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         protected override string Description => "Generate the Azure DevOps build matrix for building the images";
 
-        public override Task ExecuteAsync()
+        protected override Task ExecuteCoreAsync()
         {
             Logger.WriteHeading("GENERATING BUILD MATRIX");
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateDockerfilesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateDockerfilesCommand.cs
@@ -17,7 +17,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     {
 
         [ImportingConstructor]
-        public GenerateDockerfilesCommand(IEnvironmentService environmentService) : base(environmentService)
+        public GenerateDockerfilesCommand(IDockerService dockerService, IEnvironmentService environmentService)
+            : base(dockerService, environmentService)
         {
         }
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateDockerfilesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateDockerfilesCommand.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         protected override string Description => "Generates the Dockerfiles from Cottle based templates (http://r3c.github.io/cottle/)";
 
-        public override async Task ExecuteAsync()
+        protected override async Task ExecuteCoreAsync()
         {
             Logger.WriteHeading("GENERATING DOCKERFILES");
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateImageGraphCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateImageGraphCommand.cs
@@ -25,7 +25,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private readonly Dictionary<string, Manifest> _imageManifestCache = new Dictionary<string, Manifest>();
         private readonly Dictionary<string, DotNode> _nodeCache = new Dictionary<string, DotNode>();
 
-        public GenerateImageGraphCommand() : base()
+        [ImportingConstructor]
+        public GenerateImageGraphCommand(IDockerService dockerService)
+            : base(dockerService)
         {
         }
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateImageGraphCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateImageGraphCommand.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         protected override string Description => "Generate a DOT (graph description language) file illustrating the image and layer hierarchy";
 
-        public override Task ExecuteAsync()
+        protected override Task ExecuteCoreAsync()
         {
             Logger.WriteHeading("GENERATING IMAGE GRAPH");
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateReadmesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateReadmesCommand.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         protected override string Description =>
             "Generates the Readmes from the Cottle based templates (http://r3c.github.io/cottle/) and updates the tag listing section";
 
-        public override async Task ExecuteAsync()
+        protected override async Task ExecuteCoreAsync()
         {
             Logger.WriteHeading("GENERATING READMES");
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateReadmesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateReadmesCommand.cs
@@ -23,7 +23,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private readonly IGitService _gitService;
 
         [ImportingConstructor]
-        public GenerateReadmesCommand(IEnvironmentService environmentService, IGitService gitService) : base(environmentService)
+        public GenerateReadmesCommand(IDockerService dockerService, IEnvironmentService environmentService, IGitService gitService)
+            : base(dockerService, environmentService)
         {
             _gitService = gitService ?? throw new ArgumentNullException(nameof(gitService));
         }
@@ -131,7 +132,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     $"FROM {McrTagsRenderingToolTag}{Environment.NewLine}COPY {tagsMetadataFileName} /tableapp/files/ ");
 
                 string renderingToolId = $"renderingtool-{DateTime.Now.ToFileTime()}";
-                DockerHelper.PullImage(McrTagsRenderingToolTag, Options.IsDryRun);
+                DockerService.PullImage(McrTagsRenderingToolTag, Options.IsDryRun);
                 ExecuteHelper.Execute(
                     "docker",
                     $"build -t {renderingToolId} -f {dockerfilePath} {tempDir}",

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetBaseImageStatusCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetBaseImageStatusCommand.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         protected override string Description => "Displays the status of the referenced external base images";
 
-        public override async Task ExecuteAsync()
+        protected override async Task ExecuteCoreAsync()
         {
             if (Options.ContinuousMode)
             {

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetBaseImageStatusCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetBaseImageStatusCommand.cs
@@ -14,13 +14,12 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     [Export(typeof(ICommand))]
     public class GetBaseImageStatusCommand : ManifestCommand<GetBaseImageStatusOptions, GetBaseImageStatusOptionsBuilder>
     {
-        private readonly IDockerService _dockerService;
         private readonly ILoggerService _loggerService;
 
         [ImportingConstructor]
         public GetBaseImageStatusCommand(IDockerService dockerService, ILoggerService loggerService)
+            : base(dockerService)
         {
-            _dockerService = dockerService ?? throw new ArgumentNullException(nameof(dockerService));
             _loggerService = loggerService ?? throw new ArgumentNullException(nameof(loggerService));
         }
 
@@ -60,7 +59,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             _loggerService.WriteHeading("PULLING LATEST BASE IMAGES");
             foreach (string imageTag in imageTags)
             {
-                _dockerService.PullImage(imageTag, Options.IsDryRun);
+                DockerService.PullImage(imageTag, Options.IsDryRun);
             }
 
             _loggerService.WriteHeading("QUERYING STATUS");
@@ -68,7 +67,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 .Select(tag => new
                 {
                     Tag = tag,
-                    DateCreated = _dockerService.GetCreatedDate(tag, Options.IsDryRun)
+                    DateCreated = DockerService.GetCreatedDate(tag, Options.IsDryRun)
                 })
                 .ToList();
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetBaseImageStatusOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetBaseImageStatusOptions.cs
@@ -11,9 +11,11 @@ using static Microsoft.DotNet.ImageBuilder.Commands.CliHelper;
 #nullable enable
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
-    public class GetBaseImageStatusOptions : ManifestOptions, IFilterableOptions
+    public class GetBaseImageStatusOptions : ManifestOptions, IFilterableOptions, IDockerCredsOptionsHost
     {
         public ManifestFilterOptions FilterOptions { get; set; } = new ManifestFilterOptions();
+
+        public DockerCredsOptions DockerCredsOptions { get; set; } = new DockerCredsOptions();
 
         public bool ContinuousMode { get; set; }
 
@@ -27,9 +29,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private readonly ManifestFilterOptionsBuilder _manifestFilterOptionsBuilder =
             new ManifestFilterOptionsBuilder();
 
+        private readonly DockerCredsOptionsBuilder _dockerCredsOptionsBuilder =
+            new DockerCredsOptionsBuilder();
+
         public override IEnumerable<Option> GetCliOptions() =>
             base.GetCliOptions()
                 .Concat(_manifestFilterOptionsBuilder.GetCliOptions())
+                .Concat(_dockerCredsOptionsBuilder.GetCliOptions())
                 .Concat(
                     new Option[]
                     {
@@ -42,7 +48,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         public override IEnumerable<Argument> GetCliArguments() =>
             base.GetCliArguments()
-                .Concat(_manifestFilterOptionsBuilder.GetCliArguments());
+                .Concat(_manifestFilterOptionsBuilder.GetCliArguments())
+                .Concat(_dockerCredsOptionsBuilder.GetCliArguments());
     }
 }
 #nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         protected override string Description => "Gets paths to images whose base images are out-of-date";
 
-        public override async Task ExecuteAsync()
+        protected override async Task ExecuteCoreAsync()
         {
             string subscriptionsJson = File.ReadAllText(Options.SubscriptionsPath);
             Subscription[] subscriptions = JsonConvert.DeserializeObject<Subscription[]>(subscriptionsJson);

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.CommandLine;
 using System.ComponentModel.Composition;
 using System.IO;
 using System.Linq;
@@ -35,10 +34,12 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         [ImportingConstructor]
         public GetStaleImagesCommand(
+            IDockerService dockerService,
             IManifestToolService manifestToolService,
             IHttpClientProvider httpClientFactory,
             ILoggerService loggerService,
             IGitHubClientFactory gitHubClientFactory)
+            : base(dockerService)
         {
             _manifestToolService = manifestToolService;
             _loggerService = loggerService;

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/IDockerCredsOptionsHost.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/IDockerCredsOptionsHost.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    public interface IDockerCredsOptionsHost
+    {
+        DockerCredsOptions DockerCredsOptions { get; }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ImageSizeCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ImageSizeCommand.cs
@@ -18,11 +18,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         where TOptionsBuilder : ImageSizeOptionsBuilder, new()
     {
         public ImageSizeCommand(IDockerService dockerService)
+            : base(dockerService)
         {
-            DockerService = dockerService ?? throw new ArgumentNullException(nameof(dockerService));
         }
-
-        protected IDockerService DockerService { get; }
 
         protected void ProcessImages(ImageHandler processImage)
         {

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ImageSizeOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ImageSizeOptions.cs
@@ -9,9 +9,11 @@ using static Microsoft.DotNet.ImageBuilder.Commands.CliHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
-    public abstract class ImageSizeOptions : ManifestOptions, IFilterableOptions
+    public abstract class ImageSizeOptions : ManifestOptions, IFilterableOptions, IDockerCredsOptionsHost
     {
         public ManifestFilterOptions FilterOptions { get; set; } = new ManifestFilterOptions();
+
+        public DockerCredsOptions DockerCredsOptions { get; set; } = new DockerCredsOptions();
 
         public int AllowedVariance { get; set; }
         public string BaselinePath { get; set; }
@@ -25,9 +27,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private readonly ManifestFilterOptionsBuilder _manifestFilterOptionsBuilder =
             new ManifestFilterOptionsBuilder();
 
+        private readonly DockerCredsOptionsBuilder _dockerCredsOptionsBuilder =
+            new DockerCredsOptionsBuilder();
+
         public override IEnumerable<Option> GetCliOptions() =>
             base.GetCliOptions()
                 .Concat(_manifestFilterOptionsBuilder.GetCliOptions())
+                .Concat(_dockerCredsOptionsBuilder.GetCliOptions())
                 .Concat(
                     new Option[]
                     {
@@ -41,6 +47,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public override IEnumerable<Argument> GetCliArguments() =>
             base.GetCliArguments()
                 .Concat(_manifestFilterOptionsBuilder.GetCliArguments())
+                .Concat(_dockerCredsOptionsBuilder.GetCliArguments())
                 .Concat(
                     new Argument[]
                     {

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/IngestKustoImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/IngestKustoImageInfoCommand.cs
@@ -23,7 +23,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private readonly ILoggerService _loggerService;
 
         [ImportingConstructor]
-        public IngestKustoImageInfoCommand(ILoggerService loggerService, IKustoClient kustoClient)
+        public IngestKustoImageInfoCommand(IDockerService dockerService, ILoggerService loggerService, IKustoClient kustoClient)
+            : base(dockerService)
         {
             _loggerService = loggerService ?? throw new ArgumentNullException(nameof(loggerService));
             _kustoClient = kustoClient ?? throw new ArgumentNullException(nameof(kustoClient));

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/IngestKustoImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/IngestKustoImageInfoCommand.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         protected override string Description => "Ingests image info data into Kusto";
 
-        public override async Task ExecuteAsync()
+        protected override async Task ExecuteCoreAsync()
         {
             _loggerService.WriteHeading("INGESTING IMAGE INFO DATA INTO KUSTO");
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestCommand.cs
@@ -10,6 +10,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         where TOptions : ManifestOptions, new()
         where TOptionsBuilder : ManifestOptionsBuilder, new()
     {
+        public ManifestCommand(IDockerService dockerService)
+            : base(dockerService)
+        {
+        }
+
         public ManifestInfo Manifest { get; private set; }
 
         public void LoadManifest()

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/MergeImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/MergeImageInfoCommand.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     {
         protected override string Description => "Merges the content of multiple image info files into one file";
 
-        public override Task ExecuteAsync()
+        protected override Task ExecuteCoreAsync()
         {
             IEnumerable<string> imageInfoFiles = Directory.EnumerateFiles(
                 Options.SourceImageInfoFolderPath,

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/MergeImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/MergeImageInfoCommand.cs
@@ -17,6 +17,12 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     {
         protected override string Description => "Merges the content of multiple image info files into one file";
 
+        [ImportingConstructor]
+        public MergeImageInfoCommand(IDockerService dockerService)
+            : base(dockerService)
+        {
+        }
+
         protected override Task ExecuteCoreAsync()
         {
             IEnumerable<string> imageInfoFiles = Directory.EnumerateFiles(

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         protected override string Description => "Publishes a build's merged image info.";
 
-        public override Task ExecuteAsync()
+        protected override Task ExecuteCoreAsync()
         {
             if (Options.AzdoOptions.AzdoPath != Options.GitOptions.Path)
             {

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
@@ -22,7 +22,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private const string CommitMessage = "Merging Docker image info updates from build";
 
         [ImportingConstructor]
-        public PublishImageInfoCommand(IGitService gitService, ILoggerService loggerService)
+        public PublishImageInfoCommand(IDockerService dockerService, IGitService gitService, ILoggerService loggerService)
+            : base(dockerService)
         {
             _gitService = gitService ?? throw new ArgumentNullException(nameof(gitService));
             _loggerService = loggerService ?? throw new ArgumentNullException(nameof(loggerService));

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestCommand.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         protected override string Description => "Creates and publishes the manifest to the Docker Registry";
 
-        public override Task ExecuteAsync()
+        protected override Task ExecuteCoreAsync()
         {
             _loggerService.WriteHeading("GENERATING MANIFESTS");
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsCommand.cs
@@ -24,8 +24,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private readonly ILoggerService _loggerService;
 
         [ImportingConstructor]
-        public PublishMcrDocsCommand(IGitService gitService, IGitHubClientFactory gitHubClientFactory,
-            ILoggerService loggerService) : base()
+        public PublishMcrDocsCommand(IDockerService dockerService, IGitService gitService, IGitHubClientFactory gitHubClientFactory,
+            ILoggerService loggerService)
+            : base(dockerService)
         {
             _gitService = gitService ?? throw new ArgumentNullException(nameof(gitService));
             _gitHubClientFactory = gitHubClientFactory ?? throw new ArgumentNullException(nameof(gitHubClientFactory));

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsCommand.cs
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         protected override string Description => "Publishes the readmes to MCR";
 
-        public override async Task ExecuteAsync()
+        protected override async Task ExecuteCoreAsync()
         {
             _loggerService.WriteHeading("PUBLISHING MCR DOCS");
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/QueueBuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/QueueBuildCommand.cs
@@ -35,7 +35,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         protected override string Description => "Queues builds to update images";
 
-        public override async Task ExecuteAsync()
+        protected override async Task ExecuteCoreAsync()
         {
             string subscriptionsJson = File.ReadAllText(Options.SubscriptionsPath);
             Subscription[] subscriptions = JsonConvert.DeserializeObject<Subscription[]>(subscriptionsJson);

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/QueueBuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/QueueBuildCommand.cs
@@ -26,8 +26,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         [ImportingConstructor]
         public QueueBuildCommand(
+            IDockerService dockerService,
             IVssConnectionFactory connectionFactory,
             ILoggerService loggerService)
+            : base(dockerService)
         {
             _connectionFactory = connectionFactory;
             _loggerService = loggerService;

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ShowImageStatsCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ShowImageStatsCommand.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         protected override string Description => "Displays statistics about the number of images";
 
-        public override Task ExecuteAsync()
+        protected override Task ExecuteCoreAsync()
         {
             Logger.WriteHeading("IMAGE STATISTICS");
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ShowImageStatsCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ShowImageStatsCommand.cs
@@ -15,7 +15,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     [Export(typeof(ICommand))]
     public class ShowImageStatsCommand : ManifestCommand<ShowImageStatsOptions, ShowImageStatsOptionsBuilder>
     {
-        public ShowImageStatsCommand() : base()
+        [ImportingConstructor]
+        public ShowImageStatsCommand(IDockerService dockerService)
+            : base(dockerService)
         {
         }
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ShowManifestSchemaCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ShowManifestSchemaCommand.cs
@@ -24,7 +24,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         protected override string Description => "Outputs manifest file schema";
 
-        public override Task ExecuteAsync()
+        protected override Task ExecuteCoreAsync()
         {
             JSchemaGenerator generator = new JSchemaGenerator
             {

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ShowManifestSchemaCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ShowManifestSchemaCommand.cs
@@ -17,7 +17,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private readonly ILoggerService _loggerService;
 
         [ImportingConstructor]
-        public ShowManifestSchemaCommand(ILoggerService loggerService)
+        public ShowManifestSchemaCommand(IDockerService dockerService, ILoggerService loggerService)
+            : base(dockerService)
         {
             _loggerService = loggerService;
         }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/TrimUnchangedPlatformsCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/TrimUnchangedPlatformsCommand.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         protected override string Description => "Trims platforms marked as unchanged from the image info file";
 
-        public override async Task ExecuteAsync()
+        protected override async Task ExecuteCoreAsync()
         {
             _loggerService.WriteHeading("TRIMMING UNCHANGED PLATFORMS");
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/TrimUnchangedPlatformsCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/TrimUnchangedPlatformsCommand.cs
@@ -18,7 +18,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private readonly ILoggerService _loggerService;
 
         [ImportingConstructor]
-        public TrimUnchangedPlatformsCommand(ILoggerService loggerService)
+        public TrimUnchangedPlatformsCommand(IDockerService dockerService, ILoggerService loggerService)
+            : base(dockerService)
         {
             _loggerService = loggerService ?? throw new ArgumentNullException(nameof(loggerService));
         }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/UpdateImageSizeBaselineCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/UpdateImageSizeBaselineCommand.cs
@@ -24,7 +24,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         protected override string Description => "Updates an image size baseline file with current image sizes";
 
-        public override Task ExecuteAsync()
+        protected override Task ExecuteCoreAsync()
         {
             UpdateBaseline();
             return Task.CompletedTask;

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ValidateImageSizeCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ValidateImageSizeCommand.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         public ImageSizeValidationResults ValidationResults { get; private set; }
 
-        public override Task ExecuteAsync()
+        protected override Task ExecuteCoreAsync()
         {
             ValidationResults = ValidateImages();
             LogResults(ValidationResults);

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/WaitForMcrDocIngestionCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/WaitForMcrDocIngestionCommand.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         protected override string Description => "Waits for docs to complete ingestion into Docker Hub";
 
-        public override async Task ExecuteAsync()
+        protected override async Task ExecuteCoreAsync()
         {
             _loggerService.WriteHeading("QUERYING COMMIT RESULT");
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/WaitForMcrDocIngestionCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/WaitForMcrDocIngestionCommand.cs
@@ -20,7 +20,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         [ImportingConstructor]
         public WaitForMcrDocIngestionCommand(
-            ILoggerService loggerService, IMcrStatusClientFactory mcrStatusClientFactory, IEnvironmentService environmentService)
+            IDockerService dockerService, ILoggerService loggerService, IMcrStatusClientFactory mcrStatusClientFactory,
+            IEnvironmentService environmentService)
+            : base(dockerService)
         {
             _loggerService = loggerService ?? throw new ArgumentNullException(nameof(loggerService));
             _mcrStatusClientFactory = mcrStatusClientFactory ?? throw new ArgumentNullException(nameof(mcrStatusClientFactory));

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/WaitForMcrImageIngestionCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/WaitForMcrImageIngestionCommand.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         protected override string Description => "Waits for images to complete ingestion into MCR";
 
-        public override async Task ExecuteAsync()
+        protected override async Task ExecuteCoreAsync()
         {
             _loggerService.WriteHeading("WAITING FOR IMAGE INGESTION");
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/WaitForMcrImageIngestionCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/WaitForMcrImageIngestionCommand.cs
@@ -23,7 +23,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         [ImportingConstructor]
         public WaitForMcrImageIngestionCommand(
-            ILoggerService loggerService, IMcrStatusClientFactory mcrStatusClientFactory, IEnvironmentService environmentService)
+            IDockerService dockerService, ILoggerService loggerService, IMcrStatusClientFactory mcrStatusClientFactory,
+            IEnvironmentService environmentService)
+            : base(dockerService)
         {
             _loggerService = loggerService ?? throw new ArgumentNullException(nameof(loggerService));
             _mcrStatusClientFactory = mcrStatusClientFactory ?? throw new ArgumentNullException(nameof(mcrStatusClientFactory));

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerServiceCache.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerServiceCache.cs
@@ -7,6 +7,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 
+#nullable enable
 namespace Microsoft.DotNet.ImageBuilder
 {
     /// <summary>
@@ -30,6 +31,12 @@ namespace Microsoft.DotNet.ImageBuilder
 
         public Architecture Architecture => _inner.Architecture;
 
+        public bool IsAnonymousAccessAllowed
+        {
+            get => _inner.IsAnonymousAccessAllowed;
+            set => _inner.IsAnonymousAccessAllowed = value;
+        }
+
         public string BuildImage(string dockerfilePath, string buildContextPath, IEnumerable<string> tags, IDictionary<string, string> buildArgs, bool isRetryEnabled, bool isDryRun) =>
             _inner.BuildImage(dockerfilePath, buildContextPath, tags, buildArgs, isRetryEnabled, isDryRun);
 
@@ -50,7 +57,13 @@ namespace Microsoft.DotNet.ImageBuilder
         
         public bool LocalImageExists(string tag, bool isDryRun) =>
             _localImageExistsCache.GetOrAdd(tag, _ => _inner.LocalImageExists(tag, isDryRun));
-        
+
+        public void Login(string username, string password, string? server, bool isDryRun) =>
+            _inner.Login(username, password, server, isDryRun);
+
+        public void Logout(string? server, bool isDryRun) =>
+            _inner.Logout(server, isDryRun);
+
         public void PullImage(string image, bool isDryRun)
         {
             _pulledImages.GetOrAdd(image, _ =>
@@ -64,3 +77,4 @@ namespace Microsoft.DotNet.ImageBuilder
             _inner.PushImage(tag, isDryRun);
     }
 }
+#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerServiceExtensions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerServiceExtensions.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+
+#nullable enable
+namespace Microsoft.DotNet.ImageBuilder
+{
+    public static class DockerServiceExtensions
+    {
+        public static async Task ExecuteWithUserAsync(this IDockerService dockerService, Func<Task> action, string? username, string? password,
+            string? server, bool isDryRun)
+        {
+            bool userSpecified = username != null;
+            if (userSpecified)
+            {
+                dockerService.Login(username!, password!, server, isDryRun);
+            }
+
+            try
+            {
+                await action();
+            }
+            finally
+            {
+                if (userSpecified)
+                {
+                    dockerService.Logout(server, isDryRun);
+                }
+            }
+        }
+    }
+}
+#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/IDockerService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/IDockerService.cs
@@ -6,15 +6,18 @@ using System;
 using System.Collections.Generic;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 
+#nullable enable
 namespace Microsoft.DotNet.ImageBuilder
 {
     public interface IDockerService
     {
         Architecture Architecture { get; }
 
+        bool IsAnonymousAccessAllowed { get; set; }
+
         void PullImage(string image, bool isDryRun);
 
-        string GetImageDigest(string image, bool isDryRun);
+        string? GetImageDigest(string image, bool isDryRun);
 
         IEnumerable<string> GetImageLayers(string image, bool isDryRun);
 
@@ -35,5 +38,10 @@ namespace Microsoft.DotNet.ImageBuilder
         long GetImageSize(string image, bool isDryRun);
 
         DateTime GetCreatedDate(string image, bool isDryRun);
+
+        void Login(string username, string password, string? server, bool isDryRun);
+
+        void Logout(string? server, bool isDryRun);
     }
 }
+#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/ImageBuilder.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ImageBuilder.cs
@@ -67,6 +67,7 @@ namespace Microsoft.DotNet.ImageBuilder
                         context.BindingContext.AddModelBinder(new ModelBinder<GitOptions>());
                         context.BindingContext.AddModelBinder(new ModelBinder<ManifestFilterOptions>());
                         context.BindingContext.AddModelBinder(new ModelBinder<ServicePrincipalOptions>());
+                        context.BindingContext.AddModelBinder(new ModelBinder<DockerCredsOptions>());
                     })
                     .Build();
                 return parser.Invoke(args);

--- a/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
@@ -1235,6 +1235,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<IDictionary<string, string>>(),
                     It.IsAny<bool>(), It.IsAny<bool>()),
                 Times.Never);
+            dockerServiceMock.VerifySet(o => o.IsAnonymousAccessAllowed = false);
 
             dockerServiceMock.VerifyNoOtherCalls();
         }
@@ -1524,6 +1525,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             dockerServiceMock.Verify(o => o.GetImageDigest(It.IsAny<string>(), false));
             dockerServiceMock.Verify(o => o.Architecture);
             dockerServiceMock.Verify(o => o.GetCreatedDate(It.IsAny<string>(), false));
+            dockerServiceMock.VerifySet(o => o.IsAnonymousAccessAllowed = false);
 
             dockerServiceMock.VerifyNoOtherCalls();
         }
@@ -1725,6 +1727,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             dockerServiceMock.Verify(o => o.GetImageLayers($"{runtimeDepsRepo}:{tag}", false), Times.Once);
             dockerServiceMock.Verify(o => o.GetImageLayers($"{runtimeDeps2Repo}:{tag}", false), Times.Once);
             dockerServiceMock.Verify(o => o.GetCreatedDate(It.IsAny<string>(), false));
+            dockerServiceMock.VerifySet(o => o.IsAnonymousAccessAllowed = false);
 
             dockerServiceMock.VerifyNoOtherCalls();
         }
@@ -1922,6 +1925,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<IDictionary<string, string>>(),
                     It.IsAny<bool>(), It.IsAny<bool>()),
                 Times.Never);
+            dockerServiceMock.VerifySet(o => o.IsAnonymousAccessAllowed = false);
 
             dockerServiceMock.VerifyNoOtherCalls();
         }
@@ -2166,6 +2170,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     It.IsAny<bool>(), It.IsAny<bool>()),
                 Times.Never);
             dockerServiceMock.Verify(o => o.GetCreatedDate(It.IsAny<string>(), false));
+            dockerServiceMock.VerifySet(o => o.IsAnonymousAccessAllowed = false);
 
             dockerServiceMock.VerifyNoOtherCalls();
         }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/CleanAcrImagesCommandTest.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/CleanAcrImagesCommandTest.cs
@@ -102,7 +102,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 .ReturnsAsync(acrClientMock.Object);
 
             CleanAcrImagesCommand command = new CleanAcrImagesCommand(
-                acrClientFactoryMock.Object, Mock.Of<ILoggerService>());
+                Mock.Of<IDockerService>(), acrClientFactoryMock.Object, Mock.Of<ILoggerService>());
             command.Options.Subscription = subscription;
             command.Options.ServicePrincipal.Secret = password;
             command.Options.ServicePrincipal.ClientId = username;
@@ -239,7 +239,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 .ReturnsAsync(acrClientMock.Object);
 
             CleanAcrImagesCommand command = new CleanAcrImagesCommand(
-                acrClientFactoryMock.Object, Mock.Of<ILoggerService>());
+                Mock.Of<IDockerService>(), acrClientFactoryMock.Object, Mock.Of<ILoggerService>());
             command.Options.Subscription = subscription;
             command.Options.ServicePrincipal.Secret = password;
             command.Options.ServicePrincipal.ClientId = username;
@@ -333,7 +333,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 .ReturnsAsync(acrClientMock.Object);
 
             CleanAcrImagesCommand command = new CleanAcrImagesCommand(
-                acrClientFactoryMock.Object, Mock.Of<ILoggerService>());
+                Mock.Of<IDockerService>(), acrClientFactoryMock.Object, Mock.Of<ILoggerService>());
             command.Options.Subscription = subscription;
             command.Options.ServicePrincipal.Secret = password;
             command.Options.ServicePrincipal.ClientId = username;
@@ -419,7 +419,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 .ReturnsAsync(acrClientMock.Object);
 
             CleanAcrImagesCommand command = new CleanAcrImagesCommand(
-                acrClientFactoryMock.Object, Mock.Of<ILoggerService>());
+                Mock.Of<IDockerService>(), acrClientFactoryMock.Object, Mock.Of<ILoggerService>());
             command.Options.Subscription = subscription;
             command.Options.ServicePrincipal.Secret = password;
             command.Options.ServicePrincipal.ClientId = username;
@@ -523,7 +523,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 .ReturnsAsync(acrClientMock.Object);
 
             CleanAcrImagesCommand command = new CleanAcrImagesCommand(
-                acrClientFactoryMock.Object, Mock.Of<ILoggerService>());
+                Mock.Of<IDockerService>(), acrClientFactoryMock.Object, Mock.Of<ILoggerService>());
             command.Options.Subscription = subscription;
             command.Options.ServicePrincipal.Secret = password;
             command.Options.ServicePrincipal.ClientId = username;

--- a/src/Microsoft.DotNet.ImageBuilder/tests/CopyAcrImagesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/CopyAcrImagesCommandTests.cs
@@ -40,7 +40,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Mock<IAzureManagementFactory> azureManagementFactoryMock =
                     AzureHelper.CreateAzureManagementFactoryMock(subscriptionId, azure);
 
-                CopyAcrImagesCommand command = new CopyAcrImagesCommand(azureManagementFactoryMock.Object, Mock.Of<ILoggerService>());
+                CopyAcrImagesCommand command = new CopyAcrImagesCommand(
+                    Mock.Of<IDockerService>(), azureManagementFactoryMock.Object, Mock.Of<ILoggerService>());
                 command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
                 command.Options.Subscription = subscriptionId;
                 command.Options.ResourceGroup = "my resource group";
@@ -132,7 +133,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
                 Mock<IEnvironmentService> environmentServiceMock = new Mock<IEnvironmentService>();
 
-                CopyAcrImagesCommand command = new CopyAcrImagesCommand(azureManagementFactoryMock.Object, Mock.Of<ILoggerService>());
+                CopyAcrImagesCommand command = new CopyAcrImagesCommand(
+                    Mock.Of<IDockerService>(), azureManagementFactoryMock.Object, Mock.Of<ILoggerService>());
                 command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
                 command.Options.Subscription = subscriptionId;
                 command.Options.ResourceGroup = "my resource group";
@@ -235,7 +237,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             Mock<IEnvironmentService> environmentServiceMock = new Mock<IEnvironmentService>();
 
-            CopyAcrImagesCommand command = new CopyAcrImagesCommand(azureManagementFactoryMock.Object, Mock.Of<ILoggerService>());
+            CopyAcrImagesCommand command = new CopyAcrImagesCommand(
+                Mock.Of<IDockerService>(), azureManagementFactoryMock.Object, Mock.Of<ILoggerService>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.Subscription = subscriptionId;
             command.Options.ResourceGroup = "my resource group";
@@ -349,7 +352,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             Mock<IEnvironmentService> environmentServiceMock = new Mock<IEnvironmentService>();
 
-            CopyAcrImagesCommand command = new CopyAcrImagesCommand(azureManagementFactoryMock.Object, Mock.Of<ILoggerService>());
+            CopyAcrImagesCommand command = new CopyAcrImagesCommand(
+                Mock.Of<IDockerService>(), azureManagementFactoryMock.Object, Mock.Of<ILoggerService>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.Subscription = subscriptionId;
             command.Options.ResourceGroup = "my resource group";

--- a/src/Microsoft.DotNet.ImageBuilder/tests/CopyDockerHubImagesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/CopyDockerHubImagesCommandTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Mock<IEnvironmentService> environmentServiceMock = new Mock<IEnvironmentService>();
 
             CopyDockerHubBaseImagesCommand command = new CopyDockerHubBaseImagesCommand(
-                azureManagementFactoryMock.Object, Mock.Of<ILoggerService>());
+                Mock.Of<IDockerService>(), azureManagementFactoryMock.Object, Mock.Of<ILoggerService>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.Subscription = subscriptionId;
             command.Options.ResourceGroup = "my resource group";

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
@@ -10,6 +10,7 @@ using Microsoft.DotNet.ImageBuilder.Commands;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
+using Moq;
 using Newtonsoft.Json;
 using Xunit;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
@@ -32,7 +33,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         {
             using (TempFolderContext tempFolderContext = TestHelper.UseTempFolder())
             {
-                GenerateBuildMatrixCommand command = new GenerateBuildMatrixCommand();
+                GenerateBuildMatrixCommand command = new GenerateBuildMatrixCommand(Mock.Of<IDockerService>());
                 command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
                 command.Options.MatrixType = MatrixType.PlatformVersionedOs;
                 command.Options.ProductVersionComponents = 3;
@@ -100,7 +101,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         {
             using (TempFolderContext tempFolderContext = TestHelper.UseTempFolder())
             {
-                GenerateBuildMatrixCommand command = new GenerateBuildMatrixCommand();
+                GenerateBuildMatrixCommand command = new GenerateBuildMatrixCommand(Mock.Of<IDockerService>());
                 command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
                 command.Options.MatrixType = MatrixType.PlatformDependencyGraph;
                 if (filterPaths != null)
@@ -167,7 +168,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             using (TempFolderContext tempFolderContext = TestHelper.UseTempFolder())
             {
                 const string customBuildLegGroup = "custom";
-                GenerateBuildMatrixCommand command = new GenerateBuildMatrixCommand();
+                GenerateBuildMatrixCommand command = new GenerateBuildMatrixCommand(Mock.Of<IDockerService>());
                 command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
                 command.Options.MatrixType = MatrixType.PlatformVersionedOs;
                 command.Options.ProductVersionComponents = 2;
@@ -264,7 +265,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
             const string customBuildLegGroup = "custom";
-            GenerateBuildMatrixCommand command = new GenerateBuildMatrixCommand();
+            GenerateBuildMatrixCommand command = new GenerateBuildMatrixCommand(Mock.Of<IDockerService>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.MatrixType = MatrixType.PlatformDependencyGraph;
             command.Options.ProductVersionComponents = 2;
@@ -353,7 +354,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         public void GenerateBuildMatrixCommand_ParentGraphOutsidePlatformGroup()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
-            GenerateBuildMatrixCommand command = new GenerateBuildMatrixCommand();
+            GenerateBuildMatrixCommand command = new GenerateBuildMatrixCommand(Mock.Of<IDockerService>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.MatrixType = MatrixType.PlatformVersionedOs;
             command.Options.ProductVersionComponents = 2;
@@ -424,7 +425,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
             const string customBuildLegGroup1 = "custom1";
             const string customBuildLegGroup2 = "custom2";
-            GenerateBuildMatrixCommand command = new GenerateBuildMatrixCommand();
+            GenerateBuildMatrixCommand command = new GenerateBuildMatrixCommand(Mock.Of<IDockerService>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.MatrixType = MatrixType.PlatformVersionedOs;
             command.Options.ProductVersionComponents = 2;
@@ -532,7 +533,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         public void PlatformVersionedOs_Cached(bool isRuntimeCached, bool isAspnetCached, bool isSdkCached, string expectedPaths)
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
-            GenerateBuildMatrixCommand command = new GenerateBuildMatrixCommand();
+            GenerateBuildMatrixCommand command = new GenerateBuildMatrixCommand(Mock.Of<IDockerService>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.MatrixType = MatrixType.PlatformVersionedOs;
             command.Options.ImageInfoPath = Path.Combine(tempFolderContext.Path, "imageinfo.json");
@@ -649,7 +650,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         public void PlatformDependencyGraph_CrossReferencedDockerfileFromMultipleRepos_SingleDockerfile()
         {
             TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
-            GenerateBuildMatrixCommand command = new GenerateBuildMatrixCommand();
+            GenerateBuildMatrixCommand command = new GenerateBuildMatrixCommand(Mock.Of<IDockerService>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.MatrixType = MatrixType.PlatformDependencyGraph;
             command.Options.ProductVersionComponents = 2;
@@ -704,7 +705,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         public void CrossReferencedDockerfileFromMultipleRepos_ImageGraph(MatrixType matrixType)
         {
             TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
-            GenerateBuildMatrixCommand command = new GenerateBuildMatrixCommand();
+            GenerateBuildMatrixCommand command = new GenerateBuildMatrixCommand(Mock.Of<IDockerService>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.MatrixType = matrixType;
             command.Options.ProductVersionComponents = 2;
@@ -783,7 +784,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         public void DuplicatedPlatforms(MatrixType matrixType)
         {
             TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
-            GenerateBuildMatrixCommand command = new GenerateBuildMatrixCommand();
+            GenerateBuildMatrixCommand command = new GenerateBuildMatrixCommand(Mock.Of<IDockerService>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.MatrixType = matrixType;
             command.Options.ProductVersionComponents = 2;

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateDockerfilesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateDockerfilesCommandTests.cs
@@ -207,7 +207,8 @@ ENV TEST2 Value1";
                 .Setup(o => o.Exit(1))
                 .Throws(_exitException);
 
-            GenerateDockerfilesCommand command = new GenerateDockerfilesCommand(_environmentServiceMock.Object);
+            GenerateDockerfilesCommand command = new GenerateDockerfilesCommand(
+                Mock.Of<IDockerService>(), _environmentServiceMock.Object);
             command.Options.Manifest = manifestPath;
             command.Options.AllowOptionalTemplates = allowOptionalTemplates;
             command.Options.Validate = validate;

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateReadmesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateReadmesCommandTests.cs
@@ -180,7 +180,8 @@ Referenced Template Content";
                 .Setup(o => o.Exit(1))
                 .Throws(_exitException);
 
-            GenerateReadmesCommand command = new GenerateReadmesCommand(_environmentServiceMock.Object, gitServiceMock.Object);
+            GenerateReadmesCommand command = new GenerateReadmesCommand(
+                Mock.Of<IDockerService>(), _environmentServiceMock.Object, gitServiceMock.Object);
             command.Options.Manifest = manifestPath;
             command.Options.AllowOptionalTemplates = allowOptionalTemplates;
             command.Options.Validate = validate;

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
@@ -1432,7 +1432,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             private GetStaleImagesCommand CreateCommand()
             {
                 GetStaleImagesCommand command = new GetStaleImagesCommand(
-                    this.ManifestToolServiceMock.Object, this.httpClientFactory, this.loggerServiceMock.Object, this.gitHubClientFactory);
+                    Mock.Of<IDockerService>(), this.ManifestToolServiceMock.Object, this.httpClientFactory,
+                    this.loggerServiceMock.Object, this.gitHubClientFactory);
                 command.Options.SubscriptionsPath = this.subscriptionsPath;
                 command.Options.VariableName = VariableName;
                 command.Options.FilterOptions.OsType = this.osType;

--- a/src/Microsoft.DotNet.ImageBuilder/tests/IngestKustoImageInfoCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/IngestKustoImageInfoCommandTests.cs
@@ -281,7 +281,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         StreamReader reader = new(stream);
                         ingestedData.Add(table, reader.ReadToEnd());
                     });
-            IngestKustoImageInfoCommand command = new(Mock.Of<ILoggerService>(), kustoClientMock.Object);
+            IngestKustoImageInfoCommand command = new(Mock.Of<IDockerService>(), Mock.Of<ILoggerService>(), kustoClientMock.Object);
             command.Options.ImageInfoPath = imageInfoPath;
             command.Options.Manifest = manifestPath;
             command.Options.ImageTable = "ImageInfo";

--- a/src/Microsoft.DotNet.ImageBuilder/tests/MergeImageInfoFilesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/MergeImageInfoFilesCommandTests.cs
@@ -10,6 +10,7 @@ using Microsoft.DotNet.ImageBuilder.Commands;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
+using Moq;
 using Newtonsoft.Json;
 using Xunit;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.DockerfileHelper;
@@ -169,7 +170,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     }
                 };
 
-                MergeImageInfoCommand command = new MergeImageInfoCommand();
+                MergeImageInfoCommand command = new MergeImageInfoCommand(Mock.Of<IDockerService>());
                 command.Options.SourceImageInfoFolderPath = Path.Combine(context.Path, "image-infos");
                 command.Options.DestinationImageInfoPath = Path.Combine(context.Path, "output.json");
                 command.Options.Manifest = Path.Combine(context.Path, "manifest.json");
@@ -471,7 +472,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     }
                 };
 
-                MergeImageInfoCommand command = new MergeImageInfoCommand();
+                MergeImageInfoCommand command = new MergeImageInfoCommand(Mock.Of<IDockerService>());
                 command.Options.SourceImageInfoFolderPath = Path.Combine(context.Path, "image-infos");
                 command.Options.DestinationImageInfoPath = Path.Combine(context.Path, "output.json");
                 command.Options.Manifest = Path.Combine(context.Path, "manifest.json");
@@ -606,7 +607,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         [Fact]
         public async Task MergeImageInfoFilesCommand_SourceFolderPathNotFound()
         {
-            MergeImageInfoCommand command = new MergeImageInfoCommand();
+            MergeImageInfoCommand command = new MergeImageInfoCommand(Mock.Of<IDockerService>());
             command.Options.SourceImageInfoFolderPath = "foo";
             command.Options.DestinationImageInfoPath = "output.json";
 
@@ -629,7 +630,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 // Store the content in a .txt file which the command should NOT be looking for.
                 File.WriteAllText("image-info.txt", JsonHelper.SerializeObject(imageArtifactDetails));
 
-                MergeImageInfoCommand command = new MergeImageInfoCommand();
+                MergeImageInfoCommand command = new MergeImageInfoCommand(Mock.Of<IDockerService>());
                 command.Options.SourceImageInfoFolderPath = context.Path;
                 command.Options.DestinationImageInfoPath = "output.json";
 

--- a/src/Microsoft.DotNet.ImageBuilder/tests/PublishImageInfoCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/PublishImageInfoCommandTests.cs
@@ -162,7 +162,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Mock<IRepository> repositoryMock = GetRepositoryMock();
                 Mock<IGitService> gitServiceMock = GetGitServiceMock(repositoryMock.Object, gitOptions.Path, targetImageArtifactDetails);
 
-                PublishImageInfoCommand command = new PublishImageInfoCommand(gitServiceMock.Object, Mock.Of<ILoggerService>());
+                PublishImageInfoCommand command = new PublishImageInfoCommand(
+                    Mock.Of<IDockerService>(), gitServiceMock.Object, Mock.Of<ILoggerService>());
                 command.Options.ImageInfoPath = file;
                 command.Options.GitOptions = gitOptions;
                 command.Options.AzdoOptions = azdoOptions;
@@ -337,7 +338,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Mock<IGitService> gitServiceMock = GetGitServiceMock(repositoryMock.Object, gitOptions.Path, targetImageArtifactDetails);
 
 
-                PublishImageInfoCommand command = new PublishImageInfoCommand(gitServiceMock.Object, Mock.Of<ILoggerService>());
+                PublishImageInfoCommand command = new PublishImageInfoCommand(
+                    Mock.Of<IDockerService>(), gitServiceMock.Object, Mock.Of<ILoggerService>());
                 command.Options.ImageInfoPath = file;
                 command.Options.GitOptions = gitOptions;
                 command.Options.AzdoOptions = azdoOptions;

--- a/src/Microsoft.DotNet.ImageBuilder/tests/PublishManifestCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/PublishManifestCommandTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 .Returns(ManifestToolServiceHelper.CreateTagManifest(ManifestToolService.ManifestListMediaType, "digest2"));
 
             PublishManifestCommand command = new PublishManifestCommand(
-                manifestToolService.Object, Mock.Of<ILoggerService>());
+                Mock.Of<IDockerService>(), manifestToolService.Object, Mock.Of<ILoggerService>());
 
             using TempFolderContext tempFolderContext = new TempFolderContext();
 
@@ -236,7 +236,7 @@ manifests:
                 .Returns(ManifestToolServiceHelper.CreateTagManifest(ManifestToolService.ManifestListMediaType, "digest"));
 
             PublishManifestCommand command = new PublishManifestCommand(
-                manifestToolService.Object, Mock.Of<ILoggerService>());
+                Mock.Of<IDockerService>(), manifestToolService.Object, Mock.Of<ILoggerService>());
 
             using TempFolderContext tempFolderContext = new TempFolderContext();
 
@@ -384,7 +384,7 @@ manifests:
                 .Returns(ManifestToolServiceHelper.CreateTagManifest(ManifestToolService.ManifestListMediaType, "digest"));
 
             PublishManifestCommand command = new PublishManifestCommand(
-                manifestToolService.Object, Mock.Of<ILoggerService>());
+                Mock.Of<IDockerService>(), manifestToolService.Object, Mock.Of<ILoggerService>());
 
             using TempFolderContext tempFolderContext = new TempFolderContext();
 

--- a/src/Microsoft.DotNet.ImageBuilder/tests/QueueBuildCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/QueueBuildCommandTests.cs
@@ -396,7 +396,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             {
                 Mock<ILoggerService> loggerServiceMock = new Mock<ILoggerService>();
 
-                QueueBuildCommand command = new QueueBuildCommand(connectionFactoryMock.Object, loggerServiceMock.Object);
+                QueueBuildCommand command = new QueueBuildCommand(
+                    Mock.Of<IDockerService>(), connectionFactoryMock.Object, loggerServiceMock.Object);
                 command.Options.AzdoOptions.Organization = BuildOrganization;
                 command.Options.AzdoOptions.AccessToken = "testToken";
                 command.Options.SubscriptionsPath = this.subscriptionsPath;

--- a/src/Microsoft.DotNet.ImageBuilder/tests/ShowManifestSchemaCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/ShowManifestSchemaCommandTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         {
             Mock<ILoggerService> loggerServiceMock = new Mock<ILoggerService>();
 
-            ShowManifestSchemaCommand command = new ShowManifestSchemaCommand(loggerServiceMock.Object);
+            ShowManifestSchemaCommand command = new ShowManifestSchemaCommand(Mock.Of<IDockerService>(), loggerServiceMock.Object);
 
             await command.ExecuteAsync();
 

--- a/src/Microsoft.DotNet.ImageBuilder/tests/TrimUnchangedPlatformsCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/TrimUnchangedPlatformsCommandTests.cs
@@ -238,7 +238,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         {
             using TempFolderContext tempFolderContext = new TempFolderContext();
 
-            TrimUnchangedPlatformsCommand command = new TrimUnchangedPlatformsCommand(Mock.Of<ILoggerService>());
+            TrimUnchangedPlatformsCommand command = new TrimUnchangedPlatformsCommand(
+                Mock.Of<IDockerService>(), Mock.Of<ILoggerService>());
             command.Options.ImageInfoPath = Path.Combine(tempFolderContext.Path, "imageinfo.json");
 
             File.WriteAllText(command.Options.ImageInfoPath, JsonHelper.SerializeObject(input));

--- a/src/Microsoft.DotNet.ImageBuilder/tests/WaitForMcrDocIngestionCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/WaitForMcrDocIngestionCommandTests.cs
@@ -84,6 +84,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Mock<IEnvironmentService> environmentServiceMock = new Mock<IEnvironmentService>();
 
             WaitForMcrDocIngestionCommand command = new WaitForMcrDocIngestionCommand(
+                Mock.Of<IDockerService>(),
                 Mock.Of<ILoggerService>(),
                 statusClientFactory,
                 environmentServiceMock.Object);
@@ -179,6 +180,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 .Throws(exitException);
 
             WaitForMcrDocIngestionCommand command = new WaitForMcrDocIngestionCommand(
+                Mock.Of<IDockerService>(),
                 Mock.Of<ILoggerService>(),
                 statusClientFactory,
                 environmentServiceMock.Object);
@@ -285,6 +287,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Mock<IEnvironmentService> environmentServiceMock = new Mock<IEnvironmentService>();
 
             WaitForMcrDocIngestionCommand command = new WaitForMcrDocIngestionCommand(
+                Mock.Of<IDockerService>(),
                 Mock.Of<ILoggerService>(),
                 statusClientFactory,
                 environmentServiceMock.Object);
@@ -382,6 +385,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 .Throws(exitException);
 
             WaitForMcrDocIngestionCommand command = new WaitForMcrDocIngestionCommand(
+                Mock.Of<IDockerService>(),
                 Mock.Of<ILoggerService>(),
                 statusClientFactory,
                 environmentServiceMock.Object);
@@ -429,6 +433,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Mock<IEnvironmentService> environmentServiceMock = new Mock<IEnvironmentService>();
 
             WaitForMcrDocIngestionCommand command = new WaitForMcrDocIngestionCommand(
+                Mock.Of<IDockerService>(),
                 Mock.Of<ILoggerService>(),
                 statusClientFactory,
                 environmentServiceMock.Object);

--- a/src/Microsoft.DotNet.ImageBuilder/tests/WaitForMcrImageIngestionCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/WaitForMcrImageIngestionCommandTests.cs
@@ -202,6 +202,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Mock<IEnvironmentService> environmentServiceMock = new Mock<IEnvironmentService>();
 
             WaitForMcrImageIngestionCommand command = new WaitForMcrImageIngestionCommand(
+                Mock.Of<IDockerService>(),
                 Mock.Of<ILoggerService>(),
                 CreateMcrStatusClientFactory(tenant, clientId, clientSecret, statusClientMock.Object),
                 environmentServiceMock.Object);
@@ -451,6 +452,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Mock<IEnvironmentService> environmentServiceMock = new Mock<IEnvironmentService>();
 
             WaitForMcrImageIngestionCommand command = new WaitForMcrImageIngestionCommand(
+                Mock.Of<IDockerService>(),
                 Mock.Of<ILoggerService>(),
                 CreateMcrStatusClientFactory(tenant, clientId, clientSecret, statusClientMock.Object),
                 environmentServiceMock.Object);
@@ -607,6 +609,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Mock<IEnvironmentService> environmentServiceMock = new Mock<IEnvironmentService>();
 
             WaitForMcrImageIngestionCommand command = new WaitForMcrImageIngestionCommand(
+                Mock.Of<IDockerService>(),
                 Mock.Of<ILoggerService>(),
                 CreateMcrStatusClientFactory(tenant, clientId, clientSecret, statusClientMock.Object),
                 environmentServiceMock.Object);
@@ -787,6 +790,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Mock<IEnvironmentService> environmentServiceMock = new Mock<IEnvironmentService>();
 
             WaitForMcrImageIngestionCommand command = new WaitForMcrImageIngestionCommand(
+                Mock.Of<IDockerService>(),
                 Mock.Of<ILoggerService>(),
                 CreateMcrStatusClientFactory(tenant, clientId, clientSecret, statusClientMock.Object),
                 environmentServiceMock.Object);
@@ -891,6 +895,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Mock<IEnvironmentService> environmentServiceMock = new Mock<IEnvironmentService>();
 
             WaitForMcrImageIngestionCommand command = new WaitForMcrImageIngestionCommand(
+                Mock.Of<IDockerService>(),
                 Mock.Of<ILoggerService>(),
                 CreateMcrStatusClientFactory(tenant, clientId, clientSecret, statusClientMock.Object),
                 environmentServiceMock.Object);
@@ -1080,6 +1085,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Mock<IEnvironmentService> environmentServiceMock = new Mock<IEnvironmentService>();
 
             WaitForMcrImageIngestionCommand command = new WaitForMcrImageIngestionCommand(
+                Mock.Of<IDockerService>(),
                 Mock.Of<ILoggerService>(),
                 CreateMcrStatusClientFactory(tenant, clientId, clientSecret, statusClientMock.Object),
                 environmentServiceMock.Object);


### PR DESCRIPTION
Currently, Image Builder pulls images from Docker Hub using anonymous access.  This is problematic due to the rate limiting change (#613).  These changes update Image Builder commands to take Docker Hub creds and log in with them to ensure that any pulls are not subject to the rate limiting.

What I wanted to accomplish with these changes is a way to ensure that we don't accidentally introduce code which executes pulls (or manifest inspect requests) anonymously.  So I've consolidated things into the `DockerService` class, including the login/logout logic, which validates that any attempt to make a request to Docker Hub is done within the context of logged-in DH credentials.

For those commands that require access to Docker Hub, I've centrally located the logic to run the login/logout in the base `Command` class which wraps the entire execution of the command within the context of logged-in credentials.  This required refactoring the `ExecuteAsync` method so that it can be appropriately wrapped with this logic.  I have a commit which contains just this refactoring.