### PR TITLE
Use --platform option for docker pull

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateReadmesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateReadmesCommand.cs
@@ -129,7 +129,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     $"FROM {McrTagsRenderingToolTag}{Environment.NewLine}COPY {tagsMetadataFileName} /tableapp/files/ ");
 
                 string renderingToolId = $"renderingtool-{DateTime.Now.ToFileTime()}";
-                DockerHelper.PullImage(McrTagsRenderingToolTag, Options.IsDryRun);
+                DockerHelper.PullImage(McrTagsRenderingToolTag, null, Options.IsDryRun);
                 ExecuteHelper.Execute(
                     "docker",
                     $"build -t {renderingToolId} -f {dockerfilePath} {tempDir}",

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ImageSizeCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ImageSizeCommand.cs
@@ -12,7 +12,7 @@ using Newtonsoft.Json.Linq;
 #nullable enable
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
-    public delegate void ImageHandler(string repoId, string imageId, string imageTag);
+    public delegate void ImageHandler(string repoId, string imageId, string imageTag, string platform);
 
     public abstract class ImageSizeCommand<TOptions, TOptionsBuilder> : ManifestCommand<TOptions, TOptionsBuilder>
         where TOptions : ImageSizeOptions, new()
@@ -36,16 +36,16 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 foreach (PlatformInfo platform in platforms)
                 {
                     string tagName = platform.Tags.First().FullyQualifiedName;
-                    processImage(repo.Name, platform.Model.Dockerfile, tagName);
+                    processImage(repo.Name, platform.Model.Dockerfile, tagName, platform.PlatformLabel);
                 }
             }
         }
 
