### PR TITLE
Product version filtering fix

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestOptions.cs
@@ -21,10 +21,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         public virtual ManifestFilter GetManifestFilter()
         {
-            ManifestFilter filter = new()
-            {
-                IncludeRepos = Repos,
-            };
+            ManifestFilter filter = new(Repos);
 
             if (this is IFilterableOptions options)
             {

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestFilter.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestFilter.cs
@@ -7,19 +7,21 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 
+#nullable enable
 namespace Microsoft.DotNet.ImageBuilder.ViewModel
 {
     public class ManifestFilter
     {
-        public string IncludeArchitecture { get; set; }
-        public string IncludeOsType { get; set; }
+        public string? IncludeArchitecture { get; set; }
+        public string? IncludeOsType { get; set; }
         public IEnumerable<string> IncludeRepos { get; set; }
-        public IEnumerable<string> IncludeOsVersions { get; set; }
-        public IEnumerable<string> IncludePaths { get; set; }
-        public IEnumerable<string> IncludeProductVersions { get; set; }
+        public IEnumerable<string>? IncludeOsVersions { get; set; }
+        public IEnumerable<string>? IncludePaths { get; set; }
+        public IEnumerable<string>? IncludeProductVersions { get; set; }
 
-        public ManifestFilter()
+        public ManifestFilter(IEnumerable<string> repos)
         {
+            IncludeRepos = repos;
         }
 
         public static string GetFilterRegexPattern(params string[] patterns)
@@ -30,12 +32,13 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             return $"^({processedPatterns})$";
         }
 
-        public IEnumerable<Platform> FilterPlatforms(IEnumerable<Platform> platforms, string resolvedProductVersion)
+        public IEnumerable<Platform> FilterPlatforms(IEnumerable<Platform> platforms, string? resolvedProductVersion)
         {
             if (IncludeProductVersions?.Any() ?? false)
             {
                 string includeProductVersionsPattern = GetFilterRegexPattern(IncludeProductVersions.ToArray());
-                if (!Regex.IsMatch(resolvedProductVersion, includeProductVersionsPattern, RegexOptions.IgnoreCase))
+                if (resolvedProductVersion is not null &&
+                    !Regex.IsMatch(resolvedProductVersion, includeProductVersionsPattern, RegexOptions.IgnoreCase))
                 {
                     return Enumerable.Empty<Platform>();
                 }
@@ -85,3 +88,4 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         }
     }
 }
+#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ManifestHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ManifestHelper.cs
@@ -110,7 +110,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests.Helpers
 
             manifestOptionsMock
                 .Setup(o => o.GetManifestFilter())
-                .Returns(new ManifestFilter());
+                .Returns(new ManifestFilter(Enumerable.Empty<string>()));
 
             return manifestOptionsMock.Object;
         }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/ImageInfoHelperTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/ImageInfoHelperTests.cs
@@ -1262,7 +1262,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 },
                 "fullrepo",
                 "repo",
-                new ManifestFilter(),
+                new ManifestFilter(Enumerable.Empty<string>()),
                 new VariableHelper(new Manifest(), Mock.Of<IManifestOptionsInfo>(), null),
                 "base");
 
@@ -1285,7 +1285,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             public bool IsVerbose => false;
 
-            public ManifestFilter GetManifestFilter() => new ManifestFilter();
+            public ManifestFilter GetManifestFilter() => new ManifestFilter(Enumerable.Empty<string>());
 
             public string GetOption(string name) => throw new NotImplementedException();
         }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/PlatformDataTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/PlatformDataTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Linq;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
@@ -40,7 +41,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 },
                 "fullrepo",
                 "repo",
-                new ManifestFilter(),
+                new ManifestFilter(Enumerable.Empty<string>()),
                 new VariableHelper(new Manifest(), Mock.Of<IManifestOptionsInfo>(), null),
                 "base");
     }


### PR DESCRIPTION
An issue from https://github.com/dotnet/docker-tools/pull/859 causes Image Builder to fail when processing a manifest which has images without a product version set, such as the samples manifest.  Processing such a manifest will cause a null value to be passed to `Regex.IsMatch`, resulting in an exception.

I've fixed this by doing a simple null check and also enabling NRT checks to better catch issues like this.