### PR TITLE
Fix variable resolution logic

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
@@ -54,9 +54,18 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
                     ResolvedVariables.Add(kvp.Key, variableValue);
                 }
             }
-            else if (Options.Variables is not null)
+
+            // Include any variables exclusively defined in the options
+            if (Options.Variables is not null)
             {
-                ResolvedVariables = new Dictionary<string, string?>(Options.Variables);
+                foreach (KeyValuePair<string, string?> kvp in Options.Variables)
+                {
+                    if (!ResolvedVariables.ContainsKey(kvp.Key))
+                    {
+                        string? value = SubstituteValues(kvp.Value);
+                        ResolvedVariables.Add(kvp.Key, value);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
This fixes an issue introduced by https://github.com/dotnet/docker-tools/pull/873 where variables that are exclusively defined via the options are not exposed by VariableHelper. This specifically causes an issue when generating readmes in the dotnet/dotnet-docker repo. In that repo, a `branch` variable is provided:
https://github.com/dotnet/dotnet-docker/blob/7275e84505032552923953dce76fd478b42f63f9/eng/readme-templates/Get-GeneratedReadmes.ps1#L34

This variable does not get included by VariableHelper and subsequently not used by the GenerateReadmesCommand class. This causes the readme templates which rely on the branch variable to produce incorrect output.

I've fixed the logic to ensure that any variable exclusively defined via the options is included in the results.