### PR TITLE
Fix tagging of AutoBuilder builds

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/QueueBuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/QueueBuildCommand.cs
@@ -125,7 +125,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         SourceBranch = subscription.Manifest.Branch,
                         Parameters = parameters
                     };
-                    build.Tags.Add(AzdoTags.AutoBuilder);
 
                     inProgressBuilds = await GetInProgressBuildsAsync(client, subscription.PipelineTrigger.Id, project.Id);
                     if (!inProgressBuilds.Any())
@@ -141,6 +140,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         else
                         {
                             queuedBuild = await client.QueueBuildAsync(build);
+                            await client.AddBuildTagAsync(project.Id, queuedBuild.Id, AzdoTags.AutoBuilder);
                         }
                     }
                 }
@@ -188,9 +188,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 StringBuilder builder = new();
                 builder.AppendLine(
                     $"Due to recent failures of the following builds, a build will not be queued again for subscription '{subscription}':");
+                builder.AppendLine();
                 foreach (string buildUri in recentFailedBuilds)
                 {
-                    builder.AppendLine(buildUri);
+                    builder.AppendLine($"* {buildUri}");
                 }
 
                 builder.AppendLine();

--- a/src/Microsoft.DotNet.ImageBuilder/src/Services/IBuildHttpClient.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Services/IBuildHttpClient.cs
@@ -12,6 +12,8 @@ namespace Microsoft.DotNet.ImageBuilder.Services
 {
     public interface IBuildHttpClient : IDisposable
     {
+        Task<List<string>> AddBuildTagAsync(Guid project, int buildId, string tag);
+
         Task<IPagedList<WebApi.Build>> GetBuildsAsync(Guid projectId, IEnumerable<int> definitions = null, WebApi.BuildStatus? statusFilter = null);
 
         Task<WebApi.Build> QueueBuildAsync(WebApi.Build build);

--- a/src/Microsoft.DotNet.ImageBuilder/src/Services/VssConnectionFactory.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Services/VssConnectionFactory.cs
@@ -79,15 +79,14 @@ namespace Microsoft.DotNet.ImageBuilder.Services
                     _inner.Dispose();
                 }
 
-                public Task<IPagedList<WebApi.Build>> GetBuildsAsync(Guid projectId, IEnumerable<int> definitions = null, WebApi.BuildStatus? statusFilter = null)
-                {
-                    return _inner.GetBuildsAsync2(projectId, definitions: definitions, statusFilter: statusFilter);
-                }
+                public Task<List<string>> AddBuildTagAsync(Guid project, int buildId, string tag) =>
+                    _inner.AddBuildTagAsync(project, buildId, tag);
 
-                public Task<TeamFoundation.Build.WebApi.Build> QueueBuildAsync(TeamFoundation.Build.WebApi.Build build)
-                {
-                    return _inner.QueueBuildAsync(build);
-                }
+                public Task<IPagedList<WebApi.Build>> GetBuildsAsync(Guid projectId, IEnumerable<int> definitions = null, WebApi.BuildStatus? statusFilter = null) =>
+                    _inner.GetBuildsAsync2(projectId, definitions: definitions, statusFilter: statusFilter);
+
+                public Task<WebApi.Build> QueueBuildAsync(WebApi.Build build) =>
+                    _inner.QueueBuildAsync(build);
             }
         }
     }


### PR DESCRIPTION
The samples build for the dotnet-docker repo has been failing after the introduction of Windows Server 2022.  It had failed 3 consecutive times which mean the next time AutoBuilder attempted to queue a build, it should have not done so because the failure limit had been reached.  Instead, it continued to queue a build.

The cause of this is because the builds which had been queued were not tagged as intended.  Because the failed builds had not been tagged with `autobuilder`, the logic which queried for builds was not including them.  The assumption was that we could tag a build at the time it is queued but that is not the case.  A separate call must be made to tag a build _after_ it has been queued.  I've updated the logic to do this.  