### PR TITLE
Revert "Fix matrix generation for intra-repo dependency (#795)"

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
@@ -397,10 +397,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private IEnumerable<PlatformInfo> GetPlatformDependencies(PlatformInfo platform, IEnumerable<PlatformInfo> availablePlatforms) =>
             platform.InternalFromImages
                 .Select(fromImage => Manifest.GetPlatformByTag(fromImage))
-                .Intersect(availablePlatforms)
-                .Where(dependency =>
-                    Options.MatrixType == MatrixType.PlatformDependencyGraph ||
-                    Manifest.GetImageByPlatform(dependency).ProductVersion == Manifest.GetImageByPlatform(platform).ProductVersion);
+                .Intersect(availablePlatforms);
 
         private static void LogDiagnostics(IEnumerable<BuildMatrixInfo> matrices)
         {


### PR DESCRIPTION
This reverts commit 394953c9b2ae150076ec916ca5b6515db0bf0fcd.

I'm reverting this because there's an issue in the logic.  It ends up splitting sdk into a separate job from the other image variants because the product versions are different (the version number is a 3-part version so 5.0.6 would end up differing from 5.0.300, for example) when they should actually be seen as belong to the same product version.  Besides, there are no plans for using intra-repo dependencies anymore.