### PR TITLE
Copy base images using subscriptions

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
@@ -40,9 +40,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             LoggerService.WriteHeading("COPYING IMAGES");
 
+            string baseRegistryName = GetBaseRegistryName(Manifest.Registry);
+
             string resourceId =
                 $"/subscriptions/{Options.Subscription}/resourceGroups/{Options.ResourceGroup}/providers" +
-                $"/Microsoft.ContainerRegistry/registries/{RegistryName}";
+                $"/Microsoft.ContainerRegistry/registries/{baseRegistryName}";
 
             IEnumerable<Task> importTasks = Manifest.FilteredRepos
                 .Select(repo =>
@@ -52,6 +54,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         .Select(tagInfo =>
                             ImportImageAsync(
                                 DockerHelper.TrimRegistry(tagInfo.DestinationTag, Manifest.Registry),
+                                baseRegistryName,
                                 DockerHelper.TrimRegistry(tagInfo.SourceTag, Manifest.Registry),
                                 srcResourceId: resourceId)))
                 .SelectMany(tasks => tasks);

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyBaseImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyBaseImagesCommand.cs
@@ -2,12 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Azure.Management.ContainerRegistry.Fluent.Models;
 using Microsoft.DotNet.ImageBuilder.Services;
+using Microsoft.DotNet.ImageBuilder.ViewModel;
 
 #nullable enable
 namespace Microsoft.DotNet.ImageBuilder.Commands
@@ -15,37 +18,75 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     [Export(typeof(ICommand))]
     public class CopyBaseImagesCommand : CopyImagesCommand<CopyBaseImagesOptions, CopyBaseImagesOptionsBuilder>
     {
+        private readonly HttpClient _httpClient;
+
         [ImportingConstructor]
         public CopyBaseImagesCommand(
-            IAzureManagementFactory azureManagementFactory, ILoggerService loggerService)
+            IAzureManagementFactory azureManagementFactory, ILoggerService loggerService, IHttpClientProvider httpClientProvider)
             : base(azureManagementFactory, loggerService)
         {
+            _httpClient = httpClientProvider.GetClient();
         }
 
         protected override string Description => "Copies external base images from their source registry to ACR";
+
+        public override void LoadManifest()
+        {
+            // This command can be used either locally from a product repo or from an external repo that references
+            // a subscription file. If a subscription file is being used, don't attempt to load the manifest because
+            // one may not exist (it wouldn't be used even if it did exist).
+            if (Options.SubscriptionOptions.SubscriptionsPath is null)
+            {
+                base.LoadManifest();
+            }
+        }
 
         public override async Task ExecuteAsync()
         {
             LoggerService.WriteHeading("COPYING IMAGES");
 
-            IEnumerable<Task> importTasks = Manifest.GetExternalFromImages()
-                .Where(fromImage => !fromImage.StartsWith(Manifest.Registry))
-                .Select(fromImage =>
+            IEnumerable<Task> copyImageTasks;
+            if (Options.SubscriptionOptions.SubscriptionsPath is null)
+            {
+                copyImageTasks = GetFromImages(Manifest)
+                    .Select(fromImage => CopyImageAsync(fromImage, GetBaseRegistryName(Manifest.Registry)));
+            }
+            else
+            {
+                if (Options.RegistryOverride is null)
                 {
-                    string registry = DockerHelper.GetRegistry(fromImage) ?? "docker.io";
-                    fromImage = DockerHelper.TrimRegistry(fromImage, registry);
+                    throw new InvalidOperationException($"{Options.RegistryOverride} must be set.");
+                }
 
-                    ImportSourceCredentials? importSourceCreds = null;
-                    if (Options.CredentialsOptions.Credentials.TryGetValue(registry, out RegistryCredentials? registryCreds))
-                    {
-                        importSourceCreds = new ImportSourceCredentials(registryCreds.Password, registryCreds.Username);
-                    }
+                copyImageTasks =
+                    (await SubscriptionHelper.GetSubscriptionManifestsAsync(
+                        Options.SubscriptionOptions.SubscriptionsPath, Options.FilterOptions, _httpClient,
+                        options => options.RegistryOverride = Options.RegistryOverride))
+                    .SelectMany(subscriptionManifest => GetFromImages(subscriptionManifest.Manifest))
+                    .Distinct()
+                    .Select(fromImage => CopyImageAsync(fromImage, GetBaseRegistryName(Options.RegistryOverride)));
+            }
 
-                    return ImportImageAsync($"{Options.RepoPrefix}{fromImage}", fromImage, srcRegistryName: registry,
-                        sourceCredentials: importSourceCreds);
-                });
+            await Task.WhenAll(copyImageTasks);
+        }
 
