### PR TITLE
Allow build jobs to be canceled

### DIFF
--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -13,7 +13,7 @@ parameters:
 
 jobs:
 - job: ${{ parameters.name }}
-  condition: and(${{ parameters.matrix }}, in(dependencies.PreBuildValidation.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))
+  condition: and(${{ parameters.matrix }}, not(canceled()), in(dependencies.PreBuildValidation.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))
   dependsOn:
   - PreBuildValidation
   - CopyBaseImages

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -276,31 +276,33 @@ stages:
     dependsOn: Post_Build
   condition: "
     and(
-      contains(variables['stages'], 'publish'),
-      or(
+      not(canceled()),
+      and(
+        contains(variables['stages'], 'publish'),
         or(
-          and(
-            and(
-              contains(variables['stages'], 'build'),
-              succeeded('Post_Build')),
-            and(
-              contains(variables['stages'], 'test'),
-              in(dependencies.Test.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))),
           or(
             and(
-              not(contains(variables['stages'], 'build')),
+              and(
+                contains(variables['stages'], 'build'),
+                succeeded('Post_Build')),
               and(
                 contains(variables['stages'], 'test'),
                 in(dependencies.Test.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))),
-            and(
-              not(contains(variables['stages'], 'test')),
+            or(
               and(
-                contains(variables['stages'], 'build'),
-                succeeded('Post_Build'))))),
-        not(
-          or(
-            contains(variables['stages'], 'build'),
-            contains(variables['stages'], 'test')))))"
+                not(contains(variables['stages'], 'build')),
+                and(
+                  contains(variables['stages'], 'test'),
+                  in(dependencies.Test.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))),
+              and(
+                not(contains(variables['stages'], 'test')),
+                and(
+                  contains(variables['stages'], 'build'),
+                  succeeded('Post_Build'))))),
+          not(
+            or(
+              contains(variables['stages'], 'build'),
+              contains(variables['stages'], 'test'))))))"
   jobs:
   - template: ../jobs/publish.yml
     parameters:


### PR DESCRIPTION
Builds jobs do not cancel when the build is canceled. This was a regression introduced by https://github.com/dotnet/docker-tools/pull/866.

In that change, `succeeded()` was removed as a condition for the job because that condition interfered with having the PreBuildValidation job be skippable. If `succeeded()` was kept and the PreBuildValidation job was skipped, it would cause the build jobs to be skipped as well. This is why the `in(dependencies.PreBuildValidation.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')` condition was added. However, by removing `succeeded()`, it removed the ability to stop the job when the build is canceled.

To fix this, an explicit condition for checking whether the build is canceled has been added.