### PR TITLE
Consolidate repos that share a name

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
@@ -215,17 +215,19 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
                 .Where(prop => prop.Name != nameof(Repo.Images));
             foreach (PropertyInfo property in propertiesToValidate)
             {
-                List<string> distinctPropertyValues = grouping
+                List<string> distinctNonEmptyPropertyValues = grouping
                     .Select(repo => property.GetValue(repo))
                     .Distinct()
-                    .Select(item => $"'{item?.ToString()}'")
+                    .Select(item => item?.ToString())
+                    .Where(val => !string.IsNullOrEmpty(val))
+                    .Select(val => $"'{val}'")
                     .ToList();
 
-                if (distinctPropertyValues.Count > 1)
+                if (distinctNonEmptyPropertyValues.Count > 1)
                 {
                     throw new InvalidOperationException(
                         "The manifest contains multiple repos with the same name that also do not have the same " +
-                        $"value for the '{property.Name}' property. Distinct values: {string.Join(", ", distinctPropertyValues)}");
+                        $"value for the '{property.Name}' property. Distinct values: {string.Join(", ", distinctNonEmptyPropertyValues)}");
                 }
             }
 

--- a/src/Microsoft.DotNet.ImageBuilder/tests/ManifestInfoTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/ManifestInfoTests.cs
@@ -113,7 +113,7 @@ $@"
 $@"
 {{
   ""repos"": [
-    {CreateRepo("testRepo1", s_dockerfilePath)},
+    {CreateRepo("testRepo1", s_dockerfilePath, "testTag1")},
     {CreateRepo("testRepo2", s_dockerfilePath)}
   ]
 }}";
@@ -122,6 +122,7 @@ $@"
 $@"
 {{
   ""repos"": [
+    {CreateRepo("testRepo1", s_dockerfilePath, "testTag2")},
     {CreateRepo("testRepo3", s_dockerfilePath)}
   ]
 }}";
@@ -143,6 +144,10 @@ $@"
             Assert.Equal("testRepo1", manifestInfo.Model.Repos[0].Name);
             Assert.Equal("testRepo2", manifestInfo.Model.Repos[1].Name);
             Assert.Equal("testRepo3", manifestInfo.Model.Repos[2].Name);
+
+            Assert.Equal(2, manifestInfo.Model.Repos[0].Images.Length);
+            Assert.Equal(1, manifestInfo.Model.Repos[1].Images.Length);
+            Assert.Equal(1, manifestInfo.Model.Repos[2].Images.Length);
         }
 
         private static ManifestInfo LoadManifestInfo(string manifest, string includeManifestPath = null, string includeManifest = null)
@@ -164,7 +169,7 @@ $@"
             return ManifestInfo.Load(manifestOptions);
         }
 
-        private static string CreateRepo(string repoName, string dockerfilePath) =>
+        private static string CreateRepo(string repoName, string dockerfilePath, string tag = "testTag") =>
 $@"
 {{
     ""name"": ""{repoName}"",
@@ -176,7 +181,7 @@ $@"
             ""os"": ""linux"",
             ""osVersion"": ""stretch"",
             ""tags"": {{
-                ""testTag"": {{}}
+                ""{tag}"": {{}}
             }}
         }}
         ]


### PR DESCRIPTION
The changes in https://github.com/dotnet/docker-tools/pull/916 were incomplete because it didn't consolidate repos from separate manifests that shared the same name.

The https://github.com/dotnet/dotnet-buildtools-prereqs-docker repo will end up having multiple sub-manifest files that all define a repo named `dotnet-buildtools/prereqs`. Simply concatenating the repos together into the model isn't sufficient because there is logic throughout Image Builder that assumes that there is only one repo in the model with a given name.

To fix this, I've updated the manifest loading to consolidate all repos that share the same name. It first validates that the repo definitions don't have conflicting state. It then combines all the images from those repos into one repo model.