### PR TITLE
Set target branch to main for mcrdocs repo

### DIFF
--- a/eng/common/templates/steps/publish-readmes.yml
+++ b/eng/common/templates/steps/publish-readmes.yml
@@ -24,6 +24,10 @@ steps:
     ${{ parameters.dryRunArg }}
     $(manifestVariables)
     $(imageBuilder.queueArgs)
+    --git-owner 'Microsoft'
+    --git-repo 'mcrdocs'
+    --git-branch 'main'
+    --git-path 'teams'
     $(additionalPublishMcrDocsArgs)
   name: PublishReadmes
   displayName: Publish Readmes


### PR DESCRIPTION
The microsoft/mcrdocs repo is renaming master to main. The default branch value set in Image Builder is set to master.  I'm updating the pipeline to explicitly set these options rather than use the default.