-            await Task.WhenAll(importTasks);
+        private static IEnumerable<string> GetFromImages(ManifestInfo manifest) =>
+            manifest.GetExternalFromImages()
+                .Where(fromImage => !fromImage.StartsWith(manifest.Model.Registry));
+
+        private Task CopyImageAsync(string fromImage, string destinationRegistryName)
+        {
+            string registry = DockerHelper.GetRegistry(fromImage) ?? "docker.io";
+            fromImage = DockerHelper.TrimRegistry(fromImage, registry);
+
+            ImportSourceCredentials? importSourceCreds = null;
+            if (Options.CredentialsOptions.Credentials.TryGetValue(registry, out RegistryCredentials? registryCreds))
+            {
+                importSourceCreds = new ImportSourceCredentials(registryCreds.Password, registryCreds.Username);
+            }
+
+            return ImportImageAsync($"{Options.RepoPrefix}{fromImage}", destinationRegistryName, fromImage,
+                srcRegistryName: registry, sourceCredentials: importSourceCreds);
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyBaseImagesOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyBaseImagesOptions.cs
@@ -12,18 +12,25 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     public class CopyBaseImagesOptions : CopyImagesOptions
     {
         public RegistryCredentialsOptions CredentialsOptions { get; set; } = new RegistryCredentialsOptions();
+
+        public SubscriptionOptions SubscriptionOptions { get; set; } = new SubscriptionOptions();
     }
 
     public class CopyBaseImagesOptionsBuilder : CopyImagesOptionsBuilder
     {
         private readonly RegistryCredentialsOptionsBuilder _registryCredentialsOptionsBuilder =
             new RegistryCredentialsOptionsBuilder();
+        private readonly SubscriptionOptionsBuilder _subscriptionOptionsBuilder = new SubscriptionOptionsBuilder();
 
         public override IEnumerable<Option> GetCliOptions() =>
-            base.GetCliOptions().Concat(_registryCredentialsOptionsBuilder.GetCliOptions());
+            base.GetCliOptions()
+                .Concat(_registryCredentialsOptionsBuilder.GetCliOptions())
+                .Concat(_subscriptionOptionsBuilder.GetCliOptions());
 
         public override IEnumerable<Argument> GetCliArguments() =>
-            base.GetCliArguments().Concat(_registryCredentialsOptionsBuilder.GetCliArguments());
+            base.GetCliArguments()
+                .Concat(_registryCredentialsOptionsBuilder.GetCliArguments())
+                .Concat(_subscriptionOptionsBuilder.GetCliArguments());
     }
 }
 #nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesOptions.cs
@@ -5,7 +5,6 @@
 using System.Collections.Generic;
 using System.CommandLine;
 using System.Linq;
-using static Microsoft.DotNet.ImageBuilder.Commands.CliHelper;
 
 #nullable enable
 namespace Microsoft.DotNet.ImageBuilder.Commands
@@ -16,31 +15,27 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         public GitOptions GitOptions { get; set; } = new GitOptions();
 
