### PR TITLE
Add build notifications for AutoBuilder

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/NuGet.config
+++ b/src/Microsoft.DotNet.ImageBuilder/NuGet.config
@@ -2,7 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesOptions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
     public class GetStaleImagesOptionsBuilder : CliOptionsBuilder
     {
-        private readonly GitOptionsBuilder _gitOptionsBuilder = new GitOptionsBuilder();
+        private readonly GitOptionsBuilder _gitOptionsBuilder = GitOptionsBuilder.BuildWithDefaults();
         private readonly ManifestFilterOptionsBuilder _manifestFilterOptionsBuilder =
             new ManifestFilterOptionsBuilder();
         private readonly SubscriptionOptionsBuilder _subscriptionOptionsBuilder = new SubscriptionOptionsBuilder();

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GitOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GitOptions.cs
@@ -28,27 +28,84 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
     public class GitOptionsBuilder
     {
-        public IEnumerable<Option> GetCliOptions(
-            string? defaultOwner = null, string? defaultRepo = null, string? defaultBranch = null, string? defaultPath = null) =>
-            new Option[]
-            {
-                CreateOption("git-branch", nameof(GitOptions.Branch),
-                    $"GitHub branch to write to (defaults to '{defaultBranch}')", defaultBranch),
-                CreateOption("git-owner", nameof(GitOptions.Owner),
-                    $"Owner of the GitHub repo to write to (defaults to '{defaultOwner}')", defaultOwner),
-                CreateOption("git-path", nameof(GitOptions.Path),
-                    $"Path within the GitHub repo to write to (defaults to '{defaultPath}')", defaultPath),
-                CreateOption("git-repo", nameof(GitOptions.Repo),
-                    $"GitHub repo to write to (defaults to '{defaultRepo}')", defaultRepo)
-            };
+        private readonly List<Option> _options = new();
+        private readonly List<Argument> _arguments = new();
 
-        public IEnumerable<Argument> GetCliArguments() =>
-            new Argument[]
+        private GitOptionsBuilder()
+        {
+        }
+
+        public static GitOptionsBuilder Build() => new();
+
+        public static GitOptionsBuilder BuildWithDefaults() =>
+            Build()
+                .WithUsername(isRequired: true)
+                .WithEmail(isRequired: true)
+                .WithAuthToken(isRequired: true)
+                .WithBranch()
+                .WithOwner()
+                .WithPath()
+                .WithRepo();
+
+        public GitOptionsBuilder WithUsername(
+            bool isRequired = false,
+            string? defaultValue = null,
+            string description = "Username to use for GitHub connection") =>
+            AddSymbol("git-username", nameof(GitOptions.Username), isRequired, defaultValue, description);
+
+        public GitOptionsBuilder WithEmail(
+            bool isRequired = false,
+            string? defaultValue = null,
+            string description = "Email to use for GitHub connection") =>
+            AddSymbol("git-email", nameof(GitOptions.Email), isRequired, defaultValue, description);
+
+        public GitOptionsBuilder WithAuthToken(
+            bool isRequired = false,
+            string? defaultValue = null,
+            string description = "Auth token to use to connect to GitHub") =>
+            AddSymbol("git-token", nameof(GitOptions.AuthToken), isRequired, defaultValue, description);
+
+        public GitOptionsBuilder WithBranch(
+            bool isRequired = false,
+            string? defaultValue = null,
+            string description = "Name of GitHub branch to access") =>
+            AddSymbol("git-branch", nameof(GitOptions.Branch), isRequired, defaultValue, description);
+
+        public GitOptionsBuilder WithOwner(
+            bool isRequired = false,
+            string? defaultValue = null,
+            string description = "Owner of the GitHub repo to access") =>
+            AddSymbol("git-owner", nameof(GitOptions.Owner), isRequired, defaultValue, description);
+
+        public GitOptionsBuilder WithPath(
+            bool isRequired = false,
+            string? defaultValue = null,
+            string description = "Path of the GitHub repo to access") =>
+            AddSymbol("git-path", nameof(GitOptions.Path), isRequired, defaultValue, description);
+
+        public GitOptionsBuilder WithRepo(
+            bool isRequired = false,
+            string? defaultValue = null,
+            string description = "Name of the GitHub repo to access") =>
+            AddSymbol("git-repo", nameof(GitOptions.Repo), isRequired, defaultValue, description);
+
+        public IEnumerable<Option> GetCliOptions() => _options;
+
+        public IEnumerable<Argument> GetCliArguments() => _arguments;
+
+        private GitOptionsBuilder AddSymbol<T>(string alias, string propertyName, bool isRequired, T? defaultValue, string description)
+        {
+            if (isRequired)
             {
-                new Argument<string>(nameof(GitOptions.Username), "GitHub username"),
-                new Argument<string>(nameof(GitOptions.Email), "GitHub email"),
-                new Argument<string>(nameof(GitOptions.AuthToken), "GitHub authentication token")
-            };
+                _arguments.Add(new Argument<T>(propertyName, description));
+            }
+            else
+            {
+                _options.Add(CreateOption<T>(alias, propertyName, description, defaultValue is null ? default! : defaultValue));
+            }
+
+            return this;
+        }
     }
 }
 #nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/NotificationLabels.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/NotificationLabels.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    public static class NotificationLabels
