### PR TITLE
Exclude variant value from matrix generation

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
@@ -184,7 +184,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             string fullyQualifiedLegName =
                 (platformGrouping.Key.OsVersion ?? platformGrouping.Key.OS.GetDockerName()) +
-                platformGrouping.Key.Architecture.GetDisplayName(platformGrouping.Key.Variant) +
+                platformGrouping.Key.Architecture.GetDisplayName() +
                 leg.Name;
 
             leg.Variables.Add(("legName", fullyQualifiedLegName));
@@ -351,15 +351,14 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 .GroupBy(platform => CreatePlatformId(platform))
                 .OrderBy(platformGroup => platformGroup.Key.OS)
                 .ThenByDescending(platformGroup => platformGroup.Key.OsVersion)
-                .ThenBy(platformGroup => platformGroup.Key.Architecture)
-                .ThenByDescending(platformGroup => platformGroup.Key.Variant);
+                .ThenBy(platformGroup => platformGroup.Key.Architecture);
 
             foreach (IGrouping<PlatformId, PlatformInfo> platformGrouping in platformGroups)
             {
                 string[] matrixNameParts =
                 {
                     GetOsMatrixNamePart(platformGrouping.Key),
-                    platformGrouping.Key.Architecture.GetDisplayName(platformGrouping.Key.Variant)
+                    platformGrouping.Key.Architecture.GetDisplayName()
                 };
                 BuildMatrixInfo matrix = new() { Name = FormatMatrixName(matrixNameParts) };
                 matrices.Add(matrix);
@@ -415,8 +414,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             {
                 OS = platform.Model.OS,
                 OsVersion = osVersion,
-                Architecture = platform.Model.Architecture,
-                Variant = platform.Model.Variant
+                Architecture = platform.Model.Architecture
             };
         }
 
@@ -469,7 +467,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             public Architecture Architecture { get; set; }
             public OS OS { get; set; }
             public string? OsVersion { get; set; }
-            public string? Variant { get; set; }
 
             public bool Equals(PlatformId? other)
             {
@@ -480,8 +477,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
                 return Architecture == other.Architecture
                     && OS == other.OS
-                    && OsVersion == other.OsVersion
-                    && Variant == other.Variant;
+                    && OsVersion == other.OsVersion;
             }
 
             public override bool Equals(object? obj)
@@ -491,7 +487,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             public override int GetHashCode()
             {
-                return $"{Architecture}-{OS}-{OsVersion}-{Variant}".GetHashCode();
+                return $"{Architecture}-{OS}-{OsVersion}".GetHashCode();
             }
         }
     }


### PR DESCRIPTION
This change works around an issue that prevents Dockerfiles with the same architecture but different variant values from being built in the same build job. Specifically, this applies to the changes from https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/550 which has an arm32v6 and arm32v7 Dockerfile that are dependent on each other.

That PR itself didn't expose any issue. It wasn't until https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/564 that the issue manifested. By setting the variant in the manifest to the "correct" value, it caused the two Dockerfiles to be built in separate jobs and fail because the build of the Helix Dockerfile had a dependency on the crossbuild Dockerfile.

This is the only specific case where there is a difference in variant for the same architecture. By excluding variant as a value to determine uniqueness in splitting Dockerfile paths into jobs, it will allow Dockerfiles with the same architecture but different variants to be built in the same job.

If this is problematic later on, we can possibly provide more customizable support through additional build options. But for now, this is the simplest way to resolve the issue.