### PR TITLE
Prune dangling mirrored images

### DIFF
--- a/eng/pipelines/cleanup-acr-images.yml
+++ b/eng/pipelines/cleanup-acr-images.yml
@@ -37,4 +37,9 @@ jobs:
       repo: "public/dotnet/*/samples*"
       action: pruneDangling
       age: 0
+  - template: templates/steps/clean-acr-images.yml
+    parameters:
+      repo: "mirror/*"
+      action: pruneDangling
+      age: 0
   - template: ../common/templates/steps/cleanup-docker-linux.yml


### PR DESCRIPTION
Updates the ACR cleanup pipeline to include images contained in the `mirror` repository.  This will clean-up all untagged images in that repository.

Related to #613