### PR TITLE
Fix image caching regression

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -360,10 +360,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     if (isCachedImage)
                     {
                         CopyPlatformDataFromCachedPlatform(platformData, srcPlatformData);
+                        _cachedPlatforms[cacheKey] = srcPlatformData;
                     }
                 }
-
-                _cachedPlatforms[cacheKey] = srcPlatformData;
             }
 
             return isCachedImage;


### PR DESCRIPTION
A regression was introduced by #897 that causes builds to fail when a cache miss occurs on a shared Dockerfile. The first platform that references the Dockerfile is correctly built. When the second platform that references the same Dockerfile is processed, it ends up executing the "cache hit" code path, attempting to tag an image by digest value that doesn't exist locally. This results in an error. For example:

```
-- EXECUTING: docker tag mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:ecfdfda7ca93e02c4a8e2c54eabe7ee81363019164dac9f8518f3b4eefdf7e45 dotnetdocker.azurecr.io/build-staging/1493853/dotnet/nightly/runtime-deps:5.0-bullseye-slim
Error response from daemon: No such image: mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:ecfdfda7ca93e02c4a8e2c54eabe7ee81363019164dac9f8518f3b4eefdf7e45
```

The code change which caused the regression moved the adding of an entry to the `_cachedPlatforms` dictionary to occur outside of cache hits. That dictionary should only be set for images which are pulled as cached images. In this scenario, an entry was added to the dictionary for the first platform that referenced the shared Dockerfile even though it wasn't pulled as a cached image; it was rebuilt locally. So when the second platform was processed, it incorrectly behaved liked the image had been pulled as a cached image and assumed its digest was the same as the one defined in the image info file. But it had never been pulled so the digest didn't exist locally.

The fix for this is to simply move the line where the entry is added to the dictionary so that it is only done so when the image is processed as a cached image. I've added a unit test to verify this scenario.