+    {
+        public const string AutoBuilder = "autobuilder";
+        public const string Failure = "failure";
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/NotificationLabels.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/NotificationLabels.cs
@@ -5,7 +5,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     public static class NotificationLabels
     {
-        public const string AutoBuilder = "autobuilder";
-        public const string Failure = "failure";
+        private const string NotifyPrefix = "notify-";
+        public const string AutoBuilder = NotifyPrefix + "autobuilder";
+        public const string Failure = NotifyPrefix + "failure";
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoOptions.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     public class PublishImageInfoOptionsBuilder : ImageInfoOptionsBuilder
     {
         private readonly AzdoOptionsBuilder _azdoOptionsBuilder = new AzdoOptionsBuilder();
-        private readonly GitOptionsBuilder _gitOptionsBuilder = new GitOptionsBuilder();
+        private readonly GitOptionsBuilder _gitOptionsBuilder = GitOptionsBuilder.BuildWithDefaults();
 
         public override IEnumerable<Option> GetCliOptions() =>
             base.GetCliOptions()

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsOptions.cs
@@ -26,11 +26,19 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
     public class PublishMcrDocsOptionsBuilder : ManifestOptionsBuilder
     {
-        private readonly GitOptionsBuilder _gitOptionsBuilder = new();
+        private readonly GitOptionsBuilder _gitOptionsBuilder =
+            GitOptionsBuilder.Build()
+                .WithUsername(isRequired: true)
+                .WithEmail(isRequired: true)
+                .WithAuthToken(isRequired: true)
+                .WithOwner(defaultValue: "Microsoft")
+                .WithRepo(defaultValue: "mcrdocs")
+                .WithBranch(defaultValue: "master")
+                .WithPath(defaultValue: "teams");
 
         public override IEnumerable<Option> GetCliOptions() =>
             base.GetCliOptions()
-                .Concat(_gitOptionsBuilder.GetCliOptions("Microsoft", "mcrdocs", "master", "teams"))
+                .Concat(_gitOptionsBuilder.GetCliOptions())
                 .Append(CreateOption<bool>("exclude-product-family", nameof(PublishMcrDocsOptions.ExcludeProductFamilyReadme),
                     "Excludes the product family readme from being published"));
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/QueueBuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/QueueBuildCommand.cs
@@ -199,9 +199,19 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             string header = $"AutoBuilder - {category}";
             notificationMarkdown.Insert(0, $"# {header}{Environment.NewLine}{Environment.NewLine}");
 
-            await _notificationService.PostAsync($"{header} - {subscription}", notificationMarkdown.ToString(),
-                new string[] { NotificationLabels.AutoBuilder }.AppendIf(NotificationLabels.Failure, () => exception is not null),
-                $"https://github.com/{Options.GitOptions.Owner}/{Options.GitOptions.Repo}", Options.GitOptions.AuthToken);
+            if (Options.GitOptions.AuthToken == string.Empty ||
+                Options.GitOptions.Owner == string.Empty ||
+                Options.GitOptions.Repo == string.Empty)
+            {
+                _loggerService.WriteMessage(
+                    "Skipping posting of notification because GitHub auth token, owner, and repo options were not provided.");
+            }
+            else
+            {
+                await _notificationService.PostAsync($"{header} - {subscription}", notificationMarkdown.ToString(),
+                    new string[] { NotificationLabels.AutoBuilder }.AppendIf(NotificationLabels.Failure, () => exception is not null),
+                    $"https://github.com/{Options.GitOptions.Owner}/{Options.GitOptions.Repo}", Options.GitOptions.AuthToken);
+            }
         }
 
         private static async Task<IEnumerable<string>> GetInProgressBuildsAsync(IBuildHttpClient client, int pipelineId, Guid projectId)

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/QueueBuildOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/QueueBuildOptions.cs
@@ -13,13 +13,15 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     public class QueueBuildOptions : Options
     {
         public string SubscriptionsPath { get; set; } = string.Empty;
-        public AzdoOptions AzdoOptions { get; set; } = new AzdoOptions();
+        public AzdoOptions AzdoOptions { get; set; } = new();
         public IEnumerable<string> AllSubscriptionImagePaths { get; set; } = Enumerable.Empty<string>();
+        public GitOptions GitOptions { get; set; } = new();
     }
 
     public class QueueBuildOptionsBuilder : CliOptionsBuilder
     {
-        private readonly AzdoOptionsBuilder _azdoOptionsBuilder = new AzdoOptionsBuilder();
+        private readonly AzdoOptionsBuilder _azdoOptionsBuilder = new();
+        private readonly GitOptionsBuilder _gitOptionsBuilder = new();
 
         private const string DefaultSubscriptionsPath = "subscriptions.json";
         public override IEnumerable<Option> GetCliOptions() =>
@@ -33,10 +35,12 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         CreateMultiOption<string>("image-paths", nameof(QueueBuildOptions.AllSubscriptionImagePaths),
                             "JSON string mapping a subscription ID to the image paths to be built (from the output variable of getStaleImages)")
                     }
-                );
+                .Concat(_gitOptionsBuilder.GetCliOptions()));
 
         public override IEnumerable<Argument> GetCliArguments() =>
-            base.GetCliArguments().Concat(_azdoOptionsBuilder.GetCliArguments());
+            base.GetCliArguments()
+                .Concat(_azdoOptionsBuilder.GetCliArguments())
+                .Concat(_gitOptionsBuilder.GetCliArguments());
     }
 }
 #nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/QueueBuildOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/QueueBuildOptions.cs
