### PR TITLE
Clean images in dotnet/samples repo

### DIFF
--- a/eng/pipelines/cleanup-acr-images.yml
+++ b/eng/pipelines/cleanup-acr-images.yml
@@ -34,7 +34,7 @@ jobs:
       age: 7
   - template: templates/steps/clean-acr-images.yml
     parameters:
-      repo: "public/dotnet/*/samples*"
+      repo: "public/dotnet*/samples*"
       action: pruneDangling
       age: 0
   - template: templates/steps/clean-acr-images.yml


### PR DESCRIPTION
The pipeline to clean out unneeded images in ACR has a job to target sample images.  But it is configured to only target samples in the `dotnet/core/samples` and `dotnet/framework/samples` repos.  It doesn't take into account the the `dotnet/samples` repo that was added a while back.  I've fixed the repo string to account for this.