### PR TITLE
Provide source credentials for copying base images

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CliHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CliHelper.cs
@@ -44,16 +44,20 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             };
 
         public static Option<Dictionary<string, string>> CreateDictionaryOption(string alias, string propertyName, string description) =>
-            new Option<Dictionary<string, string>>(FormatAlias(alias), description: description,
+            CreateDictionaryOption(alias, propertyName, description, val => val);
+
+        public static Option<Dictionary<string, TValue>> CreateDictionaryOption<TValue>(string alias, string propertyName, string description,
+            Func<string, TValue> getValue) =>
+            new Option<Dictionary<string, TValue>>(FormatAlias(alias), description: description,
                 parseArgument: argResult =>
                 {
                     return argResult.Tokens
                         .ToList()
-                        .Select(token => token.Value.Split(new char[] { '=' }, 2))
-                        .ToDictionary(split => split[0], split => split[1]);
+                        .Select(token => token.Value.ParseKeyValuePair('='))
+                        .ToDictionary(kvp => kvp.Key, kvp => getValue(kvp.Value));
                 })
             {
-                Name = nameof(ManifestOptions.Variables),
+                Name = propertyName,
                 AllowMultipleArgumentsPerToken = false
             };
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyBaseImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyBaseImagesCommand.cs
@@ -35,10 +35,14 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     string registry = DockerHelper.GetRegistry(fromImage) ?? "docker.io";
                     fromImage = DockerHelper.TrimRegistry(fromImage, registry);
 
-                    Options.SourceCredentials.TryGetValue(registry, out ImportSourceCredentials? sourceCreds);
+                    ImportSourceCredentials? importSourceCreds = null;
+                    if (Options.CredentialsOptions.Credentials.TryGetValue(registry, out RegistryCredentials? registryCreds))
+                    {
+                        importSourceCreds = new ImportSourceCredentials(registryCreds.Password, registryCreds.Username);
+                    }
 
                     return ImportImageAsync($"{Options.RepoPrefix}{fromImage}", fromImage, srcRegistryName: registry,
-                        sourceCredentials: sourceCreds);
+                        sourceCredentials: importSourceCreds);
                 });
 
             await Task.WhenAll(importTasks);

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyBaseImagesOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyBaseImagesOptions.cs
@@ -5,32 +5,25 @@
 using System.Collections.Generic;
 using System.CommandLine;
 using System.Linq;
-using Microsoft.Azure.Management.ContainerRegistry.Fluent.Models;
-using static Microsoft.DotNet.ImageBuilder.Commands.CliHelper;
 
 #nullable enable
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     public class CopyBaseImagesOptions : CopyImagesOptions
     {
-        public IDictionary<string, ImportSourceCredentials> SourceCredentials { get; set; } =
-            new Dictionary<string, ImportSourceCredentials>();
+        public RegistryCredentialsOptions CredentialsOptions { get; set; } = new RegistryCredentialsOptions();
     }
 
     public class CopyBaseImagesOptionsBuilder : CopyImagesOptionsBuilder
     {
+        private readonly RegistryCredentialsOptionsBuilder _registryCredentialsOptionsBuilder =
+            new RegistryCredentialsOptionsBuilder();
+
         public override IEnumerable<Option> GetCliOptions() =>
-            base.GetCliOptions()
-                .Concat(new Option[]
-                {
-                    CreateDictionaryOption("source-creds", nameof(CopyBaseImagesOptions.SourceCredentials),
-                        "Named credentials that map to a source registry ((<registry>=<username>;<password>)",
-                        val =>
-                            {
-                                (string username, string password) = val.ParseKeyValuePair(';');
-                                return new ImportSourceCredentials(password, username);
-                            })
-                });
+            base.GetCliOptions().Concat(_registryCredentialsOptionsBuilder.GetCliOptions());
+
+        public override IEnumerable<Argument> GetCliArguments() =>
+            base.GetCliArguments().Concat(_registryCredentialsOptionsBuilder.GetCliArguments());
     }
 }
 #nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyBaseImagesOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyBaseImagesOptions.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.CommandLine;
