### PR TITLE
Set image cleanup pipeline to always run on schedule

### DIFF
--- a/eng/pipelines/cleanup-acr-images.yml
+++ b/eng/pipelines/cleanup-acr-images.yml
@@ -7,6 +7,7 @@ schedules:
   branches:
     include:
     - main
+  always: true
 
 variables:
 - template: ../common/templates/variables/common.yml


### PR DESCRIPTION
Ensures that the pipeline will always run on schedule rather than the default behavior which is to skip a scheduled run if there hasn't been a commit since the last run.