### PR TITLE
Remove custom default options for publishMcrDocs cmd

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsOptions.cs
@@ -26,15 +26,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
     public class PublishMcrDocsOptionsBuilder : ManifestOptionsBuilder
     {
-        private readonly GitOptionsBuilder _gitOptionsBuilder =
-            GitOptionsBuilder.Build()
-                .WithUsername(isRequired: true)
-                .WithEmail(isRequired: true)
-                .WithAuthToken(isRequired: true)
-                .WithOwner(defaultValue: "Microsoft")
-                .WithRepo(defaultValue: "mcrdocs")
-                .WithBranch(defaultValue: "master")
-                .WithPath(defaultValue: "teams");
+        private readonly GitOptionsBuilder _gitOptionsBuilder = GitOptionsBuilder.BuildWithDefaults();
 
         public override IEnumerable<Option> GetCliOptions() =>
             base.GetCliOptions()


### PR DESCRIPTION
Removing the hardcoded default git options for the publishMcrDocs command. It's better to not have these defined in code and instead explicitly set by the pipeline (already done by https://github.com/dotnet/docker-tools/pull/811).