### PR TITLE
Fix for Dockerfiles using "FROM scratch"

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
@@ -132,8 +132,11 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
                 .Where(from => !IsStageReference(from, fromMatches))
                 .ToArray();
 
-            FinalStageFromImage = fromImages
-                .LastOrDefault(image => !IsFromScratchImage(image));
+            FinalStageFromImage = fromImages.Last();
+            if (IsFromScratchImage(FinalStageFromImage))
+            {
+                FinalStageFromImage = null;
+            }
 
             InternalFromImages = fromImages
                 .Where(from => IsInternalFromImage(from))


### PR DESCRIPTION
Image Builder isn't correctly representing the `PlatformInfo.FinalStageFromImage` property in the case of a multi-stage Dockerfile that has `FROM scratch` as the final stage.

Here's an example Dockerfile that demonstrates the issue:

```Dockerfile
FROM mybase
FROM scratch
```

When ImageBuilder loads the model, it will have `PlatformInfo.FinalStageFromImage` set to `"mybase"` when it really should be `null`. This is because the `FROM scratch` stage gets filtered out when calculating the property. I've corrected the logic to handle this scenario.