### PR TITLE
Track syndicated manifest digests

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/IngestKustoImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/IngestKustoImageInfoCommand.cs
@@ -69,7 +69,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         string sha = DockerHelper.GetDigestSha(platform.Digest);
                         imageInfo.AppendLine(FormatImageCsv(sha, platform, image, repo.Repo, timestamp));
 
-                        IEnumerable<TagInfo> tagInfos = platform.PlatformInfo.Tags
+                        IEnumerable<TagInfo> tagInfos = (platform.PlatformInfo?.Tags ?? Enumerable.Empty<TagInfo>())
                             .Where(tagInfo => platform.SimpleTags.Contains(tagInfo.Name))
                             .ToList();
 
@@ -113,7 +113,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         }
 
         private static string FormatImageCsv(string imageId, PlatformData platform, ImageData image, string repo, string timestamp) =>
-            $"\"{imageId}\",\"{platform.Architecture}\",\"{platform.OsType}\",\"{platform.PlatformInfo.GetOSDisplayName()}\","
+            $"\"{imageId}\",\"{platform.Architecture}\",\"{platform.OsType}\",\"{platform.PlatformInfo?.GetOSDisplayName()}\","
                 + $"\"{image.ProductVersion}\",\"{platform.Dockerfile}\",\"{repo}\",\"{timestamp}\"";
 
         private static string FormatLayerCsv(

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/WaitForMcrImageIngestionCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/WaitForMcrImageIngestionCommand.cs
@@ -65,13 +65,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 string digestSha = DockerHelper.GetDigestSha(image.Manifest.Digest);
                 yield return new DigestInfo(digestSha, repo.Repo, image.Manifest.SharedTags);
 
-                foreach (string syndicatedDigest in image.Manifest.SyndicatedDigests)
-                {
-                    string syndicatedDigestSha = DockerHelper.GetDigestSha(syndicatedDigest);
-
-
-                }
-
                 // Find all syndicated shared tags grouped by their syndicated repo
                 IEnumerable<IGrouping<string, TagInfo>> syndicatedTagGroups = image.ManifestImage.SharedTags
                     .Where(tag => image.Manifest.SharedTags.Contains(tag.Name) && tag.SyndicatedRepo != null)
@@ -221,7 +214,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         throw task.Exception;
                     }
 
-                    throw new NotImplementedException();
+                    throw new NotSupportedException();
                 }));
         }
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/WaitForMcrImageIngestionCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/WaitForMcrImageIngestionCommand.cs
@@ -12,6 +12,7 @@ using Microsoft.DotNet.ImageBuilder.Models.Image;
 using Microsoft.DotNet.ImageBuilder.Models.McrStatus;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
 
+#nullable enable
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     [Export(typeof(ICommand))]
@@ -64,6 +65,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 string digestSha = DockerHelper.GetDigestSha(image.Manifest.Digest);
                 yield return new DigestInfo(digestSha, repo.Repo, image.Manifest.SharedTags);
 
+                foreach (string syndicatedDigest in image.Manifest.SyndicatedDigests)
+                {
+                    string syndicatedDigestSha = DockerHelper.GetDigestSha(syndicatedDigest);
+
+
+                }
+
                 // Find all syndicated shared tags grouped by their syndicated repo
                 IEnumerable<IGrouping<string, TagInfo>> syndicatedTagGroups = image.ManifestImage.SharedTags
                     .Where(tag => image.Manifest.SharedTags.Contains(tag.Name) && tag.SyndicatedRepo != null)
@@ -72,12 +80,18 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 foreach (IGrouping<string, TagInfo> syndicatedTags in syndicatedTagGroups)
                 {
                     string syndicatedRepo = Options.RepoPrefix + syndicatedTags.Key;
+                    string fullyQualifiedRepo = DockerHelper.GetImageName(Manifest.Model.Registry, syndicatedRepo);
 
-                    string tag = syndicatedTags.First().SyndicatedDestinationTags.First();
-                    tag = DockerHelper.GetImageName(Manifest.Registry, syndicatedRepo, tag);
+                    string? syndicatedDigest = image.Manifest.SyndicatedDigests
+                        .FirstOrDefault(digest => digest.StartsWith($"{fullyQualifiedRepo}@"));
+
+                    if (syndicatedDigest is null)
+                    {
+                        throw new InvalidOperationException($"Unable to find syndicated digest for '{fullyQualifiedRepo}'");
+                    }
 
                     yield return new DigestInfo(
-                        digestSha,
+                        DockerHelper.GetDigestSha(syndicatedDigest),
                         syndicatedRepo,
                         syndicatedTags.SelectMany(tag => tag.SyndicatedDestinationTags));
                 }
