### PR TITLE
Support pulling from mirror location during build

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -51,10 +51,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 _imageArtifactDetails = new ImageArtifactDetails();
             }
 
-            PullBaseImages();
-
             ExecuteWithUser(() =>
             {
+                PullBaseImages();
+
                 BuildImages();
 
                 if (_builtTags.Any())
@@ -149,9 +149,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             platform.Created = createdDate;
         }
 
-        private static void SetPlatformDataBaseDigest(PlatformData platform, Dictionary<string, PlatformData> platformDataByTag)
+        private void SetPlatformDataBaseDigest(PlatformData platform, Dictionary<string, PlatformData> platformDataByTag)
         {
-            if (platform.BaseImageDigest == null && platform.PlatformInfo.FinalStageFromImage != null)
+            string baseImageDigest = platform.BaseImageDigest;
+            if (platform.BaseImageDigest is null && platform.PlatformInfo.FinalStageFromImage is not null)
             {
                 if (!platformDataByTag.TryGetValue(platform.PlatformInfo.FinalStageFromImage, out PlatformData? basePlatformData))
                 {
@@ -165,8 +166,17 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     throw new InvalidOperationException($"Digest for platform '{basePlatformData.GetIdentifier()}' has not been calculated yet.");
                 }
 
-                platform.BaseImageDigest = basePlatformData.Digest;
+                baseImageDigest = basePlatformData.Digest;
             }
+
+            if (platform.PlatformInfo.FinalStageFromImage is not null)
+            {
+                baseImageDigest = DockerHelper.GetDigestString(
+                    DockerHelper.GetRepo(GetFromImagePublicTag(platform.PlatformInfo.FinalStageFromImage)),
+                    DockerHelper.GetDigestSha(baseImageDigest));
+            }
+
+            platform.BaseImageDigest = baseImageDigest;
         }
 
         private void SetPlatformDataLayers(PlatformData platform, string tag)
@@ -248,7 +258,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                             if (platformData != null)
                             {
                                 platformData.BaseImageDigest =
-                                   _imageDigestCache.GetImageDigest(platform.FinalStageFromImage, Options.IsDryRun);
+                                   _imageDigestCache.GetImageDigest(GetFromImageLocalTag(platform.FinalStageFromImage), Options.IsDryRun);
                             }
                         }
                     }
@@ -465,7 +475,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         private bool IsBaseImageDigestUpToDate(PlatformInfo platform, PlatformData srcPlatformData)
         {
-            string currentBaseImageDigest = _imageDigestCache.GetImageDigest(platform.FinalStageFromImage, Options.IsDryRun);
+            string currentBaseImageDigest = _imageDigestCache.GetImageDigest(GetFromImageLocalTag(platform.FinalStageFromImage), Options.IsDryRun);
             bool baseImageDigestMatches = DockerHelper.GetDigestSha(srcPlatformData.BaseImageDigest)?.Equals(
                 DockerHelper.GetDigestSha(currentBaseImageDigest), StringComparison.OrdinalIgnoreCase) == true;
 
@@ -584,6 +594,66 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             ExecuteHelper.Execute(startInfo, Options.IsDryRun, $"Failed to execute build hook '{scriptPath}'");
         }
 