+using System.Linq;
+using Microsoft.Azure.Management.ContainerRegistry.Fluent.Models;
+using static Microsoft.DotNet.ImageBuilder.Commands.CliHelper;
+
+#nullable enable
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    public class CopyBaseImagesOptions : CopyImagesOptions
+    {
+        public IDictionary<string, ImportSourceCredentials> SourceCredentials { get; set; } =
+            new Dictionary<string, ImportSourceCredentials>();
+    }
+
+    public class CopyBaseImagesOptionsBuilder : CopyImagesOptionsBuilder
+    {
+        public override IEnumerable<Option> GetCliOptions() =>
+            base.GetCliOptions()
+                .Concat(new Option[]
+                {
+                    CreateDictionaryOption("source-creds", nameof(CopyBaseImagesOptions.SourceCredentials),
+                        "Named credentials that map to a source registry ((<registry>=<username>;<password>)",
+                        val =>
+                            {
+                                (string username, string password) = val.ParseKeyValuePair(';');
+                                return new ImportSourceCredentials(password, username);
+                            })
+                });
+    }
+}
+#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyImagesCommand.cs
@@ -14,6 +14,7 @@ using Microsoft.DotNet.ImageBuilder.Services;
 using Polly;
 using ImportSource = Microsoft.Azure.Management.ContainerRegistry.Fluent.Models.ImportSource;
 
+#nullable enable
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     public abstract class CopyImagesCommand<TOptions, TOptionsBuilder> : ManifestCommand<TOptions, TOptionsBuilder>
@@ -35,7 +36,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public IAzureManagementFactory AzureManagementFactory { get; }
         public ILoggerService LoggerService { get; }
 
-        protected async Task ImportImageAsync(string destTagName, string srcTagName, string srcRegistryName = null, string srcResourceId = null)
+        protected async Task ImportImageAsync(string destTagName, string srcTagName, string? srcRegistryName = null, string? srcResourceId = null,
+            ImportSourceCredentials? sourceCredentials = null)
         {
             AzureCredentials credentials = SdkContext.AzureCredentialsFactory.FromServicePrincipal(
                 Options.ServicePrincipal.ClientId,
@@ -50,7 +52,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 Source = new ImportSource(
                     srcTagName,
                     srcResourceId,
-                    srcRegistryName),
+                    srcRegistryName,
+                    sourceCredentials),
                 TargetTags = new string[] { destTagName }
             };
 
@@ -60,7 +63,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             {
                 try
                 {
-                    AsyncPolicy<HttpResponseMessage> policy = HttpPolicyBuilder.Create()
+                    AsyncPolicy<HttpResponseMessage?> policy = HttpPolicyBuilder.Create()
                         .WithMeteredRetryPolicy(LoggerService)
                         .Build();
                     await policy.ExecuteAsync(async () =>
@@ -78,3 +81,4 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         }
     }
 }
+#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/DockerRegistryCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/DockerRegistryCommand.cs
@@ -4,6 +4,7 @@
 
 using System;
 
+#nullable enable
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     public abstract class DockerRegistryCommand<TOptions, TOptionsBuilder> : ManifestCommand<TOptions, TOptionsBuilder>
@@ -12,7 +13,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     {
         protected void ExecuteWithUser(Action action)
         {
-            DockerHelper.ExecuteWithUser(action, Options.Username, Options.Password, Manifest.Registry, Options.IsDryRun);
+            Options.CredentialsOptions.Credentials.TryGetValue(Manifest.Registry ?? "", out RegistryCredentials? credentials);
+            DockerHelper.ExecuteWithUser(action, credentials?.Username, credentials?.Password, Manifest.Registry, Options.IsDryRun);
         }
     }
 }
+#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/DockerRegistryOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/DockerRegistryOptions.cs
@@ -2,61 +2,28 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.CommandLine;
 using System.Linq;
