### PR TITLE
Fix usage of source branch name

### DIFF
--- a/eng/common/templates/jobs/generate-matrix.yml
+++ b/eng/common/templates/jobs/generate-matrix.yml
@@ -9,8 +9,8 @@ jobs:
   pool:
     vmImage: $(defaultLinuxAmd64PoolImage)
   steps:
-  - template: ../steps/validate-branch.yml
   - template: ../steps/init-docker-linux.yml
+  - template: ../steps/validate-branch.yml
   - ${{ if eq(parameters.isTestStage, true) }}:
     - template: ../steps/download-build-artifact.yml
       parameters:

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -13,8 +13,8 @@ jobs:
       $(manifestVariables)
       $(imageBuilder.queueArgs)
   steps:
-  - template: ../steps/validate-branch.yml
   - template: ../steps/init-docker-linux.yml
+  - template: ../steps/validate-branch.yml
   - template: ../steps/download-build-artifact.yml
     parameters:
       targetPath: $(Build.ArtifactStagingDirectory)

--- a/eng/common/templates/steps/init-common.yml
+++ b/eng/common/templates/steps/init-common.yml
@@ -1,0 +1,5 @@
+steps:
+- powershell: |
+    $sourceBranch=$Env:BUILD_SOURCEBRANCH -replace "refs/heads/","" -replace "refs/tags/","" -replace "refs/pull/","" 
+    echo "##vso[task.setvariable variable=sourceBranch]$sourceBranch"
+  displayName: Define Source Branch Variable

--- a/eng/common/templates/steps/init-docker-linux.yml
+++ b/eng/common/templates/steps/init-docker-linux.yml
@@ -4,6 +4,7 @@ parameters:
   cleanupDocker: true
 
 steps:
+- template: init-common.yml
 - script: echo "##vso[task.setvariable variable=artifactsPath]/artifacts"
   displayName: Define Artifacts Path Variable
 

--- a/eng/common/templates/steps/init-docker-windows.yml
+++ b/eng/common/templates/steps/init-docker-windows.yml
@@ -2,6 +2,7 @@ parameters:
   setupImageBuilder: true
 
 steps:
+- template: init-common.yml
 - powershell: echo "##vso[task.setvariable variable=artifactsPath]$(Build.ArtifactStagingDirectory)"
   displayName: Define Artifacts Path Variable
 

--- a/eng/common/templates/steps/publish-readmes.yml
+++ b/eng/common/templates/steps/publish-readmes.yml
@@ -4,7 +4,7 @@ parameters:
 
 steps:
 - powershell: >
-    if ($env:BUILD_SOURCEBRANCHNAME -eq "nightly" -or $env:SYSTEM_PULLREQUEST_TARGETBRANCH -eq "nightly") {
+    if ($env:SOURCEBRANCH -eq "nightly" -or $env:SYSTEM_PULLREQUEST_TARGETBRANCH -eq "nightly") {
         $additionalPublishMcrDocsArgs = "--exclude-product-family"
     }
     else {

--- a/eng/common/templates/steps/set-image-info-path-var.yml
+++ b/eng/common/templates/steps/set-image-info-path-var.yml
@@ -6,7 +6,7 @@ steps:
     if ($env:PUBLICSOURCEBRANCH) {
         $publicSourceBranch = $env:PUBLICSOURCEBRANCH
     }
-    elseif (-not $env:MANIFEST.Contains("samples") -and ($env:BUILD_SOURCEBRANCHNAME -eq "nightly" -or $env:SYSTEM_PULLREQUEST_TARGETBRANCH -eq "nightly")) {
+    elseif (-not $env:MANIFEST.Contains("samples") -and ($env:SOURCEBRANCH -eq "nightly" -or $env:SYSTEM_PULLREQUEST_TARGETBRANCH -eq "nightly")) {
         $publicSourceBranch = "nightly"
     }
     else {

--- a/eng/common/templates/steps/validate-branch.yml
+++ b/eng/common/templates/steps/validate-branch.yml
@@ -1,7 +1,7 @@
 steps:
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - script: |
-      if [[ "$OFFICIALBRANCHES" != *\'$BUILD_SOURCEBRANCHNAME\'* && \
+      if [[ "$OFFICIALBRANCHES" != *\'$SOURCEBRANCH\'* && \
             "$PUBLISHREPOPREFIX" == "public/" && \
             "$OVERRIDEOFFICIALBRANCHVALIDATION" != "true" ]]; then
           echo "##vso[task.logissue type=error]Official builds must be done from an official branch: $OFFICIALBRANCHES"


### PR DESCRIPTION
Several parts of the pipeline infra rely on the source branch name that determines which action to take.  A false assumption is made with the value of the `Build.SourceBranchName` variable, however.  It is assumed that the full branch name would be included but it only takes the last segment of the branch name.  For example, a branch name of `dev/mthalman/branch` will have a value of `branch` for the `Build.SourceBranchName` variable.  This is not what we want.

To workaround this, I've change the usage of  `Build.SourceBranchName` to `Build.SourceBranch` instead.  This value is fully-qualified, such as `refs/head/dev/mthalman/branch`.  A common build task was defined to parse that value down to `dev/mthalman/branch`.

Fixes #828