### PR TITLE
Use GitHub blobs API for image info files

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/BlobsClientExtensions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/BlobsClientExtensions.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using Octokit;
+
+#nullable enable
+namespace Microsoft.DotNet.ImageBuilder
+{
+    public static class BlobsClientExtensions
+    {
+        public static async Task<string> GetFileContentAsync(
+            this IBlobsClient blobsClient, string repoOwner, string repoName, string fileSha)
+        {
+            Blob fileBlob = await blobsClient.Get(repoOwner, repoName, fileSha);
+
+            switch (fileBlob.Encoding.Value)
+            {
+                case EncodingType.Utf8:
+                    return fileBlob.Content;
+                case EncodingType.Base64:
+                    byte[] bytes = Convert.FromBase64String(fileBlob.Content);
+                    return Encoding.UTF8.GetString(bytes);
+                default:
+                    throw new NotSupportedException(
+                       $"The blob for file SHA '{fileSha}' in repo '{repoOwner}/{repoName}' uses an unsupported encoding: {fileBlob.Encoding}");
+            }
+        }
+    }
+}
+#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GitOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GitOptions.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.CommandLine;
 using Microsoft.DotNet.VersionTools.Automation;
+using Octokit;
 using static Microsoft.DotNet.ImageBuilder.Commands.CliHelper;
 
 #nullable enable
@@ -25,6 +26,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             return new GitHubAuth(AuthToken, Username, Email);
         }
+
+        public Credentials ToOctokitCredentials() => new Credentials(AuthToken);
 
         public Uri GetRepoUrl() => new Uri($"https://github.com/{Owner}/{Repo}");
     }

--- a/src/Microsoft.DotNet.ImageBuilder/src/IOctokitClientFactory.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/IOctokitClientFactory.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Octokit;
+
+#nullable enable
+namespace Microsoft.DotNet.ImageBuilder
+{
+    public interface IOctokitClientFactory
+    {
+        IBlobsClient CreateBlobsClient(IApiConnection connection);
+        ITreesClient CreateTreesClient(IApiConnection connection);
+    }
+}
+#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/OctokitClientFactory.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/OctokitClientFactory.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel.Composition;
+using System.Reflection;
+using Octokit;
+
+#nullable enable
+namespace Microsoft.DotNet.ImageBuilder
+{
+    [Export(typeof(IOctokitClientFactory))]
+    public class OctokitClientFactory : IOctokitClientFactory
+    {
+        public static IApiConnection CreateApiConnection(Credentials credentials)
+        {
+            Connection connection = new(new ProductHeaderValue(Assembly.GetExecutingAssembly().GetName().Name));
+            connection.Credentials = credentials;
+            return new ApiConnection(connection);
+        }
+
+        public IBlobsClient CreateBlobsClient(IApiConnection connection) =>
+            new BlobsClient(connection);
+
+        public ITreesClient CreateTreesClient(IApiConnection connection) =>
+            new TreesClient(connection);
+
+    }
+}
+#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/TreesClientExtensions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/TreesClientExtensions.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Web;
+using Octokit;
+
+#nullable enable
+namespace Microsoft.DotNet.ImageBuilder
+{
+    public static class TreesClientExtensions
+    {
+        public static async Task<string> GetFileShaAsync(
+            this ITreesClient treesClient, string repoOwner, string repoName, string branch, string path)
+        {
+            string? dirPath = Path.GetDirectoryName(path)?.Replace("\\", "/");
+            TreeResponse treeResponse = await treesClient.Get(repoOwner, repoName, HttpUtility.UrlEncode($"{branch}:{dirPath}"));
+            string fileName = Path.GetFileName(path);
+            TreeItem? item = treeResponse.Tree
+                .FirstOrDefault(item => string.Equals(item.Path, fileName, StringComparison.OrdinalIgnoreCase));
+            if (item is null)
+            {
+                throw new InvalidOperationException(
+                    $"Unable to find git tree data for path '{path}' in repo '{repoName}'.");
+            }
+
+            return item.Sha;
+        }
+    }
+}
+#nullable disable


