### PR TITLE
Use WS 2022 pool to run image size tests

### DIFF
--- a/eng/common/templates/jobs/validate-image-sizes.yml
+++ b/eng/common/templates/jobs/validate-image-sizes.yml
@@ -35,7 +35,7 @@ jobs:
       dockerClientOS: linux
       validationMode: integrity
 - job: WindowsPerfTests
-  pool: Docker-20H2-${{ variables['System.TeamProject'] }}
+  pool: Docker-2022-${{ variables['System.TeamProject'] }}
   workspace:
     clean: all
   steps:


### PR DESCRIPTION
The image size validation tests are unable to pull WS 2022 images because the tests are being run on the WS 20H2 agent pool.  Updating to use WS 2022 agent pool instead.