### PR TITLE
Fix retry behavior for Kusto ingestion

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/IngestKustoImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/IngestKustoImageInfoCommand.cs
@@ -129,15 +129,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         private async Task IngestInfoAsync(string info, string table)
         {
-            using MemoryStream stream = new();
-            using StreamWriter writer = new(stream);
-            writer.Write(info);
-            writer.Flush();
-            stream.Seek(0, SeekOrigin.Begin);
-
             if (!Options.IsDryRun)
             {
-                await _kustoClient.IngestFromCsvStreamAsync(stream, Options.ServicePrincipal, Options.Cluster, Options.Database, table, Options.IsDryRun);
+                await _kustoClient.IngestFromCsvAsync(info, Options.ServicePrincipal, Options.Cluster, Options.Database, table, Options.IsDryRun);
             }
         }
     }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Services/IKustoClient.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Services/IKustoClient.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.IO;
 using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Commands;
 
@@ -10,7 +9,7 @@ namespace Microsoft.DotNet.ImageBuilder.Services
 {
     public interface IKustoClient
     {
-        Task IngestFromCsvStreamAsync(
-            Stream csv, ServicePrincipalOptions servicePrincipal, string cluster, string database, string table, bool isDryRun);
+        Task IngestFromCsvAsync(
+            string csv, ServicePrincipalOptions servicePrincipal, string cluster, string database, string table, bool isDryRun);
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/IngestKustoImageInfoCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/IngestKustoImageInfoCommandTests.cs
@@ -273,13 +273,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             Mock<IKustoClient> kustoClientMock = new();
             kustoClientMock
-                .Setup(o => o.IngestFromCsvStreamAsync(
-                    It.IsAny<Stream>(), It.IsAny<ServicePrincipalOptions>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
-                .Callback<Stream, ServicePrincipalOptions, string, string, string, bool>(
-                    (stream, servicePrincipal, cluster, database, table, isDryRun) =>
+                .Setup(o => o.IngestFromCsvAsync(
+                    It.IsAny<string>(), It.IsAny<ServicePrincipalOptions>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
+                .Callback<string, ServicePrincipalOptions, string, string, string, bool>(
+                    (csv, servicePrincipal, cluster, database, table, isDryRun) =>
                     {
-                        StreamReader reader = new(stream);
-                        ingestedData.Add(table, reader.ReadToEnd());
+                        ingestedData.Add(table, csv);
                     });
             IngestKustoImageInfoCommand command = new(Mock.Of<ILoggerService>(), kustoClientMock.Object);
             command.Options.ImageInfoPath = imageInfoPath;
@@ -296,8 +295,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             _outputHelper.WriteLine($"Expected Layer Data: {Environment.NewLine}{expectedLayerData}");
             _outputHelper.WriteLine($"Actual Layer Data: {Environment.NewLine}{ingestedData[command.Options.LayerTable]}");
 
-            kustoClientMock.Verify(o => o.IngestFromCsvStreamAsync(
-                It.IsAny<Stream>(), It.IsAny<ServicePrincipalOptions>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()));
+            kustoClientMock.Verify(o => o.IngestFromCsvAsync(
+                It.IsAny<string>(), It.IsAny<ServicePrincipalOptions>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()));
             Assert.Equal(expectedImageData, ingestedData[command.Options.ImageTable]);
             Assert.Equal(expectedLayerData, ingestedData[command.Options.LayerTable]);
         }


### PR DESCRIPTION
An [earlier change](https://github.com/dotnet/docker-tools/pull/804) for retrying Kusto ingestion doesn't work properly because of the use of a Stream object. When the throttling exception occurs, another attempt is made to run the ingestion but the KustoClient returns the result immediately with a status of Skipped because the stream that's passed in has already been read from and is positioned at the end of the stream.  Because the status is Skipped and not Succeeded, an exception is later thrown.

I've fixed this by moving the creation of the stream right up to the point where it's needed to pass it to the ingestion method.  The retry behavior wraps this, allowing for a new stream object to be created with each retry attempt.

I also fixed an error in the logic for handling a timeout.  It was essentially unreachable code because of the `if` conditions.

Fixes #800