### PR TITLE
Remove support for Windows 2004

### DIFF
--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -33,8 +33,6 @@ parameters:
     vmImage: $(defaultWindows2016PoolImage)
   windows1809Pool:
     vmImage: $(defaultWindows1809PoolImage)
-  windows2004Pool:
-    vmImage: $(defaultWindows2004PoolImage)
   windows20H2Pool:
     vmImage: $(defaultWindows20H2PoolImage)
   windows2022Pool:
@@ -114,19 +112,6 @@ stages:
       name: Windows1809_amd64
       pool: ${{ parameters.windows1809Pool }}
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.Windows1809Amd64']
-      dockerClientOS: windows
-      buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
-      customInitSteps: ${{ parameters.customBuildInitSteps }}
-      noCache: ${{ parameters.noCache }}
-      internalProjectName: ${{ parameters.internalProjectName }}
-      publicProjectName: ${{ parameters.publicProjectName }}
-      internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
-      publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
-  - template: ../jobs/build-images.yml
-    parameters:
-      name: Windows2004_amd64
-      pool: ${{ parameters.windows2004Pool }}
-      matrix: dependencies.GenerateBuildMatrix.outputs['matrix.Windows2004Amd64']
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
@@ -237,13 +222,6 @@ stages:
         name: Windows1809_amd64
         pool: ${{ parameters.windows1809Pool }}
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.Windows1809Amd64']
-        testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
-        internalProjectName: ${{ parameters.internalProjectName }}
-    - template: ../jobs/test-images-windows-client.yml
-      parameters:
-        name: Windows2004_amd64
-        pool: ${{ parameters.windows2004Pool }}
-        matrix: dependencies.GenerateTestMatrix.outputs['matrix.Windows2004Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
         internalProjectName: ${{ parameters.internalProjectName }}
     - template: ../jobs/test-images-windows-client.yml

--- a/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
@@ -57,6 +57,5 @@ stages:
         - Agent.OSArchitecture -equals ARM64
     windows2016Pool: Docker-2016-${{ variables['System.TeamProject'] }}
     windows1809Pool: Docker-1809-${{ variables['System.TeamProject'] }}
-    windows2004Pool: Docker-2004-${{ variables['System.TeamProject'] }}
     windows20H2Pool: Docker-20H2-${{ variables['System.TeamProject'] }}
     windows2022Pool: Docker-2022-${{ variables['System.TeamProject'] }}

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -41,8 +41,6 @@ variables:
   value: vs2017-win2016
 - name: defaultWindows1809PoolImage
   value: windows-2019
-- name: defaultWindows2004PoolImage
-  value: null
 - name: defaultWindows20H2PoolImage
   value: null
 - name: defaultWindows2022PoolImage


### PR DESCRIPTION
Removing infra support for Windows Server, version 2004 because it has reached EOL today.