### PR TITLE
Copy base images as part of stale image check

### DIFF
--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:988726
+  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:999010
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-buster-slim-docker-testrunner-974165
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/eng/pipelines/check-base-image-updates.yml
+++ b/eng/pipelines/check-base-image-updates.yml
@@ -12,83 +12,92 @@ schedules:
 variables:
 - template: templates/variables/common.yml
 
-jobs:
-- job: Get_Stale_Images_Linux_AMD
-  pool:
-    vmImage: $(defaultLinuxAmd64PoolImage)
-  steps:
-  - template: templates/steps/get-stale-images.yml
-    parameters:
-      osType: linux
-      architecture: amd64
-      dockerClientOS: linux
-      staleImagePathsVariableName: linux-amd-stale-image-paths
+stages:
+- stage: CopyBaseImages
+  jobs:
+  - job: CopyBaseImages
+    pool:
+      vmImage: $(defaultLinuxAmd64PoolImage)
+    steps:
+    - template: templates/steps/copy-base-images.yml
 
-- job: Get_Stale_Images_Linux_ARM32
-  pool:
-    name: DotNetCore-Docker
-    demands:
-    - Agent.OS -equals linux
-    - Agent.OSArchitecture -equals ARM64
-  steps:
-  - template: templates/steps/get-stale-images.yml
-    parameters:
-      osType: linux
-      architecture: arm
-      dockerClientOS: linux
-      staleImagePathsVariableName: linux-arm32-stale-image-paths
+- stage: GetStaleImages
+  dependsOn: CopyBaseImages
+  jobs:
+  - job: Get_Stale_Images_Linux_AMD
+    pool:
+      vmImage: $(defaultLinuxAmd64PoolImage)
+    steps:
+    - template: templates/steps/get-stale-images.yml
+      parameters:
+        osType: linux
+        architecture: amd64
+        dockerClientOS: linux
+        staleImagePathsVariableName: linux-amd-stale-image-paths
 
-- job: Get_Stale_Images_Linux_ARM64
-  pool:
-    name: DotNetCore-Docker
-    demands:
-    - Agent.OS -equals linux
-    - Agent.OSArchitecture -equals ARM64
-  steps:
-  - template: templates/steps/get-stale-images.yml
-    parameters:
-      osType: linux
-      architecture: arm64
-      dockerClientOS: linux
-      staleImagePathsVariableName: linux-arm64-stale-image-paths
+  - job: Get_Stale_Images_Linux_ARM32
+    pool:
+      name: DotNetCore-Docker
+      demands:
+      - Agent.OS -equals linux
+      - Agent.OSArchitecture -equals ARM64
+    steps:
+    - template: templates/steps/get-stale-images.yml
+      parameters:
+        osType: linux
+        architecture: arm
+        dockerClientOS: linux
+        staleImagePathsVariableName: linux-arm32-stale-image-paths
 
-- job: Get_Stale_Images_Windows_AMD
-  pool:
-    name: DotNetCore-Docker
-    demands: VSTS_OS -equals Windows_Server_2019_Data_Center_RS5
-  steps:
-  - template: templates/steps/get-stale-images.yml
-    parameters:
-      osType: windows
-      architecture: amd64
-      dockerClientOS: windows
-      staleImagePathsVariableName: windows-amd-stale-image-paths
+  - job: Get_Stale_Images_Linux_ARM64
+    pool:
+      name: DotNetCore-Docker
+      demands:
+      - Agent.OS -equals linux
+      - Agent.OSArchitecture -equals ARM64
+    steps:
+    - template: templates/steps/get-stale-images.yml
+      parameters:
+        osType: linux
+        architecture: arm64
+        dockerClientOS: linux
+        staleImagePathsVariableName: linux-arm64-stale-image-paths
 
