### PR TITLE
Update test Dockerfiles to use mirrored tags

### DIFF
--- a/eng/tests/pipeline-validation/1.0/focal/amd64/Dockerfile
+++ b/eng/tests/pipeline-validation/1.0/focal/amd64/Dockerfile
@@ -1,1 +1,1 @@
-FROM ubuntu:focal
+FROM amd64/ubuntu:focal


### PR DESCRIPTION
The `dotnet-docker-tools-eng-validation` pipeline is failing now that builds are pulling from the ACR mirror location because the test Dockerfile is referencing a tag that is not mirrored and the build itself doesn't mirror the referenced tag because it's a dry run.  

To fix this, I've updated the Dockerfile to reference a tag that does get mirrored instead.