### PR TITLE
Set template symbol to resolved value of product version

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateDockerfilesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateDockerfilesCommand.cs
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             symbols["ARCH_NUPKG"] = platform.Model.Architecture.GetNupkgName();
             symbols["ARCH_VERSIONED"] = versionedArch;
             symbols["ARCH_TAG_SUFFIX"] = $"-{versionedArch}";
-            symbols["PRODUCT_VERSION"] = image.Model.ProductVersion;
+            symbols["PRODUCT_VERSION"] = image.ProductVersion;
             symbols["OS_VERSION"] = platform.Model.OsVersion;
             symbols["OS_VERSION_BASE"] = platform.BaseOsVersion;
             symbols["OS_VERSION_NUMBER"] = GetOsVersionNumber(platform);


### PR DESCRIPTION
Currently the `PRODUCT_VERSION` symbol for generated artifacts is set to the value from the manifest model, which is an unresolved value. For example, it will be set to `$(dotnet|3.1|product-version)` instead of `3.1.22`.

To make it more useful to templates, I've set it to the resolved value.