### PR TITLE
Fix check-base-image-updates pipeline

### DIFF
--- a/eng/common/templates/variables/dotnet/build-test-publish.yml
+++ b/eng/common/templates/variables/dotnet/build-test-publish.yml
@@ -11,8 +11,6 @@ variables:
   value: ./tests/run-tests.ps1
 - name: testResultsDirectory
   value: tests/Microsoft.DotNet.Docker.Tests/TestResults/
-- name: mirrorRegistryCreds
-  value: --registry-creds 'docker.io=$(dotnetDockerHubBot.userName);$(BotAccount-dotnet-dockerhub-bot-PAT)'
 - name: officialRepoPrefix
   value: public/
 
@@ -55,7 +53,5 @@ variables:
   value: $(app-DotnetDockerTelemetryIngestion-client-secret)
 - name: mcrStatus.servicePrincipalPassword
   value: $(app-DotnetDockerMcrStatusApi-client-secret)
-- name: acr.servicePrincipalPassword
-  value: $(app-dotnetdockerbuild-client-secret)
 - name: acr.password
   value: $(BotAccount-dotnet-docker-acr-bot-password)

--- a/eng/common/templates/variables/dotnet/common.yml
+++ b/eng/common/templates/variables/dotnet/common.yml
@@ -4,6 +4,10 @@ variables:
   value: public
 - name: internalProjectName
   value: internal
+- name: mirrorRegistryCreds
+  value: --registry-creds 'docker.io=$(dotnetDockerHubBot.userName);$(BotAccount-dotnet-dockerhub-bot-PAT)'
+- name: acr.servicePrincipalPassword
+  value: $(app-dotnetdockerbuild-client-secret)
 
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNet-Docker-Common

--- a/eng/pipelines/check-base-image-updates.yml
+++ b/eng/pipelines/check-base-image-updates.yml
@@ -21,6 +21,9 @@ stages:
     parameters:
       name: CopyBaseImages
       additionalOptions: "--subscriptions-path '$(checkBaseImageSubscriptionsPath)'"
+      pool: 
+        vmImage: $(defaultLinuxAmd64PoolImage)
+      publicProjectName: ${{ variables.publicProjectName }}
 
 - stage: GetStaleImages
   dependsOn: CopyBaseImages


### PR DESCRIPTION
The check-base-image-updates pipeline was broken by https://github.com/dotnet/docker-tools/pull/884 due to a couple factors:
* In the CopyBaseImages stage, it didn't set the pool parameter on the template, causing the build to default to Ubuntu-16 pool (AzDO's defaulting behavior when pool isn't set) which was [recently removed](https://docs.microsoft.com/en-us/azure/devops/release-notes/2021/pipelines/sprint-193-update#updated-schedule-for-removal-of-ubuntu-1604-image-on-microsoft-hosted-agents). So none of the scheduled builds for this pipeline have been running due to this implicit reference of the delete VM image since Monday.
* Prior to Monday, but after https://github.com/dotnet/docker-tools/pull/884 was merged on Thursday, the CopyBaseImages stage was failing. The build was not failing though because the CopyBaseImages stage is allowed to fail without failing the build. It was failing because some secret values weren't being set in the correct variables template file.

Both these issues have been addressed.