### PR TITLE
Fix format of output variable for pullImages command

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PullImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PullImagesCommand.cs
@@ -53,14 +53,17 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 .ToList();
 
             _loggerService.WriteHeading("PULLING IMAGES");
-            foreach ((string Tag, string Platform) platformTag in platformTags)
+            foreach ((string tag, string platform) in platformTags)
             {
-                _dockerService.PullImage(platformTag.Tag, platformTag.Platform, Options.IsDryRun);
+                _dockerService.PullImage(tag, platform, Options.IsDryRun);
             }
 
             if (Options.OutputVariableName is not null)
             {
-                _loggerService.WriteMessage(PipelineHelper.FormatOutputVariable(Options.OutputVariableName, string.Join(',', platformTags)));
+                _loggerService.WriteMessage(
+                    PipelineHelper.FormatOutputVariable(
+                        Options.OutputVariableName,
+                        string.Join(',', platformTags.Select(platformTag => platformTag.Tag))));
             }
 
             return Task.CompletedTask;


### PR DESCRIPTION
The changes in https://github.com/dotnet/docker-tools/pull/955 caused a regression in the output variable of the `pullImages` command. It caused the format of the output to include the platform along with the tag.

Expected output:

```
mcr.microsoft.com/dotnet/nightly/runtime-deps:3.1.22-buster-slim,mcr.microsoft.com/dotnet/nightly/runtime-deps:3.1.22-buster-slim-arm32v7
```

Actual Output:

```
(mcr.microsoft.com/dotnet/nightly/runtime-deps:3.1.22-buster-slim, linux/amd64),(mcr.microsoft.com/dotnet/nightly/runtime-deps:3.1.22-buster-slim-arm32v7, linux/arm/v7)
```

This is because the `IEnumerable` being used to generate the output had been changed to `IEnumerable<(string, string)>` when it should be `IEnumerable<string>`.