### PR TITLE
Remove wildcard for OS parameter of test script

### DIFF
--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -52,7 +52,7 @@ steps:
     docker exec $(testRunner.container) pwsh
     -File $(testScriptPath)
     -Version '$(productVersion)'
-    -OS '$(osVariant)*'
+    -OS '$(osVariant)'
     -Architecture '$(architecture)'
     $(optionalTestArgs)
   displayName: Test Images


### PR DESCRIPTION
This ports the changes that were made in https://github.com/dotnet/dotnet-docker/pull/3223 for invoking the test script. It removes the assumption that the OS name can have additional text at the end and leaves that choice up to the script itself.  This allows the script to distinguish cases like buster/buster-slim and cbl-mariner1.0/cbl-mariner1.0-distroless, handling them differently.