### PR TITLE
Support for custom build matrix OS versions

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
@@ -379,9 +379,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             string? osVersion;
 
-            if (platform.Model.CustomMatrixOsVersion is not null)
+            if (Options.DistinctMatrixOsVersions.Contains(platform.BaseOsVersion))
             {
-                osVersion = platform.Model.CustomMatrixOsVersion;
+                osVersion = platform.BaseOsVersion;
             }
             else if (platform.Model.OS != OS.Linux)
             {

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixOptions.cs
@@ -17,6 +17,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public IEnumerable<string> CustomBuildLegGroups { get; set; } = Enumerable.Empty<string>();
         public int ProductVersionComponents { get; set; }
         public string? ImageInfoPath { get; set; }
+        public IEnumerable<string> DistinctMatrixOsVersions { get; set; } = Enumerable.Empty<string>();
 
         public GenerateBuildMatrixOptions() : base()
         {
@@ -43,7 +44,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         CreateOption("product-version-components", nameof(GenerateBuildMatrixOptions.ProductVersionComponents),
                             "Number of components of the product version considered to be significant", 2),
                         CreateOption<string?>("image-info", nameof(GenerateBuildMatrixOptions.ImageInfoPath),
-                            "Path to image info file")
+                            "Path to image info file"),
+                        CreateMultiOption<string>("distinct-matrix-os-version", nameof(GenerateBuildMatrixOptions.CustomBuildLegGroups),
+                            "OS version to be contained in its own distinct matrix"),
                     });
 
         public override IEnumerable<Argument> GetCliArguments() =>

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/Platform.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/Platform.cs
@@ -67,12 +67,6 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Manifest
         public CustomBuildLegGroup[] CustomBuildLegGroups { get; set; } = Array.Empty<CustomBuildLegGroup>();
 
         [Description(
-            "A custom OS version to use for the matrix instead of the default. This allows for certain platforms " +
-            "to be grouped into a distinct build matrix for when those platforms require custom configuration."
-            )]
-        public string? CustomMatrixOsVersion { get; set; }
-
-        [Description(
             "A label which further distinguishes the architecture when it " +
             "contains variants. For example, the ARM architecture has variants " +
             "named v6, v7, etc."

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/Platform.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/Platform.cs
@@ -8,6 +8,7 @@ using System.ComponentModel;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
+#nullable enable
 namespace Microsoft.DotNet.ImageBuilder.Models.Manifest
 {
     [Description(
@@ -21,24 +22,24 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Manifest
         [DefaultValue(Architecture.AMD64)]
         [JsonConverter(typeof(StringEnumConverter))]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public Architecture Architecture { get; set; }
+        public Architecture Architecture { get; set; } = Architecture.AMD64;
 
         [Description(
             "A set of values that will passed to the `docker build` command " +
             "to override variables defined in the Dockerfile.")]
-        public IDictionary<string, string> BuildArgs { get; set; }
+        public IDictionary<string, string> BuildArgs { get; set; } = new Dictionary<string, string>();
 
         [Description(
             "Relative path to the associated Dockerfile. This can be a file or a " +
             "directory. If it is a directory, the file name defaults to Dockerfile."
             )]
         [JsonProperty(Required = Required.Always)]
-        public string Dockerfile { get; set; }
+        public string Dockerfile { get; set; } = string.Empty;
 
         [Description(
             "Relative path to the template the Dockerfile is generated from."
             )]
-        public string DockerfileTemplate { get; set; }
+        public string? DockerfileTemplate { get; set; }
 
         [Description(
             "The generic name of the operating system associated with the image."
@@ -52,13 +53,13 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Manifest
             "Examples: alpine3.9, bionic, nanoserver-1903."
             )]
         [JsonProperty(Required = Required.Always)]
-        public string OsVersion { get; set; }
+        public string OsVersion { get; set; } = string.Empty;
 
         [Description(
             "The set of platform-specific tags associated with the image."
             )]
         [JsonProperty(Required = Required.Always)]
-        public IDictionary<string, Tag> Tags { get; set; }
+        public IDictionary<string, Tag> Tags { get; set; } = new Dictionary<string, Tag>();
 
         [Description(
             "The custom build leg groups associated with the platform."
@@ -66,14 +67,21 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Manifest
         public CustomBuildLegGroup[] CustomBuildLegGroups { get; set; } = Array.Empty<CustomBuildLegGroup>();
 
         [Description(
+            "A custom OS version to use for the matrix instead of the default. This allows for certain platforms " +
+            "to be grouped into a distinct build matrix for when those platforms require custom configuration."
+            )]
+        public string? CustomMatrixOsVersion { get; set; }
+
+        [Description(
             "A label which further distinguishes the architecture when it " +
             "contains variants. For example, the ARM architecture has variants " +
             "named v6, v7, etc."
             )]
-        public string Variant { get; set; }
+        public string? Variant { get; set; }
 
         public Platform()
         {
         }
     }
 }
+#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
@@ -12,6 +12,7 @@ using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
 using Newtonsoft.Json;
 using Xunit;
+using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.DockerfileHelper;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
@@ -150,6 +151,65 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
                 Assert.Equal(expectedPaths, imageBuilderPaths);
             }
+        }
+
+        /// <summary>
+        /// Verifies that the correct matrix is generated when the CustomMatrixOsVersion field is set in the manifest.
+        /// </summary>
+        [Fact]
+        public void GenerateBuildMatrixCommand_CustomMatrixOsVersion()
+        {
+            using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
+            GenerateBuildMatrixCommand command = new();
+            command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
+            command.Options.MatrixType = MatrixType.PlatformDependencyGraph;
+
+            const string CustomMatrixOsVersion = "custom";
+
+            Platform aspnetPlatform = CreatePlatform(
+                CreateDockerfile("1.0/aspnet/os2/amd64", tempFolderContext),
+                new string[] { "os2" });
+            aspnetPlatform.CustomMatrixOsVersion = CustomMatrixOsVersion;
+
+            Platform sdkPlatform = CreatePlatform(
+                CreateDockerfile("1.0/sdk/os2/amd64", tempFolderContext, "aspnet:os2"),
+                new string[] { "tag2" });
+            sdkPlatform.CustomMatrixOsVersion = CustomMatrixOsVersion;
+
+            Manifest manifest = CreateManifest(
+                CreateRepo("aspnet",
+                    CreateImage(
+                        CreatePlatform(
+                            CreateDockerfile("1.0/aspnet/os/amd64", tempFolderContext),
+                            new string[] { "os" })),
+                    CreateImage(aspnetPlatform)),
+                CreateRepo("sdk",
+                    CreateImage(
+                        CreatePlatform(
+                            CreateDockerfile("1.0/sdk/os/amd64", tempFolderContext, "aspnet:os"),
+                            new string[] { "tag" })),
+                    CreateImage(sdkPlatform))
+            );
+
+            File.WriteAllText(Path.Combine(tempFolderContext.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));
+
+            command.LoadManifest();
+            IEnumerable<BuildMatrixInfo> matrixInfos = command.GenerateMatrixInfo();
+            Assert.Equal(2, matrixInfos.Count());
+
+            BuildMatrixInfo matrixInfo = matrixInfos.ElementAt(0);
+            Assert.Equal($"{CustomMatrixOsVersion}Amd64", matrixInfo.Name);
+            Assert.Single(matrixInfo.Legs);
+            Assert.Equal(
+                "--path 1.0/aspnet/os2/amd64/Dockerfile --path 1.0/sdk/os2/amd64/Dockerfile",
+                matrixInfo.Legs.First().Variables.First(variable => variable.Name == "imageBuilderPaths").Value);
+
+            matrixInfo = matrixInfos.ElementAt(1);
+            Assert.Equal($"linuxAmd64", matrixInfo.Name);
+            Assert.Single(matrixInfo.Legs);
+            Assert.Equal(
+                "--path 1.0/aspnet/os/amd64/Dockerfile --path 1.0/sdk/os/amd64/Dockerfile",
+                matrixInfo.Legs.First().Variables.First(variable => variable.Name == "imageBuilderPaths").Value);
         }
 
         /// <summary>


### PR DESCRIPTION
Distroless Dockerfiles of CBL-Mariner will need to be executed on a custom agent pool. Currently, there is only one matrix defined for Linux Dockerfiles of a given architecture.  They're all lumped together targeting the same agent pool.  This is problematic because there's not a mechanism to separate out the distroless Dockerfiles to run them in a separate agent pool.  There needs to be a way for the generated build matrices to provide a distinct matrix just for the distroless Dockerfiles.  Once a separate matrix is provided, the pipeline can then explicitly reference that matrix and configure the appropriate agent pool name for that matrix.  

One way to do this is to change the matrix generation to not lump all Linux Dockerfiles together but rather define distinct matrices for each Linux OS version (e.g. mariner distroless, alpine3.14, buster, focal, etc).  That allows for maximum flexibility in that we can customize which agent pool each of those OS versions runs on. But that requires constant maintenance as supported OS versions change and also produces a lot of duplication in the pipeline YAML file.

Instead, the solution I've provided here uses an opt-in model to customize each platform so that it can define a custom OS version name for the purposes of matrix generation. In the case of distroless for Mariner, this means it can be configured to define a custom OS version (e.g. "mariner-distroless") instead of the default "Linux". This will produce a separate matrix for all platforms that use that same custom OS version. The pipeline YAML can then be configured to reference that matrix name.

Example showing both Mariner Distroless and Linux in the pipeline YAML:

```yaml
  - template: ../jobs/build-images.yml
    parameters:
      name: MarinerDistroless_amd64
      pool: ${{ parameters.marinerDistrolessAmd64BuildPool }}
      matrix: dependencies.GenerateBuildMatrix.outputs['matrix.MarinerDistrolessAmd64']
      dockerClientOS: linux
      buildJobTimeout: ${{ parameters.marinerDistrolessAmdBuildJobTimeout }}
      customInitSteps: ${{ parameters.customBuildInitSteps }}
      noCache: ${{ parameters.noCache }}
  - template: ../jobs/build-images.yml
    parameters:
      name: Linux_amd64
      pool: ${{ parameters.linuxAmd64BuildPool }}
      matrix: dependencies.GenerateBuildMatrix.outputs['matrix.LinuxAmd64']
      dockerClientOS: linux
      buildJobTimeout: ${{ parameters.linuxAmdBuildJobTimeout }}
      customInitSteps: ${{ parameters.customBuildInitSteps }}
      noCache: ${{ parameters.noCache }}
```

Related to #870