+        /// <summary>
+        /// Returns the tag to use for pulling the image of a FROM instruction.
+        /// </summary>
+        /// <param name="fromImage">Tag of the FROM image.</param>
+        private string GetFromImagePullTag(string fromImage) =>
+            // Provides the raw registry value from the manifest (e.g. mcr.microsoft.com). This accounts for images that
+            // are classified as external within the model but they are owned internally and not mirrored. An example of
+            // this is sample images. By comparing their base image tag to that raw registry value from the manifest, we
+            // can know that these are owned internally and not to attempt to pull them from the mirror location.
+            GetFromImageTag(fromImage, Manifest.Model.Registry);
+
+        /// <summary>
+        /// Returns the tag to use for interacting with the image of a FROM instruction that has been pulled or built locally.
+        /// </summary>
+        /// <param name="fromImage">Tag of the FROM image.</param>
+        private string GetFromImageLocalTag(string fromImage) =>
+            // Provides the overridable value of the registry (e.g. dotnetdocker.azurecr.io) because that is the registry that
+            // would be used for tags that exist locally.
+            GetFromImageTag(fromImage, Manifest.Registry);
+
+        /// <summary>
+        /// Gets the tag to use for the image of a FROM instruction.
+        /// </summary>
+        /// <param name="fromImage">Tag of the FROM image.</param>
+        /// <param name="registry">Registry to use for comparing against the tag to determine if it's owned internally or external.</param>
+        /// <remarks>
+        /// This is meant to provide support for external images that need to be pulled from the mirror location.
+        /// </remarks>
+        private string GetFromImageTag(string fromImage, string? registry)
+        {
+            if (DockerHelper.IsInRegistry(fromImage, registry) || Options.SourceRepoPrefix is null)
+            {
+                return fromImage;
+            }
+
+            return $"{Manifest.Registry}/{Options.SourceRepoPrefix}{DockerHelper.TrimRegistry(fromImage)}";
+        }
+
+        /// <summary>
+        /// Returns the tag that represents the publicly available tag of a FROM instruction.
+        /// </summary>
+        /// <param name="fromImage">Tag of the FROM image.</param>
+        /// <remarks>
+        /// This compares the registry of the image tag to determine if it's internally owned. If so, it returns
+        /// the tag using the raw (non-overriden) registry from the manifest (e.g. mcr.microsoft.com). Otherwise,
+        /// it returns the image tag unchanged.
+        /// </remarks>
+        private string GetFromImagePublicTag(string fromImage)
+        {
+            if (DockerHelper.IsInRegistry(fromImage, Manifest.Registry) ||
+                DockerHelper.IsInRegistry(fromImage, Manifest.Model.Registry))
+            {
+                return $"{Manifest.Model.Registry}/{DockerHelper.TrimRegistry(fromImage)}";
+            }
+            else
+            {
+                return fromImage;
+            }
+        }
+
         private void PullBaseImages()
         {
             if (!Options.IsSkipPullingEnabled)
@@ -592,23 +662,43 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 IEnumerable<string> baseImages = Manifest.GetExternalFromImages().ToArray();
                 if (baseImages.Any())
                 {
-                    foreach (string fromImage in baseImages)
+                    List<string> pulledTags = new List<string>();
+                    foreach (string pullTag in baseImages.Select(tag => GetFromImagePullTag(tag)))
                     {
-                        _dockerService.PullImage(fromImage, Options.IsDryRun);
+                        pulledTags.Add(pullTag);
+                        _dockerService.PullImage(pullTag, Options.IsDryRun);
                     }
 
                     IEnumerable<string> finalStageExternalFromImages = Manifest.GetFilteredPlatforms()
                         .Where(platform => !platform.IsInternalFromImage(platform.FinalStageFromImage))
-                        .Select(platform => platform.FinalStageFromImage)
+                        .Select(platform => GetFromImagePullTag(platform.FinalStageFromImage))
                         .Distinct();
+
+                    if (!finalStageExternalFromImages.IsSubsetOf(pulledTags))
+                    {
+                        throw new InvalidOperationException(
+                            "The following tags are identified as final stage tags but were not pulled:" +
+                            Environment.NewLine +
+                            string.Join(", ", finalStageExternalFromImages.Except(pulledTags).ToArray()));
+                    }
 
                     Parallel.ForEach(finalStageExternalFromImages, fromImage =>
                     {
                         // Ensure the digest of the pulled image is retrieved right away after pulling so it's available in
                         // the DockerServiceCache for later use.  The longer we wait to get the digest after pulling, the
-                        // greater change the tag could be updated resulting in a different digest returned than what was
+                        // greater chance the tag could be updated resulting in a different digest returned than what was
                         // originally pulled.
                         _imageDigestCache.GetImageDigest(fromImage, Options.IsDryRun);
+                    });
+
+                    // Tag the images that were pulled from the mirror as they are referenced in the Dockerfiles
+                    Parallel.ForEach(baseImages, fromImage =>
+                    {
+                        string pullTag = GetFromImagePullTag(fromImage);
+                        if (pullTag != fromImage)
+                        {
+                            _dockerService.CreateTag(pullTag, fromImage, Options.IsDryRun);
+                        }
                     });
                 }
                 else

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
@@ -21,6 +21,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public string? ImageInfoSourcePath { get; set; }
         public string? SourceRepoUrl { get; set; }
         public bool NoCache { get; set; }
+        public string? SourceRepoPrefix { get; set; }
     }
 
     public class BuildOptionsBuilder : DockerRegistryOptionsBuilder
