### PR TITLE
Update display name for Nano Server

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
@@ -146,18 +146,11 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
                 string version = os.Split('-')[1];
                 if (os.StartsWith("nanoserver"))
                 {
-                    displayName = $"Nano Server, version {version}";
+                    displayName = GetWindowsVersionDisplayName("Nano Server", version);
                 }
                 else if (os.StartsWith("windowsservercore"))
                 {
-                    if (version.StartsWith("ltsc"))
-                    {
-                        displayName = $"Windows Server Core {version.TrimStart("ltsc")}";
-                    }
-                    else
-                    {
-                        displayName = $"Windows Server Core, version {version}";
-                    }
+                    displayName = GetWindowsVersionDisplayName("Windows Server Core", version);
                 }
                 else
                 {
@@ -217,6 +210,18 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             }
 
             return displayName;
+        }
+
+        private static string GetWindowsVersionDisplayName(string windowsName, string version)
+        {
+            if (version.StartsWith("ltsc"))
+            {
+                return $"{windowsName} {version.TrimStart("ltsc")}";
+            }
+            else
+            {
+                return $"{windowsName}, version {version}";
+            }
         }
 
         public static bool AreMatchingPlatforms(ImageInfo image1, PlatformInfo platform1, ImageInfo image2, PlatformInfo platform2) =>

--- a/src/Microsoft.DotNet.ImageBuilder/tests/PlatformInfoTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/PlatformInfoTests.cs
@@ -37,6 +37,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         [InlineData("nanoserver-1809", "Nano Server, version 1809")]
         [InlineData("windowsservercore-1903", "Windows Server Core, version 1903")]
         [InlineData("nanoserver-1903", "Nano Server, version 1903")]
+        [InlineData("nanoserver-ltsc2022", "Nano Server 2022")]
         public void GetOSDisplayName_Windows(string osVersion, string expectedDisplayName)
         {
             ValidateGetOSDisplayName(OS.Windows, osVersion, expectedDisplayName);


### PR DESCRIPTION
For Windows Server 2022, Nano Server won't have a SAC version.  It'll just be Nano Server 2022.  These changes update the display name for Nano Server to support this rather than only the SAC version pattern.  The logic is now shared with Windows Server Core.