### PR TITLE
Add support to include repos from other manifest files

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/Manifest.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/Manifest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 
@@ -41,7 +42,7 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Manifest
         [Description(
             "The set of Docker repositories described by this manifest."
             )]
-        public Repo[] Repos { get; set; }
+        public Repo[] Repos { get; set; } = Array.Empty<Repo>();
 
         [Description(
             "A set of custom variables that can be referenced in various parts of the " +
@@ -51,7 +52,7 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Manifest
             "dynamically override the value of these variables. Variables may be " +
             "referenced in other parts of the manifest by using the following syntax: " +
             "$(_VariableName_).")]
-        public IDictionary<string, string> Variables { get; set; }
+        public IDictionary<string, string> Variables { get; set; } = new Dictionary<string, string>();
 
         public Manifest()
         {

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
@@ -178,8 +178,6 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
                     model.Variables = new Dictionary<string, string>();
                 }
 
-                // Limitation:  Includes only support variables at this time based on usage needs.
-                // There is nothing that prevents expanding this to support other metadata.
                 foreach (string includePath in model.Includes)
                 {
                     ModelExtensions.ValidateFileReference(includePath, manifestDirectory);
@@ -195,6 +193,8 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 
                         model.Variables.Add(kvp.Key, kvp.Value);
                     }
+
+                    model.Repos = model.Repos.Concat(includeModel.Repos).ToArray();
                 }
             }
 


### PR DESCRIPTION
This allows a large manifest file to be broken apart so that repos can be defined in separate sub-manifest files.