### PR TITLE
Revert "Temporarily remove nightly subscription (#928)"

### DIFF
--- a/eng/check-base-image-subscriptions.json
+++ b/eng/check-base-image-subscriptions.json
@@ -43,6 +43,25 @@
     "manifest": {
       "owner": "dotnet",
       "repo": "dotnet-docker",
+      "branch": "nightly",
+      "path": "manifest.json"
+    },
+    "imageInfo": {
+      "owner": "dotnet",
+      "repo": "versions",
+      "branch": "main",
+      "path": "build-info/docker/image-info.dotnet-dotnet-docker-nightly.json"
+    },
+    "pipelineTrigger": {
+      "id": 359,
+      "pathVariable": "imageBuilder.pathArgs"
+    },
+    "osType": "linux"
+  },
+  {
+    "manifest": {
+      "owner": "dotnet",
+      "repo": "dotnet-docker",
       "branch": "main",
       "path": "manifest.samples.json"
     },


### PR DESCRIPTION
Now that https://github.com/dotnet/docker-tools/pull/929 has been fixed, the nightly subscription can be re-enabled.

This reverts commit 65f8e3eac6884675e56fa211c950e82d109167cd.