### PR TITLE
Pkg scripts support for custom pkg manager args

### DIFF
--- a/eng/common/package-scripts/Dockerfile.scripts
+++ b/eng/common/package-scripts/Dockerfile.scripts
@@ -1,0 +1,3 @@
+ARG BASETAG
+FROM $BASETAG
+COPY . /scripts

--- a/eng/common/package-scripts/get-installed-packages.sh
+++ b/eng/common/package-scripts/get-installed-packages.sh
@@ -2,8 +2,50 @@
 
 # This is the main script for retrieving the list of installed packages.
 
+usage() {
+    echo "Usage: $0 [<OPTIONS>...] IMAGETAG DOCKERFILEPATH"
+    echo
+    echo "Queries a container to determine which packages are installed"
+    echo 
+    echo "Options:"
+    echo "  -h: Print this help message"
+    echo "  -a: Additional package manager arg"
+    echo "Arguments:"
+    echo "  IMAGETAG: The tag of the image to query"
+    echo "  DOCKERFILEPATH: The path to the image's Dockerfile"
+}
+
+while getopts "ha:o:" opt; do
+    case $opt in
+        h)
+            usage
+            exit 0
+            ;;
+        a)
+            pkgManagerArgs=$OPTARG
+            shift 2
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            usage
+            exit 1
+            ;;
+        :)
+            echo "Option -$OPTARG requires an argument." >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
 imageTag=$1
 dockerfilePath=$2
 scriptDir=$(dirname $(realpath $0))
 
-docker run --rm --entrypoint /bin/sh -i $imageTag < $scriptDir/get-installed-packages.container.sh
+docker run \
+    --rm \
+    -i \
+    -e PKG_MANAGER_ARGS="$pkgManagerArgs" \
+    --entrypoint /bin/sh \
+    $imageTag \
+    < $scriptDir/get-installed-packages.container.sh

--- a/eng/common/package-scripts/get-installed-packages.sh
+++ b/eng/common/package-scripts/get-installed-packages.sh
@@ -9,7 +9,7 @@ usage() {
     echo 
     echo "Options:"
     echo "  -h: Print this help message"
-    echo "  -a: Additional package manager arg"
+    echo "  -a: Additional package manager args"
     echo "Arguments:"
     echo "  IMAGETAG: The tag of the image to query"
     echo "  DOCKERFILEPATH: The path to the image's Dockerfile"

--- a/eng/common/package-scripts/get-upgradable-packages.container.sh
+++ b/eng/common/package-scripts/get-upgradable-packages.container.sh
@@ -13,6 +13,12 @@ ensureBashInstalledForApk() {
     apk add bash 1>/dev/null
 }
 
+ensureBashInstalledForDnf() {
+    echo "Ensuring bash is installed"
+    dnf makecache 1>/dev/null
+    dnf install -y bash 1>/dev/null
+}
+
 ensureBashInstalledForTdnf() {
     echo "Ensuring bash is installed"
     tdnf makecache 1>/dev/null
@@ -22,6 +28,11 @@ ensureBashInstalledForTdnf() {
 
 
 scriptDir=$(dirname $0)
+
+outputPath="$1"
+pkgManagerArgs="$2"
+shift 2
+packages=$@
 
 if type apt > /dev/null 2>/dev/null; then
     ensureBashInstalledForApt
@@ -35,9 +46,15 @@ if type apk > /dev/null 2>/dev/null; then
     exit 0
 fi
 
+if type dnf > /dev/null 2>/dev/null; then
+    ensureBashInstalledForDnf
+    $scriptDir/get-upgradable-packages.container.bash.sh $@
+    exit 0
+fi
+
 if type tdnf > /dev/null 2>/dev/null; then
     ensureBashInstalledForTdnf
-    $scriptDir/get-upgradable-packages.container.bash.sh $@
+    $scriptDir/get-upgradable-packages.container.bash.sh $outputPath "$pkgManagerArgs" $packages
     exit 0
 fi
 

--- a/eng/common/package-scripts/get-upgradable-packages.sh
+++ b/eng/common/package-scripts/get-upgradable-packages.sh
@@ -9,7 +9,7 @@ usage() {
     echo 
     echo "Options:"
     echo "  -h: Print this help message"
-    echo "  -a: Additional package manager arg"
+    echo "  -a: Additional package manager args"
     echo "  -o: Output path for a formatted list of upgradable packages"
     echo "Arguments:"
     echo "  IMAGETAG: The tag of the image to query"

--- a/eng/common/package-scripts/get-upgradable-packages.sh
+++ b/eng/common/package-scripts/get-upgradable-packages.sh
@@ -2,18 +2,68 @@
 
 # This is the main script for retrieving the list of upgradable packages.
 
+usage() {
+    echo "Usage: $0 [<OPTIONS>...] IMAGETAG DOCKERFILEPATH [PACKAGEVERSION...]"
+    echo
+    echo "Queries a container to determine which packages are upgradable"
+    echo 
+    echo "Options:"
+    echo "  -h: Print this help message"
+    echo "  -a: Additional package manager arg"
+    echo "  -o: Output path for a formatted list of upgradable packages"
+    echo "Arguments:"
+    echo "  IMAGETAG: The tag of the image to query"
+    echo "  DOCKERFILEPATH: The path to the image's Dockerfile"
+    echo "  PACKAGEVERSION: A package version to check whether its upgradable (format: NAME=VERSION)"
+}
+
+while getopts "ha:o:" opt; do
+    case $opt in
+        h)
+            usage
+            exit 0
+            ;;
+        a)
+            pkgManagerArgs=$OPTARG
+            shift 2
+            ;;
+        o)
+            outputPath=$OPTARG
+            shift 2
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            usage
+            exit 1
+            ;;
+        :)
+            echo "Option -$OPTARG requires an argument." >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
 imageTag=$1
 dockerfilePath=$2