-        public string SubscriptionsPath { get; set; } = string.Empty;
+        public SubscriptionOptions SubscriptionOptions { get; set; } = new SubscriptionOptions();
+
         public string VariableName { get; set; } = string.Empty;
     }
 
     public class GetStaleImagesOptionsBuilder : CliOptionsBuilder
     {
-        private const string DefaultSubscriptionsPath = "subscriptions.json";
-
         private readonly GitOptionsBuilder _gitOptionsBuilder = new GitOptionsBuilder();
         private readonly ManifestFilterOptionsBuilder _manifestFilterOptionsBuilder =
             new ManifestFilterOptionsBuilder();
+        private readonly SubscriptionOptionsBuilder _subscriptionOptionsBuilder = new SubscriptionOptionsBuilder();
 
         public override IEnumerable<Option> GetCliOptions() =>
             base.GetCliOptions()
-                .Concat(
-                    new Option[]
-                    {
-                        CreateOption("subscriptions-path", nameof(GetStaleImagesOptions.SubscriptionsPath),
-                            $"Path to the subscriptions file (defaults to '{DefaultSubscriptionsPath}').", DefaultSubscriptionsPath)
-                    })
+                .Concat(_subscriptionOptionsBuilder.GetCliOptions())
                 .Concat(_manifestFilterOptionsBuilder.GetCliOptions())
                 .Concat(_gitOptionsBuilder.GetCliOptions());
 
         public override IEnumerable<Argument> GetCliArguments() =>
             base.GetCliArguments()
+                .Concat(_subscriptionOptionsBuilder.GetCliArguments())
                 .Concat(_manifestFilterOptionsBuilder.GetCliArguments())
                 .Concat(_gitOptionsBuilder.GetCliArguments())
                 .Concat(

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestCommand.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     {
         public ManifestInfo Manifest { get; private set; }
 
-        public void LoadManifest()
+        public virtual void LoadManifest()
         {
             if (Manifest is null)
             {

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/SubscriptionOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/SubscriptionOptions.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.CommandLine;
+using System.Linq;
+using static Microsoft.DotNet.ImageBuilder.Commands.CliHelper;
+
+#nullable enable
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    public class SubscriptionOptions
+    {
+        public string? SubscriptionsPath { get; set; }
+    }
+
+    public class SubscriptionOptionsBuilder
+    {
+        public IEnumerable<Option> GetCliOptions() =>
+            new Option[]
+            {
+                CreateOption<string?>("subscriptions-path", nameof(SubscriptionOptions.SubscriptionsPath),
+                    $"Path to the subscriptions file")
+            };
+
+        public IEnumerable<Argument> GetCliArguments() => Enumerable.Empty<Argument>();
+    }
+}
+#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/ImageBuilder.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ImageBuilder.cs
@@ -68,6 +68,7 @@ namespace Microsoft.DotNet.ImageBuilder
                         context.BindingContext.AddModelBinder(new ModelBinder<ManifestFilterOptions>());
                         context.BindingContext.AddModelBinder(new ModelBinder<RegistryCredentialsOptions>());
                         context.BindingContext.AddModelBinder(new ModelBinder<ServicePrincipalOptions>());
+                        context.BindingContext.AddModelBinder(new ModelBinder<SubscriptionOptions>());
                     })
                     .Build();
                 return parser.Invoke(args);

--- a/src/Microsoft.DotNet.ImageBuilder/src/SubscriptionHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/SubscriptionHelper.cs
@@ -1,0 +1,83 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Microsoft.DotNet.ImageBuilder.Commands;
+using Microsoft.DotNet.ImageBuilder.Models.Subscription;
+using Microsoft.DotNet.ImageBuilder.ViewModel;
+using Newtonsoft.Json;
+
+#nullable enable
+namespace Microsoft.DotNet.ImageBuilder
+{
+    public static class SubscriptionHelper
+    {
+        public static async Task<IEnumerable<(Subscription Subscription, ManifestInfo Manifest)>> GetSubscriptionManifestsAsync(
+            string subscriptionsPath, ManifestFilterOptions filterOptions, HttpClient httpClient, Action<ManifestOptions>? configureOptions = null)
+        {
+            string subscriptionsJson = File.ReadAllText(subscriptionsPath);
+            Subscription[] subscriptions = JsonConvert.DeserializeObject<Subscription[]>(subscriptionsJson);
+
+            List<(Subscription Subscription, ManifestInfo Manifest)> subscriptionManifests = new
+                List<(Subscription Subscription, ManifestInfo Manifest)>();
+            foreach (Subscription subscription in subscriptions)
+            {
+                ManifestInfo? manifest = await GetSubscriptionManifestAsync(subscription, filterOptions, httpClient, configureOptions);
+                if (manifest is not null)
+                {
+                    subscriptionManifests.Add((subscription, manifest));
+                }
+            }
+
+            return subscriptionManifests;
+        }
+
+        private static async Task<ManifestInfo?> GetSubscriptionManifestAsync(Subscription subscription,
+            ManifestFilterOptions filterOptions, HttpClient httpClient, Action<ManifestOptions>? configureOptions)
+        {
+            // If the command is filtered with an OS type that does not match the OsType filter of the subscription,
+            // then there are no images that need to be inspected.
+            string osTypeRegexPattern = ManifestFilter.GetFilterRegexPattern(filterOptions.OsType);
+            if (!string.IsNullOrEmpty(subscription.OsType) &&
+                !Regex.IsMatch(subscription.OsType, osTypeRegexPattern, RegexOptions.IgnoreCase))
+            {
+                return null;
+            }
+
+            string repoPath = await GitHelper.DownloadAndExtractGitRepoArchiveAsync(httpClient, subscription.Manifest);
+            try
+            {
+                TempManifestOptions manifestOptions = new TempManifestOptions(filterOptions)
+                {
+                    Manifest = Path.Combine(repoPath, subscription.Manifest.Path),
+                };
+
+                configureOptions?.Invoke(manifestOptions);
+
+                return ManifestInfo.Load(manifestOptions);
+            }
+            finally
+            {
+                // The path to the repo is stored inside a zip extraction folder so be sure to delete that
+                // zip extraction folder, not just the inner repo folder.
+                Directory.Delete(new DirectoryInfo(repoPath).Parent!.FullName, true);
+            }
+        }
+
+        private class TempManifestOptions : ManifestOptions, IFilterableOptions
+        {
+            public TempManifestOptions(ManifestFilterOptions filterOptions)
+            {
+                FilterOptions = filterOptions;
+            }
+
+            public ManifestFilterOptions FilterOptions { get; }
+        }
+    }
+}
+#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/tests/CopyBaseImagesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/CopyBaseImagesCommandTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Mock<IEnvironmentService> environmentServiceMock = new Mock<IEnvironmentService>();
 
             CopyBaseImagesCommand command = new CopyBaseImagesCommand(
-                azureManagementFactoryMock.Object, Mock.Of<ILoggerService>());
+                azureManagementFactoryMock.Object, Mock.Of<ILoggerService>(), Mock.Of<IHttpClientProvider>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.Subscription = subscriptionId;
             command.Options.ResourceGroup = "my resource group";

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
@@ -1433,7 +1433,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             {
                 GetStaleImagesCommand command = new GetStaleImagesCommand(
                     this.ManifestToolServiceMock.Object, this.httpClientFactory, this.loggerServiceMock.Object, this.gitHubClientFactory);
-                command.Options.SubscriptionsPath = this.subscriptionsPath;
+                command.Options.SubscriptionOptions.SubscriptionsPath = this.subscriptionsPath;
                 command.Options.VariableName = VariableName;
                 command.Options.FilterOptions.OsType = this.osType;
                 command.Options.GitOptions.Email = "test";


### PR DESCRIPTION
Updates the `copyBaseImages` command to optionally consume a subscriptions file instead of a local manifest.  This is needed in the scenario where this command will be run as part of checking for any base image updates, which occurs from the dotnet/docker-tools repo. In that case, the subscription is used to determine all the manifests from all the product repos that are participating in the base image check logic and copies those base images to the mirroring location.  

Related to #613