### PR TITLE
Track components of built images

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -183,8 +183,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     .Split(Environment.NewLine)
                     .Select(val =>
                     {
-                        string[] pkgVersion = val.Split(new char[] { ',', '=' });
-                        return new Component(type: pkgVersion[0], name: pkgVersion[1], version: pkgVersion[2]);
+                        string[] pkgInfo = val.Split(new char[] { ',', '=' });
+                        return new Component(type: pkgInfo[0], name: pkgInfo[1], version: pkgInfo[2]);
                     })
                     .ToList();
             }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
@@ -22,6 +22,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public string? SourceRepoUrl { get; set; }
         public bool NoCache { get; set; }
         public string? SourceRepoPrefix { get; set; }
+        public string? GetInstalledPackagesScriptPath { get; set; }
     }
 
     public class BuildOptionsBuilder : DockerRegistryOptionsBuilder
@@ -51,6 +52,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                             "Disables build cache feature"),
                         CreateOption<string?>("source-repo-prefix", nameof(BuildOptions.SourceRepoPrefix),
                             "Prefix to add to the external base image names when pulling them"),
+                        CreateOption<string?>("get-installed-pkgs-path", nameof(BuildOptions.GetInstalledPackagesScriptPath),
+                            "Path to the default script file that outputs list of installed packages"),
                     });
 
         public override IEnumerable<Argument> GetCliArguments() =>

--- a/src/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
@@ -9,37 +9,38 @@ using System.Text;
 using Polly;
 using Polly.Contrib.WaitAndRetry;
 
