### PR TITLE
Use Alpine RID

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/Dockerfile.linux
+++ b/src/Microsoft.DotNet.ImageBuilder/Dockerfile.linux
@@ -8,17 +8,19 @@ ARG ALPINE_TAG_SUFFIX=""
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
 
 ARG RID_ARCH=x64
+# The rid must be version-specific to workaround a libgit2sharp issue (see https://github.com/dotnet/dotnet-docker/pull/2111)
+ARG RID=alpine.3.14-${RID_ARCH}
 
 WORKDIR /image-builder
 
 # restore packages before copying entire source - provides optimizations when rebuilding
 COPY NuGet.config ./
 COPY src/Microsoft.DotNet.ImageBuilder.csproj ./src/
-RUN dotnet restore -r linux-musl-$RID_ARCH ./src/Microsoft.DotNet.ImageBuilder.csproj
+RUN dotnet restore -r $RID ./src/Microsoft.DotNet.ImageBuilder.csproj
 
 # copy everything else and publish
 COPY . ./
-RUN dotnet publish ./src/Microsoft.DotNet.ImageBuilder.csproj -c Release -o out -r linux-musl-$RID_ARCH --no-restore --self-contained
+RUN dotnet publish ./src/Microsoft.DotNet.ImageBuilder.csproj -c Release -o out -r $RID --no-restore --self-contained
 
 
 # build runtime image


### PR DESCRIPTION
This fixes a change that was made in https://github.com/dotnet/docker-tools/pull/895 which set the RID to `linux-musl`. This causes the `publishImageInfo` command to fail because of an [issue with libgit2sharp](https://github.com/dotnet/dotnet-docker/pull/2111) that requires access to native DLLs. These native DLLs are only provided when using a versioned RID.