### PR TITLE
Include WS 2022 version of Image Builder

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/manifest.json
+++ b/src/Microsoft.DotNet.ImageBuilder/manifest.json
@@ -80,6 +80,17 @@
               "tags": {
                 "nanoserver-20H2-amd64-$(UniqueId)": {}
               }
+            },
+            {
+              "buildArgs": {
+                "WINDOWS_BASE": "nanoserver:ltsc2022-amd64"
+              },
+              "dockerfile": "Dockerfile.windows",
+              "os": "windows",
+              "osVersion": "nanoserver-ltsc2022",
+              "tags": {
+                "nanoserver-ltsc2022-amd64-$(UniqueId)": {}
+              }
             }
           ]
         }


### PR DESCRIPTION
Related to https://github.com/dotnet/docker-tools/issues/798