+#nullable enable
 namespace Microsoft.DotNet.ImageBuilder
 {
     public static class ExecuteHelper
     {
         private static readonly ILoggerService s_loggerService = new LoggerService();
 
-        public static string Execute(
+        public static string? Execute(
             string fileName,
             string args,
             bool isDryRun,
-            string errorMessage = null,
-            string executeMessageOverride = null)
+            string? errorMessage = null,
+            string? executeMessageOverride = null)
         {
             return Execute(new ProcessStartInfo(fileName, args), isDryRun, errorMessage, executeMessageOverride);
         }
 
-        public static string Execute(
+        public static string? Execute(
             ProcessStartInfo info,
             bool isDryRun,
-            string errorMessage = null,
-            string executeMessageOverride = null)
+            string? errorMessage = null,
+            string? executeMessageOverride = null)
         {
             return Execute(info, info => ExecuteProcess(info), isDryRun, errorMessage, executeMessageOverride);
         }
 
-        public static string ExecuteWithRetry(
+        public static string? ExecuteWithRetry(
             string fileName,
             string args,
             bool isDryRun,
-            string errorMessage = null,
-            string executeMessageOverride = null)
+            string? errorMessage = null,
+            string? executeMessageOverride = null)
         {
             return ExecuteWithRetry(
                 new ProcessStartInfo(fileName, args),
@@ -49,12 +50,12 @@ namespace Microsoft.DotNet.ImageBuilder
             );
         }
 
-        public static string ExecuteWithRetry(
+        public static string? ExecuteWithRetry(
             ProcessStartInfo info,
-            Action<Process> processStartedCallback = null,
+            Action<Process>? processStartedCallback = null,
             bool isDryRun = false,
-            string errorMessage = null,
-            string executeMessageOverride = null)
+            string? errorMessage = null,
+            string? executeMessageOverride = null)
         {
             return Execute(
                 info,
@@ -65,16 +66,16 @@ namespace Microsoft.DotNet.ImageBuilder
             );
         }
 
-        private static string Execute(
+        private static string? Execute(
             ProcessStartInfo info,
             Func<ProcessStartInfo, ProcessResult> executor,
             bool isDryRun,
-            string errorMessage = null,
-            string executeMessageOverride = null)
+            string? errorMessage = null,
+            string? executeMessageOverride = null)
         {
             info.RedirectStandardError = true;
 
-            ProcessResult processResult = null;
+            ProcessResult? processResult = null;
 
             if (executeMessageOverride == null)
             {
@@ -104,7 +105,7 @@ namespace Microsoft.DotNet.ImageBuilder
             return processResult?.StandardOutput;
         }
 
-        private static ProcessResult ExecuteProcess(ProcessStartInfo info, Action<Process> processStartedCallback = null)
+        private static ProcessResult ExecuteProcess(ProcessStartInfo info, Action<Process>? processStartedCallback = null)
         {
             info.RedirectStandardOutput = true;
             info.RedirectStandardError = true;
@@ -119,7 +120,7 @@ namespace Microsoft.DotNet.ImageBuilder
             {
                 return new DataReceivedEventHandler((sender, e) =>
                 {
-                    string line = e.Data;
+                    string? line = e.Data;
                     if (line != null)
                     {
                         stringBuilder.AppendLine(line);
@@ -170,3 +171,4 @@ namespace Microsoft.DotNet.ImageBuilder
         }
     }
 }
+#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/IProcessService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/IProcessService.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+#nullable enable
+namespace Microsoft.DotNet.ImageBuilder
+{
+    public interface IProcessService
+    {
+        string? Execute(string fileName, string args, bool isDryRun, string? errorMessage = null, string? executeMessageOverride = null);
+
+        string? Execute(ProcessStartInfo info, bool isDryRun, string? errorMessage = null, string? executeMessageOverride = null);
+    }
+}
+#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
@@ -201,6 +201,10 @@ namespace Microsoft.DotNet.ImageBuilder
                 {
                     MergePropertyData(srcObj, targetObj, property, options);
                 }
+                else if (typeof(IList<Component>).IsAssignableFrom(property.PropertyType))
+                {
+                    MergeLists<Component>(property, srcObj, targetObj, options);
+                }
                 else
                 {
                     throw new NotSupportedException($"Unsupported model property type: '{property.PropertyType.FullName}'");

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/Component.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/Component.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+#nullable enable
+namespace Microsoft.DotNet.ImageBuilder.Models.Image
+{
+    public class Component : IComparable<Component>
+    {
+        public string Name {  get; }
+        public string Version { get; }
+        public string Type { get; }
+
+        public Component(string type, string name, string version)
+        {
+            Type = type;
+            Name = name;
+            Version = version;
+        }
+
+        public int CompareTo([AllowNull] Component other)
+        {
+            if (other is null)
+            {
+                return 1;
+            }
+
+            return ToString().CompareTo(other.ToString());
+        }
+
+        public override string ToString() => $"{Type}:{Name}={Version}";
+    }
+}
+#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/PlatformData.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Image/PlatformData.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Image
         [JsonProperty(Required = Required.Always)]
         public string Dockerfile { get; set; } = string.Empty;
 
-        public List<string> SimpleTags { get; set; } = new List<string>();
+        public List<string> SimpleTags { get; set; } = new();
 
         [JsonProperty(Required = Required.Always)]
         public string Digest { get; set; } = string.Empty;
@@ -49,7 +49,9 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Image
         [JsonProperty(Required = Required.Always)]
         public string CommitUrl { get; set; } = string.Empty;
 
-        public List<string> Layers { get; set; } = new List<string>();
+        public List<string> Layers { get; set; } = new();
+
+        public List<Component> Components { get; set; } = new();
 
         /// <summary>
         /// Gets or sets whether the image or its associated tag names have changed since it was last published.

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/PackageQueryInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/PackageQueryInfo.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+using System.ComponentModel;
+
+namespace Microsoft.DotNet.ImageBuilder.Models.Manifest
+{
+    [Description(
+        "Relative path to the template the Dockerfile is generated from."
+    )]
+    public class PackageQueryInfo
+    {
+        [Description(
+            "Relative path from the manifest file to the script which queries the packages installed for a platform Dockerfile."
+            )]
+        public string? GetInstalledPackagesPath { get; set; }
+
+        [Description(
+            "Relative path from the manifest file to the script which queries the packages available for upgrade for a platform Dockerfile."
+            )]
+        public string? GetUpgradablePackagesPath { get; set; }
+    }
+}
+#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/Platform.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/Platform.cs
@@ -67,6 +67,11 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Manifest
         public CustomBuildLegGroup[] CustomBuildLegGroups { get; set; } = Array.Empty<CustomBuildLegGroup>();
 
         [Description(
+            "Overrides the default script paths for querying package info."
+            )]
+        public PackageQueryInfo? PackageQueryOverrides { get; set; }
+
+        [Description(
             "A label which further distinguishes the architecture when it " +
             "contains variants. For example, the ARM architecture has variants " +
             "named v6, v7, etc."

--- a/src/Microsoft.DotNet.ImageBuilder/src/ProcessService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ProcessService.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel.Composition;
+using System.Diagnostics;
+
+#nullable enable
+namespace Microsoft.DotNet.ImageBuilder
+{
+    [Export(typeof(IProcessService))]
+    public class ProcessService : IProcessService
+    {
+        public string? Execute(
+            string fileName, string args, bool isDryRun, string? errorMessage = null, string? executeMessageOverride = null) =>
+            ExecuteHelper.Execute(fileName, args, isDryRun, errorMessage, executeMessageOverride);
+
+        public string? Execute(
+            ProcessStartInfo info, bool isDryRun, string? errorMessage = null, string? executeMessageOverride = null) =>
+            ExecuteHelper.Execute(info, isDryRun, errorMessage, executeMessageOverride);
+    }
+}
+#nullable disable


### PR DESCRIPTION
These changes allow the components installed within built images to be tracked within the image info file. The word "component" used here is intended to be general purpose name to refer to any versioned thing that we want to track in the image. For now, only Linux packages will be tracked.

This consumes the scripts added by https://github.com/dotnet/docker-tools/pull/824 in order to get the list of packages and versions that are in the image. By default, it uses the script defined in that PR. But an option is available for a custom script to be used for certain Dockerfiles. This accounts for the distroless scenario where it's not possible to execute the commands within the container that are done for regular containers. Each distroless Dockerfile can be associated with its own custom script that can be used to retrieve the packages that are installed.

The downside to storing these components in the image info file, particularly as an array, is the amount of vertical space the text file has for each entry. There are a lot of components installed for some images so the list is lengthy.

Related to https://github.com/dotnet/dotnet-docker/issues/1455