### PR TITLE
Add display name for Ubuntu 21.10

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
@@ -206,6 +206,10 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
                 {
                     displayName = "Ubuntu 21.04";
                 }
+                else if (os.Contains("impish"))
+                {
+                    displayName = "Ubuntu 21.10";
+                }
                 else if (os.Contains("alpine") || os.Contains("centos") || os.Contains("fedora"))
                 {
                     displayName = FormatVersionableOsName(os, name => name.FirstCharToUpper());


### PR DESCRIPTION
Allows `impish` OS version in manifest to be translated to a display name of `Ubuntu 21.10`.