### PR TITLE
Fix matrix generation for intra-repo dependency

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
@@ -397,7 +397,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private IEnumerable<PlatformInfo> GetPlatformDependencies(PlatformInfo platform, IEnumerable<PlatformInfo> availablePlatforms) =>
             platform.InternalFromImages
                 .Select(fromImage => Manifest.GetPlatformByTag(fromImage))
-                .Intersect(availablePlatforms);
+                .Intersect(availablePlatforms)
+                .Where(dependency =>
+                    Options.MatrixType == MatrixType.PlatformDependencyGraph ||
+                    Manifest.GetImageByPlatform(dependency).ProductVersion == Manifest.GetImageByPlatform(platform).ProductVersion);
 
         private static void LogDiagnostics(IEnumerable<BuildMatrixInfo> matrices)
         {

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
@@ -25,7 +25,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// https://github.com/dotnet/docker-tools/issues/243
         /// </remarks>
         [Theory]
-        [InlineData(null, "--path 2.1.1/runtime-deps/os --path 2.2/runtime/os", "2.1.1")]
+        [InlineData(null, "--path 2.1.1/runtime-deps/os", "2.1.1")]
+        [InlineData(null, "--path 2.1.1/runtime-deps/os --path 2.2/runtime/os", "2.2")]
         [InlineData("--path 2.2/runtime/os", "--path 2.2/runtime/os", "2.2")]
         [InlineData("--path 2.1.1/runtime-deps/os", "--path 2.1.1/runtime-deps/os", "2.1.1")]
         public void GenerateBuildMatrixCommand_PlatformVersionedOs(string filterPaths, string expectedPaths, string verificationLegName)
@@ -51,16 +52,22 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 DirectoryInfo runtimeDir = Directory.CreateDirectory(
                     Path.Combine(tempFolderContext.Path, runtimeRelativeDir));
                 string dockerfileRuntimePath = Path.Combine(runtimeDir.FullName, "Dockerfile");
-                File.WriteAllText(dockerfileRuntimePath, "FROM runtime-deps:tag");
+                File.WriteAllText(dockerfileRuntimePath, "FROM runtime-deps:tag-2.2");
 
                 Manifest manifest = CreateManifest(
                     CreateRepo("runtime-deps",
                         CreateImage(
                             new Platform[]
                             {
-                                CreatePlatform(runtimeDepsRelativeDir, new string[] { "tag" })
+                                CreatePlatform(runtimeDepsRelativeDir, new string[] { "tag-2.1" })
                             },
-                            productVersion: "2.1.1")),
+                            productVersion: "2.1.1"),
+                        CreateImage(
+                            new Platform[]
+                            {
+                                CreatePlatform(runtimeDepsRelativeDir, new string[] { "tag-2.2" })
+                            },
+                            productVersion: "2.2.3-preview")),
                     CreateRepo("runtime",
                         CreateImage(
                             new Platform[]
@@ -81,6 +88,62 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 string imageBuilderPaths = leg.Variables.First(variable => variable.Name == "imageBuilderPaths").Value;
 
                 Assert.Equal(expectedPaths, imageBuilderPaths);
+            }
+        }
+
+        /// <summary>
+        /// Verifies the PlatformDependencyGraph matrix type
+        /// </summary>
+        [Fact]
+        public void GenerateBuildMatrixCommand_PlatformDependencyGraph_CrossVersionDependency()
+        {
+            using (TempFolderContext tempFolderContext = TestHelper.UseTempFolder())
+            {
+                GenerateBuildMatrixCommand command = new GenerateBuildMatrixCommand();
+                command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
+                command.Options.MatrixType = MatrixType.PlatformDependencyGraph;
+                command.Options.ProductVersionComponents = 2;
+
+                Manifest manifest = CreateManifest(
+                    CreateRepo("runtime-deps",
+                        CreateImage(
+                            new Platform[]
+                            {
+                                CreatePlatform(
+                                    DockerfileHelper.CreateDockerfile("5.0/runtime-deps/os", tempFolderContext, "base"),
+                                    new string[] { "tag-5.0" })
+                            },
+                            productVersion: "5.0"),
+                        CreateImage(
+                            new Platform[]
+                            {
+                                CreatePlatform(
+                                    DockerfileHelper.CreateDockerfile("6.0/runtime-deps/os", tempFolderContext, "runtime-deps:tag-5.0"),
+                                    new string[] { "tag-6.0" })
+                            },
+                            productVersion: "6.0")),
+                    CreateRepo("runtime",
+                        CreateImage(
+                            new Platform[]
+                            {
+                                CreatePlatform(
+                                    DockerfileHelper.CreateDockerfile("6.0/runtime/os", tempFolderContext, "runtime-deps:tag-6.0"),
+                                    new string[] { "tag-6.0" })
+                            },
+                            productVersion: "6.0"))
+                );
+
+                File.WriteAllText(Path.Combine(tempFolderContext.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));
+
+                command.LoadManifest();
+                IEnumerable<BuildMatrixInfo> matrixInfos = command.GenerateMatrixInfo();
+                Assert.Single(matrixInfos);
+
+                BuildMatrixInfo matrixInfo = matrixInfos.First();
+                BuildLegInfo leg = matrixInfo.Legs.First(leg => leg.Name.StartsWith("5.0"));
+                string imageBuilderPaths = leg.Variables.First(variable => variable.Name == "imageBuilderPaths").Value;
+
+                Assert.Equal("--path 5.0/runtime-deps/os/Dockerfile --path 6.0/runtime-deps/os/Dockerfile --path 6.0/runtime/os/Dockerfile", imageBuilderPaths);
             }
         }
 


### PR DESCRIPTION
When attempting to implement a dependency between a 6.0 Dockerfile and a 5.0 Dockerfile within the same Docker repository (in order to satisfy https://github.com/dotnet/dotnet-docker/pull/2841#discussion_r641771618), I discovered an issue in the matrix generation. It generates an incorrect matrix for the platformVersionedOs matrix type.

In the specific example, the runtime-deps Dockerfile for 6.0 is based on the runtime-deps image for 5.0 via its `FROM` instruction.  The matrix generation will produce a matrix that groups 5.0 and 6.0 together.  This is incorrect for this matrix type because 5.0 and 6.0 should be tested in separate build jobs.

The reason they are grouped together is because it simply sees that the 6.0 Dockerfile has a dependency on a 5.0 image.  But for this matrix type, that in itself should not be the sole decided factor of whether they should grouped.  They should also belong to the same product version because we essentially want to produce test jobs that are testing one product version per job.