### PR TITLE
Support InsertTemplate function in Dockerfile templates

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateArtifactsCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateArtifactsCommand.cs
@@ -110,12 +110,17 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         private static string GetSnippet(string source, int index) => source.Substring(index, Math.Min(100, source.Length - index));
 
-        protected Dictionary<Value, Value> GetSymbols()
+        protected Dictionary<Value, Value> GetSymbols<TContext>(
+            string sourceTemplatePath,
+            TContext context,
+            Func<TContext, IReadOnlyDictionary<Value, Value>> getSymbols)
         {
             return new Dictionary<Value, Value>
             {
                 ["VARIABLES"] = Manifest.VariableHelper.ResolvedVariables
-                    .ToDictionary(kvp => (Value)kvp.Key, kvp => (Value)kvp.Value)
+                    .ToDictionary(kvp => (Value)kvp.Key, kvp => (Value)kvp.Value),
+                ["InsertTemplate"] = Value.FromFunction(Function.CreatePure1((state, path) =>
+                    RenderTemplateAsync(Path.Combine(Path.GetDirectoryName(sourceTemplatePath), path.AsString), context, getSymbols).Result))
             };
         }
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateDockerfilesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateDockerfilesCommand.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 (platform) => platform.DockerfileTemplate,
                 (platform) => platform.DockerfilePath,
                 (platform) => GetSymbols(platform),
-                nameof(Models.Manifest.Platform.DockerfileTemplate),
+                nameof(Platform.DockerfileTemplate),
                 "Dockerfile");
 
             ValidateArtifacts();
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             string versionedArch = platform.Model.Architecture.GetDisplayName(platform.Model.Variant);
             ImageInfo image = Manifest.GetImageByPlatform(platform);
 
-            Dictionary<Value, Value> symbols = GetSymbols();
+            Dictionary<Value, Value> symbols = GetSymbols(platform.DockerfileTemplate, platform, platform => GetSymbols(platform));
             symbols["ARCH_SHORT"] = platform.Model.Architecture.GetShortName();
             symbols["ARCH_NUPKG"] = platform.Model.Architecture.GetNupkgName();
             symbols["ARCH_VERSIONED"] = versionedArch;

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateReadmesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateReadmesCommand.cs
@@ -76,10 +76,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             TContext context,
             Func<TContext, IReadOnlyDictionary<Value, Value>> getSymbols)
         {
-            Dictionary<Value, Value> symbols = GetSymbols();
+            Dictionary<Value, Value> symbols = GetSymbols(sourceTemplatePath, context, getSymbols);
             symbols["IS_PRODUCT_FAMILY"] = context is ManifestInfo;
-            symbols["InsertTemplate"] = Value.FromFunction(Function.CreatePure1((state, path) =>
-                RenderTemplateAsync(Path.Combine(Path.GetDirectoryName(sourceTemplatePath), path.AsString), context, getSymbols).Result));
 
             return symbols;
         }


### PR DESCRIPTION
Currently, Image Builder only implements the `InsertTemplate` function for readme templates. In order to support https://github.com/dotnet/dotnet-docker/issues/2152, there's a need to also have support for this function in the Dockerfile templates.

These changes refactor the code to move the implementation of the `InsertTemplate` function to the base `GenerateArtifactsCommand` class that both readme and Dockerfile template generation share.