### PR TITLE
Expose indentation of template as a symbol

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateArtifactsCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateArtifactsCommand.cs
@@ -177,7 +177,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             (IReadOnlyDictionary<Value, Value> Symbols, string Indent) state = getTemplateState(context, templatePath, currentIndent);
             IReadOnlyDictionary<Value, Value> symbols = new Dictionary<Value, Value>(state.Symbols)
             {
-                { "ARGS", new Dictionary<Value, Value>(templateArgs.Fields) }
+                { "ARGS", new Dictionary<Value, Value>(templateArgs.Fields) },
+                { "INDENT", state.Indent }
             };          
 
             if (!string.IsNullOrEmpty(state.Indent))


### PR DESCRIPTION
This allows templates to use conditional logic based on whether any indentation is being applied to it. See https://github.com/dotnet/dotnet-docker/pull/3445#discussion_r795756396.