### PR TITLE
Pass test matrix custom build leg group args in pipeline template

### DIFF
--- a/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
@@ -6,6 +6,7 @@ parameters:
   internalProjectName: null
   publicProjectName: null
   buildMatrixCustomBuildLegGroupArgs: ""
+  testMatrixCustomBuildLegGroupArgs: ""
   customBuildInitSteps: []
   customPublishInitSteps: []
   windowsAmdBuildJobTimeout: 60
@@ -23,6 +24,7 @@ stages:
     internalProjectName: ${{ parameters.internalProjectName }}
     publicProjectName: ${{ parameters.publicProjectName }}
     buildMatrixCustomBuildLegGroupArgs: ${{ parameters.buildMatrixCustomBuildLegGroupArgs }}
+    testMatrixCustomBuildLegGroupArgs: ${{ parameters.testMatrixCustomBuildLegGroupArgs }}
     customBuildInitSteps: ${{ parameters.customBuildInitSteps }}
     customPublishInitSteps:
     - pwsh: |


### PR DESCRIPTION
The .NET-specific `build-test-publish-repo.yml` pipeline template was not configured to pass the `testMatrixCustomBuildLegGroupArgs` parameter that the base `build-test-publish-repo.yml` allows for. This is necessary in order to customize the args which are used for the test matrix in .NET scenarios.