### PR TITLE
Validate duplicate leg names in build matrix

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
@@ -372,6 +372,23 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 }
             }
 
+            // Guard against any duplicate leg names: https://github.com/dotnet/docker-tools/issues/891
+            foreach (BuildMatrixInfo matrix in matrices)
+            {
+                List<string> duplicateLegNames = matrix.Legs
+                    .Select(leg => leg.Name)
+                    .GroupBy(name => name)
+                    .Where(grouping => grouping.Count() > 1)
+                    .Select(grouping => grouping.Key)
+                    .ToList();
+
+                if (duplicateLegNames.Any())
+                {
+                    throw new InvalidOperationException(
+                        $"Duplicate leg name(s) found in matrix '{matrix.Name}': {string.Join(", ", duplicateLegNames)}");
+                }
+            }
+
             return matrices;
         }
 

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
@@ -439,7 +439,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     CreateImage(
                         new Platform[]
                         {
-                            CreatePlatform(dockerfileRuntime2FullPath, new string[] { "runtime" }, osVersion: "buster")
+                            CreatePlatform(dockerfileRuntime2FullPath, new string[] { "runtime" }, osVersion: "bullseye")
                         },
                         productVersion: "1.0")),
                 CreateRepo("runtime3",
@@ -498,7 +498,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             CreatePlatform(
                                 DockerfileHelper.CreateDockerfile("1.0/repo1/os", tempFolderContext),
-                                new string[] { "tag" })
+                                new string[] { "tag" },
+                                osVersion: "bionic")
                         },
                         productVersion: "1.0")),
                 CreateRepo("repo2",
@@ -508,6 +509,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             CreatePlatform(
                                 DockerfileHelper.CreateDockerfile("1.0/repo2/os", tempFolderContext),
                                 new string[] { "tag" },
+                                osVersion: "focal",
                                 customBuildLegGroups: new CustomBuildLegGroup[]
                                 {
                                     new CustomBuildLegGroup
@@ -528,7 +530,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         {
                             CreatePlatform(
                                 DockerfileHelper.CreateDockerfile("1.0/repo3/os", tempFolderContext),
-                                new string[] { "tag" })
+                                new string[] { "tag" },
+                                osVersion: "buster")
                         },
                         productVersion: "1.0")),
                 CreateRepo("repo4",
@@ -538,6 +541,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             CreatePlatform(
                                 DockerfileHelper.CreateDockerfile("1.0/repo4/os", tempFolderContext),
                                 new string[] { "tag" },
+                                osVersion: "bullseye",
                                 customBuildLegGroups: new CustomBuildLegGroup[]
                                 {
                                     new CustomBuildLegGroup


### PR DESCRIPTION
Fixes #891 

This required updating some test data because it was using Dockerfile graphs that we technically don't support.