### PR TITLE
Fix relative path referencing of template files

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateArtifactsCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateArtifactsCommand.cs
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             IEnumerable<TContext> contexts,
             Func<TContext, string> getTemplatePath,
             Func<TContext, string> getArtifactPath,
-            Func<TContext, IReadOnlyDictionary<Value, Value>> getSymbols,
+            Func<TContext, string, IReadOnlyDictionary<Value, Value>> getSymbols,
             string templatePropertyName,
             string artifactName,
             Func<string, TContext, string> postProcess = null)
@@ -71,7 +71,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             string templatePath,
             string artifactPath,
             TContext context,
-            Func<TContext, IReadOnlyDictionary<Value, Value>> getSymbols,
+            Func<TContext, string, IReadOnlyDictionary<Value, Value>> getSymbols,
             string artifactName,
             Func<string, TContext, string> postProcess)
         {
@@ -113,7 +113,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         protected Dictionary<Value, Value> GetSymbols<TContext>(
             string sourceTemplatePath,
             TContext context,
-            Func<TContext, IReadOnlyDictionary<Value, Value>> getSymbols)
+            Func<TContext, string, IReadOnlyDictionary<Value, Value>> getSymbols)
         {
             return new Dictionary<Value, Value>
             {
@@ -137,7 +137,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         protected async Task<string> RenderTemplateAsync<TContext>(
             string templatePath,
             TContext context,
-            Func<TContext, IReadOnlyDictionary<Value, Value>> getSymbols,
+            Func<TContext, string, IReadOnlyDictionary<Value, Value>> getSymbols,
             Value templateArgs,
             string indent,
             bool trimTemplate)
@@ -165,7 +165,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             try
             {
                 IDocument document = Document.CreateDefault(template, _config).DocumentOrThrow;
-                IReadOnlyDictionary<Value, Value> symbols = new Dictionary<Value, Value>(getSymbols(context))
+                IReadOnlyDictionary<Value, Value> symbols = new Dictionary<Value, Value>(getSymbols(context, templatePath))
                 {
                     { "ARGS", new Dictionary<Value, Value>(templateArgs.Fields) }
                 };

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateDockerfilesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateDockerfilesCommand.cs
@@ -31,19 +31,19 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 Manifest.GetFilteredPlatforms(),
                 (platform) => platform.DockerfileTemplate,
                 (platform) => platform.DockerfilePath,
-                (platform) => GetSymbols(platform),
+                (platform, templatePath) => GetSymbols(platform, templatePath),
                 nameof(Platform.DockerfileTemplate),
                 "Dockerfile");
 
             ValidateArtifacts();
         }
 
-        public Dictionary<Value, Value> GetSymbols(PlatformInfo platform)
+        public Dictionary<Value, Value> GetSymbols(PlatformInfo platform, string templatePath)
         {
             string versionedArch = platform.Model.Architecture.GetDisplayName(platform.Model.Variant);
             ImageInfo image = Manifest.GetImageByPlatform(platform);
 
-            Dictionary<Value, Value> symbols = GetSymbols(platform.DockerfileTemplate, platform, platform => GetSymbols(platform));
+            Dictionary<Value, Value> symbols = GetSymbols(templatePath, platform, (platform, templatePath) => GetSymbols(platform, templatePath));
             symbols["ARCH_SHORT"] = platform.Model.Architecture.GetShortName();
             symbols["ARCH_NUPKG"] = platform.Model.Architecture.GetNupkgName();
             symbols["ARCH_VERSIONED"] = versionedArch;

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateReadmesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateReadmesCommand.cs
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 new ManifestInfo[] { Manifest },
                 (manifest) => manifest.ReadmeTemplatePath,
                 (manifest) => manifest.ReadmePath,
-                (manifest) => GetSymbols(manifest),
+                (manifest, templatePath) => GetSymbols(manifest, templatePath),
                 nameof(Models.Manifest.Manifest.ReadmeTemplate),
                 ArtifactName);
 
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 Manifest.FilteredRepos,
                 (repo) => repo.ReadmeTemplatePath,
                 (repo) => repo.ReadmePath,
-                (repo) => GetSymbols(repo),
+                (repo, templatePath) => GetSymbols(repo, templatePath),
                 nameof(Models.Manifest.Repo.ReadmeTemplate),
                 ArtifactName,
                 (readme, repo) => UpdateTagsListing(readme, repo));
