### PR TITLE
Option to exclude publishing of product family readme

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsCommand.cs
@@ -73,7 +73,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private async Task<IEnumerable<GitObject>> FilterUpdatedGitObjectsAsync(
             IEnumerable<GitObject> gitObjects, IGitHubClient gitHubClient, GitHubBranch branch)
         {
-            List<GitObject> updatedGitObjects = new List<GitObject>();
+            List<GitObject> updatedGitObjects = new();
             foreach (GitObject gitObject in gitObjects)
             {
                 string currentContent = await gitHubClient.GetGitHubFileContentsAsync(gitObject.Path, branch);
@@ -114,9 +114,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         private GitObject[] GetUpdatedReadmes()
         {
-            List<GitObject> readmes = new List<GitObject>();
+            List<GitObject> readmes = new();
 
-            if (!string.IsNullOrEmpty(Manifest.ReadmePath))
+            if (!string.IsNullOrEmpty(Manifest.ReadmePath) && !Options.ExcludeProductFamilyReadme)
             {
                 IEnumerable<string> productRepoNames = Manifest.FilteredRepos
                     .Select(repo => GetProductRepoName(repo))
@@ -148,7 +148,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         private GitObject[] GetUpdatedTagsMetadata()
         {
-            List<GitObject> metadata = new List<GitObject>();
+            List<GitObject> metadata = new();
 
             foreach (RepoInfo repo in Manifest.FilteredRepos)
             {

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsOptions.cs
@@ -6,14 +6,18 @@ using System.Collections.Generic;
 using System.CommandLine;
 using System.Linq;
 
+using static Microsoft.DotNet.ImageBuilder.Commands.CliHelper;
+
 #nullable enable
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     public class PublishMcrDocsOptions : ManifestOptions, IGitOptionsHost
     {
-        public GitOptions GitOptions { get; set; } = new GitOptions();
+        public GitOptions GitOptions { get; set; } = new();
 
         public string SourceRepoUrl { get; set; } = string.Empty;
+
+        public bool ExcludeProductFamilyReadme { get; set; }
 
         public PublishMcrDocsOptions() : base()
         {
@@ -22,11 +26,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
     public class PublishMcrDocsOptionsBuilder : ManifestOptionsBuilder
     {
-        private readonly GitOptionsBuilder _gitOptionsBuilder = new GitOptionsBuilder();
+        private readonly GitOptionsBuilder _gitOptionsBuilder = new();
 
         public override IEnumerable<Option> GetCliOptions() =>
             base.GetCliOptions()
-                .Concat(_gitOptionsBuilder.GetCliOptions("Microsoft", "mcrdocs", "master", "teams"));
+                .Concat(_gitOptionsBuilder.GetCliOptions("Microsoft", "mcrdocs", "master", "teams"))
+                .Append(CreateOption<bool>("exclude-product-family", nameof(PublishMcrDocsOptions.ExcludeProductFamilyReadme),
+                    "Excludes the product family readme from being published"));
 
         public override IEnumerable<Argument> GetCliArguments() =>
             base.GetCliArguments()

--- a/src/Microsoft.DotNet.ImageBuilder/tests/PublishMcrDocsCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/PublishMcrDocsCommandTests.cs
@@ -1,0 +1,106 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.DotNet.ImageBuilder.Commands;
+using Microsoft.DotNet.ImageBuilder.Models.Manifest;
+using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
+using Microsoft.DotNet.VersionTools.Automation;
+using Microsoft.DotNet.VersionTools.Automation.GitHubApi;
+using Moq;
+using Newtonsoft.Json;
+using Xunit;
+
+using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.DockerfileHelper;
+using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
+
+namespace Microsoft.DotNet.ImageBuilder.Tests
+{
+    public class PublishMcrDocsCommandTests
+    {
+        private const string ProductFamilyReadmePath = "ProductFamilyReadme.md";
+        private const string RepoReadmePath = "RepoReadme.md";
+        private const string TagsYamlPath = "tags.yml";
+        private const string DefaultReadme = "Default Readme Contents\n# Full Tag Listing\n<!--End of generated tags-->\n";
+        private const string ReadmeTemplatePath = "Readme.Template.md";
+        private const string AboutRepoTemplatePath = "About.repo.Template.md";
+        private const string AboutRepoTemplate =
+@"Referenced Template Content";
+        private const string ReadmeTemplate =
+@"About {{if IS_PRODUCT_FAMILY:Product Family^else:{{SHORT_REPO}}}}
+{{if !IS_PRODUCT_FAMILY:{{InsertTemplate(join(filter([""About"", SHORT_REPO, ""Template"", ""md""], len), "".""))}}}}";
+
+        [Fact]
+        public async Task ExcludeProductFamilyReadme()
+        {
+            Mock<IGitHubClient> gitHubClientMock = new();
+            gitHubClientMock
+                .Setup(o => o.GetReferenceAsync(It.IsAny<GitHubProject>(), It.IsAny<string>()))
+                .ReturnsAsync(new GitReference
+                {
+                    Object = new GitReferenceObject()
+                });
+
+            gitHubClientMock
+                .Setup(o => o.PostTreeAsync(It.IsAny<GitHubProject>(), It.IsAny<string>(), It.IsAny<GitObject[]>()))
+                .ReturnsAsync(new GitTree());
+
+            gitHubClientMock
+                .Setup(o => o.PostCommitAsync(It.IsAny<GitHubProject>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string[]>()))
+                .ReturnsAsync(new GitCommit());
+
+            Mock<IGitHubClientFactory> gitHubClientFactoryMock = new();
+            gitHubClientFactoryMock
+                .Setup(o => o.GetClient(It.IsAny<GitHubAuth>(), false))
+                .Returns(gitHubClientMock.Object);
+
+            PublishMcrDocsCommand command = new(Mock.Of<IGitService>(), gitHubClientFactoryMock.Object, Mock.Of<ILoggerService>());
+
+            using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
+
+            DockerfileHelper.CreateFile(ProductFamilyReadmePath, tempFolderContext, DefaultReadme);
+            DockerfileHelper.CreateFile(RepoReadmePath, tempFolderContext, DefaultReadme);
+            DockerfileHelper.CreateFile(AboutRepoTemplatePath, tempFolderContext, AboutRepoTemplate);
+            DockerfileHelper.CreateFile(ReadmeTemplatePath, tempFolderContext, ReadmeTemplate);
+
+            // Create MCR tags metadata template file
+            StringBuilder tagsMetadataTemplateBuilder = new();
+            tagsMetadataTemplateBuilder.AppendLine($"$(McrTagsYmlRepo:repo)");
+            tagsMetadataTemplateBuilder.Append($"$(McrTagsYmlTagGroup:tag)");
+            string tagsMetadataTemplatePath = Path.Combine(tempFolderContext.Path, TagsYamlPath);
+            File.WriteAllText(tagsMetadataTemplatePath, tagsMetadataTemplateBuilder.ToString());
+
+            Repo repo;
+            Manifest manifest = CreateManifest(
+                repo = CreateRepo("dotnet/repo", new Image[]
+                {
+                    CreateImage(
+                        CreatePlatform(CreateDockerfile("1.0/runtime/linux", tempFolderContext), new string[] { "tag" }))
+                }, RepoReadmePath, ReadmeTemplatePath, Path.GetFileName(tagsMetadataTemplatePath)));
+            manifest.Registry = "mcr.microsoft.com";
+            manifest.Readme = ProductFamilyReadmePath;
+            manifest.ReadmeTemplate = ReadmeTemplatePath;
+            repo.Id = "repo";
+
+            string manifestPath = Path.Combine(tempFolderContext.Path, "manifest.json");
+            File.WriteAllText(manifestPath, JsonConvert.SerializeObject(manifest));
+
+            command.Options.Manifest = manifestPath;
+            command.Options.ExcludeProductFamilyReadme = true;
+            command.LoadManifest();
+
+            await command.ExecuteAsync();
+
+            // Verify published file list does not contain ProductFamilyReadmePath
+            gitHubClientMock
+                .Verify(o =>
+                    o.PostTreeAsync(It.IsAny<GitHubProject>(), It.IsAny<string>(),
+                        It.Is<GitObject[]>(objs =>
+                            objs.Length == 2 &&
+                            Path.GetFileName(objs[0].Path) == RepoReadmePath &&
+                            Path.GetFileName(objs[1].Path) == TagsYamlPath)));
+        }
+    }
+}


### PR DESCRIPTION
In order to complete the work for dotnet/dotnet-docker#2361, we need to be able to exclude the publishing of the product family readme in the nightly branch. This adds an option to the `publishMcrDocs` command that allows the product family readme to be excluded.