@@ -47,7 +48,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         CreateOption<string?>("source-repo", nameof(BuildOptions.SourceRepoUrl),
                             "Repo URL of the Dockerfile sources"),
                         CreateOption<bool>("no-cache", nameof(BuildOptions.NoCache),
-                            "Disables build cache feature")
+                            "Disables build cache feature"),
+                        CreateOption<string?>("source-repo-prefix", nameof(BuildOptions.SourceRepoPrefix),
+                            "Prefix to add to the external base image names when pulling them"),
                     });
 
         public override IEnumerable<Argument> GetCliArguments() =>

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
@@ -177,7 +177,11 @@ namespace Microsoft.DotNet.ImageBuilder
             return imageName;
         }
 
+        public static string TrimRegistry(string tag) => TrimRegistry(tag, GetRegistry(tag));
+
         public static string TrimRegistry(string tag, string registry) => tag.TrimStart($"{registry}/");
+
+        public static bool IsInRegistry(string tag, string registry) => registry is not null && tag.StartsWith(registry);
 
         /// <remarks>
         /// This method depends on the experimental Docker CLI `manifest` command.  As a result, this method
@@ -192,11 +196,16 @@ namespace Microsoft.DotNet.ImageBuilder
 
         public static string GetRegistry(string imageName)
         {
-            string firstSegment = imageName.Substring(0, imageName.IndexOf("/"));
-            if (firstSegment.Contains(".") || firstSegment.Contains(":"))
+            int separatorIndex = imageName.IndexOf("/");
+            if (separatorIndex >= 0)
             {
-                return firstSegment;
+                string firstSegment = imageName.Substring(0, separatorIndex);
+                if (firstSegment.Contains(".") || firstSegment.Contains(":"))
+                {
+                    return firstSegment;
+                }
             }
+            
 
             return null;
         }

--- a/src/Microsoft.DotNet.ImageBuilder/src/EnumerableExtensions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/EnumerableExtensions.cs
@@ -36,5 +36,8 @@ namespace Microsoft.DotNet.ImageBuilder
 
             return true;
         }
+
+        public static bool IsSubsetOf<T>(this IEnumerable<T> source, IEnumerable<T> items) =>
+            !source.Except(items).Any();
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
@@ -944,8 +944,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         [Fact]
         public async Task BuildCommand_Caching_SharedDockerfile_MissingSourceImageInfoEntry()
         {
-            const string runtimeDepsRepo = "runtime-deps";
-            const string runtimeDeps2Repo = "runtime-deps2";
+            string runtimeDepsRepo = $"runtime-deps";
+            string runtimeDeps2Repo = $"runtime-deps2";
             string runtimeDepsLinuxDigest = $"{runtimeDepsRepo}@sha1-linux";
             string runtimeDepsWindowsDigest = $"{runtimeDepsRepo}@sha1-windows";
             string runtimeDeps2Digest = $"{runtimeDeps2Repo}@sha1-linux";
@@ -2166,6 +2166,454 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     It.IsAny<bool>(), It.IsAny<bool>()),
                 Times.Never);
             dockerServiceMock.Verify(o => o.GetCreatedDate(It.IsAny<string>(), false));
