### PR TITLE
Fix script to pull Image Builder

### DIFF
--- a/eng/common/Get-ImageBuilder.ps1
+++ b/eng/common/Get-ImageBuilder.ps1
@@ -9,7 +9,7 @@ ForEach-Object {
 }
 
 & docker inspect ${imageNames.imagebuilder} | Out-Null
-if ($LASTEXITCODE -ne 0) {
+if (-not $?) {
     Write-Output "Pulling"
     & $PSScriptRoot/Invoke-WithRetry.ps1 "docker pull ${imageNames.imagebuilder}"
 }


### PR DESCRIPTION
Ports the change from https://github.com/dotnet/dotnet-docker/pull/2580 to docker-tools.