### PR TITLE
Include SBOM generation in build

### DIFF
--- a/eng/common/templates/jobs/generate-sbom.yml
+++ b/eng/common/templates/jobs/generate-sbom.yml
@@ -4,6 +4,14 @@ parameters:
 jobs:
 - job: GenerateSBOM
   pool: ${{ parameters.pool }}
+  strategy:
+    matrix:
+      amd64:
+        arch: amd64
+      arm32:
+        arch: arm
+      arm64:
+        arch: arm64
   variables:
     sbomDirectory: $(Build.ArtifactStagingDirectory)/sbom
   steps:
@@ -18,7 +26,7 @@ jobs:
     displayName: Trim Unchanged Images
   - script: >
       $(runImageBuilderCmd) pullImages
-      --architecture '*'
+      --architecture '$(arch)'
       --manifest 'manifest.json'
       --output-var 'pulledImages'
       --image-info '$(artifactsPath)/image-info.json'
@@ -29,11 +37,11 @@ jobs:
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: Generate SBOM
     inputs:
-      PackageName: $(Build.DefinitionName)
+      PackageName: ".NET"
       PackageVersion: $(Build.BuildNumber)
       BuildDropPath: $(Build.ArtifactStagingDirectory)
       ManifestDirPath: $(sbomDirectory)
       dockerImagesToScan: $(PullImages.pulledImages)
   - publish: $(sbomDirectory)
-    artifact: sbom_linux
+    artifact: sbom_linux_$(arch)
     displayName: Publish SBOM

--- a/eng/common/templates/jobs/generate-sbom.yml
+++ b/eng/common/templates/jobs/generate-sbom.yml
@@ -1,0 +1,39 @@
+parameters:
+  pool: {}
+
+jobs:
+- job: GenerateSBOM
+  pool: ${{ parameters.pool }}
+  variables:
+    sbomDirectory: $(Build.ArtifactStagingDirectory)/sbom
+  steps:
+  - template: ../steps/init-docker-linux.yml
+  - template: ../steps/download-build-artifact.yml
+    parameters:
+      targetPath: $(Build.ArtifactStagingDirectory)
+      artifactName: image-info
+  - script: >
+      $(runImageBuilderCmd) trimUnchangedPlatforms
+      '$(artifactsPath)/image-info.json'
+    displayName: Trim Unchanged Images
+  - script: >
+      $(runImageBuilderCmd) pullImages
+      --architecture '*'
+      --manifest 'manifest.json'
+      --output-var 'pulledImages'
+      --image-info '$(artifactsPath)/image-info.json'
+    name: PullImages
+    displayName: Pull Images
+  - script: mkdir $(sbomDirectory)
+    displayName: Create SBOM Directory
+  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+    displayName: Generate SBOM
+    inputs:
+      PackageName: $(Build.DefinitionName)
+      PackageVersion: $(Build.BuildNumber)
+      BuildDropPath: $(Build.ArtifactStagingDirectory)
+      ManifestDirPath: $(sbomDirectory)
+      dockerImagesToScan: $(PullImages.pulledImages)
+  - publish: $(sbomDirectory)
+    artifact: sbom_linux
+    displayName: Publish SBOM

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -249,6 +249,25 @@ stages:
         internalProjectName: ${{ parameters.internalProjectName }}
 
 ################################################################################
+# Generate SBOM
+################################################################################
+- ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+  - stage: Generate_SBOM
+    dependsOn: Post_Build
+    condition: "
+      and(
+        contains(variables['stages'], 'sbom'),
+        or(
+          and(
+            succeeded(),
+            contains(variables['stages'], 'build')),
+          not(contains(variables['stages'], 'build'))))"
+    jobs:
+    - template: ../jobs/generate-sbom.yml
+      parameters:
+        pool: ${{ parameters.linuxAmd64Pool }}
+
+################################################################################
 # Publish Images
 ################################################################################
 - stage: Publish

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1602635
+  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1614668
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-buster-slim-docker-testrunner-974165
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)


### PR DESCRIPTION
This adds a pipeline stage which will generate an SBOM from the built images. It runs after the Post-Build stage, in parallel with the Test stage. It has the following workflow:

1. Consumes the image-info.json artifact produced by the Post-Build stage
2. Trims out any unchanged images that were pulled from the cache and not actually built
3. Pulls the images
4. Generate an SBOM from the images
5. Upload the SBOM as a pipeline artifact

Fixes #961