-outputPath=$3
-
 shift 3
 packagelist=$@
 
 scriptDir="$(dirname $(realpath $0))"
-containerName="$(uuidgen)"
+containerName="container-$RANDOM"
 containerOutputPath="/$containerName.txt"
 
-docker run --name $containerName -v $scriptDir:/scripts --entrypoint /bin/sh $imageTag -c "/scripts/get-upgradable-packages.container.sh $containerOutputPath $packagelist"
+scriptsWrapperImageTag="tag-$RANDOM"
+docker build -t $scriptsWrapperImageTag -f $scriptDir/Dockerfile.scripts --build-arg BASETAG=$imageTag $scriptDir 1>/dev/null 2>/dev/null
 
-docker cp $containerName:$containerOutputPath $outputPath
+docker run \
+    --name $containerName \
+    --entrypoint /bin/sh \
+    $scriptsWrapperImageTag \
+    -c "/scripts/get-upgradable-packages.container.sh $containerOutputPath \"$pkgManagerArgs\" $packagelist"
+
+if [ -n "$outputPath" ]; then
+    docker cp $containerName:$containerOutputPath $outputPath
+fi
+
 docker rm $containerName 1>/dev/null


### PR DESCRIPTION
In order to support querying packages of distroless containers, custom package scripts need to be implemented rather than using the common scripts defined here. But in order to allow for reusability of the logic in these common scripts, they need the ability to allow the caller to pass custom arguments for the package manager. As an example, for distroless scenarios for CBL-Mariner, the custom args needed to pass to the dnf package manager would be `--releasever=$version --installroot /staging`. This allows the logic to target a specific install root location for querying the packages.

These changes update the scripts to support custom package manager args.

In addition, support for the dnf package manager was added because the CBL-Mariner distroless scripts also require the use of that package manager.

There was also an issue discovered with the `get-upgradable-packages.sh` script that prevent it from running properly within Image Builder due to the nested containers. The original implementation used volume mounting to provide access to the scripts within the container. This doesn't work when running within the Image Builder container because the source location of volume mounts must be from the host, even when running in a nested container. To work around this issue, the logic has been updated to build a derivative image which contains the scripts rather than relying on volume mounting.