### PR DESCRIPTION
After the [enablement to store component data in the image info file](https://github.com/dotnet/dotnet-docker/pull/3319), it's caused the [check-base-image-updates](https://github.com/dotnet/docker-tools/blob/main/eng/pipelines/check-base-image-updates.yml) pipeline to fail with the error:

```
Unhandled exception: Microsoft.DotNet.VersionTools.Automation.GitHubApi.HttpFailureResponseException: Response code does not indicate success: 403 (Forbidden) with content: {"message":"This API returns blobs up to 1 MB in size. The requested blob is too large to fetch via the API, but you can use the Git Data API to request blobs up to 100 MB in size.","errors":[{"resource":"Blob","field":"data","code":"too_large"}],"documentation_url":"https://docs.github.com/rest/reference/repos#get-repository-content"}
   at Microsoft.DotNet.VersionTools.Automation.GitHubApi.GitHubClient.EnsureSuccessfulAsync(HttpResponseMessage response) in /_/src/Microsoft.DotNet.VersionTools/lib/src/Automation/GitHubApi/GitHubClient.cs:line 466
   at Microsoft.DotNet.VersionTools.Automation.GitHubApi.GitHubClient.DeserializeSuccessfulAsync[T](HttpResponseMessage response) in /_/src/Microsoft.DotNet.VersionTools/lib/src/Automation/GitHubApi/GitHubClient.cs:line 440
   at Microsoft.DotNet.VersionTools.Automation.GitHubApi.GitHubClient.GetGitHubFileAsync(String path, GitHubProject project, String ref) in /_/src/Microsoft.DotNet.VersionTools/lib/src/Automation/GitHubApi/GitHubClient.cs:line 76
   at Microsoft.DotNet.VersionTools.Automation.GitHubApi.GitHubClient.GetGitHubFileContentsAsync(String path, GitHubBranch branch) in /_/src/Microsoft.DotNet.VersionTools/lib/src/Automation/GitHubApi/GitHubClient.cs:line 86
   at Polly.Retry.AsyncRetryEngine.ImplementationAsync[TResult](Func`3 action, Context context, CancellationToken cancellationToken, ExceptionPredicates shouldRetryExceptionPredicates, ResultPredicates`1 shouldRetryResultPredicates, Func`5 onRetryAsync, Int32 permittedRetryCount, IEnumerable`1 sleepDurationsEnumerable, Func`4 sleepDurationProvider, Boolean continueOnCapturedContext)
   at Polly.AsyncPolicy.ExecuteAsync[TResult](Func`3 action, Context context, CancellationToken cancellationToken, Boolean continueOnCapturedContext)
   at Microsoft.DotNet.ImageBuilder.Commands.GetStaleImagesCommand.GetImageInfoForSubscriptionAsync(Subscription subscription, ManifestInfo manifest) in /image-builder/src/Commands/GetStaleImagesCommand.cs:line 189
   at Microsoft.DotNet.ImageBuilder.Commands.GetStaleImagesCommand.GetPathsToRebuildAsync(Subscription subscription, ManifestInfo manifest) in /image-builder/src/Commands/GetStaleImagesCommand.cs:line 85
   at Microsoft.DotNet.ImageBuilder.Commands.GetStaleImagesCommand.<ExecuteAsync>b__9_1(ValueTuple`2 subscriptionManifest) in /image-builder/src/Commands/GetStaleImagesCommand.cs:line 57
   at Microsoft.DotNet.ImageBuilder.Commands.GetStaleImagesCommand.ExecuteAsync() in /image-builder/src/Commands/GetStaleImagesCommand.cs:line 65
```

This happens because the REST API being used to download the image info file contents is throttled to only allow up to 1 MB files. The [image-info.dotnet-dotnet-docker-nightly.json](https://github.com/dotnet/versions/blob/97cf10da209c186468848909cd564fd56b022b89/build-info/docker/image-info.dotnet-dotnet-docker-nightly.json) file is now larger than 1 MB, causing this failure.

A [temporary workaround](https://github.com/dotnet/docker-tools/pull/928) has been implemented by removing the nightly branch from the set of subscriptions. This works because the nightly branch is the only branch that currently stores component data in the image info leading to the large file size.

In order to download content larger than 1 MB, the [blob API](https://docs.github.com/en/rest/reference/git#blobs) must be used instead of the [content API](https://docs.github.com/rest/reference/repos#get-repository-content). These changes update the code to use the blob API.