@@ -90,7 +104,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 yield return new DigestInfo(sha, repo.Repo, platform.SimpleTags);
 
                 // Find all syndicated simple tags grouped by their syndicated repo
-                IEnumerable<IGrouping<string, TagInfo>> syndicatedTagGroups = platform.PlatformInfo.Tags
+                IEnumerable<IGrouping<string, TagInfo>> syndicatedTagGroups = (platform.PlatformInfo?.Tags ?? Enumerable.Empty<TagInfo>())
                     .Where(tagInfo => platform.SimpleTags.Contains(tagInfo.Name) && tagInfo.SyndicatedRepo != null)
                     .GroupBy(tagInfo => tagInfo.SyndicatedRepo);
 
@@ -202,12 +216,12 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                             return task.Result;
                         }
                     }
-                    else if (task.IsFaulted)
+                    else if (task.Exception is not null)
                     {
                         throw task.Exception;
                     }
 
-                    return null;
+                    throw new NotImplementedException();
                 }));
         }
 
@@ -289,15 +303,17 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 _loggerService.WriteMessage(stringBuilder.ToString());
             }
 
-            return new ImageResultInfo
-            {
-                ImageResult = imageResult,
-                DigestInfo = digestInfo
-            };
+            return new ImageResultInfo(imageResult, digestInfo);
         }
 
         private class ImageResultInfo
         {
+            public ImageResultInfo(ImageResult imageResult, DigestInfo digestInfo)
+            {
+                ImageResult = imageResult;
+                DigestInfo = digestInfo;
+            }
+
             public ImageResult ImageResult { get; set; }
             public DigestInfo DigestInfo { get; set; }
         }
@@ -322,3 +338,4 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         }
     }
 }