-using static Microsoft.DotNet.ImageBuilder.Commands.CliHelper;
 
 #nullable enable
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     public abstract class DockerRegistryOptions : ManifestOptions
     {
-        public string? Password { get; set; }
-        public string? Username { get; set; }
+        public RegistryCredentialsOptions CredentialsOptions { get; set; } = new RegistryCredentialsOptions();
     }
 
     public abstract class DockerRegistryOptionsBuilder : ManifestOptionsBuilder
     {
-        public override IEnumerable<Option> GetCliOptions()
-        {
-            Option<string?>? passwordOption = null;
-            Option<string?>? usernameOption = null;
-            return base.GetCliOptions().Concat(
-                new Option[]
-                {
-                    (passwordOption = CreateOption<string?>("password", nameof(DockerRegistryOptions.Password),
-                        "Password for the Docker Registry the images are pushed to",
-                        resultArg =>
-                        {
-                            string password = resultArg.GetTokenValue();
-                            string? username = resultArg.FindResultFor(
-                                usernameOption ?? throw new InvalidOperationException("username option not set yet"))?.GetTokenValue();
-                            ValidateUsernameAndPassword(username, password);
-                            return password;
-                        })),
-                    (usernameOption = CreateOption<string?>("username", nameof(DockerRegistryOptions.Username),
-                        "Username for the Docker Registry the images are pushed to",
-                        resultArg =>
-                        {
-                            string username = resultArg.GetTokenValue();
-                            string? password = resultArg.FindResultFor(
-                                passwordOption ?? throw new InvalidOperationException("password option not set yet"))?.GetTokenValue();
-                            ValidateUsernameAndPassword(username, password);
-                            return username;
-                        }))
-                });
-        }
+        private readonly RegistryCredentialsOptionsBuilder _registryCredentialsOptionsBuilder =
+            new RegistryCredentialsOptionsBuilder();
 
-        private static void ValidateUsernameAndPassword(string? username, string? password)
-        {
-            if (!string.IsNullOrEmpty(username) ^ !string.IsNullOrEmpty(password))
-            {
-                Logger.WriteError($"error: `username` and `password` must both be specified.");
-                Environment.Exit(1);
-            }
-        }
+        public override IEnumerable<Option> GetCliOptions() =>
+            base.GetCliOptions().Concat(_registryCredentialsOptionsBuilder.GetCliOptions());
+
+        public override IEnumerable<Argument> GetCliArguments() =>
+            base.GetCliArguments().Concat(_registryCredentialsOptionsBuilder.GetCliArguments());
     }
 }
 #nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/RegistryCredentialsOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/RegistryCredentialsOptions.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.CommandLine;
+using System.Linq;
+using static Microsoft.DotNet.ImageBuilder.Commands.CliHelper;
+
+#nullable enable
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    public class RegistryCredentialsOptions
+    {
+        public IDictionary<string, RegistryCredentials> Credentials { get; set; } =
+            new Dictionary<string, RegistryCredentials>();
+    }
+
+    public class RegistryCredentialsOptionsBuilder
+    {
+        public IEnumerable<Option> GetCliOptions() =>
+            new Option[]
+            {
+                CreateDictionaryOption("registry-creds", nameof(RegistryCredentialsOptions.Credentials),
+                    "Named credentials that map to a registry (<registry>=<username>;<password>)",
+                    val =>
+                        {
+                            (string username, string password) = val.ParseKeyValuePair(';');
+                            return new RegistryCredentials(username, password);
+                        })
+            };
+
+        public IEnumerable<Argument> GetCliArguments() => Enumerable.Empty<Argument>();
+    }
+
+    public class RegistryCredentials
+    {
+        public RegistryCredentials(string username, string password)
+        {
+            Username = username;
+            Password = password;
+        }
+
+        public string Username { get; }
+        public string Password { get; }
+    }
+}
+#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
@@ -190,6 +190,17 @@ namespace Microsoft.DotNet.ImageBuilder
             return JsonConvert.DeserializeObject<Docker.Manifest>(manifest);
         }
 
