### PR TITLE
Support for nested manifest variables

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateArtifactsCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateArtifactsCommand.cs
@@ -114,7 +114,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             return new Dictionary<Value, Value>
             {
-                ["VARIABLES"] = Manifest.VariableHelper.GetVariables()
+                ["VARIABLES"] = Manifest.VariableHelper.ResolvedVariables
                     .ToDictionary(kvp => (Value)kvp.Key, kvp => (Value)kvp.Value)
             };
         }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/PlatformData.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/PlatformData.cs
@@ -111,7 +111,7 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Image
                 return null;
             }
 
-            string fullVersion = ImageInfo.ProductVersion;
+            string? fullVersion = ImageInfo.ProductVersion;
 
             if (string.IsNullOrEmpty(fullVersion))
             {

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
                 foreach (KeyValuePair<string, string?> kvp in Manifest.Variables)
                 {
                     string? variableValue;
-                    if (Options.Variables?.TryGetValue(kvp.Key, out string? overridenValue) == true)
+                    if (Options.Variables != null && Options.Variables.TryGetValue(kvp.Key, out string? overridenValue))
                     {
                         variableValue = overridenValue;
                     }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
@@ -79,12 +79,6 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
                 else
                 {
                     variableValue = GetUserValue(variableName);
-
-                    if (variableValue is null && Manifest.Variables.ContainsKey(variableName))
-                    {
-                        throw new NotSupportedException(
-                            $"Unable to resolve value for variable '{variableName}' because it references a variable whose value hasn't been resolved yet. Dependencies between variables need to be ordered according to their dependency.");
-                    }
                 }
 
                 if (variableValue == null)
@@ -139,6 +133,12 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             if (!Options.Variables?.TryGetValue(variableName, out variableValue) == true)
             {
                 ResolvedVariables?.TryGetValue(variableName, out variableValue);
+            }
+
+            if (variableValue is null && Manifest.Variables.ContainsKey(variableName))
+            {
+                throw new NotSupportedException(
+                    $"Unable to resolve value for variable '{variableName}' because it references a variable whose value hasn't been resolved yet. Dependencies between variables need to be ordered according to their dependency.");
             }
 
             return variableValue;

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
                 foreach (KeyValuePair<string, string?> kvp in Manifest.Variables)
                 {
                     string? variableValue;
-                    if (Options.Variables != null && Options.Variables.TryGetValue(kvp.Key, out string? overridenValue))
+                    if (Options.Variables is not null && Options.Variables.TryGetValue(kvp.Key, out string? overridenValue))
                     {
                         variableValue = overridenValue;
                     }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/VariableHelperTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/VariableHelperTests.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.DotNet.ImageBuilder.Models.Manifest;
+using Microsoft.DotNet.ImageBuilder.ViewModel;
+using Moq;
+using Xunit;
+using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
+
+namespace Microsoft.DotNet.ImageBuilder.Tests
+{
+    public class VariableHelperTests
+    {
+        [Fact]
+        public void NestedVariables()
+        {
+            Manifest manifest = CreateManifest();
+            manifest.Variables = new Dictionary<string, string>()
+            {
+                { "test", "abc" },
+                { "test2", "$(test)" },
+                { "test3", "$(test2)" },
+                { "test4", "xyz" }
+            };
+
+            Mock<IManifestOptionsInfo> manifestOptionsInfoMock = new();
+            manifestOptionsInfoMock
+                .SetupGet(o => o.Variables)
+                .Returns(new Dictionary<string, string>
+                {
+                    { "test4", "$(test)-123" }
+                });
+
+            VariableHelper helper = new(manifest, manifestOptionsInfoMock.Object, id => null);
+
+            Assert.Equal(4, helper.ResolvedVariables.Count);
+            Assert.Equal("abc", helper.ResolvedVariables["test"]);
+            Assert.Equal("abc", helper.ResolvedVariables["test2"]);
+            Assert.Equal("abc", helper.ResolvedVariables["test3"]);
+            Assert.Equal("abc-123", helper.ResolvedVariables["test4"]);
+        }
+
+        [Fact]
+        public void ReferenceToUnresolvedVariable()
+        {
+            Manifest manifest = CreateManifest();
+            manifest.Variables = new Dictionary<string, string>()
+            {
+                { "test1", "$(test2)" },
+                { "test2", "abc" }
+            };
+
+
+            Assert.Throws<NotSupportedException>(() => new VariableHelper(manifest, Mock.Of<IManifestOptionsInfo>(), id => null));
+        }
+
+        [Fact]
+        public void ReferenceToUndefinedVariable()
+        {
+            Manifest manifest = CreateManifest();
+            manifest.Variables = new Dictionary<string, string>()
+            {
+                { "test1", "$(test2)" }
+            };
+
+
+            Assert.Throws<InvalidOperationException>(() => new VariableHelper(manifest, Mock.Of<IManifestOptionsInfo>(), id => null));
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/tests/VariableHelperTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/VariableHelperTests.cs
@@ -52,7 +52,6 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 { "test2", "abc" }
             };
 
-
             Assert.Throws<NotSupportedException>(() => new VariableHelper(manifest, Mock.Of<IManifestOptionsInfo>(), id => null));
         }
 


### PR DESCRIPTION
This supports https://github.com/microsoft/dotnet-framework-docker/issues/811 by adding support for nested variables in the manifest. This means the value of a variable can reference another variable.