### PR TITLE
Revert pipeline changes

### DIFF
--- a/eng/pipelines/check-base-image-updates.yml
+++ b/eng/pipelines/check-base-image-updates.yml
@@ -100,7 +100,6 @@ stages:
         $(System.AccessToken)
         dnceng
         internal
-        $(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)
         --git-token '$(BotAccount-dotnet-docker-bot-PAT)'
         --git-owner 'dotnet'
         --git-repo '$(internalGitHubRepo)'
@@ -109,6 +108,5 @@ stages:
         --image-paths "$(imagePaths2)"
         --image-paths "$(imagePaths3)"
         --image-paths "$(imagePaths4)"
-        --enable-upgradable-pkgs:$(enableUpgradablePackagesForRebuild)
       displayName: Queue Build for Stale Images
     - template: ../common/templates/steps/cleanup-docker-linux.yml

--- a/eng/pipelines/templates/steps/get-stale-images.yml
+++ b/eng/pipelines/templates/steps/get-stale-images.yml
@@ -13,8 +13,6 @@ steps:
       $(dotnetDockerBot.email)
       $(BotAccount-dotnet-docker-bot-PAT)
       ${{ parameters.staleImagePathsVariableName }}
-      $(engPath)/get-installed-packages.sh
-      $(engPath)/get-upgradable-packages.sh
       --subscriptions-path ${{ parameters.subscriptionsPath }}
       --os-type ${{ parameters.osType }}
       --architecture ${{ parameters.architecture }}


### PR DESCRIPTION
Reverts pipeline changes made in https://github.com/dotnet/docker-tools/pull/824. These changes were never intended to be part of that PR. They were used for testing a scenario but they require dependent changes that don't exist yet in Image Builder.