@@ -57,12 +57,12 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             ValidateArtifacts();
         }
 
-        public Dictionary<Value, Value> GetSymbols(ManifestInfo manifest) =>
-            GetCommonSymbols(manifest.ReadmeTemplatePath, manifest, (manifest) => GetSymbols(manifest));
+        public Dictionary<Value, Value> GetSymbols(ManifestInfo manifest, string templatePath) =>
+            GetCommonSymbols(templatePath, manifest, (manifest, templatePath) => GetSymbols(manifest, templatePath));
 
-        public Dictionary<Value, Value> GetSymbols(RepoInfo repo)
+        public Dictionary<Value, Value> GetSymbols(RepoInfo repo, string templatePath)
         {
-            Dictionary<Value, Value> symbols = GetCommonSymbols(repo.ReadmeTemplatePath, repo, (repo) => GetSymbols(repo));
+            Dictionary<Value, Value> symbols = GetCommonSymbols(templatePath, repo, (repo, templatePath) => GetSymbols(repo, templatePath));
             symbols["FULL_REPO"] = repo.QualifiedName;
             symbols["REPO"] = repo.Name;
             symbols["PARENT_REPO"] = GetParentRepoName(repo);
@@ -74,7 +74,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private Dictionary<Value, Value> GetCommonSymbols<TContext>(
             string sourceTemplatePath,
             TContext context,
-            Func<TContext, IReadOnlyDictionary<Value, Value>> getSymbols)
+            Func<TContext, string, IReadOnlyDictionary<Value, Value>> getSymbols)
         {
             Dictionary<Value, Value> symbols = GetSymbols(sourceTemplatePath, context, getSymbols);
             symbols["IS_PRODUCT_FAMILY"] = context is ManifestInfo;

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateDockerfilesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateDockerfilesCommandTests.cs
@@ -130,7 +130,7 @@ ENV TEST2 Value1";
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
             GenerateDockerfilesCommand command = InitializeCommand(tempFolderContext);
 
-            IReadOnlyDictionary<Value, Value> symbols = command.GetSymbols(command.Manifest.GetPlatformByTag(tag));
+            IReadOnlyDictionary<Value, Value> symbols = command.GetSymbols(command.Manifest.GetPlatformByTag(tag), DockerfileTemplatePath);
 
             Value variableValue;
             if (isVariable)

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateReadmesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateReadmesCommandTests.cs
@@ -145,11 +145,11 @@ ABC-123";
             IReadOnlyDictionary<Value, Value> symbols;
             if (isManifest)
             {
-                symbols = command.GetSymbols(command.Manifest);
+                symbols = command.GetSymbols(command.Manifest, ReadmeTemplatePath);
             }
             else
             {
-                symbols = command.GetSymbols(command.Manifest.GetRepoByModelName("dotnet/repo"));
+                symbols = command.GetSymbols(command.Manifest.GetRepoByModelName("dotnet/repo"), ReadmeTemplatePath);
             }
 
             Value actualSymbolValue = symbols[symbol];


### PR DESCRIPTION
There's an issue with how the `InsertTemplate` function behaves when using it from nested templates. The path to the referenced template file must be relative to the root template file, not the referencing template file. This makes the template file referencing dependent on knowing where in the directory structure the root template file is located. Instead, the relative path should be based from the referencing template.

Here's an example to illustrate the issue in concrete terms.

Path: dockerfile-templates/aspnet/3.1/Dockerfile.linux
```
{{InsertTemplate("../my-template-1")}}
```

Path: dockerfile-templates/aspnet/template-foo
```
{{InsertTemplate("../template-bar")}}
```

Path: dockerfile-templates/template-bar
```
Hello World
```

The above templates will end up failing to generate because of the path being referenced in template-foo: `../template-bar`. Image Builder will attempt to look for that file in the `dockerfile-templates/aspnet` folder rather than `dockerfile-templates`. This happens because it uses `dockerfile-templates/aspnet/3.1`, the location of the root template file, as the base of the relative path.

To get this to work without fixing Image Builder, you'd have to change template-foo to navigate up 2 directories: `"../../template-bar"`. This is non-intuitive because the expectation is that the relative path would be relative from the template file that's calling the `InsertTemplate` function.

I've fixed this by ensuring that the logic uses the location of the referencing template file as the base of the relative path rather than strictly the root template file.