### PR TITLE
Fix image info merge to replace syndicated digests

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
@@ -150,7 +150,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
                 ImageInfoMergeOptions options = new ImageInfoMergeOptions
                 {
-                    ReplaceTags = true
+                    IsPublish = true
                 };
 
                 ImageInfoHelper.MergeImageArtifactDetails(srcImageArtifactDetails, targetImageArtifactDetails, options);

--- a/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
@@ -159,9 +159,7 @@ namespace Microsoft.DotNet.ImageBuilder
                 }
                 else if (typeof(IList<string>).IsAssignableFrom(property.PropertyType))
                 {
-                    if (options.ReplaceTags &&
-                        ((srcObj is PlatformData && property.Name == nameof(PlatformData.SimpleTags)) ||
-                        (srcObj is ManifestData && property.Name == nameof(ManifestData.SharedTags))))
+                    if (options.IsPublish && IsReplaceableValueProperty(srcObj, property))
                     {
                         // Tags can be merged or replaced depending on the scenario.
                         // When merging multiple image info files together into a single file, the tags should be
@@ -214,6 +212,19 @@ namespace Microsoft.DotNet.ImageBuilder
                 }
             }
         }
+
+        private static bool IsReplaceableValueProperty(object srcObj, PropertyInfo property) =>
+            (
+                srcObj is PlatformData &&
+                property.Name == nameof(PlatformData.SimpleTags)
+            ) ||
+            (
+                srcObj is ManifestData &&
+                (
+                    property.Name == nameof(ManifestData.SharedTags) ||
+                    property.Name == nameof(ManifestData.SyndicatedDigests)
+                )
+            );
 
         private static void ReplaceValue(PropertyInfo property, object srcObj, object targetObj)
         {

--- a/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoMergeOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoMergeOptions.cs
@@ -7,9 +7,12 @@ namespace Microsoft.DotNet.ImageBuilder
     public class ImageInfoMergeOptions
     {
         /// <summary>
-        /// Gets or sets a value indicating whether existing tag values
-        /// are overwritten are replaced rather than merged.
+        /// Gets or sets a value indicating whether the image info merge is occurring as part of publishing
+        /// the image info file. There is different merge logic involved depending on whether it's merging
+        /// two image info files as part of the build versus merging a consolidated image info file into
+        /// a previously published version (the publish scenario). For example, for the publish scenario,
+        /// existing tag values are replaced rather than merged.
         /// </summary>
-        public bool ReplaceTags { get; set; }
+        public bool IsPublish { get; set; }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/ImageInfoHelperTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/ImageInfoHelperTests.cs
@@ -800,7 +800,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             ImageInfoMergeOptions options = new ImageInfoMergeOptions
             {
-                ReplaceTags = true
+                IsPublish = true
             };
 
             ImageInfoHelper.MergeImageArtifactDetails(imageArtifactDetails, targetImageArtifactDetails, options);


### PR DESCRIPTION
I noticed that the image info files contain more values than expected in the `syndicatedDigests` array. This is because each time the image info file from a build is merged into the previously published version in the dotnet/versions repo, it becomes an additive operation for the `syndicatedDigests` array. New syndicated digest values keep getting added into the array but never removed. This is incorrect. It should be replacing the previous values with each publish, just as is done for tags.

There is currently no negative behavior of this other than simply filling up the image info file with content we don't need. This is because nothing actually consumes the `syndicatedDigests` field after the image info file has been published. It's only consumed as part of the locally generated image info file during the build.

I've updated the logic to add the `syndicatedDigests` field to the list of fields which have this "replace rather than merge" behavior on publish. I also found that the unit tests weren't actually verifying the image info file output so I've fixed that too.