### PR TITLE
Disable cleanup of mirrored images

### DIFF
--- a/eng/pipelines/cleanup-acr-images.yml
+++ b/eng/pipelines/cleanup-acr-images.yml
@@ -38,9 +38,10 @@ jobs:
       repo: "public/dotnet*/samples*"
       action: pruneDangling
       age: 0
-  - template: templates/steps/clean-acr-images.yml
-    parameters:
-      repo: "mirror/*"
-      action: pruneDangling
-      age: 0
+  # Disabled due to https://github.com/dotnet/docker-tools/issues/797
+  # - template: templates/steps/clean-acr-images.yml
+  #   parameters:
+  #     repo: "mirror/*"
+  #     action: pruneDangling
+  #     age: 0
   - template: ../common/templates/steps/cleanup-docker-linux.yml


### PR DESCRIPTION
This is a stop-gap solution for #797.  It disables the cleanup of mirrored images because some of them may be the result of importing a multi-arch tag which causes the underlying image to be untagged and subject to deletion.  For now, we'll disable this cleanup until a workable solution can be implemented.