### PR TITLE
Add docker-tools to check-base-image-subscriptions

### DIFF
--- a/eng/check-base-image-subscriptions.json
+++ b/eng/check-base-image-subscriptions.json
@@ -2,6 +2,27 @@
   {
     "manifest": {
       "owner": "dotnet",
+      "repo": "docker-tools",
+      "branch": "main",
+      "path": "src/Microsoft.DotNet.ImageBuilder/manifest.json",
+      "variables": {
+        "UniqueId": ""
+      }
+    },
+    "imageInfo": {
+      "owner": "dotnet",
+      "repo": "versions",
+      "branch": "main",
+      "path": "build-info/docker/image-info.dotnet-docker-tools-main-imagebuilder.json"
+    },
+    "pipelineTrigger": {
+      "id": 367,
+      "pathVariable": "imageBuilder.pathArgs"
+    }
+  },
+  {
+    "manifest": {
+      "owner": "dotnet",
       "repo": "dotnet-docker",
       "branch": "main",
       "path": "manifest.json"

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1222106
+  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1283742
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-buster-slim-docker-testrunner-974165
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)


### PR DESCRIPTION
Adds a subscription to ensure that the Image Builder image is monitored for base image updates.

Fixes #807