### PR TITLE
Handle images with non-default entrypoint

### DIFF
--- a/eng/common/package-scripts/get-installed-packages.sh
+++ b/eng/common/package-scripts/get-installed-packages.sh
@@ -6,4 +6,4 @@ imageTag=$1
 dockerfilePath=$2
 scriptDir=$(dirname $(realpath $0))
 
-docker run --rm -i $imageTag /bin/sh < $scriptDir/get-installed-packages.container.sh
+docker run --rm --entrypoint /bin/sh -i $imageTag < $scriptDir/get-installed-packages.container.sh

--- a/eng/common/package-scripts/get-upgradable-packages.sh
+++ b/eng/common/package-scripts/get-upgradable-packages.sh
@@ -13,7 +13,7 @@ scriptDir="$(dirname $(realpath $0))"
 containerName="$(uuidgen)"
 containerOutputPath="/$containerName.txt"
 
-docker run --name $containerName -v $scriptDir:/scripts $imageTag /bin/sh -c "/scripts/get-upgradable-packages.container.sh $containerOutputPath $packagelist"
+docker run --name $containerName -v $scriptDir:/scripts --entrypoint /bin/sh $imageTag -c "/scripts/get-upgradable-packages.container.sh $containerOutputPath $packagelist"
 
 docker cp $containerName:$containerOutputPath $outputPath
 docker rm $containerName 1>/dev/null


### PR DESCRIPTION
When attempting to run the package scripts against the .NET Monitor image it doesn't work because the entrypoint of that image is the `dotnet-monitor` executable. So passing the script path to it via the `docker run` command isn't going to execute the script. 

I've updated the scripts to override the entrypoint so that the scripts will be executed.