### PR TITLE
Add Windows version-specific images of Image Builder

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/Dockerfile.linux
+++ b/src/Microsoft.DotNet.ImageBuilder/Dockerfile.linux
@@ -33,7 +33,7 @@ RUN apk add --no-cache \
 
 # install manifest-tool
 RUN wget -O /usr/local/bin/manifest-tool \
-        "https://github.com/estesp/manifest-tool/releases/download/v1.0.2/manifest-tool-linux-$MANIFEST_TOOL_ARCH" \
+        "https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-$MANIFEST_TOOL_ARCH" \
     && chmod +x /usr/local/bin/manifest-tool
 
 # install image-builder

--- a/src/Microsoft.DotNet.ImageBuilder/Dockerfile.windows
+++ b/src/Microsoft.DotNet.ImageBuilder/Dockerfile.windows
@@ -1,5 +1,7 @@
 # escape=`
 
+ARG WINDOWS_BASE
+
 # build Microsoft.DotNet.ImageBuilder
 FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build-env
 WORKDIR /image-builder
@@ -18,10 +20,10 @@ RUN pwsh -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         Invoke-WebRequest `
             -UseBasicParsing `
-            -Uri "https://github.com/estesp/manifest-tool/releases/download/v1.0.2/manifest-tool-windows-amd64.exe" `
+            -Uri "https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-windows-amd64.exe" `
             -OutFile out/manifest-tool.exe;
 
 # build runtime image
-FROM mcr.microsoft.com/windows/nanoserver:sac2016
+FROM mcr.microsoft.com/windows/$WINDOWS_BASE
 WORKDIR /image-builder
 COPY --from=build-env /image-builder/out ./

--- a/src/Microsoft.DotNet.ImageBuilder/manifest.json
+++ b/src/Microsoft.DotNet.ImageBuilder/manifest.json
@@ -38,11 +38,47 @@
               "variant": "v8"
             },
             {
+              "buildArgs": {
+                "WINDOWS_BASE": "servercore:ltsc2016-amd64"
+              },
               "dockerfile": "Dockerfile.windows",
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2019",
               "tags": {
-                "windows-amd64-$(UniqueId)": {}
+                "windowsservercore-ltsc2016-amd64-$(UniqueId)": {}
+              }
+            },
+            {
+              "buildArgs": {
+                "WINDOWS_BASE": "nanoserver:1809-amd64"
+              },
+              "dockerfile": "Dockerfile.windows",
+              "os": "windows",
+              "osVersion": "nanoserver-1809",
+              "tags": {
+                "nanoserver-1809-amd64-$(UniqueId)": {}
+              }
+            },
+            {
+              "buildArgs": {
+                "WINDOWS_BASE": "nanoserver:2004-amd64"
+              },
+              "dockerfile": "Dockerfile.windows",
+              "os": "windows",
+              "osVersion": "nanoserver-2004",
+              "tags": {
+                "nanoserver-2004-amd64-$(UniqueId)": {}
+              }
+            },
+            {
+              "buildArgs": {
+                "WINDOWS_BASE": "nanoserver:20H2-amd64"
+              },
+              "dockerfile": "Dockerfile.windows",
+              "os": "windows",
+              "osVersion": "nanoserver-20H2",
+              "tags": {
+                "nanoserver-20H2-amd64-$(UniqueId)": {}
               }
             }
           ]


### PR DESCRIPTION
This produces an image of Image Builder for each version of Windows.  Doing this allows us to target `servercore:ltsc2016` instead of `nanoserver:sac2016` and still target Nano Server for the other versions.

Fixes #721