### PR TITLE
Support for template args

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateReadmesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateReadmesCommandTests.cs
@@ -59,6 +59,29 @@ Referenced Template Content";
         }
 
         [Fact]
+        public async Task GenerateReadmesCommand_TemplateArgs()
+        {
+            const string readmeTemplate =
+@"Hello World
+{{InsertTemplate(""template-with-args.md"", [ ""my-arg"": 123 ])}}";
+
+            const string templateWithArgs =
+@"ABC-{{ARGS[""my-arg""]}}";
+
+            using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
+            DockerfileHelper.CreateFile("template-with-args.md", tempFolderContext, templateWithArgs);
+            GenerateReadmesCommand command = InitializeCommand(tempFolderContext, readmeTemplate);
+
+            await command.ExecuteAsync();
+
+            string generatedReadme = File.ReadAllText(Path.Combine(tempFolderContext.Path, ProductFamilyReadmePath));
+            string expectedReadme =
+@"Hello World
+ABC-123";
+            Assert.Equal(expectedReadme, generatedReadme);
+        }
+
+        [Fact]
         public async Task GenerateReadmesCommand_InvalidTemplate()
         {
             string template = "about{{if:}}";


### PR DESCRIPTION
Updates Image Builder's artifact generation to support passing arguments to templates. This allows for a sub-template to be more reusable. For example, we can define a sub-template for Dockerfiles that just handles installation of PowerShell. That sub-template can then be inserted by the sdk Dockerfile templates. This greatly reduces the duplication of content across Dockerfiles and enforces consistency.

This is implemented by defining two additional optional arguments for the `InsertTemplate` function. The first arg is a map, in Cottle terms, which can be defined using a JSON-like syntax. The map defines the fields and their values which will be made available to the sub-template to consume via the `ARGS` symbol. The second arg is a string that can be used to dynamically indent the content of the template. This allows sub-templates to be more reusable across a variety of contexts which may have different indentation requirements.

Here's an example of how the `InsertTemplate` function can be called with the map and indent args:

```
{{InsertTemplate("../Dockerfile.linux.install-powershell",
    [
        "dotnet-version": "3.1",
        "nupkg-platform": cat("Linux.", ARCH_NUPKG),
        "sha-platform": cat("Linux|", ARCH_NUPKG)
    ],
    "    ")}}
```

And the sub-template can consume the args that were passed to it like this:

```
{{ARGS["dotnet-version"]}}
```