+
+            dockerServiceMock.VerifyNoOtherCalls();
+        }
+
+        /// <summary>
+        /// Verifies the command pulls base images from a mirror location.
+        /// </summary>
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task BuildCommand_MirroredImages(bool hasCachedImage)
+        {
+            const string Registry = "mcr.microsoft.com";
+            const string RegistryOverride = "dotnetdocker.azurecr.io";
+            const string RuntimeDepsRepo = "runtime-deps";
+            const string RuntimeRepo = "runtime";
+            const string AspnetRepo = "aspnet";
+            const string RuntimeDepsDigest = "sha256:c74364a9f125ca612f9a67e4a0551937b7a37c82fabb46172c4867b73edd638c";
+            const string RuntimeDigest = "sha256:adc914a9f125ca612f9a67e4a0551937b7a37c82fabb46172c4867b73ed99227";
+            const string AspnetDigest = "sha256:781914a9f125ca612f9a67e4a0551937b7a37c82fabb46172c4867b73ed0045a";
+            const string Tag = "tag";
+            const string BaseImageRepo = "baserepo";
+            string baseImageTag = $"{BaseImageRepo}:basetag";
+
+            const string SourceRepoPrefix = "my-mirror/";
+            string mirrorBaseTag = $"{RegistryOverride}/{SourceRepoPrefix}{baseImageTag}";
+            string baseImageDigest =
+                $"{BaseImageRepo}@sha256:d21234a9f125ca612f9a67e4a0551937b7a37c82fabb46172c4867b73edd1349";
+            string mirrorBaseImageDigest =
+                $"{RegistryOverride}/{SourceRepoPrefix}{baseImageDigest}";
+
+            using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
+            Mock<IDockerService> dockerServiceMock = CreateDockerServiceMock();
+
+            if (hasCachedImage)
+            {
+                dockerServiceMock
+                    .Setup(o => o.GetImageDigest($"{Registry}/{RuntimeDepsRepo}:{Tag}", false))
+                    .Returns($"{Registry}/{RuntimeDepsRepo}@{RuntimeDepsDigest}");
+
+                dockerServiceMock
+                    .Setup(o => o.GetImageDigest($"{Registry}/{RuntimeRepo}:{Tag}", false))
+                    .Returns($"{Registry}/{RuntimeRepo}@{RuntimeDigest}");
+
+                dockerServiceMock
+                    .Setup(o => o.GetImageDigest($"{Registry}/{AspnetRepo}:{Tag}", false))
+                    .Returns($"{Registry}/{AspnetRepo}@{AspnetDigest}");
+
+                dockerServiceMock
+                    .Setup(o => o.GetImageDigest($"{RegistryOverride}/{RuntimeDepsRepo}:{Tag}", false))
+                    .Returns($"{RegistryOverride}/{RuntimeDepsRepo}@{RuntimeDepsDigest}");
+
+                dockerServiceMock
+                    .Setup(o => o.GetImageDigest($"{RegistryOverride}/{RuntimeRepo}:{Tag}", false))
+                    .Returns($"{RegistryOverride}/{RuntimeRepo}@{RuntimeDigest}");
+
+                dockerServiceMock
+                    .Setup(o => o.GetImageDigest($"{RegistryOverride}/{AspnetRepo}:{Tag}", false))
+                    .Returns($"{RegistryOverride}/{AspnetRepo}@{AspnetDigest}");
+            }
+            else
+            {
+                // Locally built images will not have a digest until they get pushed. So don't return a digest until
+                // the appropriate request.
+                dockerServiceMock
+                    .Setup(o => o.GetImageDigest($"{RegistryOverride}/{RuntimeDepsRepo}:{Tag}", false))
+                    .Returns(callCount => callCount > 2 ? $"{RegistryOverride}/{RuntimeDepsRepo}@{RuntimeDepsDigest}" : null);
+
+                dockerServiceMock
+                    .Setup(o => o.GetImageDigest($"{RegistryOverride}/{RuntimeRepo}:{Tag}", false))
+                    .Returns(callCount => callCount > 1 ? $"{RegistryOverride}/{RuntimeRepo}@{RuntimeDigest}" : null);
+
+                dockerServiceMock
+                    .Setup(o => o.GetImageDigest($"{RegistryOverride}/{AspnetRepo}:{Tag}", false))
+                    .Returns(callCount => callCount > 0 ? $"{RegistryOverride}/{AspnetRepo}@{AspnetDigest}" : null);
+            }
+            
+            dockerServiceMock
+                .Setup(o => o.GetImageDigest(mirrorBaseTag, false))
+                .Returns(mirrorBaseImageDigest);
+
+            DateTime createdDate = DateTime.Now.ToUniversalTime();
+            dockerServiceMock
+                .Setup(o => o.GetCreatedDate(It.IsAny<string>(), false))
+                .Returns(createdDate);
+
+            string runtimeDepsDockerfileRelativePath = DockerfileHelper.CreateDockerfile(
+                "1.0/runtime-deps/os", tempFolderContext, baseImageTag);
+
+            string runtimeDockerfileRelativePath = DockerfileHelper.CreateDockerfile(
+                "1.0/runtime/os", tempFolderContext, $"$REPO:{Tag}");
+
+            string aspnetDockerfileRelativePath = DockerfileHelper.CreateDockerfile(
+                "1.0/aspnet/os", tempFolderContext, $"$REPO:{Tag}");
+
+            const string dockerfileCommitSha = "mycommit";
+            Mock<IGitService> gitServiceMock = new Mock<IGitService>();
+            gitServiceMock
+                .Setup(o => o.GetCommitSha(It.IsAny<string>(), It.IsAny<bool>()))
+                .Returns(dockerfileCommitSha);
+
+            BuildCommand command = new BuildCommand(
+                dockerServiceMock.Object,
+                Mock.Of<ILoggerService>(),
+                gitServiceMock.Object);
+            command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
+            command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "image-info.json");
+            command.Options.ImageInfoSourcePath = Path.Combine(tempFolderContext.Path, "src-image-info.json");
+            command.Options.IsPushEnabled = true;
+            command.Options.SourceRepoUrl = "https://github.com/dotnet/test";
+            command.Options.SourceRepoPrefix = SourceRepoPrefix;
+            command.Options.RegistryOverride = RegistryOverride;
+
+            const string ProductVersion = "1.0.1";
+
+            List<RepoData> sourceRepos = new List<RepoData>
+            {
+                new RepoData
+                {
+                    Repo = RuntimeDepsRepo,
+                    Images =
+                    {
+                        new ImageData
+                        {
+                            ProductVersion = ProductVersion,
+                            Platforms =
+                            {
+                                new PlatformData
+                                {
+                                    Dockerfile = runtimeDepsDockerfileRelativePath,
+                                    Architecture = "amd64",
+                                    OsType = "Linux",
+                                    OsVersion = "focal",
+                                    Digest = $"{Registry}/{RuntimeDepsRepo}@{RuntimeDepsDigest}",
+                                    BaseImageDigest = hasCachedImage ? mirrorBaseImageDigest : mirrorBaseImageDigest + "b",
+                                    CommitUrl = $"{command.Options.SourceRepoUrl}/blob/{dockerfileCommitSha}/{runtimeDepsDockerfileRelativePath}",
+                                    SimpleTags = new List<string>
+                                    {
+                                        Tag
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                new RepoData
+                {
+                    Repo = RuntimeRepo,
+                    Images =
+                    {
+                        new ImageData
+                        {
+                            ProductVersion = ProductVersion,
+                            Platforms =
+                            {
+                                new PlatformData
+                                {
+                                    Dockerfile = runtimeDockerfileRelativePath,
+                                    Architecture = "amd64",
+                                    OsType = "Linux",
+                                    OsVersion = "focal",
+                                    Digest = $"{Registry}/{RuntimeRepo}@{RuntimeDigest}",
+                                    BaseImageDigest = hasCachedImage ?
+                                        $"{Registry}/{RuntimeDepsRepo}@{RuntimeDepsDigest}" :
+                                        $"{Registry}/{RuntimeDepsRepo}@{RuntimeDepsDigest}" + "b",
+                                    CommitUrl = $"{command.Options.SourceRepoUrl}/blob/{dockerfileCommitSha}/{runtimeDockerfileRelativePath}",
+                                    SimpleTags = new List<string>
+                                    {
+                                        Tag
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            ImageArtifactDetails sourceImageArtifactDetails = new ImageArtifactDetails
+            {
+                Repos = sourceRepos.ToList()
+            };
+
+            string sourceImageArtifactDetailsOutput = JsonHelper.SerializeObject(sourceImageArtifactDetails);
+            File.WriteAllText(command.Options.ImageInfoSourcePath, sourceImageArtifactDetailsOutput);
+
+            Manifest manifest = CreateManifest(
+                CreateRepo(RuntimeDepsRepo,
+                    CreateImage(
+                        new Platform[]
+                        {
+                            CreatePlatform(runtimeDepsDockerfileRelativePath, new string[] { Tag })
+                        },
+                        productVersion: ProductVersion)),
+                CreateRepo(RuntimeRepo,
+                    CreateImage(
+                        new Platform[]
+                        {
+                            CreatePlatformWithRepoBuildArg(
+                                runtimeDockerfileRelativePath,
+                                $"{RegistryOverride}/{RuntimeDepsRepo}",
+                                new string[] { Tag })
+                        },
+                        productVersion: ProductVersion)),
+                CreateRepo(AspnetRepo,
+                    CreateImage(
+                        new Platform[]
+                        {
+                            CreatePlatformWithRepoBuildArg(
+                                aspnetDockerfileRelativePath,
+                                $"{RegistryOverride}/{RuntimeRepo}",
+                                new string[] { Tag })
+                        },
+                        productVersion: ProductVersion))
+            );
+            manifest.Registry = Registry;
+
+            File.WriteAllText(Path.Combine(tempFolderContext.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));
+
+            command.LoadManifest();
+            await command.ExecuteAsync();
+
+            ImageArtifactDetails expectedOutputImageArtifactDetails = new ImageArtifactDetails
+            {
+                Repos = new List<RepoData>
+                {
+                    new RepoData
+                    {
+                        Repo = RuntimeDepsRepo,
+                        Images =
+                        {
+                            new ImageData
+                            {
+                                ProductVersion = ProductVersion,
+                                Platforms =
+                                {
+                                    new PlatformData
+                                    {
+                                        Dockerfile = runtimeDepsDockerfileRelativePath,
+                                        Architecture = "amd64",
+                                        OsType = "Linux",
+                                        OsVersion = "focal",
+                                        Digest = $"{Registry}/{RuntimeDepsRepo}@{RuntimeDepsDigest}",
+                                        BaseImageDigest = baseImageDigest,
+                                        CommitUrl = $"{command.Options.SourceRepoUrl}/blob/{dockerfileCommitSha}/{runtimeDepsDockerfileRelativePath}",
+                                        Created = createdDate,
+                                        IsUnchanged = hasCachedImage,
+                                        SimpleTags = new List<string>
+                                        {
+                                            Tag
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    new RepoData
+                    {
+                        Repo = RuntimeRepo,
+                        Images =
+                        {
+                            new ImageData
+                            {
+                                ProductVersion = ProductVersion,
+                                Platforms =
+                                {
+                                    new PlatformData
+                                    {
+                                        Dockerfile = runtimeDockerfileRelativePath,
+                                        Architecture = "amd64",
+                                        OsType = "Linux",
+                                        OsVersion = "focal",
+                                        Digest = $"{Registry}/{RuntimeRepo}@{RuntimeDigest}",
+                                        BaseImageDigest = $"{Registry}/{RuntimeDepsRepo}@{RuntimeDepsDigest}",
+                                        CommitUrl = $"{command.Options.SourceRepoUrl}/blob/{dockerfileCommitSha}/{runtimeDockerfileRelativePath}",
+                                        Created = createdDate,
+                                        IsUnchanged = hasCachedImage,
+                                        SimpleTags = new List<string>
+                                        {
+                                            Tag
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    new RepoData
+                    {
+                        Repo = AspnetRepo,
+                        Images =
+                        {
+                            new ImageData
+                            {
+                                ProductVersion = ProductVersion,
+                                Platforms =
+                                {
+                                    new PlatformData
+                                    {
+                                        Dockerfile = aspnetDockerfileRelativePath,
+                                        Architecture = "amd64",
+                                        OsType = "Linux",
+                                        OsVersion = "focal",
+                                        Digest = $"{Registry}/{AspnetRepo}@{AspnetDigest}",
+                                        BaseImageDigest = $"{Registry}/{RuntimeRepo}@{RuntimeDigest}",
+                                        CommitUrl = $"{command.Options.SourceRepoUrl}/blob/{dockerfileCommitSha}/{aspnetDockerfileRelativePath}",
+                                        Created = createdDate,
+                                        SimpleTags = new List<string>
+                                        {
+                                            Tag
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            string expectedOutput = JsonHelper.SerializeObject(expectedOutputImageArtifactDetails);
+            string actualOutput = File.ReadAllText(command.Options.ImageInfoOutputPath);
+
+            Assert.Equal(expectedOutput, actualOutput);
+
+            dockerServiceMock.Verify(o => o.PullImage(mirrorBaseTag, false));
+            dockerServiceMock.Verify(o => o.CreateTag(mirrorBaseTag, baseImageTag, false));
+
+            dockerServiceMock.Verify(
+                o => o.BuildImage(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<IDictionary<string, string>>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>()));
+            dockerServiceMock.Verify(o => o.Architecture);
+
+            if (hasCachedImage)
+            {
+                dockerServiceMock.Verify(o => o.PullImage($"{Registry}/{RuntimeDepsRepo}@{RuntimeDepsDigest}", false));
+                dockerServiceMock.Verify(o => o.CreateTag($"{Registry}/{RuntimeDepsRepo}@{RuntimeDepsDigest}", $"{RegistryOverride}/{RuntimeDepsRepo}:{Tag}", false));
+
+                dockerServiceMock.Verify(o => o.PullImage($"{Registry}/{RuntimeRepo}@{RuntimeDigest}", false));
+                dockerServiceMock.Verify(o => o.CreateTag($"{Registry}/{RuntimeRepo}@{RuntimeDigest}", $"{RegistryOverride}/{RuntimeRepo}:{Tag}", false));
+            }
+            else
+            {
+                dockerServiceMock.Verify(o => o.GetImageDigest($"{RegistryOverride}/{RuntimeDepsRepo}:{Tag}", false));
+                dockerServiceMock.Verify(o => o.GetImageDigest($"{RegistryOverride}/{RuntimeRepo}:{Tag}", false));
+            }
+
+            dockerServiceMock.Verify(o => o.GetImageDigest(mirrorBaseTag, false));
+            
+            dockerServiceMock.Verify(o => o.GetImageDigest($"{RegistryOverride}/{AspnetRepo}:{Tag}", false));
+
+            dockerServiceMock.Verify(o => o.PushImage($"{RegistryOverride}/{RuntimeDepsRepo}:{Tag}", false));
+            dockerServiceMock.Verify(o => o.PushImage($"{RegistryOverride}/{RuntimeRepo}:{Tag}", false));
+            dockerServiceMock.Verify(o => o.PushImage($"{RegistryOverride}/{AspnetRepo}:{Tag}", false));
+
+            dockerServiceMock.Verify(o => o.GetCreatedDate($"{RegistryOverride}/{RuntimeDepsRepo}:{Tag}", false));
+            dockerServiceMock.Verify(o => o.GetCreatedDate($"{RegistryOverride}/{RuntimeRepo}:{Tag}", false));
+            dockerServiceMock.Verify(o => o.GetCreatedDate($"{RegistryOverride}/{AspnetRepo}:{Tag}", false));
+
+            dockerServiceMock.Verify(o => o.GetImageLayers($"{RegistryOverride}/{RuntimeDepsRepo}:{Tag}", false));
+            dockerServiceMock.Verify(o => o.GetImageLayers($"{RegistryOverride}/{RuntimeRepo}:{Tag}", false));
+            dockerServiceMock.Verify(o => o.GetImageLayers($"{RegistryOverride}/{AspnetRepo}:{Tag}", false));
+
+            dockerServiceMock.VerifyNoOtherCalls();
+        }
+
+        /// <summary>
+        /// Scenario simulates one of the .NET sample images whose base image is considered external even though it's mcr.microsoft.com.
+        /// </summary>
+        [Fact]
+        public async Task BuildCommand_MirroredImages_Sample()
+        {
+            const string Registry = "mcr.microsoft.com";
+            const string RegistryOverride = "dotnetdocker.azurecr.io";
+            const string RuntimeRepo = "runtime";
+            const string SamplesRepo = "samples";
+            const string RuntimeDigest = "sha256:adc914a9f125ca612f9a67e4a0551937b7a37c82fabb46172c4867b73ed99227";
+            const string SampleDigest = "sha256:781914a9f125ca612f9a67e4a0551937b7a37c82fabb46172c4867b73ed0045a";
+            const string Tag = "tag";
+
+            using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
+            Mock<IDockerService> dockerServiceMock = CreateDockerServiceMock();
+
+            dockerServiceMock
+                .Setup(o => o.GetImageDigest($"{Registry}/{RuntimeRepo}:{Tag}", false))
+                .Returns($"{Registry}/{RuntimeRepo}@{RuntimeDigest}");
+
+            dockerServiceMock
+                .Setup(o => o.GetImageDigest($"{RegistryOverride}/{SamplesRepo}:{Tag}", false))
+                .Returns($"{RegistryOverride}/{SamplesRepo}@{SampleDigest}");
+
+            string sampleDockerfileRelativePath = DockerfileHelper.CreateDockerfile(
+                "1.0/samples/os", tempFolderContext, $"{Registry}/{RuntimeRepo}:{Tag}");
+
+            const string dockerfileCommitSha = "mycommit";
+            Mock<IGitService> gitServiceMock = new Mock<IGitService>();
+            gitServiceMock
+                .Setup(o => o.GetCommitSha(It.IsAny<string>(), It.IsAny<bool>()))
+                .Returns(dockerfileCommitSha);
+
+            BuildCommand command = new BuildCommand(
+                dockerServiceMock.Object,
+                Mock.Of<ILoggerService>(),
+                gitServiceMock.Object);
+            command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
+            command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "image-info.json");
+            command.Options.IsPushEnabled = true;
+            command.Options.SourceRepoUrl = "https://github.com/dotnet/test";
+            command.Options.RegistryOverride = RegistryOverride;
+
+            const string ProductVersion = "1.0.1";
+
+            Manifest manifest = CreateManifest(
+                CreateRepo(SamplesRepo,
+                    CreateImage(
+                        new Platform[]
+                        {
+                            CreatePlatform(
+                                sampleDockerfileRelativePath,
+                                new string[] { Tag })
+                        },
+                        productVersion: ProductVersion))
+            );
+            manifest.Registry = Registry;
+
+            File.WriteAllText(Path.Combine(tempFolderContext.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));
+
+            command.LoadManifest();
+            await command.ExecuteAsync();
+
+            dockerServiceMock.Verify(
+                o => o.BuildImage(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<IDictionary<string, string>>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>()));
+            dockerServiceMock.Verify(o => o.Architecture);
+
+            dockerServiceMock.Verify(o => o.PullImage($"{Registry}/{RuntimeRepo}:{Tag}", false));
+            dockerServiceMock.Verify(o => o.GetImageDigest($"{Registry}/{RuntimeRepo}:{Tag}", false));
+            dockerServiceMock.Verify(o => o.GetImageDigest($"{RegistryOverride}/{SamplesRepo}:{Tag}", false));
+            dockerServiceMock.Verify(o => o.PushImage($"{RegistryOverride}/{SamplesRepo}:{Tag}", false));
+            dockerServiceMock.Verify(o => o.GetCreatedDate($"{RegistryOverride}/{SamplesRepo}:{Tag}", false));
+            dockerServiceMock.Verify(o => o.GetImageLayers($"{RegistryOverride}/{SamplesRepo}:{Tag}", false));
 
             dockerServiceMock.VerifyNoOtherCalls();
         }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ReturnsExtensions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ReturnsExtensions.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Moq.Language;
+using Moq.Language.Flow;
+
+namespace Microsoft.DotNet.ImageBuilder.Tests.Helpers
+{
+    public static class ReturnsExtensions
+    {
+        public static IReturnsResult<TMock> Returns<TMock, TResult>(this IReturns<TMock, TResult> returns, Func<int, TResult> valueFunction)
+            where TMock : class
+        {
+            int callCount = 0;
+            return returns.Returns(() => valueFunction(++callCount));
+        }
+    }
+}


### PR DESCRIPTION
This updates the `build` command so that it can handle pulling base images from a specified mirror location instead of directly from an externally-owned registry like Docker Hub.

This defines an additional option, `source-repo-prefix`, to the `build` command. When that option is set, it pulls any external base images by constructing a tag that represents the mirror location.

For example, consider the following scenario:

* Dockerfile has `FROM amd64/alpine:3.13`
* `source-repo-prefix` is set to `mirror/`
* `registry-override` is set to `dotnetdocker.azurecr.io`

When pulling base images the `build` command will pull from `dotnetdocker.azurecr.io/mirror/amd64/alpine:3.13` instead of from `amd64/alpine:3.13`.  It then tags the pulled image as `amd64/alpine:3.13` so that the Dockerfile can be built directly without modification.

Related to #613