-        protected long GetImageSize(string tagName)
+        protected long GetImageSize(string tagName, string platform)
         {
             if (Options.IsPullEnabled)
             {
-                DockerService.PullImage(tagName, Options.IsDryRun);
+                DockerService.PullImage(tagName, platform, Options.IsDryRun);
             }
             else if (!DockerService.LocalImageExists(tagName, Options.IsDryRun))
             {

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/UpdateImageSizeBaselineCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/UpdateImageSizeBaselineCommand.cs
@@ -44,11 +44,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             JObject json = new();
 
-            void processImage(string repoId, string imageId, string imageTag)
+            void processImage(string repoId, string imageId, string imageTag, string platform)
             {
                 _loggerService.WriteMessage($"Processing '{imageId}'");
 
-                long imageSize = GetImageSize(imageTag);
+                long imageSize = GetImageSize(imageTag, platform);
 
                 if (!Options.AllBaselineData &&
                     imageData is not null &&
@@ -71,7 +71,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 }
 
                 JObject repo;
-                if (json.TryGetValue(repoId, out JToken repoToken))
+                if (json.TryGetValue(repoId, out JToken? repoToken))
                 {
                     repo = (JObject)repoToken;
                 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ValidateImageSizeCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ValidateImageSizeCommand.cs
@@ -44,12 +44,12 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             Dictionary<string, ImageSizeInfo> imageData = LoadBaseline();
 
             // This handler will be invoked for each image defined in the manifest
-            void processImage(string repoId, string imageId, string tagName)
+            void processImage(string repoId, string imageId, string tagName, string platform)
             {
                 long? currentSize = null;
                 if (Options.Mode.HasFlag(ImageSizeValidationMode.Size))
                 {
-                    currentSize = GetImageSize(tagName);
+                    currentSize = GetImageSize(tagName, platform);
                 }
 
                 // If the image is found in the generated set of ImageSizeInfos, it means we have

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
@@ -108,9 +108,15 @@ namespace Microsoft.DotNet.ImageBuilder
             }
         }
 
-        public static void PullImage(string image, bool isDryRun)
+        public static void PullImage(string image, string? platform, bool isDryRun)
         {
-            ExecuteHelper.ExecuteWithRetry("docker", $"pull {image}", isDryRun);
+            string platformArg = "";
+            if (platform is not null)
+            {
+                platformArg = $"--platform {platform} ";
+            }
+
+            ExecuteHelper.ExecuteWithRetry("docker", $"pull {platformArg}{image}", isDryRun);
         }
 
         public static string ReplaceRepo(string image, string newRepo) =>

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerService.cs
@@ -56,7 +56,7 @@ namespace Microsoft.DotNet.ImageBuilder
 
         public IEnumerable<string> GetImageManifestLayers(string image, bool isDryRun) => _manifestToolService.GetImageLayers(image, isDryRun);
 
-        public void PullImage(string image, bool isDryRun) => DockerHelper.PullImage(image, isDryRun);
+        public void PullImage(string image, string? platform, bool isDryRun) => DockerHelper.PullImage(image, platform, isDryRun);
 
         public void PushImage(string tag, bool isDryRun) => ExecuteHelper.ExecuteWithRetry("docker", $"push {tag}", isDryRun);
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerServiceCache.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerServiceCache.cs
@@ -58,11 +58,11 @@ namespace Microsoft.DotNet.ImageBuilder
         public bool LocalImageExists(string tag, bool isDryRun) =>
             _localImageExistsCache.GetOrAdd(tag, _ => _inner.LocalImageExists(tag, isDryRun));
         
-        public void PullImage(string image, bool isDryRun)
+        public void PullImage(string image, string? platform, bool isDryRun)
         {
             _pulledImages.GetOrAdd(image, _ =>
             {
-                _inner.PullImage(image, isDryRun);
+                _inner.PullImage(image, platform, isDryRun);
                 return true;
             });
         }

--- a/src/Microsoft.DotNet.ImageBuilder/src/IDockerService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/IDockerService.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.ImageBuilder
     {
         Architecture Architecture { get; }
 
-        void PullImage(string image, bool isDryRun);
+        void PullImage(string image, string? platform, bool isDryRun);
 
         string? GetImageDigest(string image, bool isDryRun);
 

--- a/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
@@ -1021,7 +1021,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             Assert.Equal(expectedOutput, actualOutput);
 
-            dockerServiceMock.Verify(o => o.PullImage(runtimeDepsDigest, false), Times.Once);
+            dockerServiceMock.Verify(o => o.PullImage(runtimeDepsDigest, null, false), Times.Once);
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsDigest, $"{runtimeDepsRepo}:{tag}", false), Times.Once);
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsDigest, $"{runtimeDepsRepo}:{newTag}", false), Times.Once);
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsDigest, $"{runtimeDepsRepo}:shared", false), Times.Once);
@@ -1500,12 +1500,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Assert.Equal(expectedOutput, actualOutput);
 
             Times expectedTimes = isRuntimeDepsCached ? Times.Once() : Times.Never();
-            dockerServiceMock.Verify(o => o.PullImage(runtimeDepsDigest, false), expectedTimes);
+            dockerServiceMock.Verify(o => o.PullImage(runtimeDepsDigest, null, false), expectedTimes);
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsDigest, $"{overridePrefix}{runtimeDepsRepo}:{tag}", false), expectedTimes);
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsDigest, $"{overridePrefix}{runtimeDepsRepo}:shared", false), expectedTimes);
 
             expectedTimes = isRuntimeCached ? Times.Once() : Times.Never();
-            dockerServiceMock.Verify(o => o.PullImage(runtimeDigest, false), expectedTimes);
+            dockerServiceMock.Verify(o => o.PullImage(runtimeDigest, null, false), expectedTimes);
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDigest, $"{overridePrefix}{runtimeRepo}:{tag}", false), expectedTimes);
 
             // Verify that a script call to get installed packages is not made when the image is cached
@@ -1796,10 +1796,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             dockerServiceMock.Verify(o => o.GetImageDigest(linuxBaseImageTag, false), Times.Once);
             dockerServiceMock.Verify(o => o.GetImageDigest(windowsBaseImageTag, false), Times.Once);
