### PR TITLE
Enable publish notifications

### DIFF
--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -14,9 +14,15 @@ jobs:
       --registry-override '$(acr.server)'
       $(manifestVariables)
       $(imageBuilder.queueArgs)
+  - name: publishNotificationRepoName
+    value: $(Build.Repository.Name)
   - ${{ parameters.customPublishVariables }}
   steps:
   - template: ../steps/init-docker-linux.yml
+  - pwsh: |
+      $azdoOrgName = Split-Path -Leaf $Env:SYSTEM_COLLECTIONURI
+      echo "##vso[task.setvariable variable=azdoOrgName]$azdoOrgName"
+    displayName: Set Publish Variables
   - ${{ parameters.customInitSteps }}
   - template: ../steps/validate-branch.yml
     parameters:
@@ -115,4 +121,27 @@ jobs:
       $(imageBuilder.commonCmdArgs)
     displayName: Ingest Kusto Image Info
     condition: and(succeeded(), eq(variables['ingestKustoImageInfo'], 'true'))
+  - script: >
+      $(runImageBuilderCmd) postPublishNotification
+      '$(publishNotificationRepoName)'
+      '$(Build.SourceBranchName)'
+      '$(artifactsPath)/image-info.json'
+      $(Build.BuildId)
+      '$(System.AccessToken)'
+      '$(azdoOrgName)'
+      '$(System.TeamProject)'
+      '$(gitHubNotificationsRepoInfo.accessToken)'
+      '$(gitHubNotificationsRepoInfo.org)'
+      '$(gitHubNotificationsRepoInfo.repo)'
+      --task "Copy Images"
+      --task "Publish Manifest"
+      --task "Wait for Image Ingestion"
+      --task "Publish Readmes"
+      --task "Wait for MCR Doc Ingestion"
+      --task "Publish Image Info"
+      --task "Ingest Kusto Image Info"
+      $(dryRunArg)
+      $(imageBuilder.commonCmdArgs)
+    displayName: Post Publish Notification
+    condition: and(always(), eq(variables['publishNotificationsEnabled'], 'true'))
   - template: ../steps/cleanup-docker-linux.yml

--- a/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
@@ -24,7 +24,25 @@ stages:
     publicProjectName: ${{ parameters.publicProjectName }}
     buildMatrixCustomBuildLegGroupArgs: ${{ parameters.buildMatrixCustomBuildLegGroupArgs }}
     customBuildInitSteps: ${{ parameters.customBuildInitSteps }}
-    customPublishInitSteps: ${{ parameters.customPublishInitSteps }}
+    customPublishInitSteps:
+    - pwsh: |
+        # When reporting the repo name in the publish notification, we don't want to include
+        # the org part of the repo name (e.g. we want "dotnet-docker", not "dotnet-dotnet-docker").
+        # This also accounts for the different separators between AzDO and GitHub repo names.
+
+        $repoName = "$(Build.Repository.Name)"
+
+        $orgSeparatorIndex = $repoName.IndexOf("/")
+        if ($orgSeparatorIndex -eq -1) {
+          $orgSeparatorIndex = $repoName.IndexOf("-")
+        }
+
+        if ($orgSeparatorIndex -ge 0) {
+          $repoName = $repoName.Substring($orgSeparatorIndex + 1)
+        }
+        echo "##vso[task.setvariable variable=publishNotificationRepoName]$repoName"
+      displayName: "Set Custom Repo Name Var"
+    - ${{ parameters.customPublishInitSteps }}
     windowsAmdBuildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
     windowsAmdTestJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
     linuxAmdBuildJobTimeout: ${{ parameters.linuxAmdBuildJobTimeout }}

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -17,6 +17,8 @@ variables:
   value: ""
 - name: ingestKustoImageInfo
   value: true
+- name: publishNotificationsEnabled
+  value: false
 - name: manifestVariables
   value: ""
 - name: mcrImageIngestionTimeout

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1512874
+  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1514933
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-buster-slim-docker-testrunner-974165
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/eng/common/templates/variables/dotnet/build-test-publish.yml
+++ b/eng/common/templates/variables/dotnet/build-test-publish.yml
@@ -21,6 +21,15 @@ variables:
 - name: mcrDocsRepoInfo.email
   value: $(dotnetDockerBot.email)
 
+- name: publishNotificationsEnabled
+  value: true
+- name: gitHubNotificationsRepoInfo.org
+  value: dotnet
+- name: gitHubNotificationsRepoInfo.repo
+  value: dotnet-docker-internal
+- name: gitHubNotificationsRepoInfo.accessToken
+  value: $(BotAccount-dotnet-docker-bot-PAT)
+
 - name: gitHubVersionsRepoInfo.org
   value: dotnet
 - name: gitHubVersionsRepoInfo.repo


### PR DESCRIPTION
Updates the publish stage to call the new `postPublishNotification` command from https://github.com/dotnet/docker-tools/pull/838. This reports the results of the significant tasks that comprise the publish stage.