@@ -21,7 +21,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     public class QueueBuildOptionsBuilder : CliOptionsBuilder
     {
         private readonly AzdoOptionsBuilder _azdoOptionsBuilder = new();
-        private readonly GitOptionsBuilder _gitOptionsBuilder = new();
+        private readonly GitOptionsBuilder _gitOptionsBuilder =
+            GitOptionsBuilder.Build()
+                .WithAuthToken(description: "Auth token to use to connect to GitHub for posting notifications")
+                .WithOwner(description: "Owner of the GitHub repo to post notifications to")
+                .WithRepo(description: "Name of the GitHub repo to post notifications to");
 
         private const string DefaultSubscriptionsPath = "subscriptions.json";
         public override IEnumerable<Option> GetCliOptions() =>

--- a/src/Microsoft.DotNet.ImageBuilder/src/EnumerableExtensions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/EnumerableExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -39,5 +40,8 @@ namespace Microsoft.DotNet.ImageBuilder
 
         public static bool IsSubsetOf<T>(this IEnumerable<T> source, IEnumerable<T> items) =>
             !source.Except(items).Any();
+
+        public static IEnumerable<T> AppendIf<T>(this IEnumerable<T> source, T item, Func<bool> condition) =>
+            condition() ? source.Append(item) : source;
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/INotificationServices.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/INotificationServices.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.ImageBuilder
+{
+    public interface INotificationService
+    {
+        Task<Uri> PostAsync(string title, string description, IEnumerable<string> labels, string repoUrl, string gitHubAccessToken);
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
@@ -13,7 +13,8 @@
     <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
     <PackageReference Include="Microsoft.Azure.Kusto.Ingest" Version="8.0.9" />
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.22.0" />
-    <PackageReference Include="Microsoft.DotNet.VersionTools" Version="1.0.0-beta.19426.12" />
+    <PackageReference Include="Microsoft.DotNet.Git.IssueManager" Version="6.0.0-beta.21275.4" />
+    <PackageReference Include="Microsoft.DotNet.VersionTools" Version="6.0.0-beta.21275.4" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.0" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.153.0" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.11" />

--- a/src/Microsoft.DotNet.ImageBuilder/src/NotificationService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/NotificationService.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Git.IssueManager;
+
+namespace Microsoft.DotNet.ImageBuilder
+{
+    [Export(typeof(INotificationService))]
+    public class NotificationService : INotificationService
+    {
+        public async Task<Uri> PostAsync(string title, string description, IEnumerable<string> labels, string repoUrl, string gitHubAccessToken)
+        {
+            IssueManager issueManager = new(gitHubAccessToken);
+            int issueId = await issueManager.CreateNewIssueAsync(repoUrl, title, description, labels: labels);
+            return new Uri($"{repoUrl}/issues/{issueId}");
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/Services/IBuildHttpClient.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Services/IBuildHttpClient.cs
@@ -5,15 +5,15 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.TeamFoundation.Build.WebApi;
 using Microsoft.VisualStudio.Services.WebApi;
+using WebApi = Microsoft.TeamFoundation.Build.WebApi;
 
 namespace Microsoft.DotNet.ImageBuilder.Services
 {
     public interface IBuildHttpClient : IDisposable
     {
-        Task<IPagedList<Build>> GetBuildsAsync(Guid projectId, IEnumerable<int> definitions = null, BuildStatus? statusFilter = null);
+        Task<IPagedList<WebApi.Build>> GetBuildsAsync(Guid projectId, IEnumerable<int> definitions = null, WebApi.BuildStatus? statusFilter = null);
 
-        Task QueueBuildAsync(Build build);
+        Task<WebApi.Build> QueueBuildAsync(WebApi.Build build);
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Services/VssConnectionFactory.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Services/VssConnectionFactory.cs
@@ -6,10 +6,10 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
-using Microsoft.TeamFoundation.Build.WebApi;
 using Microsoft.TeamFoundation.Core.WebApi;
 using Microsoft.VisualStudio.Services.Common;
 using Microsoft.VisualStudio.Services.WebApi;
+using WebApi = Microsoft.TeamFoundation.Build.WebApi;
 
 namespace Microsoft.DotNet.ImageBuilder.Services
 {
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.ImageBuilder.Services
 
             public IBuildHttpClient GetBuildHttpClient()
             {
-                return new BuildHttpClientWrapper(_inner.GetClient<BuildHttpClient>());
+                return new BuildHttpClientWrapper(_inner.GetClient<WebApi.BuildHttpClient>());
             }
 
             private class ProjectHttpClientWrapper : IProjectHttpClient
@@ -67,9 +67,9 @@ namespace Microsoft.DotNet.ImageBuilder.Services
 
             private class BuildHttpClientWrapper : IBuildHttpClient
             {
-                private readonly BuildHttpClient _inner;
+                private readonly WebApi.BuildHttpClient _inner;
 
-                public BuildHttpClientWrapper(BuildHttpClient inner)
+                public BuildHttpClientWrapper(WebApi.BuildHttpClient inner)
                 {
                     _inner = inner ?? throw new ArgumentNullException(nameof(inner));
                 }
@@ -79,12 +79,12 @@ namespace Microsoft.DotNet.ImageBuilder.Services
                     _inner.Dispose();
                 }
 
-                public Task<IPagedList<Build>> GetBuildsAsync(Guid projectId, IEnumerable<int> definitions = null, BuildStatus? statusFilter = null)
+                public Task<IPagedList<WebApi.Build>> GetBuildsAsync(Guid projectId, IEnumerable<int> definitions = null, WebApi.BuildStatus? statusFilter = null)
                 {
                     return _inner.GetBuildsAsync2(projectId, definitions: definitions, statusFilter: statusFilter);
                 }
 
-                public Task QueueBuildAsync(Build build)
+                public Task<TeamFoundation.Build.WebApi.Build> QueueBuildAsync(TeamFoundation.Build.WebApi.Build build)
                 {
                     return _inner.QueueBuildAsync(build);
                 }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
@@ -18,7 +18,6 @@ using Microsoft.DotNet.ImageBuilder.Models.Subscription;
 using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
 using Microsoft.DotNet.VersionTools.Automation;
 using Microsoft.DotNet.VersionTools.Automation.GitHubApi;
-using Microsoft.TeamFoundation.Build.WebApi;
 using Microsoft.TeamFoundation.Core.WebApi;
 using Microsoft.VisualStudio.Services.WebApi;
 using Moq;
@@ -27,6 +26,7 @@ using Newtonsoft.Json.Linq;
 using Xunit;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ImageInfoHelper;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
+using WebApi = Microsoft.TeamFoundation.Build.WebApi;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
@@ -1587,7 +1587,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             /// <param name="build">The <see cref="Build"/> to validate.</param>
             /// <param name="subscription">Subscription object that contains metadata to compare against the <paramref name="build"/>.</param>
             /// <param name="expectedPaths">The set of expected path arguments that should have been passed to the build.</param>
-            private static bool FilterBuildToSubscription(Build build, Subscription subscription, IList<string> expectedPaths)
+            private static bool FilterBuildToSubscription(WebApi.Build build, Subscription subscription, IList<string> expectedPaths)
             {
                 return build.Definition.Id == subscription.PipelineTrigger.Id &&
                     build.SourceBranch == subscription.Manifest.Branch &&


### PR DESCRIPTION
This implements a basic notification service within Image Builder that allows notifications to be posted as issues in a GitHub repo.  The use of the service will be expanded in the future but for now I've configured it so that a notification will be sent whenever AutoBuilder queues a build.

Related to https://github.com/dotnet/docker-tools/issues/394