### PR TITLE
Skip tests if test script path not set

### DIFF
--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -9,7 +9,7 @@ parameters:
 
 jobs:
 - job: ${{ parameters.name }}
-  condition: and(succeeded(), ${{ parameters.matrix }})
+  condition: and(${{ parameters.matrix }}, in(dependencies.PreBuildValidation.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))
   dependsOn:
   - PreBuildValidation
   - CopyBaseImages
@@ -47,9 +47,12 @@ jobs:
 
         $engCommonPath = "$(Build.Repository.LocalPath)/$buildRepoName/$(engCommonRelativePath)"
         $engPath = "$(Build.Repository.LocalPath)/$buildRepoName/eng"
-        $testScriptPath = "$buildRepoName/$(testScriptPath)"
         $manifest = "$buildRepoName/$(manifest)"
         $testResultsDirectory = "$buildRepoName/$testResultsDirectory"
+
+        if ("$(testScriptPath)") {
+          $testScriptPath = "$buildRepoName/$(testScriptPath)"
+        }
 
         echo "##vso[task.setvariable variable=buildRepoName]$buildRepoName"
         echo "##vso[task.setvariable variable=manifest]$manifest"
@@ -91,4 +94,6 @@ jobs:
     displayName: Publish Image Info File Artifact
   - ${{ if eq(variables['System.TeamProject'], 'public') }}:
     - template: ${{ format('../steps/test-images-{0}-client.yml', parameters.dockerClientOS) }}
+      parameters:
+        condition: ne(variables.testScriptPath, '')
   - template: ${{ format('../steps/cleanup-docker-{0}.yml', parameters.dockerClientOS) }}

--- a/eng/common/templates/jobs/test-images-linux-client.yml
+++ b/eng/common/templates/jobs/test-images-linux-client.yml
@@ -11,6 +11,8 @@ jobs:
     dependsOn: GenerateTestMatrix
     strategy:
       matrix: $[ ${{ parameters.matrix }} ]
+  ${{ if eq(parameters.preBuildValidation, 'true') }}:
+    condition: and(succeeded(), ne(variables.testScriptPath, ''))
   pool: ${{ parameters.pool }}
   timeoutInMinutes: ${{ parameters.testJobTimeout }}
   steps:

--- a/eng/common/templates/jobs/wait-for-ingestion.yml
+++ b/eng/common/templates/jobs/wait-for-ingestion.yml
@@ -7,7 +7,7 @@ jobs:
   - template: ../steps/download-build-artifact.yml
     parameters:
       targetPath: $(Build.ArtifactStagingDirectory)
-      condition: and(succeeded(), ne(variables['sourceBuildId'], ''))
+      condition: ne(variables['sourceBuildId'], '')
   - powershell: |
       # Get the last image info artifact that was published
       $imageInfoDirName = @($(dir $(Build.ArtifactStagingDirectory)/image-info-final-* | select -ExpandProperty Name))[-1]

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -145,12 +145,14 @@ stages:
     dependsOn: Post_Build
     condition: "
       and(
-        contains(variables['stages'], 'test'),
-        or(
-          and(
-            succeeded(),
-            contains(variables['stages'], 'build')),
-          not(contains(variables['stages'], 'build'))))"
+        ne(variables['testScriptPath'], ''),
+        and(
+          contains(variables['stages'], 'test'),
+          or(
+            and(
+              succeeded(),
+              contains(variables['stages'], 'build')),
+            not(contains(variables['stages'], 'build')))))"
     jobs:
     - template: ../jobs/generate-matrix.yml
       parameters:
