### PR TITLE
Support product version for manifest filter

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestFilterOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestFilterOptions.cs
@@ -18,6 +18,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public string OsType { get; set; } = string.Empty;
         public IEnumerable<string> OsVersions { get; set; } = Array.Empty<string>();
         public IEnumerable<string> Paths { get; set; } = Array.Empty<string>();
+        public IEnumerable<string> ProductVersions { get; set; } = Array.Empty<string>();
     }
 
     public class ManifestFilterOptionsBuilder
@@ -37,7 +38,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 CreateMultiOption<string>(OsVersionOptionName, nameof(ManifestFilterOptions.OsVersions),
                     "OS versions of the Dockerfiles to build - wildcard chars * and ? supported (default is to build all)"),
                 CreateMultiOption<string>(PathOptionName, nameof(ManifestFilterOptions.Paths),
-                    "Directory paths containing the Dockerfiles to build - wildcard chars * and ? supported (default is to build all)")
+                    "Directory paths containing the Dockerfiles to build - wildcard chars * and ? supported (default is to build all)"),
+                CreateMultiOption<string>("version", nameof(ManifestFilterOptions.ProductVersions),
+                    "Product versions of the Dockerfiles to build - wildcard chars * and ? supported (default is to build all)")
             };
 
         public IEnumerable<Argument> GetCliArguments() => Enumerable.Empty<Argument>();

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestOptions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         public virtual ManifestFilter GetManifestFilter()
         {
-            ManifestFilter filter = new ManifestFilter()
+            ManifestFilter filter = new()
             {
                 IncludeRepos = Repos,
             };
@@ -33,6 +33,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 filter.IncludeOsType = filterOptions.OsType;
                 filter.IncludeOsVersions = filterOptions.OsVersions;
                 filter.IncludePaths = filterOptions.Paths;
+                filter.IncludeProductVersions = filterOptions.ProductVersions;
             }
 
             return filter;

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ImageInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ImageInfo.cs
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
                 .Select(platform => PlatformInfo.Create(platform, fullRepoModelName, repoName, variableHelper, baseDirectory))
                 .ToArray();
 
-            IEnumerable<Platform> filteredPlatformModels = manifestFilter.GetPlatforms(model);
+            IEnumerable<Platform> filteredPlatformModels = manifestFilter.FilterPlatforms(model.Platforms, imageInfo.ProductVersion);
             imageInfo.FilteredPlatforms = imageInfo.AllPlatforms
                 .Where(platform => filteredPlatformModels.Contains(platform.Model));
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestFilter.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestFilter.cs
@@ -16,6 +16,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         public IEnumerable<string> IncludeRepos { get; set; }
         public IEnumerable<string> IncludeOsVersions { get; set; }
         public IEnumerable<string> IncludePaths { get; set; }
+        public IEnumerable<string> IncludeProductVersions { get; set; }
 
         public ManifestFilter()
         {
@@ -29,9 +30,16 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             return $"^({processedPatterns})$";
         }
 
-        public IEnumerable<Platform> GetPlatforms(Image image)
+        public IEnumerable<Platform> FilterPlatforms(IEnumerable<Platform> platforms, string resolvedProductVersion)
         {
-            IEnumerable<Platform> platforms = image.Platforms;
+            if (IncludeProductVersions?.Any() ?? false)
+            {
+                string includeProductVersionsPattern = GetFilterRegexPattern(IncludeProductVersions.ToArray());
+                if (!Regex.IsMatch(resolvedProductVersion, includeProductVersionsPattern, RegexOptions.IgnoreCase))
+                {
+                    return Enumerable.Empty<Platform>();
+                }
+            }
 
             if (!string.IsNullOrEmpty(IncludeArchitecture))
             {


### PR DESCRIPTION
This adds support for filtering the manifest by product version since the only way currently to filter by product version is with the `--path` option.  The problem with the `--path` option being the only way is that it hampers the ability to provide common scripts that can be used across any repo's folder structure.

Related to https://github.com/dotnet/docker-tools/issues/836