-            dockerServiceMock.Verify(o => o.PullImage(linuxBaseImageTag, false), Times.Once);
-            dockerServiceMock.Verify(o => o.PullImage(windowsBaseImageTag, false), Times.Once);
-            dockerServiceMock.Verify(o => o.PullImage(runtimeDepsLinuxDigest, false), Times.Once);
-            dockerServiceMock.Verify(o => o.PullImage(runtimeDepsWindowsDigest, false), Times.Once);
+            dockerServiceMock.Verify(o => o.PullImage(linuxBaseImageTag, "linux/amd64", false), Times.Once);
+            dockerServiceMock.Verify(o => o.PullImage(windowsBaseImageTag, "windows/amd64", false), Times.Once);
+            dockerServiceMock.Verify(o => o.PullImage(runtimeDepsLinuxDigest, null, false), Times.Once);
+            dockerServiceMock.Verify(o => o.PullImage(runtimeDepsWindowsDigest, null, false), Times.Once);
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsLinuxDigest, $"{runtimeDepsRepo}:shared", false), Times.Once);
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsLinuxDigest, $"{runtimeDepsRepo}:{linuxTag}", false), Times.Once);
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsLinuxDigest, $"{runtimeDeps2Repo}:{linuxTag}", false), Times.Once);
@@ -2086,7 +2086,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             Assert.Equal(expectedOutput, actualOutput);
 
-            dockerServiceMock.Verify(o => o.PullImage(runtimeDepsDigest, false));
+            dockerServiceMock.Verify(o => o.PullImage(runtimeDepsDigest, null, false));
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsDigest, $"{runtimeDepsRepo}:{tag}", false));
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsDigest, $"{runtimeDeps2Repo}:{tag}", false));
             dockerServiceMock.Verify(o => o.GetImageManifestLayers($"{runtimeDepsRepo}:{tag}", false), Times.Once);
@@ -2105,7 +2105,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     It.IsAny<bool>(),
                     It.IsAny<bool>()));
 
-            dockerServiceMock.Verify(o => o.PullImage(baseImageTag, false));
+            dockerServiceMock.Verify(o => o.PullImage(baseImageTag, "linux/amd64", false));
             dockerServiceMock.Verify(o => o.GetImageDigest(It.IsAny<string>(), false));
             dockerServiceMock.Verify(o => o.GetCreatedDate(It.IsAny<string>(), false));
             dockerServiceMock.Verify(o => o.GetImageArch(baseImageTag, false));
@@ -2304,7 +2304,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     Times.Once);
             }
 
-            dockerServiceMock.Verify(o => o.PullImage(baseImageTag, false));
+            dockerServiceMock.Verify(o => o.PullImage(baseImageTag, "linux/amd64", false));
             dockerServiceMock.Verify(o => o.GetImageDigest(baseImageTag, false));
             dockerServiceMock.Verify(o => o.GetImageDigest($"{runtimeDepsRepo}:{tag}", false));
             dockerServiceMock.Verify(o => o.GetImageDigest($"{runtimeDeps2Repo}:{tag}", false));
@@ -2546,7 +2546,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     Times.Once);
             }
 
-            dockerServiceMock.Verify(o => o.PullImage(baseImageTag, false));
+            dockerServiceMock.Verify(o => o.PullImage(baseImageTag, "linux/amd64", false));
             dockerServiceMock.Verify(o => o.GetImageDigest(baseImageTag, false));
             dockerServiceMock.Verify(o => o.GetImageDigest($"{runtimeDepsRepo}:{tag}", false));
             dockerServiceMock.Verify(o => o.GetImageDigest($"{runtimeDeps2Repo}:{tag}", false));
@@ -2735,8 +2735,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Assert.Equal(expectedOutput, actualOutput);
 
             dockerServiceMock.Verify(o => o.GetImageDigest(baseImageTag, false), Times.Once);
-            dockerServiceMock.Verify(o => o.PullImage(baseImageTag, false), Times.Once);
-            dockerServiceMock.Verify(o => o.PullImage(runtimeDepsDigest, false), Times.Once);
+            dockerServiceMock.Verify(o => o.PullImage(baseImageTag, "linux/amd64", false), Times.Once);
+            dockerServiceMock.Verify(o => o.PullImage(runtimeDepsDigest, null, false), Times.Once);
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsDigest, $"{runtimeDepsRepo}:{tag}", false), Times.Once);
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsDigest, $"{runtimeDepsRepo}:{newTag}", false), Times.Once);
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsDigest, $"{runtimeDepsRepo}:shared", false), Times.Once);
@@ -2977,8 +2977,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             Assert.Equal(expectedOutput, actualOutput);
 
