### PR TITLE
Use scale set agent pools for internal builds

### DIFF
--- a/eng/common/templates/jobs/validate-image-sizes.yml
+++ b/eng/common/templates/jobs/validate-image-sizes.yml
@@ -35,12 +35,7 @@ jobs:
       dockerClientOS: linux
       validationMode: integrity
 - job: WindowsPerfTests
-  pool:
-    ${{ if eq(variables['System.TeamProject'], 'public') }}:
-      name: Docker-20H2-Public
-    ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-      name: DotNetCore-Docker
-      demands: VSTS_OS -equals Windows-ServerDatacenter-2009
+  pool: Docker-20H2-${{ variables['System.TeamProject'] }}
   workspace:
     clean: all
   steps:

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -87,12 +87,7 @@ stages:
   - template: ../jobs/build-images.yml
     parameters:
       name: Windows1809_amd64
-      pool:
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: Docker-1809-Public
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: DotNetCore-Docker
-          demands: VSTS_OS -equals Windows_Server_2019_Data_Center_RS5
+      pool: Docker-1809-${{ variables['System.TeamProject'] }}
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.Windows1809Amd64']
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
@@ -101,12 +96,7 @@ stages:
   - template: ../jobs/build-images.yml
     parameters:
       name: Windows2004_amd64
-      pool:
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: Docker-2004-Public
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: DotNetCore-Docker
-          demands: VSTS_OS -equals Windows-ServerDatacenter-2004
+      pool: Docker-2004-${{ variables['System.TeamProject'] }}
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.Windows2004Amd64']
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
@@ -115,12 +105,7 @@ stages:
   - template: ../jobs/build-images.yml
     parameters:
       name: Windows20H2_amd64
-      pool:
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: Docker-20H2-Public
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: DotNetCore-Docker
-          demands: VSTS_OS -equals Windows-ServerDatacenter-2009
+      pool: Docker-20H2-${{ variables['System.TeamProject'] }}
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.Windows20H2Amd64']
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
@@ -129,12 +114,7 @@ stages:
   - template: ../jobs/build-images.yml
     parameters:
       name: WindowsLtsc2016_amd64
-      pool:
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: Docker-2016-Public
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: DotNetCore-Docker
-          demands: VSTS_OS -equals Windows_Server_2016_Data_Center_with_Containers
+      pool: Docker-2016-${{ variables['System.TeamProject'] }}
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.WindowsLtsc2016Amd64']
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
@@ -202,33 +182,25 @@ stages:
     - template: ../jobs/test-images-windows-client.yml
       parameters:
         name: Windows1809_amd64
-        pool:
-          name: DotNetCore-Docker
-          demands: VSTS_OS -equals Windows_Server_2019_Data_Center_RS5
+        pool: Docker-1809-${{ variables['System.TeamProject'] }}
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.Windows1809Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
     - template: ../jobs/test-images-windows-client.yml
       parameters:
         name: Windows2004_amd64
-        pool:
-          name: DotNetCore-Docker
-          demands: VSTS_OS -equals Windows-ServerDatacenter-2004
+        pool: Docker-2004-${{ variables['System.TeamProject'] }}
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.Windows2004Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
     - template: ../jobs/test-images-windows-client.yml
       parameters:
         name: Windows20H2_amd64
-        pool:
-          name: DotNetCore-Docker
-          demands: VSTS_OS -equals Windows-ServerDatacenter-2009
+        pool: Docker-20H2-${{ variables['System.TeamProject'] }}
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.Windows20H2Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
     - template: ../jobs/test-images-windows-client.yml
       parameters:
         name: WindowsLtsc2016_amd64
-        pool:
-          name: DotNetCore-Docker
-          demands: VSTS_OS -equals Windows_Server_2016_Data_Center_with_Containers
+        pool: Docker-2016-${{ variables['System.TeamProject'] }}
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.WindowsLtsc2016Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
 

--- a/eng/pipelines/check-base-image-updates.yml
+++ b/eng/pipelines/check-base-image-updates.yml
@@ -64,9 +64,7 @@ stages:
         staleImagePathsVariableName: linux-arm64-stale-image-paths
 
   - job: Get_Stale_Images_Windows_AMD
-    pool:
-      name: DotNetCore-Docker
-      demands: VSTS_OS -equals Windows_Server_2019_Data_Center_RS5
+    pool: Docker-2019-Internal
     steps:
     - template: templates/steps/get-stale-images.yml
       parameters:


### PR DESCRIPTION
Rolls out the changes to use scale set agent pools for internal builds in the common infra.

Related to dotnet/docker-tools#532