### PR TITLE
Template generation: accumulate indentation for nested templates

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateDockerfilesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateDockerfilesCommandTests.cs
@@ -179,7 +179,8 @@ ENV TEST2 Value1";
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
             GenerateDockerfilesCommand command = InitializeCommand(tempFolderContext);
 
-            IReadOnlyDictionary<Value, Value> symbols = command.GetSymbols(command.Manifest.GetPlatformByTag(tag), DockerfileTemplatePath);
+            (IReadOnlyDictionary<Value, Value> symbols, string indent) = command.GetTemplateState(
+                command.Manifest.GetPlatformByTag(tag), DockerfileTemplatePath, string.Empty);
 
             Value variableValue;
             if (isVariable)

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateReadmesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateReadmesCommandTests.cs
@@ -142,17 +142,17 @@ ABC-123";
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
             GenerateReadmesCommand command = InitializeCommand(tempFolderContext);
 
-            IReadOnlyDictionary<Value, Value> symbols;
+            (IReadOnlyDictionary<Value, Value> Symbols, string Indent) templateState;
             if (isManifest)
             {
-                symbols = command.GetSymbols(command.Manifest, ReadmeTemplatePath);
+                templateState = command.GetTemplateState(command.Manifest, ReadmeTemplatePath, string.Empty);
             }
             else
             {
-                symbols = command.GetSymbols(command.Manifest.GetRepoByModelName("dotnet/repo"), ReadmeTemplatePath);
+                templateState = command.GetTemplateState(command.Manifest.GetRepoByModelName("dotnet/repo"), ReadmeTemplatePath, string.Empty);
             }
 
-            Value actualSymbolValue = symbols[symbol];
+            Value actualSymbolValue = templateState.Symbols[symbol];
             Value expectedSymbolValue;
             if (actualSymbolValue.Type == ValueContent.Boolean)
             {


### PR DESCRIPTION
An issue exists with how content is generated from artifact templates when the `indent` argument of the `InsertTemplate` function is being used. The indent value doesn't get applied to the next nested template. This prevents the reusability of sub-templates when indentation is involved.

Here's an example:

### RootTemplate
```
RootTemplate Content
{{InsertTemplate("TemplateA", [], "  ")}}
```

### TemplateA

```
TemplateA Content
{{InsertTemplate("TemplateB")}}
```

### TemplateB

```
TemplateB Content
```

Generating the content from RootTemplate yields the following output:

```
RootTemplate Content
  TemplateA Content
TemplateB Content
```

Since TemplateB was referenced by TemplateA, the indentation of TemplateA should also apply to TemplateB's content in this scope.

The expected output is the following:

```
RootTemplate Content
  TemplateA Content
  TemplateB Content
```

Similarly, if TemplateA passed its own indent value to TemplateB, the result should be cumulative with TemplateA's own indentation.

For example, if TemplateA was defined like this:

```
TemplateA Content
{{InsertTemplate("TemplateB", [], "    ")}}
```

The overall result should be the following:

```
RootTemplate Content
  TemplateA Content
      TemplateB Content
```

This is been fixed in Image Builder by accumulating the indent values across nested templates.