-            dockerServiceMock.Verify(o => o.PullImage(runtimeDepsLinuxDigest, false), Times.Once);
-            dockerServiceMock.Verify(o => o.PullImage(baseImageTag, false), Times.Once);
+            dockerServiceMock.Verify(o => o.PullImage(runtimeDepsLinuxDigest, null, false), Times.Once);
+            dockerServiceMock.Verify(o => o.PullImage(baseImageTag, "linux/amd64", false), Times.Once);
             dockerServiceMock.Verify(o => o.GetImageDigest(baseImageTag, false), Times.Once);
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsLinuxDigest, $"{runtimeDepsRepo}:{tag}", false), Times.Once);
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsLinuxDigest, $"{runtimeDepsRepo}:shared", false), Times.Once);
@@ -3326,7 +3326,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             Assert.Equal(expectedOutput, actualOutput);
 
-            dockerServiceMock.Verify(o => o.PullImage(mirrorBaseTag, false));
+            dockerServiceMock.Verify(o => o.PullImage(mirrorBaseTag, "linux/amd64", false));
             dockerServiceMock.Verify(o => o.CreateTag(mirrorBaseTag, referencedBaseImageTag, false));
 
             dockerServiceMock.Verify(
@@ -3341,10 +3341,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             if (hasCachedImage)
             {
-                dockerServiceMock.Verify(o => o.PullImage($"{Registry}/{RuntimeDepsRepo}@{RuntimeDepsDigest}", false));
+                dockerServiceMock.Verify(o => o.PullImage($"{Registry}/{RuntimeDepsRepo}@{RuntimeDepsDigest}", null, false));
                 dockerServiceMock.Verify(o => o.CreateTag($"{Registry}/{RuntimeDepsRepo}@{RuntimeDepsDigest}", $"{RegistryOverride}/{RepoPrefix}{RuntimeDepsRepo}:{Tag}", false));
 
-                dockerServiceMock.Verify(o => o.PullImage($"{Registry}/{RuntimeRepo}@{RuntimeDigest}", false));
+                dockerServiceMock.Verify(o => o.PullImage($"{Registry}/{RuntimeRepo}@{RuntimeDigest}", null, false));
                 dockerServiceMock.Verify(o => o.CreateTag($"{Registry}/{RuntimeRepo}@{RuntimeDigest}", $"{RegistryOverride}/{RepoPrefix}{RuntimeRepo}:{Tag}", false));
             }
             else
@@ -3466,7 +3466,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     It.IsAny<bool>(),
                     It.IsAny<bool>()));
 
-            dockerServiceMock.Verify(o => o.PullImage($"{baseImageRepoPrefix}/{RuntimeRepo}:{Tag}", false));
+            dockerServiceMock.Verify(o => o.PullImage($"{baseImageRepoPrefix}/{RuntimeRepo}:{Tag}", "linux/amd64", false));
             dockerServiceMock.Verify(o => o.GetImageDigest($"{baseImageRepoPrefix}/{RuntimeRepo}:{Tag}", false));
             dockerServiceMock.Verify(o => o.GetImageDigest($"{RegistryOverride}/{SamplesRepo}:{Tag}", false));
             dockerServiceMock.Verify(o => o.PushImage($"{RegistryOverride}/{SamplesRepo}:{Tag}", false));


### PR DESCRIPTION
Due to the changes in https://github.com/dotnet/docker-tools/pull/940, the build for the .NET 6 samples is failing with the following error in the Arm32 legs:

```
Unhandled exception: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
 ---> System.InvalidOperationException: Failed to execute docker build --platform linux/arm/v7 -t dotnetdocker.azurecr.io/build-staging/1573227/dotnet/samples:aspnetapp-buster-slim-arm32v7 -t dotnetdocker.azurecr.io/build-staging/1573227/dotnet/samples:aspnetapp -f dotnet-dotnet-docker/samples/aspnetapp/Dockerfile.debian-arm32 dotnet-dotnet-docker/samples/aspnetapp

failed to get destination image "sha256:d43c51a2603110b8392b050705c55f7f0e777487fcce103ac9dd9f3089af4cf2": image with reference sha256:d43c51a2603110b8392b050705c55f7f0e777487fcce103ac9dd9f3089af4cf2 was found but does not match the specified platform: wanted linux/arm/v7, actual: linux/arm64/v8
   at Microsoft.DotNet.ImageBuilder.ExecuteHelper.Execute(ProcessStartInfo info, Func`2 executor, Boolean isDryRun, String errorMessage, String executeMessageOverride) in /image-builder/src/ExecuteHelper.cs:line 101
   at Microsoft.DotNet.ImageBuilder.ExecuteHelper.ExecuteWithRetry(ProcessStartInfo info, Action`1 processStartedCallback, Boolean isDryRun, String errorMessage, String executeMessageOverride) in /image-builder/src/ExecuteHelper.cs:line 60
   at Microsoft.DotNet.ImageBuilder.ExecuteHelper.ExecuteWithRetry(String fileName, String args, Boolean isDryRun, String errorMessage, String executeMessageOverride) in /image-builder/src/ExecuteHelper.cs:line 45
   at Microsoft.DotNet.ImageBuilder.DockerService.BuildImage(String dockerfilePath, String buildContextPath, String platform, IEnumerable`1 tags, IDictionary`2 buildArgs, Boolean isRetryEnabled, Boolean isDryRun) in /image-builder/src/DockerService.cs:line 84
   at Microsoft.DotNet.ImageBuilder.DockerServiceCache.BuildImage(String dockerfilePath, String buildContextPath, String platform, IEnumerable`1 tags, IDictionary`2 buildArgs, Boolean isRetryEnabled, Boolean isDryRun) in /image-builder/src/DockerServiceCache.cs:line 38
   at Microsoft.DotNet.ImageBuilder.Commands.BuildCommand.BuildImage(PlatformInfo platform, IEnumerable`1 allTags) in /image-builder/src/Commands/BuildCommand.cs:line 465
   at Microsoft.DotNet.ImageBuilder.Commands.BuildCommand.BuildImages() in /image-builder/src/Commands/BuildCommand.cs:line 313
   at Microsoft.DotNet.ImageBuilder.Commands.BuildCommand.<ExecuteAsync>b__12_0() in /image-builder/src/Commands/BuildCommand.cs:line 60
   at Microsoft.DotNet.ImageBuilder.DockerHelper.ExecuteWithUser(Action action, String username, String password, String server, Boolean isDryRun) in /image-builder/src/DockerHelper.cs:line 37
   at Microsoft.DotNet.ImageBuilder.Commands.DockerRegistryCommand`2.ExecuteWithUser(Action action) in /image-builder/src/Commands/DockerRegistryCommand.cs:line 17
   at Microsoft.DotNet.ImageBuilder.Commands.BuildCommand.ExecuteAsync() in /image-builder/src/Commands/BuildCommand.cs:line 56
   at Microsoft.DotNet.ImageBuilder.Commands.Command`2.<GetCliCommand>b__9_0(TOptions options) in /image-builder/src/Commands/Command.TOptions.cs:line 46
```

In this scenario, Image Builder pre-pulls the `mcr.microsoft.com/dotnet/sdk:6.0` tag. Since this is a multi-arch tag and it's running on an Arm64 machine, it actually pulls the Arm64 image of the SDK. Later when it runs `docker build`, it passes the `--platform linux/arm32/v7` option which causes Docker to fail because the image layer that exists locally is Arm64 and doesn't match the platform.

To fix this, we need to also be using the `--platform` option when pulling the image to ensure that we're pulling the image with the matching platform that will be needed for the build.