+        public static string GetRegistry(string imageName)
+        {
+            string firstSegment = imageName.Substring(0, imageName.IndexOf("/"));
+            if (firstSegment.Contains("."))
+            {
+                return firstSegment;
+            }
+
+            return null;
+        }
+
         private static int GetTagOrDigestSeparatorIndex(string imageName)
         {
             int separatorPosition = imageName.IndexOf('@');

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
@@ -193,7 +193,7 @@ namespace Microsoft.DotNet.ImageBuilder
         public static string GetRegistry(string imageName)
         {
             string firstSegment = imageName.Substring(0, imageName.IndexOf("/"));
-            if (firstSegment.Contains("."))
+            if (firstSegment.Contains(".") || firstSegment.Contains(":"))
             {
                 return firstSegment;
             }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ImageBuilder.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ImageBuilder.cs
@@ -66,6 +66,7 @@ namespace Microsoft.DotNet.ImageBuilder
                         context.BindingContext.AddModelBinder(new ModelBinder<AzdoOptions>());
                         context.BindingContext.AddModelBinder(new ModelBinder<GitOptions>());
                         context.BindingContext.AddModelBinder(new ModelBinder<ManifestFilterOptions>());
+                        context.BindingContext.AddModelBinder(new ModelBinder<RegistryCredentialsOptions>());
                         context.BindingContext.AddModelBinder(new ModelBinder<ServicePrincipalOptions>());
                     })
                     .Build();

--- a/src/Microsoft.DotNet.ImageBuilder/src/StringExtensions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/StringExtensions.cs
@@ -70,5 +70,11 @@ namespace Microsoft.DotNet.ImageBuilder
 
             return value;
         }
+
+        public static (string Key, string Value) ParseKeyValuePair(this string value, char delimiter)
+        {
+            int firstEqualIndex = value.IndexOf(delimiter);
+            return (value.Substring(0, firstEqualIndex), value.Substring(firstEqualIndex + 1));
+        }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/CopyBaseImagesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/CopyBaseImagesCommandTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             command.Options.Subscription = subscriptionId;
             command.Options.ResourceGroup = "my resource group";
             command.Options.RepoPrefix = "custom-repo/";
-            command.Options.SourceCredentials.Add("docker.io", new ImportSourceCredentials("pass", "user"));
+            command.Options.CredentialsOptions.Credentials.Add("docker.io", new RegistryCredentials("user", "pass"));
 
             const string runtimeRelativeDir = "1.0/runtime/os";
             Directory.CreateDirectory(Path.Combine(tempFolderContext.Path, runtimeRelativeDir));

--- a/src/Microsoft.DotNet.ImageBuilder/tests/CopyBaseImagesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/CopyBaseImagesCommandTests.cs
@@ -22,7 +22,7 @@ using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.DockerfileHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
-    public class CopyDockerHubImagesCommandTests
+    public class CopyBaseImagesCommandTests
     {
         [Fact]
         public async Task MultipleBaseTags()
@@ -37,12 +37,13 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             Mock<IEnvironmentService> environmentServiceMock = new Mock<IEnvironmentService>();
 
-            CopyDockerHubBaseImagesCommand command = new CopyDockerHubBaseImagesCommand(
+            CopyBaseImagesCommand command = new CopyBaseImagesCommand(
                 azureManagementFactoryMock.Object, Mock.Of<ILoggerService>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.Subscription = subscriptionId;
             command.Options.ResourceGroup = "my resource group";
             command.Options.RepoPrefix = "custom-repo/";
+            command.Options.SourceCredentials.Add("docker.io", new ImportSourceCredentials("pass", "user"));
 
             const string runtimeRelativeDir = "1.0/runtime/os";
             Directory.CreateDirectory(Path.Combine(tempFolderContext.Path, runtimeRelativeDir));
@@ -92,6 +93,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         manifest.Registry,
                         It.Is<ImportImageParametersInner>(parameters =>
                             parameters.Source.RegistryUri == "docker.io" &&
+                            parameters.Source.Credentials.Password == "pass" &&
+                            parameters.Source.Credentials.Username == "user" &&
                             parameters.Source.SourceImage == expectedTagInfo.SourceImage &&
                             TestHelper.CompareLists(new List<string> { expectedTagInfo.TargetTag }, parameters.TargetTags)),
                         It.IsAny<Dictionary<string, List<string>>>(),


### PR DESCRIPTION
* Renames `CopyDockerHubBaseImagesCommand` to `CopyBaseImagesCommand`.
* Provides source credentials options on a per-registry basis that the command will pass along to the ACR Import operation.
* Dynamically determines source registry from the image tag.

Related to #613