@@ -236,13 +238,13 @@ stages:
               succeeded('Post_Build')),
             and(
               contains(variables['stages'], 'test'),
-              succeeded('Test'))),
+              in(dependencies.Test.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))),
           or(
             and(
               not(contains(variables['stages'], 'build')),
               and(
                 contains(variables['stages'], 'test'),
-                succeeded('Test'))),
+                in(dependencies.Test.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))),
             and(
               not(contains(variables['stages'], 'test')),
               and(

--- a/eng/common/templates/steps/cleanup-docker-linux.yml
+++ b/eng/common/templates/steps/cleanup-docker-linux.yml
@@ -1,12 +1,15 @@
+parameters:
+  condition: true
+
 steps:
   ################################################################################
   # Cleanup local Docker server
   ################################################################################
 - script: docker stop $(docker ps -q) || true
   displayName: Stop Running Containers
-  condition: always()
+  condition: and(always(), ${{ parameters.condition }})
   continueOnError: true
 - script: docker system prune -a -f --volumes
   displayName: Cleanup Docker
-  condition: always()
+  condition: and(always(), ${{ parameters.condition }})
   continueOnError: true

--- a/eng/common/templates/steps/download-build-artifact.yml
+++ b/eng/common/templates/steps/download-build-artifact.yml
@@ -14,4 +14,4 @@ steps:
     targetPath: ${{ parameters.targetPath }}
     artifactName: ${{ parameters.artifactName }}
   displayName: Download Build Artifact(s)
-  condition: ${{ parameters.condition }}
+  condition: and(succeeded(), ${{ parameters.condition }})

--- a/eng/common/templates/steps/init-common.yml
+++ b/eng/common/templates/steps/init-common.yml
@@ -1,5 +1,9 @@
+parameters:
+  condition: true
+
 steps:
 - powershell: |
     $sourceBranch=$Env:BUILD_SOURCEBRANCH -replace "refs/heads/","" -replace "refs/tags/","" -replace "refs/pull/","" 
     echo "##vso[task.setvariable variable=sourceBranch]$sourceBranch"
   displayName: Define Source Branch Variable
+  condition: and(succeeded(), ${{ parameters.condition }})

--- a/eng/common/templates/steps/init-docker-linux.yml
+++ b/eng/common/templates/steps/init-docker-linux.yml
@@ -2,17 +2,23 @@ parameters:
   setupImageBuilder: true
   setupTestRunner: false
   cleanupDocker: true
+  condition: true
 
 steps:
 - template: init-common.yml
+  parameters:
+    condition: ${{ parameters.condition }}
 - script: echo "##vso[task.setvariable variable=artifactsPath]/artifacts"
   displayName: Define Artifacts Path Variable
+  condition: and(succeeded(), ${{ parameters.condition }})
 
   ################################################################################
   # Cleanup Docker Resources
   ################################################################################
 - ${{ if eq(parameters.cleanupDocker, 'true') }}:
   - template: cleanup-docker-linux.yml
+    parameters:
+      condition: ${{ parameters.condition }}
 
   ################################################################################
   # Setup Image Builder (Optional)
@@ -20,12 +26,14 @@ steps:
 - ${{ if eq(parameters.setupImageBuilder, 'true') }}:
   - script: $(engCommonPath)/pull-image.sh $(imageNames.imageBuilder)
     displayName: Pull Image Builder
+    condition: and(succeeded(), ${{ parameters.condition }})
   - script: >
       docker build
       -t $(imageNames.imageBuilder.withrepo)
       --build-arg IMAGE=$(imageNames.imageBuilder)
       -f $(engCommonPath)/Dockerfile.WithRepo .
     displayName: Build Image for Image Builder
+    condition: and(succeeded(), ${{ parameters.condition }})
   - script: >
       echo "##vso[task.setvariable variable=runImageBuilderCmd]
       docker run --rm
@@ -35,6 +43,7 @@ steps:
       $(imageBuilderDockerRunExtraOptions)
       $(imageNames.imageBuilder.withrepo)"
     displayName: Define runImageBuilderCmd Variable
+    condition: and(succeeded(), ${{ parameters.condition }})
 
   ################################################################################
   # Setup Test Runner (Optional)
@@ -42,9 +51,11 @@ steps:
 - ${{ if eq(parameters.setupTestRunner, 'true') }}:
   - script: $(engCommonPath)/pull-image.sh $(imageNames.testrunner)
     displayName: Pull Test Runner
+    condition: and(succeeded(), ${{ parameters.condition }})
   - script: >
       docker build
       -t $(imageNames.testRunner.withrepo)
       --build-arg IMAGE=$(imageNames.testrunner)
       -f $(engCommonPath)/Dockerfile.WithRepo .
     displayName: Build Test Runner Image
+    condition: and(succeeded(), ${{ parameters.condition }})

--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -1,5 +1,6 @@
 parameters:
   preBuildValidation: false
+  condition: true
 
 steps:
 - template: init-docker-linux.yml
@@ -7,6 +8,7 @@ steps:
     setupImageBuilder: false
     setupTestRunner: true
     cleanupDocker: ${{ eq(variables['System.TeamProject'], 'internal') }}
+    condition: ${{ parameters.condition }}
 - script: |
     echo "##vso[task.setvariable variable=testRunner.container]testrunner-$(Build.BuildId)-$(System.JobId)"
 
@@ -23,6 +25,7 @@ steps:
     fi
     echo "##vso[task.setvariable variable=optionalTestArgs]$optionalTestArgs"
   displayName: Set Test Variables
+  condition: and(succeeded(), ${{ parameters.condition }})
 - script: >
     docker run -t -d
     -v /var/run/docker.sock:/var/run/docker.sock
@@ -31,16 +34,19 @@ steps:
     --name $(testRunner.container)
     $(imageNames.testRunner.withrepo)
   displayName: Start Test Runner Container
+  condition: and(succeeded(), ${{ parameters.condition }})
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - script: >
       docker exec $(testRunner.container) pwsh
       -File $(engCommonRelativePath)/Invoke-WithRetry.ps1
       "docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)"
     displayName: Docker login
+    condition: and(succeeded(), ${{ parameters.condition }})
   - ${{ if eq(parameters.preBuildValidation, 'false') }}:
     - template: ../steps/download-build-artifact.yml
       parameters:
         targetPath: $(Build.ArtifactStagingDirectory)
+        condition: ${{ parameters.condition }}
 - script: >
     docker exec $(testRunner.container) pwsh
     -File $(testScriptPath)
@@ -49,21 +55,22 @@ steps:
     -Architecture '$(architecture)'
     $(optionalTestArgs)
   displayName: Test Images
+  condition: and(succeeded(), ${{ parameters.condition }})
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - script: docker exec $(testRunner.container) docker logout $(acr.server)
     displayName: Docker logout
-    condition: always()
+    condition: and(always(), ${{ parameters.condition }})
     continueOnError: true
 - script: >
     docker cp
     $(testRunner.container):/repo/$(testResultsDirectory)
     $(Common.TestResultsDirectory)/.
   displayName: Copy Test Results
-  condition: always()
+  condition: and(always(), ${{ parameters.condition }})
   continueOnError: true
 - task: PublishTestResults@2
   displayName: Publish Test Results
-  condition: always()
+  condition: and(always(), ${{ parameters.condition }})
   continueOnError: true
   inputs:
     testRunner: vSTest
@@ -77,7 +84,9 @@ steps:
       testRunTitle: Pre-Build Validation
 - script: docker rm -f $(testRunner.container)
   displayName: Cleanup TestRunner Container
-  condition: always()
+  condition: and(always(), ${{ parameters.condition }})
   continueOnError: true
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - template: cleanup-docker-linux.yml
+    parameters:
+      condition: ${{ parameters.condition }}

--- a/eng/common/templates/variables/common-paths.yml
+++ b/eng/common/templates/variables/common-paths.yml
@@ -2,4 +2,4 @@ variables:
   engCommonRelativePath: eng/common
   engCommonPath: $(Build.Repository.LocalPath)/$(engCommonRelativePath)
   engPath: $(Build.Repository.LocalPath)/eng
-  testScriptPath: ./tests/run-tests.ps1
+  testScriptPath: ""


### PR DESCRIPTION
In order to support other teams consuming the common infra, this removes the assumption that a test script will exist for the source repo.  If the `testScriptPath` variable is not set, it will skip execution of the PreBuildValidation job and any test steps.

Related to #830