### PR TITLE
Support for CBL-Mariner

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateDockerfilesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateDockerfilesCommand.cs
@@ -61,12 +61,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             const string PrefixGroup = "Prefix";
             const string VersionGroup = "Version";
-            Match match = Regex.Match(platform.Model.OsVersion, @$"(-(?<{PrefixGroup}>\w*))?(?<{VersionGroup}>\d+.\d+)");
+            const string LtscPrefix = "ltsc";
+            Match match = Regex.Match(platform.Model.OsVersion, @$"(-(?<{PrefixGroup}>[a-zA-Z_]*))?(?<{VersionGroup}>\d+.\d+)");
 
             string versionNumber = string.Empty;
-            if (match.Groups[PrefixGroup].Success)
+            if (match.Groups[PrefixGroup].Success && match.Groups[PrefixGroup].Value == LtscPrefix)
             {
-                versionNumber = match.Groups[PrefixGroup].Value;
+                versionNumber = LtscPrefix;
             }
 
             versionNumber += match.Groups[VersionGroup].Value;

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
@@ -208,13 +208,11 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
                 }
                 else if (os.Contains("alpine") || os.Contains("centos") || os.Contains("fedora"))
                 {
-                    int versionIndex = os.IndexOfAny(new char[] { '1', '2', '3', '4', '5', '6', '7', '8', '9', '0' });
-                    if (versionIndex != -1)
-                    {
-                        os = os.Insert(versionIndex, " ");
-                    }
-
-                    displayName = os.FirstCharToUpper();
+                    displayName = FormatVersionableOsName(os, name => name.FirstCharToUpper());
+                }
+                else if (os.Contains("cbl-mariner"))
+                {
+                    displayName = FormatVersionableOsName(os, name => "CBL-Mariner");
                 }
                 else
                 {
@@ -230,6 +228,31 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 
         public string GetUniqueKey(ImageInfo parentImageInfo) =>
             $"{DockerfilePathRelativeToManifest}-{Model.OS}-{Model.OsVersion}-{Model.Architecture}-{parentImageInfo.ProductVersion}";
+
+        private static string FormatVersionableOsName(string os, Func<string, string> formatName)
+        {
+            (string osName, string osVersion) = GetOsVersionInfo(os);
+            if (string.IsNullOrEmpty(osVersion))
+            {
+                return formatName(osName);
+            }
+            else
+            {
+                return $"{formatName(osName)} {osVersion}";
+            }
+        }
+
+        private static (string Name, string Version) GetOsVersionInfo(string osVersion)
+        {
+            int versionIndex = osVersion.IndexOfAny(new char[] { '1', '2', '3', '4', '5', '6', '7', '8', '9', '0' });
+            if (versionIndex != -1)
+            {
+                return (osVersion.Substring(0, versionIndex), osVersion.Substring(versionIndex));
+            }
+
+            return (osVersion, string.Empty);
+        }
+            
 
         private static bool IsStageReference(string fromImage, IList<Match> fromMatches)
         {

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateDockerfilesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateDockerfilesCommandTests.cs
@@ -117,11 +117,13 @@ ENV TEST2 Value1";
         [InlineData("repo1:tag3", "OS_VERSION_NUMBER", "1903")]
         [InlineData("repo1:tag4", "OS_VERSION_NUMBER", "ltsc2019")]
         [InlineData("repo1:tag5", "OS_VERSION_NUMBER", "3.12")]
+        [InlineData("repo1:tag6", "OS_VERSION_NUMBER", "1.0")]
         [InlineData("repo1:tag1", "OS_ARCH_HYPHENATED", "Debian-10-arm32")]
         [InlineData("repo1:tag2", "OS_ARCH_HYPHENATED", "NanoServer-1903")]
         [InlineData("repo1:tag3", "OS_ARCH_HYPHENATED", "WindowsServerCore-1903")]
         [InlineData("repo1:tag4", "OS_ARCH_HYPHENATED", "WindowsServerCore-ltsc2019")]
         [InlineData("repo1:tag5", "OS_ARCH_HYPHENATED", "Alpine-3.12")]
+        [InlineData("repo1:tag6", "OS_ARCH_HYPHENATED", "CBL-Mariner-1.0")]
         [InlineData("repo1:tag1", "Variable1", "Value1", true)]
         public void GenerateDockerfilesCommand_SupportedSymbols(string tag, string symbol, string expectedValue, bool isVariable = false)
         {
@@ -191,7 +193,12 @@ ENV TEST2 Value1";
                                 DockerfilePath,
                                 new string[] { "tag5" },
                                 OS.Linux,
-                                "alpine3.12")
+                                "alpine3.12"),
+                            CreatePlatform(
+                                DockerfilePath,
+                                new string[] { "tag6" },
+                                OS.Linux,
+                                "cbl-mariner1.0")
                         },
                         productVersion: "1.2.3"
                     )


### PR DESCRIPTION
Updates Image Builder to handle a new distro: [CBL-Mariner](https://github.com/microsoft/CBL-Mariner).

The changes that were made:
* `PlatformInfo.GetOSDisplayName` updated to provide a display name for this distro.
* Refactored `PlatformInfo.GetOSDisplayName` to have a generic algorithm for pulling out the version name from the distro name.
* Updated regex in `GenerateDockerfilesCommand` for parsing the OS version number so that it can support OS names that contain a `-` character.

Related to https://github.com/dotnet/dotnet-docker/issues/2837