+#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/DateTimeService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DateTimeService.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.ComponentModel.Composition;
+
+namespace Microsoft.DotNet.ImageBuilder
+{
+    [Export(typeof(IDateTimeService))]
+    public class DateTimeService : IDateTimeService
+    {
+        public DateTime UtcNow => DateTime.UtcNow;
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/IDateTimeService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/IDateTimeService.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.DotNet.ImageBuilder
+{
+    public interface IDateTimeService
+    {
+        DateTime UtcNow { get; }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/JsonHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/JsonHelper.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections;
+using System.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
@@ -11,16 +14,36 @@ namespace Microsoft.DotNet.ImageBuilder
     {
         public static string SerializeObject(object value)
         {
-            JsonSerializerSettings settings = new JsonSerializerSettings
+            JsonSerializerSettings settings = new()
             {
-                ContractResolver = new DefaultContractResolver
-                {
-                    NamingStrategy = new CamelCaseNamingStrategy()
-                },
+                ContractResolver = new CustomContractResolver(),
                 Formatting = Formatting.Indented
             };
 
             return JsonConvert.SerializeObject(value, settings);
+        }
+
+        private class CustomContractResolver : DefaultContractResolver
+        {
+            public CustomContractResolver()
+            {
+                NamingStrategy = new CamelCaseNamingStrategy();
+            }
+
+            protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+            {
+                JsonProperty property = base.CreateProperty(member, memberSerialization);
+
+                Predicate<object> capturedPredicate = property.ShouldSerialize;
+                property.ShouldSerialize = val => (capturedPredicate is null || capturedPredicate(val)) && !IsEmptyList(property, val);
+                return property;
+            }
+
+            private static bool IsEmptyList(JsonProperty property, object targetObj)
+            {
+                object propVal = property.ValueProvider.GetValue(targetObj);
+                return propVal is IList list && list.Count == 0;
+            }
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/ManifestData.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/ManifestData.cs
@@ -10,7 +10,8 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Image
     public class ManifestData
     {
         public string Digest { get; set; }
+        public List<string> SyndicatedDigests { get; set; } = new();
         public DateTime Created { get; set; }
-        public List<string> SharedTags { get; set; } = new List<string>();
+        public List<string> SharedTags { get; set; } = new();
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/PlatformData.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/PlatformData.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
 using Newtonsoft.Json;
 
+#nullable enable
 namespace Microsoft.DotNet.ImageBuilder.Models.Image
 {
     public class PlatformData : IComparable<PlatformData>
@@ -23,24 +24,24 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Image
             PlatformInfo = platformInfo;
         }
 
-        public string Dockerfile { get; set; }
+        public string? Dockerfile { get; set; }
 
         public List<string> SimpleTags { get; set; } = new List<string>();
 
-        public string Digest { get; set; }
+        public string? Digest { get; set; }
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public string BaseImageDigest { get; set; }
+        public string? BaseImageDigest { get; set; }
 
-        public string OsType { get; set; }
+        public string? OsType { get; set; }
 
-        public string OsVersion { get; set; }
+        public string? OsVersion { get; set; }
 
-        public string Architecture { get; set; }
+        public string? Architecture { get; set; }
 
         public DateTime Created { get; set; }
 
-        public string CommitUrl { get; set; }
+        public string? CommitUrl { get; set; }
 
         public List<string> Layers { get; set; } = new List<string>();
 
@@ -55,14 +56,14 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Image
         public bool IsUnchanged { get; set; }
 
         [JsonIgnore]
-        public ImageInfo ImageInfo { get; set; }
+        public ImageInfo? ImageInfo { get; set; }
 
         [JsonIgnore]
-        public PlatformInfo PlatformInfo { get; set; }
+        public PlatformInfo? PlatformInfo { get; set; }
 
         [JsonIgnore]
         public IEnumerable<TagInfo> AllTags =>
-            ImageInfo?.SharedTags.Union(PlatformInfo.Tags ?? Enumerable.Empty<TagInfo>()) ?? Enumerable.Empty<TagInfo>();
+            ImageInfo?.SharedTags.Union(PlatformInfo?.Tags ?? Enumerable.Empty<TagInfo>()) ?? Enumerable.Empty<TagInfo>();
 
         public int CompareTo([AllowNull] PlatformData other)
         {
@@ -87,8 +88,8 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Image
 
         public bool HasDifferentTagState(PlatformData other) =>
             // If either of the platforms has no simple tags while the other does have simple tags, they are not equal
-            (SimpleTags?.Count == 0 && other.SimpleTags?.Count > 0) ||
-            (SimpleTags?.Count > 0 && other.SimpleTags?.Count == 0);
+            (IsNullOrEmpty(SimpleTags) && !IsNullOrEmpty(other.SimpleTags)) ||
+            (!IsNullOrEmpty(SimpleTags) && IsNullOrEmpty(other.SimpleTags));
 
         public static PlatformData FromPlatformInfo(PlatformInfo platform, ImageInfo image) =>
             new PlatformData(image, platform)
@@ -100,7 +101,10 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Image
                 SimpleTags = platform.Tags.Select(tag => tag.Name).ToList()
             };
 
-        private string GetMajorMinorVersion()
+        private bool IsNullOrEmpty<T>(List<T>? list) =>
+            list is null || !list.Any();
+
+        private string? GetMajorMinorVersion()
         {
             if (ImageInfo is null)
             {
@@ -125,3 +129,4 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Image
         }
     }
 }
+#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
@@ -72,10 +72,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         {
                                             CreatePlatform(
                                                 dockerfile1Path,
-                                                baseImageDigest: "base1@base1digest-diff"),
+                                                baseImageDigest: "base1@base1digest-diff",
+                                                simpleTags: new List<string> { "tag1" }),
                                             CreatePlatform(
                                                 dockerfile2Path,
-                                                baseImageDigest: "base2@base2digest")
+                                                baseImageDigest: "base2@base2digest",
+                                                simpleTags: new List<string> { "tag2" })
                                         }
                                     }
                                 }
@@ -155,10 +157,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         {
                                             CreatePlatform(
                                                 dockerfile1Path,
-                                                baseImageDigest: "base2@base2digest-diff"),
+                                                baseImageDigest: "base2@base2digest-diff",
+                                                simpleTags: new List<string> { "tag1" }),
                                             CreatePlatform(
                                                 dockerfile2Path,
-                                                baseImageDigest: "base3@base3digest")
+                                                baseImageDigest: "base3@base3digest",
+                                                simpleTags: new List<string> { "tag2" })
                                         }
                                     }
                                 }
@@ -432,7 +436,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         {
                                             CreatePlatform(
                                                 dockerfile1Path,
-                                                baseImageDigest: "base1@base1digest-diff")
+                                                baseImageDigest: "base1@base1digest-diff",
+                                                simpleTags: new List<string> { "tag1" })
                                         }
                                     }
                                 }
@@ -482,7 +487,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         {
                                             CreatePlatform(
                                                 dockerfile1Path,
-                                                baseImageDigest: "base1@base1digest-diff")
+                                                baseImageDigest: "base1@base1digest-diff",
+                                                simpleTags: new List<string> { "tag1" })
                                         }
                                     }
                                 }
@@ -498,7 +504,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         {
                                             CreatePlatform(
                                                 dockerfile2Path,
-                                                baseImageDigest: "base2@base2digest-diff")
+                                                baseImageDigest: "base2@base2digest-diff",
+                                                simpleTags: new List<string> { "tag2" })
                                         }
                                     }
                                 }
