### PR TITLE
Enables the collection of component data by default

### DIFF
--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -65,6 +65,15 @@ jobs:
         echo "##vso[task.setvariable variable=testScriptPath]$testScriptPath"
         echo "##vso[task.setvariable variable=testResultsDirectory]$testResultsDirectory"
       displayName: Override Common Paths
+  - powershell: |
+      if ("${{ parameters.noCache }}" -eq "false") {
+        $baseContainerRepoPath = "/repo/$(buildRepoName)"
+      }
+      else {
+        $baseContainerRepoPath = "/repo"
+      }
+      echo "##vso[task.setvariable variable=baseContainerRepoPath]$baseContainerRepoPath"
+    displayName: Set Base Container Repo Path
   - template: ${{ format('../steps/init-docker-{0}.yml', parameters.dockerClientOS) }}
   - ${{ parameters.customInitSteps }}
   - template: ../steps/set-image-info-path-var.yml
@@ -92,6 +101,7 @@ jobs:
       --architecture $(architecture)
       --retry
       --source-repo $(publicGitRepoUri)
+      --get-installed-pkgs-path $(baseContainerRepoPath)/$(engCommonRelativePath)/package-scripts/get-installed-packages.sh
       $(manifestVariables)
       $(imageBuilderBuildArgs)
     displayName: Build Images


### PR DESCRIPTION
This is a migration of the changes from https://github.com/dotnet/dotnet-docker/pull/3319. It enables component data collection in the builds by default for the `eng/common` infrastructure.