### PR TITLE
Support optional windows tests

### DIFF
--- a/eng/common/templates/steps/cleanup-docker-windows.yml
+++ b/eng/common/templates/steps/cleanup-docker-windows.yml
@@ -1,15 +1,18 @@
+parameters:
+  condition: true
+  
 steps:
   ################################################################################
   # Cleanup Docker Resources
   ################################################################################
 - powershell: $(engCommonPath)/Invoke-CleanupDocker.ps1
   displayName: Cleanup Docker Images
-  condition: always()
+  condition: and(always(), ${{ parameters.condition }})
   continueOnError: true
 - powershell: |
     if (Test-Path $(Build.BinariesDirectory)\.Microsoft.DotNet.ImageBuilder) {
       Remove-Item $(Build.BinariesDirectory)\.Microsoft.DotNet.ImageBuilder -Force -Recurse;
     }
   displayName: Cleanup Image Builder
-  condition: always()
+  condition: and(always(), ${{ parameters.condition }})
   continueOnError: true

--- a/eng/common/templates/steps/init-docker-windows.yml
+++ b/eng/common/templates/steps/init-docker-windows.yml
@@ -1,15 +1,21 @@
 parameters:
   setupImageBuilder: true
+  condition: true
 
 steps:
 - template: init-common.yml
+  parameters:
+    condition: ${{ parameters.condition }}
 - powershell: echo "##vso[task.setvariable variable=artifactsPath]$(Build.ArtifactStagingDirectory)"
   displayName: Define Artifacts Path Variable
+  condition: and(succeeded(), ${{ parameters.condition }})
 
   ################################################################################
   # Cleanup Docker Resources
   ################################################################################
 - template: cleanup-docker-windows.yml
+  parameters:
+    condition: ${{ parameters.condition }}
 
   ################################################################################
   # Setup Image Builder (Optional)
@@ -17,18 +23,22 @@ steps:
 - ${{ if eq(parameters.setupImageBuilder, 'true') }}:
   - powershell: $(engCommonPath)/Invoke-WithRetry.ps1 "docker pull $(imageNames.imageBuilder)"
     displayName: Pull Image Builder
+    condition: and(succeeded(), ${{ parameters.condition }})
   - script: docker create --name setupImageBuilder-$(Build.BuildId)-$(System.JobId) $(imageNames.imageBuilder)
     displayName: Create Setup Container
+    condition: and(succeeded(), ${{ parameters.condition }})
   - script: >
       docker cp
       setupImageBuilder-$(Build.BuildId)-$(System.JobId):/image-builder
       $(Build.BinariesDirectory)/.Microsoft.DotNet.ImageBuilder
     displayName: Copy Image Builder
+    condition: and(succeeded(), ${{ parameters.condition }})
   - script: docker rm -f setupImageBuilder-$(Build.BuildId)-$(System.JobId)
     displayName: Cleanup Setup Container
-    condition: always()
+    condition: and(always(), ${{ parameters.condition }})
     continueOnError: true
   - powershell: >
       echo "##vso[task.setvariable variable=runImageBuilderCmd]
       $(Build.BinariesDirectory)\.Microsoft.DotNet.ImageBuilder\Microsoft.DotNet.ImageBuilder.exe"
     displayName: Define runImageBuilderCmd Variable
+    condition: and(succeeded(), ${{ parameters.condition }})

--- a/eng/common/templates/steps/test-images-windows-client.yml
+++ b/eng/common/templates/steps/test-images-windows-client.yml
@@ -1,12 +1,17 @@
+parameters:
+  condition: true
+
 steps:
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - template: init-docker-windows.yml
     parameters:
       setupImageBuilder: false
+      condition: ${{ parameters.condition }}
   - powershell: >
       $(engCommonPath)/Invoke-WithRetry.ps1
       "cmd /c 'docker login -u $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server) 2>&1'"
     displayName: Docker login
+    condition: and(succeeded(), ${{ parameters.condition }})
 - powershell: |
     if ("${{ eq(variables['System.TeamProject'], 'public') }}" -eq "False") {
       $optionalTestArgs="$optionalTestArgs -PullImages -Registry $env:ACR_SERVER -RepoPrefix $env:STAGINGREPOPREFIX -ImageInfoPath $(artifactsPath)/image-info/image-info.json"
@@ -16,26 +21,30 @@ steps:
     }
     echo "##vso[task.setvariable variable=optionalTestArgs]$optionalTestArgs"
   displayName: Set Test Variables
+  condition: and(succeeded(), ${{ parameters.condition }})
 - powershell: Get-ChildItem -Path tests -r | Where {$_.Extension -match "trx"} | Remove-Item
   displayName: Cleanup Old Test Results
+  condition: and(succeeded(), ${{ parameters.condition }})
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - template: ../steps/download-build-artifact.yml
     parameters:
       targetPath: $(Build.ArtifactStagingDirectory)
+      condition: ${{ parameters.condition }}
 - powershell: >
     $(testScriptPath)
     -Version '$(productVersion)'
     -OS '$(osVariant)'
     $(optionalTestArgs)
   displayName: Test Images
+  condition: and(succeeded(), ${{ parameters.condition }})
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - script: docker logout $(acr.server)
     displayName: Docker logout
-    condition: always()
+    condition: and(always(), ${{ parameters.condition }})
     continueOnError: true
 - task: PublishTestResults@2
   displayName: Publish Test Results
-  condition: always()
+  condition: and(always(), ${{ parameters.condition }})
   continueOnError: true
   inputs:
     testRunner: vSTest
@@ -45,3 +54,5 @@ steps:
     testRunTitle: $(productVersion) $(osVariant) amd64
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - template: cleanup-docker-windows.yml
+    parameters:
+      condition: ${{ parameters.condition }}


### PR DESCRIPTION
The previous changes in #866 did not include changes to support an optional test script for Windows builds.  This causes Windows build jobs for PR builds to fail if a test script doesn't exist. These changes apply the same condition checks to the Windows-related files that were initially made to the Linux-related files.

Related to #830