### PR TITLE
Use parameterized pool for post-build job

### DIFF
--- a/eng/common/templates/jobs/post-build.yml
+++ b/eng/common/templates/jobs/post-build.yml
@@ -1,7 +1,9 @@
+parameters:
+  pool: {}
+
 jobs:
 - job: Build
-  pool:
-    vmImage: $(defaultLinuxAmd64PoolImage)
+  pool: ${{ parameters.pool }}
   steps:
   - template: ../steps/init-docker-linux.yml
   - template: ../steps/download-build-artifact.yml

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -168,6 +168,8 @@ stages:
   condition: and(succeeded(), contains(variables['stages'], 'build'))
   jobs:
   - template: ../jobs/post-build.yml
+    parameters:
+      pool: ${{ parameters.linuxAmd64Pool }}
 
 ################################################################################
 # Test Images


### PR DESCRIPTION
The Post-Build job is using the `defaultLinuxAmd64PoolImage` VM image for its agent pool which ends up being `ubuntu-latest`. For builds that make use of the `build-test-publish-repo.yml` template, the Post-Build job should instead be using whatever pool is passed for the `linuxAmd64Pool` parameter instead. This will ensure it uses the 1ES hosted pool instead.