### PR TITLE
Parameterize matrix type

### DIFF
--- a/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
@@ -13,6 +13,8 @@ parameters:
   linuxAmdBuildJobTimeout: 60
   linuxAmd64Pool:
     vmImage: $(defaultLinuxAmd64PoolImage)
+  buildMatrixType: platformDependencyGraph
+  testMatrixType: platformVersionedOs
 
 stages:
 - template: ../build-test-publish-repo.yml
@@ -26,6 +28,8 @@ stages:
     windowsAmdBuildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
     windowsAmdTestJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
     linuxAmdBuildJobTimeout: ${{ parameters.linuxAmdBuildJobTimeout }}
+    buildMatrixType: ${{ parameters.buildMatrixType }}
+    testMatrixType: ${{ parameters.testMatrixType }}
 
     internalVersionsRepoRef: InternalVersionsRepo
     publicVersionsRepoRef: PublicVersionsRepo
@@ -33,9 +37,6 @@ stages:
     ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
       customPublishVariables:
       - group: DotNet-AllOrgs-Darc-Pats
-    
-    ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
-      buildMatrixType: platformVersionedOs
 
     linuxAmd64Pool: ${{ parameters.linuxAmd64Pool }}
     linuxArm64Pool:

--- a/eng/pipelines/dotnet-docker-tools-eng-validation-pr.yml
+++ b/eng/pipelines/dotnet-docker-tools-eng-validation-pr.yml
@@ -15,6 +15,7 @@ variables:
 stages:
 - template: ../common/templates/stages/dotnet/build-test-publish-repo.yml
   parameters:
+    buildMatrixType: platformVersionedOs
     noCache: true
     internalProjectName: ${{ variables.internalProjectName }}
     publicProjectName: ${{ variables.publicProjectName }}


### PR DESCRIPTION
The changes from https://github.com/dotnet/docker-tools/pull/884 caused a regression in the PR-related pipelines of https://github.com/dotnet/dotnet-buildtools-prereqs-docker repo. They incorrectly generated a platformVersionedOs matrix for PR builds when they were previously always using a platformDependencyGraph matrix for both official and PR builds. By using a platformVersionedOs matrix, it caused Image Builder to produce a matrix with duplicate leg names due to their being multiple root Dockerfiles for a given OS/arch.

This is an example of the build matrix it was incorrectly generating:

```
  linuxAmd64:
    bionic:
      legName: linuxamd64bionic
      osType: linux
      architecture: amd64
      osVersions: --os-version bionic
      productVersion: 
      osVariant: bionic
      imageBuilderPaths: --path src/ubuntu/18.04/coredeps --path src/ubuntu/18.04/android --path src/ubuntu/18.04/webassembly --path src/ubuntu/18.04/crossdeps --path src/ubuntu/18.04/cross/arm64/16.04 --path src/ubuntu/18.04/cross/arm64 --path src/ubuntu/18.04/cross/arm-alpine --path src/ubuntu/18.04/cross/x86-linux --path src/ubuntu/18.04/cross/arm64-alpine --path src/ubuntu/18.04/cross/armel-tizen --path src/ubuntu/18.04/cross/s390x --path src/ubuntu/18.04/cross --path src/ubuntu/18.04/cross/arm/16.04 --path src/ubuntu/18.04/cross/freebsd/12 --path src/ubuntu/18.04/cross/illumos --path src/ubuntu/18.04/mlnet/cross/arm --path src/ubuntu/18.04/mlnet/cross/arm64
    bionic:
      legName: linuxamd64bionic
      osType: linux
      architecture: amd64
      osVersions: --os-version bionic
      productVersion: 
      osVariant: bionic
      imageBuilderPaths: --path src/ubuntu/18.04/msquic/amd64
    bionic:
      legName: linuxamd64bionic
      osType: linux
      architecture: amd64
      osVersions: --os-version bionic
      productVersion: 
      osVariant: bionic
      imageBuilderPaths: --path src/ubuntu/18.04/amd64 --path src/ubuntu/18.04/debpkg --path src/ubuntu/18.04/mlnet --path src/ubuntu/18.04/mlnet/helix
    bionic:
      legName: linuxamd64bionic
      osType: linux
      architecture: amd64
      osVersions: --os-version bionic
      productVersion: 
      osVariant: bionic
      imageBuilderPaths: --path src/ubuntu/18.04/helix/amd64 --path src/ubuntu/18.04/helix/sqlserver/amd64
    bionic:
      legName: linuxamd64bionic
      osType: linux
      architecture: amd64
      osVersions: --os-version bionic
      productVersion: 
      osVariant: bionic
      imageBuilderPaths: --path src/ubuntu/18.04/mono/amd64
```

This is the matrix it should be generating:

```
  linuxAmd64:
    src-ubuntu-18.04-coredeps-graph:
      imageBuilderPaths: --path src/ubuntu/18.04/coredeps --path src/ubuntu/18.04/android --path src/ubuntu/18.04/webassembly --path src/ubuntu/18.04/crossdeps --path src/ubuntu/18.04/cross/arm64/16.04 --path src/ubuntu/18.04/cross/arm64 --path src/ubuntu/18.04/cross/arm-alpine --path src/ubuntu/18.04/cross/x86-linux --path src/ubuntu/18.04/cross/arm64-alpine --path src/ubuntu/18.04/cross/armel-tizen --path src/ubuntu/18.04/cross/s390x --path src/ubuntu/18.04/cross --path src/ubuntu/18.04/cross/arm/16.04 --path src/ubuntu/18.04/cross/freebsd/12 --path src/ubuntu/18.04/cross/illumos --path src/ubuntu/18.04/mlnet/cross/arm --path src/ubuntu/18.04/mlnet/cross/arm64
      legName: linuxamd64src-ubuntu-18.04-coredeps-graph
      osType: linux
      architecture: amd64
      osVersions: --os-version bionic
    src-ubuntu-18.04-graph:
      imageBuilderPaths: --path src/ubuntu/18.04/amd64 --path src/ubuntu/18.04/debpkg --path src/ubuntu/18.04/mlnet --path src/ubuntu/18.04/mlnet/helix
      legName: linuxamd64src-ubuntu-18.04-graph
      osType: linux
      architecture: amd64
      osVersions: --os-version bionic
    src-ubuntu-18.04-helix-graph:
      imageBuilderPaths: --path src/ubuntu/18.04/helix/amd64 --path src/ubuntu/18.04/helix/sqlserver/amd64
      legName: linuxamd64src-ubuntu-18.04-helix-graph
      osType: linux
      architecture: amd64
      osVersions: --os-version bionic
    src-ubuntu-18.04-mono:
      imageBuilderPaths: --path src/ubuntu/18.04/mono/amd64
      legName: linuxamd64src-ubuntu-18.04-mono
      osType: linux
      architecture: amd64
      osVersions: --os-version bionic
    src-ubuntu-18.04-msquic:
      imageBuilderPaths: --path src/ubuntu/18.04/msquic/amd64
      legName: linuxamd64src-ubuntu-18.04-msquic
      osType: linux
      architecture: amd64
      osVersions: --os-version bionic
```

As a result of having duplicate build leg names, the last one wins for the matrix expansion in AzDO.  This means the PR build only built the `src/ubuntu/18.04/mono/amd64` Dockerfile.

To fix this, I've updated the pipeline template to allow the matrix type to be set by the consuming pipeline rather than hard-coded to always use platformVersionedOs for public builds.