### PR TITLE
Update .NET SDK version to Current/6.0

### DIFF
--- a/eng/common/Install-DotNetSdk.ps1
+++ b/eng/common/Install-DotNetSdk.ps1
@@ -38,7 +38,7 @@ if (!(Test-Path $DotnetInstallScript)) {
     & "$PSScriptRoot/Invoke-WithRetry.ps1" "Invoke-WebRequest 'https://dot.net/v1/$DotnetInstallScript' -OutFile $InstallPath/$DotnetInstallScript"
 }
 
-$DotnetChannel = "5.0"
+$DotnetChannel = "Current"
 
 $InstallFailed = $false
 if ($IsRunningOnUnix) {
@@ -50,5 +50,8 @@ else {
     & $InstallPath/$DotnetInstallScript -Channel $DotnetChannel -Version "latest" -InstallDir $InstallPath
     $InstallFailed = (-not $?)
 }
+
+# See https://github.com/NuGet/NuGet.Client/pull/4259
+$Env:NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY = "3,1000"
 
 if ($InstallFailed) { throw "Failed to install the .NET Core SDK" }

--- a/eng/src/file-pusher/Dockerfile
+++ b/eng/src/file-pusher/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile is intended to be built at the root of the repo.
 
 # build image
-FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build-env
 
 WORKDIR /file-pusher
 
@@ -16,7 +16,7 @@ RUN dotnet publish -c Release -o out --no-restore
 
 
 # runtime image
-FROM mcr.microsoft.com/dotnet/runtime:5.0-alpine
+FROM mcr.microsoft.com/dotnet/runtime:6.0-alpine
 
 # copy file-pusher
 WORKDIR /file-pusher

--- a/eng/src/file-pusher/file-pusher.csproj
+++ b/eng/src/file-pusher/file-pusher.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>FilePusher</RootNamespace>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>

--- a/eng/src/yaml-updater/Dockerfile
+++ b/eng/src/yaml-updater/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile is intended to be built at the root of the repo.
 
 # build image
-FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build-env
 
 WORKDIR /src
 
@@ -19,7 +19,7 @@ RUN dotnet publish ./yaml-updater/*.csproj -c Release -o out --no-restore
 
 
 # runtime image
-FROM mcr.microsoft.com/dotnet/runtime:5.0-alpine
+FROM mcr.microsoft.com/dotnet/runtime:6.0-alpine
 
 # copy yaml-updater
 WORKDIR /yaml-updater

--- a/eng/src/yaml-updater/yaml-updater.csproj
+++ b/eng/src/yaml-updater/yaml-updater.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>YamlUpdater</RootNamespace>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>

--- a/src/Microsoft.DotNet.ImageBuilder/.dockerignore
+++ b/src/Microsoft.DotNet.ImageBuilder/.dockerignore
@@ -3,5 +3,5 @@
 **/out
 **/.vscode
 **/.vs
-**/Dockerfile.nanoserver
-**/Dockerfile.debian
+**/Dockerfile.windows
+**/Dockerfile.linux

--- a/src/Microsoft.DotNet.ImageBuilder/Dockerfile.linux
+++ b/src/Microsoft.DotNet.ImageBuilder/Dockerfile.linux
@@ -18,11 +18,11 @@ RUN dotnet restore -r linux-musl-$RID_ARCH ./src/Microsoft.DotNet.ImageBuilder.c
 
 # copy everything else and publish
 COPY . ./
-RUN dotnet publish ./src/Microsoft.DotNet.ImageBuilder.csproj -c Release -o out -r linux-musl-$RID_ARCH --no-restore --no-self-contained
+RUN dotnet publish ./src/Microsoft.DotNet.ImageBuilder.csproj -c Release -o out -r linux-musl-$RID_ARCH --no-restore --self-contained
 
 
 # build runtime image
-FROM mcr.microsoft.com/dotnet/runtime:6.0-alpine$ALPINE_TAG_SUFFIX
+FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-alpine$ALPINE_TAG_SUFFIX
 
 ARG MANIFEST_TOOL_ARCH=amd64
 

--- a/src/Microsoft.DotNet.ImageBuilder/Dockerfile.linux
+++ b/src/Microsoft.DotNet.ImageBuilder/Dockerfile.linux
@@ -5,7 +5,7 @@
 ARG ALPINE_TAG_SUFFIX=""
 
 # build Microsoft.DotNet.ImageBuilder
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
 
 ARG RID_ARCH=x64
 
@@ -14,15 +14,15 @@ WORKDIR /image-builder
 # restore packages before copying entire source - provides optimizations when rebuilding
 COPY NuGet.config ./
 COPY src/Microsoft.DotNet.ImageBuilder.csproj ./src/
-RUN dotnet restore -r alpine.3.9-$RID_ARCH ./src/Microsoft.DotNet.ImageBuilder.csproj
+RUN dotnet restore -r linux-musl-$RID_ARCH ./src/Microsoft.DotNet.ImageBuilder.csproj
 
 # copy everything else and publish
 COPY . ./
-RUN dotnet publish ./src/Microsoft.DotNet.ImageBuilder.csproj -c Release -o out -r alpine.3.9-$RID_ARCH --no-restore /p:ShowLinkerSizeComparison=true
+RUN dotnet publish ./src/Microsoft.DotNet.ImageBuilder.csproj -c Release -o out -r linux-musl-$RID_ARCH --no-restore --no-self-contained
 
 
 # build runtime image
-FROM mcr.microsoft.com/dotnet/runtime-deps:5.0-alpine$ALPINE_TAG_SUFFIX
+FROM mcr.microsoft.com/dotnet/runtime:6.0-alpine$ALPINE_TAG_SUFFIX
 
 ARG MANIFEST_TOOL_ARCH=amd64
 

--- a/src/Microsoft.DotNet.ImageBuilder/Dockerfile.windows
+++ b/src/Microsoft.DotNet.ImageBuilder/Dockerfile.windows
@@ -13,7 +13,7 @@ RUN dotnet restore -r win-x64 ./src/Microsoft.DotNet.ImageBuilder.csproj
 
 # copy everything else and publish
 COPY . ./
-RUN dotnet publish ./src/Microsoft.DotNet.ImageBuilder.csproj -c Release -o out -r win-x64 --no-restore --no-self-contained
+RUN dotnet publish ./src/Microsoft.DotNet.ImageBuilder.csproj -c Release -o out -r win-x64 --no-restore --self-contained
 
 RUN pwsh -Command `
         $ErrorActionPreference = 'Stop'; `
@@ -24,7 +24,7 @@ RUN pwsh -Command `
             -OutFile out/manifest-tool.exe;
 
 # build runtime image
-FROM mcr.microsoft.com/dotnet/runtime:6.0
+FROM mcr.microsoft.com/windows/$WINDOWS_BASE
 WORKDIR /image-builder
 COPY --from=build-env /image-builder/out ./
 

--- a/src/Microsoft.DotNet.ImageBuilder/Dockerfile.windows
+++ b/src/Microsoft.DotNet.ImageBuilder/Dockerfile.windows
@@ -3,17 +3,17 @@
 ARG WINDOWS_BASE
 
 # build Microsoft.DotNet.ImageBuilder
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
 WORKDIR /image-builder
 
 # restore packages before copying entire source - provides optimizations when rebuilding
 COPY NuGet.config ./
 COPY src/Microsoft.DotNet.ImageBuilder.csproj ./src/
-RUN dotnet restore -r win7-x64 ./src/Microsoft.DotNet.ImageBuilder.csproj
+RUN dotnet restore -r win-x64 ./src/Microsoft.DotNet.ImageBuilder.csproj
 
 # copy everything else and publish
 COPY . ./
-RUN dotnet publish ./src/Microsoft.DotNet.ImageBuilder.csproj -c Release -o out -r win7-x64 --no-restore
+RUN dotnet publish ./src/Microsoft.DotNet.ImageBuilder.csproj -c Release -o out -r win-x64 --no-restore --no-self-contained
 
 RUN pwsh -Command `
         $ErrorActionPreference = 'Stop'; `
@@ -24,6 +24,8 @@ RUN pwsh -Command `
             -OutFile out/manifest-tool.exe;
 
 # build runtime image
-FROM mcr.microsoft.com/windows/$WINDOWS_BASE
+FROM mcr.microsoft.com/dotnet/runtime:6.0
 WORKDIR /image-builder
 COPY --from=build-env /image-builder/out ./
+
+ENTRYPOINT ["/image-builder/Microsoft.DotNet.ImageBuilder"]

--- a/src/Microsoft.DotNet.ImageBuilder/manifest.json
+++ b/src/Microsoft.DotNet.ImageBuilder/manifest.json
@@ -66,18 +66,6 @@
             },
             {
               "buildArgs": {
-                "WINDOWS_BASE": "nanoserver:2004-amd64"
-              },
-              "dockerfile": "Dockerfile.windows",
-              "os": "windows",
-              "osVersion": "nanoserver-2004",
-              "tags": {
-                "nanoserver-2004-amd64": {},
-                "nanoserver-2004-amd64-$(UniqueId)": {}
-              }
-            },
-            {
-              "buildArgs": {
                 "WINDOWS_BASE": "nanoserver:20H2-amd64"
               },
               "dockerfile": "Dockerfile.windows",

--- a/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <PublishTrimmed>False</PublishTrimmed>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Microsoft.DotNet.ImageBuilder</RootNamespace>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.ImageBuilder/tests/Microsoft.DotNet.ImageBuilder.Tests.csproj
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/Microsoft.DotNet.ImageBuilder.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
This also applies a [workaround to NuGet restore errors](https://github.com/NuGet/NuGet.Client/pull/4259) that have been showing up in builds.