### PR TITLE
Fix matrix leg name to not include slash

### DIFF
--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1561596
+  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1560816
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-buster-slim-docker-testrunner-974165
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1562340
+  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1561596
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-buster-slim-docker-testrunner-974165
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
@@ -265,6 +265,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 BuildLegInfo leg = new()
                 {
                     Name = $"{(productVersion is not null ? productVersion + "-" : string.Empty)}{osVariant}-{Manifest.GetRepoByImage(image).Id}"
+                        .Replace("/", "-")
                 };
                 matrix.Legs.Add(leg);
 

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
@@ -832,7 +832,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             {
                 Assert.Equal(2, matrixInfo.Legs.Count);
 
-                Assert.Equal("3.1-focal-core/runtime-deps", matrixInfo.Legs[0].Name);
+                Assert.Equal("3.1-focal-core-runtime-deps", matrixInfo.Legs[0].Name);
                 string imageBuilderPaths = matrixInfo.Legs[0].Variables.First(variable => variable.Name == "imageBuilderPaths").Value;
                 Assert.Equal($"--path 3.1/runtime-deps/os/Dockerfile --path 3.1/runtime/os/Dockerfile", imageBuilderPaths);
 


### PR DESCRIPTION
The changes in https://github.com/dotnet/docker-tools/pull/947 have caused builds to no longer work on the Image Builder pipeline because the matrix leg name contains a forward slash. This happens when the repo ID resolves to a value that contains a slash. The leg name is subsequently used by the pipeline as part of a file path. The presence of the forward slash implicitly defines a directory name and messes up the logic. Specifically, it's causing the following exception:

```
 ---> System.IO.DirectoryNotFoundException: Could not find a part of the path '/artifacts/linuxamd64alpine-dotnet-buildtools/image-builder-image-info.json'.
   at Interop.ThrowExceptionForIoErrno(ErrorInfo errorInfo, String path, Boolean isDirectory, Func`2 errorRewriter)
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String path, OpenFlags flags, Int32 mode)
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
   at System.IO.Strategies.FileStreamHelpers.ChooseStrategy(FileStream fileStream, String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options, Int64 preallocationSize)
   at System.IO.StreamWriter.ValidateArgsAndOpenPath(String path, Boolean append, Encoding encoding, Int32 bufferSize)
   at System.IO.File.WriteAllText(String path, String contents)
   at Microsoft.DotNet.ImageBuilder.Commands.BuildCommand.PublishImageInfo() in /image-builder/src/Commands/BuildCommand.cs:line 77
   at Microsoft.DotNet.ImageBuilder.Commands.BuildCommand.<ExecuteAsync>b__12_0() in /image-builder/src/Commands/BuildCommand.cs:line 67
   at Microsoft.DotNet.ImageBuilder.DockerHelper.ExecuteWithUser(Action action, String username, String password, String server, Boolean isDryRun) in /image-builder/src/DockerHelper.cs:line 37
   at Microsoft.DotNet.ImageBuilder.Commands.DockerRegistryCommand`2.ExecuteWithUser(Action action) in /image-builder/src/Commands/DockerRegistryCommand.cs:line 17
   at Microsoft.DotNet.ImageBuilder.Commands.BuildCommand.ExecuteAsync() in /image-builder/src/Commands/BuildCommand.cs:line 56
   at Microsoft.DotNet.ImageBuilder.Commands.Command`2.<GetCliCommand>b__9_0(TOptions options) in /image-builder/src/Commands/Command.TOptions.cs:line 46
```

I've fixed this by sanitizing the leg name string.