### PR TITLE
Support for "FROM scratch" Dockerfiles

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateImageGraphCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateImageGraphCommand.cs
@@ -60,8 +60,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private void AddBaseImages(DotGraph graph, PlatformInfo[] platforms)
         {
             IEnumerable<string> externalBaseImages = platforms
-                .Where(platform => !platform.IsInternalFromImage(platform.FinalStageFromImage))
+                .Where(platform => platform.FinalStageFromImage is not null && !platform.IsInternalFromImage(platform.FinalStageFromImage))
                 .Select(platform => platform.FinalStageFromImage)
+                .Cast<string>()
                 .Distinct()
                 .OrderBy(name => name)
                 .ToArray();
@@ -114,12 +115,15 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 IEnumerable<string> tags = platform.Tags.Select(tag => tag.FullyQualifiedName);
                 DotNode imageNode = AddImageNode(graph, tags, Color.Navy, platform.FinalStageFromImage);
 
-                var myEdge = new DotEdge(imageNode.Id, _nodeCache[platform.FinalStageFromImage].Id);
-                myEdge.Attributes.ArrowHead = DotArrowType.Normal;
-                myEdge.Attributes.ArrowTail = DotArrowType.None;
-                myEdge.Attributes.Color = Color.Black;
-                myEdge.Attributes.Style = DotStyle.Dashed;
-                graph.Edges.Add(myEdge);
+                if (platform.FinalStageFromImage is not null)
+                {
+                    var myEdge = new DotEdge(imageNode.Id, _nodeCache[platform.FinalStageFromImage].Id);
+                    myEdge.Attributes.ArrowHead = DotArrowType.Normal;
+                    myEdge.Attributes.ArrowTail = DotArrowType.None;
+                    myEdge.Attributes.Color = Color.Black;
+                    myEdge.Attributes.Style = DotStyle.Dashed;
+                    graph.Edges.Add(myEdge);
+                }
             }
         }
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetBaseImageStatusCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetBaseImageStatusCommand.cs
@@ -50,7 +50,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     // Find the last FROM image that's an external image. This is not the same as the last
                     // ExternalFromImage because that could be the first FROM listed in the Dockerfile which is
                     // not what we want.
-                    return platform.IsInternalFromImage(platform.FinalStageFromImage) ?
+                    return platform.FinalStageFromImage is not null && platform.IsInternalFromImage(platform.FinalStageFromImage) ?
                         null : platform.FinalStageFromImage;
                 })
                 .Where(image => image != null)

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
@@ -23,10 +23,10 @@ namespace Microsoft.DotNet.ImageBuilder
 
         public const string DockerHubRegistry = "docker.io";
 
-        public static void ExecuteWithUser(Action action, string? username, string? password, string server, bool isDryRun)
+        public static void ExecuteWithUser(Action action, string? username, string? password, string? server, bool isDryRun)
         {
             bool loggedIn = false;
-            if (username is not null && password is not null)
+            if (username is not null && password is not null && server is not null)
             {
                 DockerHelper.Login(username, password, server, isDryRun);
                 loggedIn = true;
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.ImageBuilder
             }
             finally
             {
-                if (loggedIn)
+                if (loggedIn && server is not null)
                 {
                     DockerHelper.Logout(server, isDryRun);
                 }


### PR DESCRIPTION
This updates the semantics of `PlatformInfo.FinalStageFromImage` to be nullable. When the value is null, it means the final stage of the Dockerfile has `FROM scratch`. Using the semantics of nullability provides better language support to identify all dependencies that would be affected by having a "FROM scratch" Dockerfile.

Related to #871