### PR TITLE
Fix merging of platform data that contains components

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
@@ -148,7 +148,10 @@ namespace Microsoft.DotNet.ImageBuilder
                     property.PropertyType == typeof(DateTime) ||
                     property.PropertyType == typeof(bool))
                 {
-                    property.SetValue(targetObj, property.GetValue(srcObj));
+                    if (property.CanWrite)
+                    {
+                        property.SetValue(targetObj, property.GetValue(srcObj));
+                    }
                 }
                 else if (typeof(IDictionary).IsAssignableFrom(property.PropertyType))
                 {

--- a/src/Microsoft.DotNet.ImageBuilder/tests/MergeImageInfoFilesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/MergeImageInfoFilesCommandTests.cs
@@ -30,6 +30,23 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 string repo4Image2Dockerfile = CreateDockerfile("1.0/repo4/os2", context);
                 string repo4Image3Dockerfile = CreateDockerfile("1.0/repo4/os3", context);
 
+                PlatformData platform1 = CreatePlatform(
+                    repo2Image1Dockerfile,
+                    simpleTags: new List<string>
+                    {
+                        "tag3"
+                    });
+                platform1.Components.Add(new Component("DEB", "pkg", "1.0"));
+
+                PlatformData platform2 = CreatePlatform(
+                    repo2Image1Dockerfile,
+                    simpleTags: new List<string>
+                    {
+                        "tag1"
+                    },
+                    baseImageDigest: "base1hash");
+                platform2.Components.Add(new Component("DEB", "pkg", "1.0"));
+
                 List<ImageArtifactDetails> imageArtifactDetailsList = new List<ImageArtifactDetails>
                 {
                     new ImageArtifactDetails
@@ -49,12 +66,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     {
                                         Platforms =
                                         {
-                                            CreatePlatform(
-                                                repo2Image1Dockerfile,
-                                                simpleTags: new List<string>
-                                                {
-                                                    "tag3"
-                                                })
+                                            platform1
                                         },
                                         ProductVersion = "1.0"
                                     },
@@ -107,13 +119,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     {
                                         Platforms =
                                         {
-                                            CreatePlatform(
-                                                repo2Image1Dockerfile,
-                                                simpleTags: new List<string>
-                                                {
-                                                    "tag1"
-                                                },
-                                                baseImageDigest: "base1hash")
+                                            platform2
                                         },
                                         ProductVersion = "1.0"
                                     },
@@ -223,6 +229,16 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 string resultsContent = File.ReadAllText(command.Options.DestinationImageInfoPath);
                 ImageArtifactDetails actual = JsonConvert.DeserializeObject<ImageArtifactDetails>(resultsContent);
 
+                PlatformData expectedPlatform = CreatePlatform(
+                    repo2Image1Dockerfile,
+                    simpleTags: new List<string>
+                    {
+                        "tag1",
+                        "tag3"
+                    },
+                    baseImageDigest: "base1hash");
+                expectedPlatform.Components.Add(new Component("DEB", "pkg", "1.0"));
+
                 ImageArtifactDetails expected = new ImageArtifactDetails
                 {
                     Repos =
@@ -240,14 +256,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                 {
                                     Platforms =
                                     {
-                                        CreatePlatform(
-                                            repo2Image1Dockerfile,
-                                            simpleTags: new List<string>
-                                            {
-                                                "tag1",
-                                                "tag3"
-                                            },
-                                            baseImageDigest: "base1hash")
+                                        expectedPlatform
                                     },
                                     ProductVersion = "1.0"
                                 },


### PR DESCRIPTION
The changes from https://github.com/dotnet/docker-tools/pull/897 have an issue when image info files get merged by the `mergeImageInfo` command. If a platform containing a component gets merged with another platform containing the same component, it results in the following error:

```
Unhandled exception: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
 ---> System.ArgumentException: Property set method not found.
   at System.Reflection.RuntimePropertyInfo.SetValue(Object obj, Object value, BindingFlags invokeAttr, Binder binder, Object[] index, CultureInfo culture)
   at System.Reflection.RuntimePropertyInfo.SetValue(Object obj, Object value, Object[] index)
   at Microsoft.DotNet.ImageBuilder.ImageInfoHelper.MergeData(Object srcObj, Object targetObj, ImageInfoMergeOptions options) in /image-builder/src/ImageInfoHelper.cs:line 147
   at Microsoft.DotNet.ImageBuilder.ImageInfoHelper.MergeLists[T](PropertyInfo property, Object srcObj, Object targetObj, ImageInfoMergeOptions options) in /image-builder/src/ImageInfoHelper.cs:line 277
   at Microsoft.DotNet.ImageBuilder.ImageInfoHelper.MergeData(Object srcObj, Object targetObj, ImageInfoMergeOptions options) in /image-builder/src/ImageInfoHelper.cs:line 206
   at Microsoft.DotNet.ImageBuilder.ImageInfoHelper.MergeLists[T](PropertyInfo property, Object srcObj, Object targetObj, ImageInfoMergeOptions options) in /image-builder/src/ImageInfoHelper.cs:line 277
   at Microsoft.DotNet.ImageBuilder.ImageInfoHelper.MergeData(Object srcObj, Object targetObj, ImageInfoMergeOptions options) in /image-builder/src/ImageInfoHelper.cs:line 194
   at Microsoft.DotNet.ImageBuilder.ImageInfoHelper.MergeLists[T](PropertyInfo property, Object srcObj, Object targetObj, ImageInfoMergeOptions options) in /image-builder/src/ImageInfoHelper.cs:line 277
   at Microsoft.DotNet.ImageBuilder.ImageInfoHelper.MergeData(Object srcObj, Object targetObj, ImageInfoMergeOptions options) in /image-builder/src/ImageInfoHelper.cs:line 190
   at Microsoft.DotNet.ImageBuilder.ImageInfoHelper.MergeLists[T](PropertyInfo property, Object srcObj, Object targetObj, ImageInfoMergeOptions options) in /image-builder/src/ImageInfoHelper.cs:line 277
   at Microsoft.DotNet.ImageBuilder.ImageInfoHelper.MergeData(Object srcObj, Object targetObj, ImageInfoMergeOptions options) in /image-builder/src/ImageInfoHelper.cs:line 198
   at Microsoft.DotNet.ImageBuilder.Commands.MergeImageInfoCommand.ExecuteAsync() in /image-builder/src/Commands/MergeImageInfoCommand.cs:line 38
   at Microsoft.DotNet.ImageBuilder.Commands.Command`2.<GetCliCommand>b__9_0(TOptions options) in /image-builder/src/Commands/Command.TOptions.cs:line 46
```

This happens because the logic assumes that a data class should have its scalar properties writable in order to merge the data between two objects. In this case, the data class is `Component` which is immutable. There is no need to merge it because it only equates to another `Component` if _all_ of their properties are equal. So a merge in that case would be a no-op anyway.

I've updated the logic to only set properties that are writable during the merge process.