### PR TITLE
Common component governance detection job

### DIFF
--- a/eng/common/templates/jobs/cg-detection.yml
+++ b/eng/common/templates/jobs/cg-detection.yml
@@ -1,0 +1,10 @@
+jobs:
+- job: Build
+  pool:
+    vmImage: $(defaultLinuxAmd64PoolImage)
+  steps:
+  - script: >
+      find . -name '*.csproj' | grep $(cgBuildGrepArgs) | xargs -n 1 dotnet build
+    displayName: Build Projects
+  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+    displayName: Component Detection

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -101,7 +101,4 @@ jobs:
       $(dryRunArg)
       $(imageBuilder.commonCmdArgs)
     displayName: Ingest Kusto Image Info
-  - ${{ if eq(variables['System.TeamProject'], 'internal') }}:    
-    - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-      displayName: Component Detection
   - template: ../steps/cleanup-docker-linux.yml

--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -81,5 +81,3 @@ steps:
   continueOnError: true
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - template: cleanup-docker-linux.yml
-- task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-  displayName: Component Detection

--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -81,3 +81,5 @@ steps:
   continueOnError: true
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - template: cleanup-docker-linux.yml
+- task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+  displayName: Component Detection

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -28,6 +28,8 @@ variables:
   value: "'main'"
 - name: mirrorRepoPrefix
   value: 'mirror/'
+- name: cgBuildGrepArgs
+  value: "''"
 
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNet-Docker-Common

--- a/eng/pipelines/cg-detection.yml
+++ b/eng/pipelines/cg-detection.yml
@@ -1,0 +1,11 @@
+trigger:
+  branches:
+    include:
+    - main
+pr: none
+
+variables:
+- template: ../common/templates/variables/common.yml
+
+jobs:
+- template: ../common/templates/jobs/cg-detection.yml


### PR DESCRIPTION
The CG component detection task that gets [executed in the publish job](https://github.com/dotnet/docker-tools/blob/main/eng/common/templates/jobs/publish.yml#L105-L106) isn't actually doing what we think it's doing.  It was thought that this could just scan the source code and detect components.  But it actually requires the source to be built, at least it does to detect NuGet packages that are referenced from projects.  So it's not actually reporting any NuGet package references from our repos.

Another problem is that we build all of our jobs within a container.  And the component detection task is run on the agent where it scans the agent's source directory.  Since the project is built in a container, it's outside the context of the agent's file system and the component detection will not find anything in that case either.

To solve this problem, I've defined a common job template that can be used across the repos.  It will dynamically build all projects in the repo directly on the build agent and then run the component detection task.  This will allow reporting of _all_ components that are referenced within the repos.

In some cases, there are projects that we don't want to build such as test projects.  In that case, the pipeline can set the common `cgBuildGrepArgs` to set argument values to the `grep` command that can filter out project file paths as necessary.