### PR TITLE
Only execute component detection on internal builds

### DIFF
--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -108,6 +108,7 @@ jobs:
       $(dryRunArg)
       $(imageBuilder.commonCmdArgs)
     displayName: Ingest Kusto Image Info
-  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-    displayName: Component Detection
+  - ${{ if eq(variables['System.TeamProject'], 'internal') }}:    
+    - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+      displayName: Component Detection
   - template: ../steps/cleanup-docker-linux.yml


### PR DESCRIPTION
A failure occurs running the Component Detection step in PR builds with the error:

```
Microsoft.TeamFoundation.Core.WebApi.ProjectDoesNotExistException: VS800075: The project with id 'vstfs:///Classification/TeamProject/9ee6d478-d288-47f7-aacc-f6e6d082ae6d' does not exist, or you do not have permission to access it.
```

The reason for this is unclear but is related to it being based on a GitHub repo rather than AzDO.  So it works correctly in AzDO builds.  It also doesn't happen when the task is auto-injected into a build.  We explicitly disable the auto-injection across the board in order to avoid have it appear in our all jobs redundantly.

The mitigation to this is to avoid executing the task in public builds.

Related to https://github.com/dotnet/core-eng/issues/12353.