### PR TITLE
Fix tag mirroring for non-standard tag variations

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -631,7 +631,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 return fromImage;
             }
 
-            return $"{Manifest.Registry}/{Options.SourceRepoPrefix}{TrimInternallyOwnedRegistry(fromImage)}";
+            string srcImage = TrimInternallyOwnedRegistry(DockerHelper.NormalizeRepo(fromImage));
+            return $"{Manifest.Registry}/{Options.SourceRepoPrefix}{srcImage}";
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyBaseImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyBaseImagesCommand.cs
@@ -82,7 +82,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         private Task CopyImageAsync(string fromImage, string destinationRegistryName)
         {
-            string registry = DockerHelper.GetRegistry(fromImage) ?? "docker.io";
+            fromImage = DockerHelper.NormalizeRepo(fromImage);
+
+            string registry = DockerHelper.GetRegistry(fromImage) ?? DockerHelper.DockerHubRegistry;
+            string srcImage = DockerHelper.TrimRegistry(fromImage, registry);
 
             ImportSourceCredentials? importSourceCreds = null;
             if (Options.CredentialsOptions.Credentials.TryGetValue(registry, out RegistryCredentials? registryCreds))
@@ -90,7 +93,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 importSourceCreds = new ImportSourceCredentials(registryCreds.Password, registryCreds.Username);
             }
 
-            return ImportImageAsync($"{Options.RepoPrefix}{fromImage}", destinationRegistryName, fromImage,
+            return ImportImageAsync($"{Options.RepoPrefix}{fromImage}", destinationRegistryName, srcImage,
                 srcRegistryName: registry, sourceCredentials: importSourceCreds);
         }
     }

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
@@ -20,6 +20,8 @@ namespace Microsoft.DotNet.ImageBuilder
         public static Architecture Architecture => s_architecture.Value;
         public static OS OS => s_os.Value;
 
+        public const string DockerHubRegistry = "docker.io";
+
         public static void ExecuteWithUser(Action action, string username, string password, string server, bool isDryRun)
         {
             bool userSpecified = username != null;
@@ -161,6 +163,24 @@ namespace Microsoft.DotNet.ImageBuilder
             }
 
             return imageName;
+        }
+
+        public static string NormalizeRepo(string image)
+        {
+            string registry = GetRegistry(image);
+            string repoAndTag = TrimRegistry(image, registry);
+
+            if ((registry is null || registry == DockerHubRegistry) && !repoAndTag.Contains('/'))
+            {
+                repoAndTag = $"library/{repoAndTag}";
+            }
+
+            if (registry is null)
+            {
+                return repoAndTag;
+            }
+
+            return $"{registry}/{repoAndTag}";
         }
 
         public static string TrimRegistry(string tag) => TrimRegistry(tag, GetRegistry(tag));

--- a/src/Microsoft.DotNet.ImageBuilder/tests/CopyBaseImagesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/CopyBaseImagesCommandTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             CreateDockerfile("1.0/runtime/os/arm32v7", tempFolderContext, "arm32v7/base:tag"),
                             new string[] { "arm32v7" }),
                         CreatePlatform(
-                            CreateDockerfile("1.0/runtime/os/amd64", tempFolderContext, "amd64/base:tag"),
+                            CreateDockerfile("1.0/runtime/os/amd64", tempFolderContext, "base:tag"),
                             new string[] { "amd64" }))),
                 CreateRepo("aspnet",
                     CreateImage(
@@ -88,8 +88,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             var expectedTagInfos = new (string SourceImage, string TargetTag, string Registry, string Username, string Password)[]
             {
                 ( "arm32v7/base:tag", $"{command.Options.RepoPrefix}arm32v7/base:tag", "docker.io", "user", "pass" ),
-                ( "amd64/base:tag", $"{command.Options.RepoPrefix}amd64/base:tag", "docker.io", "user", "pass" ),
-                ( "my-registry.com/repo:tag", $"{command.Options.RepoPrefix}my-registry.com/repo:tag", "my-registry.com", "me", "secret" )
+                ( "library/base:tag", $"{command.Options.RepoPrefix}library/base:tag", "docker.io", "user", "pass" ),
+                ( "repo:tag", $"{command.Options.RepoPrefix}my-registry.com/repo:tag", "my-registry.com", "me", "secret" )
             };
 
             foreach (var expectedTagInfo in expectedTagInfos)


### PR DESCRIPTION
The [dotnet-buildtools-prereqs-docker](https://github.com/dotnet/dotnet-buildtools-prereqs-docker) repo uncovered two issues with how tags are mirrored from the DH registry to ACR:

* If a `FROM` instruction references the base tag as `alpine:3.13` instead of `<arch>/alpine:3.13`, for example, it results in an error during the call to ACR's import because there isn't actually a repository name `alpine` in `docker.io`.  That's just a shortcut for referencing the actual repository name of `library/alpine`.  This is fixed by checking whether the registry being targeted is DH and doesn't have a multi-segment repository name. If so, then `library/` should be prepended.
* In some cases, a `FROM` instruction references a non-DH external registry, such as `registry.fedoraproject.org`. The logic to generate the input values to the ACR import call doesn't handle it correctly and ends up specifying an image name like `registry.fedoraproject.org/fedora:33` instead of `fedora:33`.  This is simply fixed by trimming off the registry name.