### PR TITLE
Support manifest variables when loading manifests from subscription

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Subscription/Subscription.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Subscription/Subscription.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Subscription
     public class Subscription
     {
         [JsonProperty(Required = Required.Always)]
-        public GitFile Manifest { get; set; }
+        public SubscriptionManifest Manifest { get; set; }
 
         [JsonProperty(Required = Required.Always)]
         public GitFile ImageInfo { get; set; }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Subscription/SubscriptionManifest.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Subscription/SubscriptionManifest.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.ImageBuilder.Models.Subscription
+{
+    public class SubscriptionManifest : GitFile
+    {
+        public Dictionary<string, string> Variables { get; set; } = new();
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/SubscriptionHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/SubscriptionHelper.cs
@@ -52,9 +52,10 @@ namespace Microsoft.DotNet.ImageBuilder
             string repoPath = await GitHelper.DownloadAndExtractGitRepoArchiveAsync(httpClient, subscription.Manifest);
             try
             {
-                TempManifestOptions manifestOptions = new TempManifestOptions(filterOptions)
+                TempManifestOptions manifestOptions = new(filterOptions)
                 {
                     Manifest = Path.Combine(repoPath, subscription.Manifest.Path),
+                    Variables = subscription.Manifest.Variables
                 };
 
                 configureOptions?.Invoke(manifestOptions);

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
@@ -1310,7 +1310,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     Id = 1,
                     PathVariable = "--my-path"
                 },
-                Manifest = new GitFile
+                Manifest = new SubscriptionManifest
                 {
                     Branch = "testBranch" + index,
                     Repo = repoName,

--- a/src/Microsoft.DotNet.ImageBuilder/tests/QueueBuildCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/QueueBuildCommandTests.cs
@@ -438,7 +438,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     Id = 1,
                     PathVariable = "--my-path"
                 },
-                Manifest = new GitFile
+                Manifest = new SubscriptionManifest
                 {
                     Branch = "testBranch" + index,
                     Repo = repoName,


### PR DESCRIPTION
In order to add docker-tools to the subscription file to allow Image Builder to be checked for rebuilds, we need the ability to load its manifest file. The manifest file requires a value for the `UniqueId` variable in order to be loaded. The `getStaleImages` command doesn't provide a value for that variable when it loads the manifest, causing the load to fail.

To fix this, I've updated the subscription schema to support the ability to define manifest variables which will be passed along to the manifest loading logic.  This will allow the docker-tools manifest to be loaded.

For the purposes of the `getStaleImages` command, it's only necessary to have _some_ value defined for `UniqueId`; it doesn't actually matter what that value is because the tags which consume the variable are not relevant to the functionality of the command.

Related to #807