### PR TITLE
Build/test job support for ARM32 v6 variant

### DIFF
--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -96,6 +96,19 @@ stages:
       publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
   - template: ../jobs/build-images.yml
     parameters:
+      name: Linux_arm32v6
+      pool: ${{ parameters.linuxArm32Pool }}
+      matrix: dependencies.GenerateBuildMatrix.outputs['matrix.LinuxArm32v6']
+      dockerClientOS: linux
+      buildJobTimeout: ${{ parameters.linuxArmBuildJobTimeout }}
+      customInitSteps: ${{ parameters.customBuildInitSteps }}
+      noCache: ${{ parameters.noCache }}
+      internalProjectName: ${{ parameters.internalProjectName }}
+      publicProjectName: ${{ parameters.publicProjectName }}
+      internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
+      publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
+  - template: ../jobs/build-images.yml
+    parameters:
       name: Linux_arm32v7
       pool: ${{ parameters.linuxArm32Pool }}
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.LinuxArm32v7']
@@ -208,6 +221,13 @@ stages:
         name: Linux_arm64v8
         pool: ${{ parameters.linuxArm64Pool }}
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.LinuxArm64v8']
+        testJobTimeout: ${{ parameters.linuxArmTestJobTimeout }}
+        internalProjectName: ${{ parameters.internalProjectName }}
+    - template: ../jobs/test-images-linux-client.yml
+      parameters:
+        name: Linux_arm32v6
+        pool: ${{ parameters.linuxArm32Pool }}
+        matrix: dependencies.GenerateTestMatrix.outputs['matrix.LinuxArm32v6']
         testJobTimeout: ${{ parameters.linuxArmTestJobTimeout }}
         internalProjectName: ${{ parameters.internalProjectName }}
     - template: ../jobs/test-images-linux-client.yml


### PR DESCRIPTION
This was originally added to support https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/550.