### PR TITLE
Omit repo prefix from base image digest

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -631,7 +631,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 return fromImage;
             }
 
-            string srcImage = TrimInternallyOwnedRegistry(DockerHelper.NormalizeRepo(fromImage));
+            string srcImage = TrimInternallyOwnedRegistryAndRepoPrefix(DockerHelper.NormalizeRepo(fromImage));
             return $"{Manifest.Registry}/{Options.SourceRepoPrefix}{srcImage}";
         }
 
@@ -646,7 +646,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         /// </remarks>
         private string GetFromImagePublicTag(string fromImage)
         {
-            string trimmed = TrimInternallyOwnedRegistry(fromImage);
+            string trimmed = TrimInternallyOwnedRegistryAndRepoPrefix(fromImage);
             if (trimmed == fromImage)
             {
                 return trimmed;
@@ -657,9 +657,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             }
         }
 
-        private string TrimInternallyOwnedRegistry(string imageTag) =>
+        private string TrimInternallyOwnedRegistryAndRepoPrefix(string imageTag) =>
             IsInInternallyOwnedRegistry(imageTag) ?
-                DockerHelper.TrimRegistry(imageTag) :
+                DockerHelper.TrimRegistry(imageTag).TrimStart(Options.RepoPrefix) :
                 imageTag;
 
         private bool IsInInternallyOwnedRegistry(string imageTag) =>

--- a/src/Microsoft.DotNet.ImageBuilder/src/StringExtensions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/StringExtensions.cs
@@ -28,6 +28,11 @@ namespace Microsoft.DotNet.ImageBuilder
 
         public static string TrimEnd(this string source, string trimString)
         {
+            if (string.IsNullOrEmpty(trimString))
+            {
+                return source;
+            }
+
             while (source.EndsWith(trimString))
             {
                 source = source.Substring(0, source.Length - trimString.Length);
@@ -40,6 +45,11 @@ namespace Microsoft.DotNet.ImageBuilder
 
         public static string TrimStart(this string source, string trimString)
         {
+            if (string.IsNullOrEmpty(trimString))
+            {
+                return source;
+            }
+
             while (source.StartsWith(trimString))
             {
                 source = source.Substring(trimString.Length);

--- a/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ManifestHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ManifestHelper.cs
@@ -36,6 +36,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests.Helpers
             return new Repo
             {
                 Name = name,
+                Id = name,
                 Images = images,
                 McrTagsMetadataTemplate = mcrTagsMetadataTemplate,
                 Readme = readme,


### PR DESCRIPTION
There's an issue with the base image digest values that get stored in the image info files.  The repo portion of the string includes the repo prefix that was defined for the build.  See https://github.com/dotnet/versions/blob/fe78c22877055de295c38b9b3d606bf1ba04af69/build-info/docker/image-info.dotnet-dotnet-docker-nightly.json#L17

This specifically occurs for the base image digests that represent internally built images, not for external images.  So this doesn't impact the behavior of the automated builds from base image updates.

This issue was introduced by the changes in https://github.com/dotnet/docker-tools/pull/765.  When a base image digest gets translated from the internal ACR value to the public MCR value, there's code which strips off the ACR name and replaces it with the MCR name.  But it doesn't end up stripping off the repo prefix as well.

The issue is fixed by simply ensuring that the repo prefix gets stripped off.