-- job: Queue_Stale_Image_Builds
-  dependsOn:
-  - Get_Stale_Images_Linux_AMD
-  - Get_Stale_Images_Linux_ARM32
-  - Get_Stale_Images_Linux_ARM64
-  - Get_Stale_Images_Windows_AMD
-  pool:
-    vmImage: $(defaultLinuxAmd64PoolImage)
-  variables:
-    imagePaths1: $[ dependencies.Get_Stale_Images_Linux_AMD.outputs['GetStaleImages.linux-amd-stale-image-paths'] ]
-    imagePaths2: $[ dependencies.Get_Stale_Images_Linux_ARM32.outputs['GetStaleImages.linux-arm32-stale-image-paths'] ]
-    imagePaths3: $[ dependencies.Get_Stale_Images_Linux_ARM64.outputs['GetStaleImages.linux-arm64-stale-image-paths'] ]
-    imagePaths4: $[ dependencies.Get_Stale_Images_Windows_AMD.outputs['GetStaleImages.windows-amd-stale-image-paths'] ]
-  steps:
-  - template: ../common/templates/steps/init-docker-linux.yml
-  - script: >
-      $(runImageBuilderCmd)
-      queueBuild
-      $(System.AccessToken)
-      dnceng
-      internal
-      --subscriptions-path $(checkBaseImageSubscriptionsPath)
-      --image-paths "$(imagePaths1)"
-      --image-paths "$(imagePaths2)"
-      --image-paths "$(imagePaths3)"
-      --image-paths "$(imagePaths4)"
-    displayName: Queue Build for Stale Images
-  - template: ../common/templates/steps/cleanup-docker-linux.yml
+  - job: Get_Stale_Images_Windows_AMD
+    pool:
+      name: DotNetCore-Docker
+      demands: VSTS_OS -equals Windows_Server_2019_Data_Center_RS5
+    steps:
+    - template: templates/steps/get-stale-images.yml
+      parameters:
+        osType: windows
+        architecture: amd64
+        dockerClientOS: windows
+        staleImagePathsVariableName: windows-amd-stale-image-paths
+
+- stage: QueueBuilds
+  dependsOn: GetStaleImages
+  jobs:
+  - job: Queue_Stale_Image_Builds
+    pool:
+      vmImage: $(defaultLinuxAmd64PoolImage)
+    variables:
+      imagePaths1: $[ stageDependencies.GetStaleImages.Get_Stale_Images_Linux_AMD.outputs['GetStaleImages.linux-amd-stale-image-paths'] ]
+      imagePaths2: $[ stageDependencies.GetStaleImages.Get_Stale_Images_Linux_ARM32.outputs['GetStaleImages.linux-arm32-stale-image-paths'] ]
+      imagePaths3: $[ stageDependencies.GetStaleImages.Get_Stale_Images_Linux_ARM64.outputs['GetStaleImages.linux-arm64-stale-image-paths'] ]
+      imagePaths4: $[ stageDependencies.GetStaleImages.Get_Stale_Images_Windows_AMD.outputs['GetStaleImages.windows-amd-stale-image-paths'] ]
+    steps:
+    - template: ../common/templates/steps/init-docker-linux.yml
+    - script: >
+        $(runImageBuilderCmd)
+        queueBuild
+        $(System.AccessToken)
+        dnceng
+        internal
+        --subscriptions-path $(checkBaseImageSubscriptionsPath)
+        --image-paths "$(imagePaths1)"
+        --image-paths "$(imagePaths2)"
+        --image-paths "$(imagePaths3)"
+        --image-paths "$(imagePaths4)"
+      displayName: Queue Build for Stale Images
+    - template: ../common/templates/steps/cleanup-docker-linux.yml

--- a/eng/pipelines/templates/steps/copy-base-images.yml
+++ b/eng/pipelines/templates/steps/copy-base-images.yml
@@ -1,0 +1,19 @@
+steps:
+  - template: ../../../common/templates/steps/init-docker-linux.yml
+  - script: >
+      $(runImageBuilderCmd)
+      copyBaseImages
+      '$(acr.servicePrincipalName)'
+      '$(app-dotnetdockerbuild-client-secret)'
+      '$(acr.servicePrincipalTenant)'
+      '$(acr.subscription)'
+      '$(acr.resourceGroup)'
+      --registry-creds 'docker.io=$(dotnetDockerHubBot.userName);$(BotAccount-dotnet-dockerhub-bot-PAT)'
+      --repo-prefix 'mirror/'
+      --subscriptions-path '$(checkBaseImageSubscriptionsPath)'
+      --registry-override '$(acr.server)'
+      --os-type 'linux'
+      --architecture '*'
+    displayName: Copy Base Images
+    continueOnError: true
+  - template: ../../../common/templates/steps/cleanup-docker-linux.yml


### PR DESCRIPTION
Updates the pipeline which rebuilds any out-of-date images when a base image changes to include an additional step to copy all external base images to a mirror location.  This is just one of the phases in implementing the full solution for #613.  The intent is to just have this additional step executed but for the rest of the pipeline to continue as usual and not to actually consume the mirrored images.  Once we've determined that the mirror logic is working properly within the pipeline, then we can proceed with consuming it.

Related to #613