### PR TITLE
Use image info as input to pullImages command

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PullImagesOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PullImagesOptions.cs
@@ -15,6 +15,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public ManifestFilterOptions FilterOptions { get; set; } = new();
 
         public string? OutputVariableName { get; set; }
+        public string? ImageInfoPath { get; set; }
     }
 
     public class PullImagesOptionsBuilder : ManifestOptionsBuilder
@@ -27,7 +28,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 .Concat(new Option[]
                 {
                     CreateOption<string>("output-var", nameof(PullImagesOptions.OutputVariableName),
-                        "Azure DevOps variable name to use for outputting the list of pulled image tags")
+                        "Azure DevOps variable name to use for outputting the list of pulled image tags"),
+                    CreateOption<string>("image-info", nameof(PullImagesOptions.ImageInfoPath),
+                        "Path to the image info file describing which images are to be pulled")
                 });
 
         public override IEnumerable<Argument> GetCliArguments() =>


### PR DESCRIPTION
As described in https://github.com/dotnet/docker-tools/issues/961#issuecomment-1032792234, we'll use the image info file to determine which images are to be scanned for SBOM generation.

In order to do that, we need to pull those images to the build agent first. There is an existing `pullImages` command but this doesn't use an image info file as input. It pulls images strictly based on what's defined in the manifest and whatever filtering is applied.

These changes update the `pullImages` command to optionally accept an image info path as input. It will then use the tags defined in that file as the basis for which tags are to be pulled.

This ensures that we only pull what was actually built rather than everything defined in the manifest.