### PR TITLE
Support native product version filtering from build script

### DIFF
--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -2,12 +2,12 @@
 
 <#
     .SYNOPSIS
-        Builds the .NET Dockerfiles
+        Builds the Dockerfiles
 #>
 
 [cmdletbinding()]
 param(
-    # Versions of .NET to filter by
+    # Product versions to filter by
     [string[]]$Version = "*",
 
     # Names of OS to filter by

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -2,21 +2,21 @@
 
 <#
     .SYNOPSIS
-        Builds the .NET Core Dockerfiles
+        Builds the .NET Dockerfiles
 #>
 
 [cmdletbinding()]
 param(
-    # Version of .NET Core to filter by
-    [string]$Version = "*",
+    # Versions of .NET to filter by
+    [string[]]$Version = "*",
 
-    # Name of OS to filter by
-    [string]$OS,
+    # Names of OS to filter by
+    [string[]]$OS,
 
     # Type of architecture to filter by
     [string]$Architecture,
 
-    # Additional custom path filters (overrides Version)
+    # Additional custom path filters
     [string[]]$Paths,
 
     # Path to manifest file
@@ -49,8 +49,12 @@ pushd $PSScriptRoot/../..
 try {
     $args = $OptionalImageBuilderArgs
 
+    if ($Version) {
+        $args += " --version " + ($Version -join " --version ")
+    }
+
     if ($OS) {
-        $args += " --os-version $OS"
+        $args += " --os-version " + ($OS -join " --os-version ")
     }
 
     if ($Architecture) {
@@ -59,9 +63,6 @@ try {
 
     if ($Paths) {
         $args += " --path " + ($Paths -join " --path ")
-    }
-    else {
-        $args += " --path 'src/*/$Version/*'"
     }
 
     if ($Manifest) {


### PR DESCRIPTION
Now that Image Builder [supports product version filtering](https://github.com/dotnet/docker-tools/pull/859) natively, this can be utilized from the common build script.

Related to #836