### PR TITLE
Clarify error message for queueBuild command

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/QueueBuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/QueueBuildCommand.cs
@@ -196,7 +196,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
                 builder.AppendLine();
                 builder.AppendLine(
-                    "Please investigate the cause of the failures, resolve the issue, and manually queue a build for the Dockerfile paths listed above. You must manually tag the build with a tag named 'autobuilder' in order for AutoBuilder to recognize that a successful build has occurred.");
+                    $"Please investigate the cause of the failures, resolve the issue, and manually queue a build for the Dockerfile paths listed above. You must manually tag the build with a tag named '{AzdoTags.AutoBuilder}' in order for AutoBuilder to recognize that a successful build has occurred.");
 
                 string message = builder.ToString();
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/QueueBuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/QueueBuildCommand.cs
@@ -196,7 +196,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
                 builder.AppendLine();
                 builder.AppendLine(
-                    "Please investigate the cause of the failures, resolve the issue, and manually queue a build for the Dockerfile paths listed above.");
+                    "Please investigate the cause of the failures, resolve the issue, and manually queue a build for the Dockerfile paths listed above. You must manually tag the build with a tag named 'autobuilder' in order for AutoBuilder to recognize that a successful build has occurred.");
 
                 string message = builder.ToString();
 


### PR DESCRIPTION
In the case when AutoBuilder disables queuing new builds due to too many recent failures, an error message is provided stating that a build must be queued manually as part of resolving the issue.  However, the error message leaves out some important information. That build must be tagged with `autobuilder` in order to cause AutoBuilder to recognize that a successful build has occurred.

When AutoBuilder queries for recent failures, it is specifically filtering builds to only those tagged with `autobuilder`. So if a user has manually queued a build to fix whatever issue was occurring, AutoBuilder will not see that build in its query unless it was tagged with `autobuilder`. If the build wasn't queued that way, then the next time AutoBuilder attempts to queue a build, it will see that the same set of recent failed builds exist and will not queue another one.

So I've clarified the error message to state that the build must be tagged with `autobuilder` to get the system back in a working state.