@@ -514,7 +521,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         {
                                             CreatePlatform(
                                                 dockerfile3Path,
-                                                baseImageDigest: "base3@base3digest")
+                                                baseImageDigest: "base3@base3digest",
+                                                simpleTags: new List<string> { "tag3" })
                                         }
                                     }
                                 }
@@ -609,10 +617,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         {
                                             CreatePlatform(
                                                 dockerfile1Path,
-                                                baseImageDigest: baseImageDigest + "-diff"),
+                                                baseImageDigest: baseImageDigest + "-diff",
+                                                simpleTags: new List<string> { "tag1" }),
                                             CreatePlatform(
                                                 dockerfile2Path,
-                                                baseImageDigest: baseImageDigest + "-diff")
+                                                baseImageDigest: baseImageDigest + "-diff",
+                                                simpleTags: new List<string> { "tag2" })
                                         }
                                     }
                                 }
@@ -697,7 +707,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         {
                                             CreatePlatform(
                                                 dockerfile1Path,
-                                                baseImageDigest: $"{baseImage}@{baseImageDigest}")
+                                                baseImageDigest: $"{baseImage}@{baseImageDigest}",
+                                                simpleTags: new List<string> { "tag1" })
                                         }
                                     }
                                 }
@@ -795,7 +806,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         {
                                             CreatePlatform(
                                                 runtimeDepsDockerfilePath,
-                                                baseImageDigest: $"{baseImage}@{baseImageDigest}-diff")
+                                                baseImageDigest: $"{baseImage}@{baseImageDigest}-diff",
+                                                simpleTags: new List<string> { "tag1" })
                                         }
                                     }
                                 }
@@ -824,7 +836,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         {
                                             CreatePlatform(
                                                 otherDockerfilePath,
-                                                baseImageDigest: $"{otherImage}@{otherImageDigest}")
+                                                baseImageDigest: $"{otherImage}@{otherImageDigest}",
+                                                simpleTags: new List<string> { "tag1" })
                                         }
                                     }
                                 }
@@ -1005,10 +1018,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         {
                                             CreatePlatform(
                                                 dockerfile1Path,
-                                                baseImageDigest: "base1@base1digest-diff"),
+                                                baseImageDigest: "base1@base1digest-diff",
+                                                simpleTags: new List<string> { "tag1" }),
                                             CreatePlatform(
                                                 dockerfile2Path,
-                                                baseImageDigest: "base2@base2digest")
+                                                baseImageDigest: "base2@base2digest",
+                                                simpleTags: new List<string> { "tag2" })
                                         }
                                     }
                                 }
@@ -1166,7 +1181,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                             CreatePlatform(dockerfile1Path),
                                             CreatePlatform(
                                                 dockerfile2Path,
-                                                baseImageDigest: "base1@base1digest")
+                                                baseImageDigest: "base1@base1digest",
+                                                simpleTags: new List<string> { "tag1" })
                                         }
                                     }
                                 }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ImageInfoHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ImageInfoHelper.cs
@@ -28,18 +28,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests.Helpers
                 Architecture = architecture,
                 OsType = osType,
                 OsVersion = osVersion,
-                SimpleTags = simpleTags,
+                SimpleTags = simpleTags ?? new List<string>(),
+                Layers = layers ?? new List<string>(),
                 BaseImageDigest = baseImageDigest,
             };
 
             if (created.HasValue)
             {
                 platform.Created = created.Value;
-            }
-
-            if (layers != null)
-            {
-                platform.Layers = layers;
             }
 
             return platform;

--- a/src/Microsoft.DotNet.ImageBuilder/tests/MergeImageInfoFilesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/MergeImageInfoFilesCommandTests.cs
@@ -62,7 +62,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     {
                                         Platforms =
                                         {
-                                            CreatePlatform(repo2Image2Dockerfile)
+                                            CreatePlatform(repo2Image2Dockerfile,
+                                            simpleTags: new List<string>
+                                            {
+                                                "tag2"
+                                            })
                                         },
                                         ProductVersion = "1.0"
                                     }


### PR DESCRIPTION
As [described in the issue](https://github.com/dotnet/docker-tools/issues/847#issuecomment-912552874), multi-arch tags which are syndicated are not being tracked properly when waiting for MCR ingestion. There is no guarantee that the digest of a multi-arch tag will be the same digest in the syndicated destination because the underlying manifest list can be based on different images.

These changes fix this by explicitly tracking the digest of syndicated multi-arch tags in the image info file.  The logic for waiting for MCR ingestion consumes that data to ensure that both the primary and syndicated digests are successfully ingested.

Fixes #847