### PR TITLE
Command to pull images

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PullImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PullImagesCommand.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+#nullable enable
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    [Export(typeof(ICommand))]
+    public class PullImagesCommand : ManifestCommand<PullImagesOptions, PullImagesOptionsBuilder>
+    {
+        private readonly IDockerService _dockerService;
+        private readonly ILoggerService _loggerService;
+
+        [ImportingConstructor]
+        public PullImagesCommand(IDockerService dockerService, ILoggerService loggerService)
+        {
+            _dockerService = dockerService ?? throw new ArgumentNullException(nameof(dockerService));
+            _loggerService = loggerService ?? throw new ArgumentNullException(nameof(loggerService));
+        }
+
+        protected override string Description => "Pulls the images described in the manifest";
+
+        public override Task ExecuteAsync()
+        {
+            IEnumerable<string> imageTags = Manifest.GetFilteredPlatforms()
+                .Where(platform => platform.Tags.Any())
+                .Select(platform => platform.Tags.First().FullyQualifiedName)
+                .ToList();
+
+            StringBuilder pulledImages = new();
+
+            _loggerService.WriteHeading("PULLING IMAGES");
+            foreach (string imageTag in imageTags)
+            {
+                _dockerService.PullImage(imageTag, Options.IsDryRun);
+
+                if (pulledImages.Length > 0)
+                {
+                    pulledImages.Append(',');
+                }
+
+                pulledImages.Append(imageTag);
+            }
+
+            if (Options.OutputVariableName is not null)
+            {
+                _loggerService.WriteMessage(PipelineHelper.FormatOutputVariable(Options.OutputVariableName, pulledImages.ToString()));
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}
+#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PullImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PullImagesCommand.cs
@@ -33,24 +33,15 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 .Select(platform => platform.Tags.First().FullyQualifiedName)
                 .ToList();
 
-            StringBuilder pulledImages = new();
-
             _loggerService.WriteHeading("PULLING IMAGES");
             foreach (string imageTag in imageTags)
             {
-                _dockerService.PullImage(imageTag, Options.IsDryRun);
-
-                if (pulledImages.Length > 0)
-                {
-                    pulledImages.Append(',');
-                }
-
-                pulledImages.Append(imageTag);
+                _dockerService.PullImage(imageTag, true);
             }
 
             if (Options.OutputVariableName is not null)
             {
-                _loggerService.WriteMessage(PipelineHelper.FormatOutputVariable(Options.OutputVariableName, pulledImages.ToString()));
+                _loggerService.WriteMessage(PipelineHelper.FormatOutputVariable(Options.OutputVariableName, string.Join(',', imageTags)));
             }
 
             return Task.CompletedTask;

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PullImagesOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PullImagesOptions.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.CommandLine;
+using System.Linq;
+
+using static Microsoft.DotNet.ImageBuilder.Commands.CliHelper;
+
+#nullable enable
+namespace Microsoft.DotNet.ImageBuilder.Commands
+{
+    public class PullImagesOptions : ManifestOptions, IFilterableOptions
+    {
+        public ManifestFilterOptions FilterOptions { get; set; } = new();
+
+        public string? OutputVariableName { get; set; }
+    }
+
+    public class PullImagesOptionsBuilder : ManifestOptionsBuilder
+    {
+        private readonly ManifestFilterOptionsBuilder _manifestFilterOptionsBuilder = new();
+
+        public override IEnumerable<Option> GetCliOptions() =>
+            base.GetCliOptions()
+                .Concat(_manifestFilterOptionsBuilder.GetCliOptions())
+                .Concat(new Option[]
+                {
+                    CreateOption<string>("output-var", nameof(PullImagesOptions.OutputVariableName),
+                        "Azure DevOps variable name to use for outputting the list of pulled image tags")
+                });
+
+        public override IEnumerable<Argument> GetCliArguments() =>
+            base.GetCliArguments()
+                .Concat(_manifestFilterOptionsBuilder.GetCliArguments());
+    }
+}
+#nullable disable


### PR DESCRIPTION
In order to execute a component governance scan over the supported images, we first need to pull those images to the build agent. The CG tool requires that the images to be scanned exist locally on the machine.

These changes add a command to pull the images which can be executed by the pipeline.

Related to dotnet/dotnet-docker#3001