### PR TITLE
Pass manifest variables to copyBaseImages command

### DIFF
--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -37,7 +37,7 @@ stages:
       name: CopyBaseImages
       pool:
         vmImage: $(defaultLinuxAmd64PoolImage)
-      additionalOptions: "--manifest $(manifest)"
+      additionalOptions: "--manifest '$(manifest)' $(manifestVariables)"
   - template: ../jobs/generate-matrix.yml
     parameters:
       matrixType: ${{ parameters.buildMatrixType }}


### PR DESCRIPTION
Builds in the dotnet-buildtools-prereqs-docker repo are silently failing when calling the copyBaseImages command because the `UniqueId` variable being used in the manifest doesn't have a value provided for it.

The setting of this variable is embedded in the common `manifestVariables` variable which is passed to other manifest-based commands but it isn't being passed to the copyBaseImages command.

I've fixed the pipeline so that this `manifestVariables` variable does get passed, allowing the `UniqueId` variable in the manifest to be resolved to a value.