### PR TITLE
Package script updates

### DIFF
--- a/eng/common/package-scripts/get-installed-packages.sh
+++ b/eng/common/package-scripts/get-installed-packages.sh
@@ -47,5 +47,6 @@ docker run \
     -i \
     -e PKG_MANAGER_ARGS="$pkgManagerArgs" \
     --entrypoint /bin/sh \
+    --user root \
     $imageTag \
     < $scriptDir/get-installed-packages.container.sh

--- a/eng/common/package-scripts/get-upgradable-packages.container.sh
+++ b/eng/common/package-scripts/get-upgradable-packages.container.sh
@@ -13,18 +13,18 @@ ensureBashInstalledForApk() {
     apk add bash 1>/dev/null
 }
 
-ensureBashInstalledForDnf() {
+ensureBashInstalledForRpmBasedPkgMgr() {
     echo "Ensuring bash is installed"
-    dnf makecache 1>/dev/null
-    dnf install -y bash 1>/dev/null
+    local pkgMgr=$1
+    $pkgMgr makecache 1>/dev/null
+    $pkgMgr install -y bash 1>/dev/null
 }
 
-ensureBashInstalledForTdnf() {
+ensureBashInstalledForZypper() {
     echo "Ensuring bash is installed"
-    tdnf makecache 1>/dev/null
-    tdnf install -y bash 1>/dev/null
+    zypper ref 1>/dev/null
+    zypper install -y bash 1>/dev/null
 }
-
 
 
 scriptDir=$(dirname $0)
@@ -36,27 +36,39 @@ packages=$@
 
 if type apt > /dev/null 2>/dev/null; then
     ensureBashInstalledForApt
-    $scriptDir/get-upgradable-packages.container.bash.sh $@
+    $scriptDir/get-upgradable-packages.container.bash.sh $outputPath "$pkgManagerArgs" $packages
     exit 0
 fi
 
 if type apk > /dev/null 2>/dev/null; then
     ensureBashInstalledForApk
-    $scriptDir/get-upgradable-packages.container.bash.sh $@
-    exit 0
-fi
-
-if type dnf > /dev/null 2>/dev/null; then
-    ensureBashInstalledForDnf
-    $scriptDir/get-upgradable-packages.container.bash.sh $@
-    exit 0
-fi
-
-if type tdnf > /dev/null 2>/dev/null; then
-    ensureBashInstalledForTdnf
     $scriptDir/get-upgradable-packages.container.bash.sh $outputPath "$pkgManagerArgs" $packages
     exit 0
 fi
 
-echo "Unsupported package manager. Current supported package managers: apt, apk, tdnf" >&2
+if type dnf > /dev/null 2>/dev/null; then
+    ensureBashInstalledForRpmBasedPkgMgr dnf
+    $scriptDir/get-upgradable-packages.container.bash.sh $outputPath "$pkgManagerArgs" $packages
+    exit 0
+fi
+
+if type tdnf > /dev/null 2>/dev/null; then
+    ensureBashInstalledForRpmBasedPkgMgr tdnf
+    $scriptDir/get-upgradable-packages.container.bash.sh $outputPath "$pkgManagerArgs" $packages
+    exit 0
+fi
+
+if type yum > /dev/null 2>/dev/null; then
+    ensureBashInstalledForRpmBasedPkgMgr yum
+    $scriptDir/get-upgradable-packages.container.bash.sh $outputPath "$pkgManagerArgs" $packages
+    exit 0
+fi
+
+if type zypper > /dev/null 2>/dev/null; then
+    ensureBashInstalledForZypper
+    $scriptDir/get-upgradable-packages.container.bash.sh $outputPath "$pkgManagerArgs" $packages
+    exit 0
+fi
+
+echo "Unsupported package manager. Current supported package managers: apt, apk, tdnf, yum, zypper" >&2
 exit 1

--- a/eng/common/package-scripts/get-upgradable-packages.sh
+++ b/eng/common/package-scripts/get-upgradable-packages.sh
@@ -46,19 +46,20 @@ done
 
 imageTag=$1
 dockerfilePath=$2
-shift 3
+shift 2
 packagelist=$@
 
 scriptDir="$(dirname $(realpath $0))"
-containerName="container-$RANDOM"
+containerName="container$RANDOM"
 containerOutputPath="/$containerName.txt"
 
-scriptsWrapperImageTag="tag-$RANDOM"
+scriptsWrapperImageTag="tag$RANDOM"
 docker build -t $scriptsWrapperImageTag -f $scriptDir/Dockerfile.scripts --build-arg BASETAG=$imageTag $scriptDir 1>/dev/null 2>/dev/null
 
 docker run \
     --name $containerName \
     --entrypoint /bin/sh \
+    --user root \
     $scriptsWrapperImageTag \
     -c "/scripts/get-upgradable-packages.container.sh $containerOutputPath \"$pkgManagerArgs\" $packagelist"
 


### PR DESCRIPTION
Several updates made to the scripts for getting installed and upgradable Linux packages:
* Add support for yum package manager. Relevant to CentOS which is used in the https://github.com/dotnet/dotnet-buildtools-prereqs-docker repo. The dnf, tdnf, and yum package managers all have the same command syntax used by the scripts so most of the logic has been encapsulated to support all three of these package managers.
* Add support for zypper package manager. Relevant to openSUSE which is used in the https://github.com/dotnet/dotnet-buildtools-prereqs-docker repo.
* Ensure that the container is run as root. This is necessary to override the non-root user that is defined by Helix images in the https://github.com/dotnet/dotnet-buildtools-prereqs-docker repo.
* A couple minor fixes in the `get-upgradable-packages.sh` script:
  * Fixed the index to shift the arg array so that the correct package list can be passed to the container.
  * For usage of `$RANDOM` for Docker tag/container names, I've removed the `-` separator because `$RANDOM` will be an empty string when testing the script in WSL. Removing the separator ensures that even if the suffix is empty, it'll still be a valid name.