### PR TITLE
Stop queuing builds if there are recent failures

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/AzdoTags.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/AzdoTags.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    public static class AzdoTags
+    {
+        public const string AutoBuilder = "autobuilder";
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/QueueBuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/QueueBuildCommand.cs
@@ -27,6 +27,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private readonly ILoggerService _loggerService;
         private readonly INotificationService _notificationService;
 
+        // The number of most recent builds that must have failed consecutively before skipping the queuing of another build
+        public const int BuildFailureLimit = 3;
+
         [ImportingConstructor]
         public QueueBuildCommand(
             IVssConnectionFactory connectionFactory,
@@ -103,6 +106,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             WebApi.Build? queuedBuild = null;
             Exception? exception = null;
             IEnumerable<string>? inProgressBuilds = null;
+            IEnumerable<string>? recentFailedBuilds = null;
 
             try
             {
@@ -121,11 +125,21 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         SourceBranch = subscription.Manifest.Branch,
                         Parameters = parameters
                     };
+                    build.Tags.Add(AzdoTags.AutoBuilder);
 
                     inProgressBuilds = await GetInProgressBuildsAsync(client, subscription.PipelineTrigger.Id, project.Id);
                     if (!inProgressBuilds.Any())
                     {
-                        queuedBuild = await client.QueueBuildAsync(build);
+                        recentFailedBuilds = await GetRecentFailedBuildsAsync(client, subscription.PipelineTrigger.Id, project.Id);
+                        if (!recentFailedBuilds.Any())
+                        {
+                            queuedBuild = await client.QueueBuildAsync(build);
+                        }
+                        else
+                        {
+                            _loggerService.WriteMessage(
+                                PipelineHelper.FormatErrorCommand("Unable to queue build due to too many recent build failures."));
+                        }
                     }
                 }
             }
@@ -136,12 +150,14 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             }
             finally
             {
-                await LogAndNotifyResultsAsync(subscription, pathsToRebuild, queuedBuild, exception, inProgressBuilds);
+                await LogAndNotifyResultsAsync(
+                    subscription, pathsToRebuild, queuedBuild, exception, inProgressBuilds, recentFailedBuilds);
             }
         }
 
         private async Task LogAndNotifyResultsAsync(
-            Subscription subscription, IEnumerable<string> pathsToRebuild, WebApi.Build? queuedBuild, Exception? exception, IEnumerable<string>? inProgressBuilds)
+            Subscription subscription, IEnumerable<string> pathsToRebuild, WebApi.Build? queuedBuild, Exception? exception,
+            IEnumerable<string>? inProgressBuilds, IEnumerable<string>? recentFailedBuilds)
         {
             StringBuilder notificationMarkdown = new();
             notificationMarkdown.AppendLine($"Subscription: {subscription}");
@@ -162,6 +178,27 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 string webLink = GetWebLink(queuedBuild);
                 _loggerService.WriteMessage($"Queued build {webLink}");
                 notificationMarkdown.AppendLine($"[Build Link]({webLink})");
+            }
+            else if (recentFailedBuilds is not null)
+            {
+                category = "Failed";
+
+                StringBuilder builder = new();
+                builder.AppendLine(
+                    $"Due to recent failures of the following builds, a build will not be queued again for subscription '{subscription}':");
+                foreach (string buildUri in recentFailedBuilds)
+                {
+                    builder.AppendLine(buildUri);
+                }
+
+                builder.AppendLine();
+                builder.AppendLine(
+                    "Please investigate the cause of the failures, resolve the issue, and manually queue a build for the Dockerfile paths listed above.");
+
+                string message = builder.ToString();
+
+                _loggerService.WriteMessage(message);
+                notificationMarkdown.AppendLine(message);
             }
             else if (inProgressBuilds is not null)
             {
@@ -223,6 +260,23 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         private static string GetWebLink(WebApi.Build build) =>
             ((ReferenceLink)build.Links.Links["web"]).Href;
+
+		private static async Task<IEnumerable<string>> GetRecentFailedBuildsAsync(IBuildHttpClient client, int pipelineId, Guid projectId)
+        {
+            List<WebApi.Build> autoBuilderBuilds = (await client.GetBuildsAsync(projectId, definitions: new int[] { pipelineId }))
+                .Where(build => build.Tags.Contains(AzdoTags.AutoBuilder))
+                .OrderByDescending(build => build.QueueTime)
+                .Take(BuildFailureLimit)
+                .ToList();
+
+            if (autoBuilderBuilds.Count == BuildFailureLimit &&
+                autoBuilderBuilds.All(build => build.Status == WebApi.BuildStatus.Completed && build.Result == WebApi.BuildResult.Failed))
+            {
+                return autoBuilderBuilds.Select(GetWebLink);
+            }
+
+            return Enumerable.Empty<string>();
+        }
     }
 }
 #nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/PipelineHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/PipelineHelper.cs
@@ -8,5 +8,7 @@ namespace Microsoft.DotNet.ImageBuilder
     {
         public static string FormatOutputVariable(string variableName, string value) =>
             $"##vso[task.setvariable variable={variableName};isoutput=true]{value}";
+
+        public static string FormatErrorCommand(string message) => $"##[error]{message}";
     }
 }


### PR DESCRIPTION
This adds logic to ensure we don't have builds being automatically queued continuously over and over even when they are failing.  For now, a simple test is used to check whether the last 3 builds queued by Auto Builder have failed. If so, it won't queue a build and will fail the scheduled build instead, as well as logging a notification. The only way to get back into a good state is to resolve whatever the issue is and have a human manually queue a build to produce a successful build.

Fixes #715