### PR TITLE
Fix matrix generation to differentiate versions of separate repos

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
@@ -258,11 +258,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             foreach (IEnumerable<PlatformInfo> subgraph in subgraphs)
             {
-                string osVariant = subgraph.First().BaseOsVersion;
-                string? productVersion = GetProductVersion(Manifest.GetImageByPlatform(subgraph.First()));
+                PlatformInfo platform = subgraph.First();
+                ImageInfo image = Manifest.GetImageByPlatform(platform);
+                string osVariant = platform.BaseOsVersion;
+                string? productVersion = GetProductVersion(image);
                 BuildLegInfo leg = new()
                 {
-                    Name = $"{(productVersion is not null ? productVersion + "-" : string.Empty)}{osVariant}"
+                    Name = $"{(productVersion is not null ? productVersion + "-" : string.Empty)}{osVariant}-{Manifest.GetRepoByImage(image).Id}"
                 };
                 matrix.Legs.Add(leg);
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
@@ -167,6 +167,10 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             return AllRepos.FirstOrDefault(repo => repo.Model.Name == name);
         }
 
+        public RepoInfo GetRepoByImage(ImageInfo image) =>
+            AllRepos
+                .FirstOrDefault(repoImage => repoImage.AllImages.Contains(image));
+
         private static Manifest LoadModel(string path, string manifestDirectory)
         {
             string manifestJson = File.ReadAllText(path);


### PR DESCRIPTION
The changes from https://github.com/dotnet/docker-tools/pull/941 have exposed an issue with generation of the PlatformVersionedOs matrix type.

The scenario involves two repos that don't have a dependency on each other but share the same architecture, product version, and OS version. The current behavior will cause separate matrix legs to be generated, as expected, however the names of the legs are the same because the name is only based on the product version and OS version.

These changes update the leg name generation to also include the first platform's repo name as a differentiator.