### PR TITLE
Fix call to build command to work on both Windows and Linux

### DIFF
--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -63,7 +63,7 @@ jobs:
   - powershell: |
       $imageBuilderBuildArgs = "$(imageBuilder.queueArgs) --image-info-output-path $(artifactsPath)/$(legName)-image-info.json"
       if ($env:SYSTEM_TEAMPROJECT -eq "internal") {
-        $imageBuilderBuildArgs = "$imageBuilderBuildArgs --registry-override $(acr.server) --repo-prefix $(stagingRepoPrefix) --push --registry-creds '$(acr.server)=$(acr.userName);$(BotAccount-dotnet-docker-acr-bot-password)'"
+        $imageBuilderBuildArgs = "$imageBuilderBuildArgs --registry-override $(acr.server) --repo-prefix $(stagingRepoPrefix) --push --registry-creds ""$(acr.server)=$(acr.userName);$(BotAccount-dotnet-docker-acr-bot-password)"""
       }
 
       # If the pipeline isn't configured to disable the cache and a build variable hasn't been set to disable the cache


### PR DESCRIPTION
The changes from https://github.com/dotnet/docker-tools/pull/758 weren't working properly on Windows because of the parsing of the `registry-creds` argument.  I've fixed this so that it works on both Windows and Linux.