### PR TITLE
Use registry name as part of repo name for mirrored tags

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyBaseImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyBaseImagesCommand.cs
@@ -83,7 +83,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private Task CopyImageAsync(string fromImage, string destinationRegistryName)
         {
             string registry = DockerHelper.GetRegistry(fromImage) ?? "docker.io";
-            fromImage = DockerHelper.TrimRegistry(fromImage, registry);
 
             ImportSourceCredentials? importSourceCreds = null;
             if (Options.CredentialsOptions.Credentials.TryGetValue(registry, out RegistryCredentials? registryCreds))


### PR DESCRIPTION
The mirror logic has the potential for running into repo collisions because the logic strips out the registry name.  While this wouldn't happen today since all of the images we'd be mirroring are coming from Docker Hub, it could happen if we also mirrored from another external registry.

For example, let's say we have two Dockerfiles like this:

Dockerfile 1:
```Dockerfile
FROM amd64/alpine:3.13
```

Dockerfile 2:
```Dockerfile
FROM other-registry.com/amd64/alpine:3.13
```

Mirroring these base images would cause a collision.  They'd both end up being mirrored to `dotnetdocker.azurecr.io/mirror/amd64/alpine:3.13`, for example.

To handle this, I've updated the code to not strip out the registry.  Using the example above, the tags would be mirrored to the following:
* `dotnetdocker.azurecr.io/mirror/amd64/alpine:3.13`
* `dotnetdocker.azurecr.io/mirror/other-registry.com/amd64/alpine:3.13`

Related to #613