### PR TITLE
Allow platform check in build command to be skipped

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -427,7 +427,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         private void ValidatePlatformIsCompatibleWithBaseImage(PlatformInfo platform)
         {
-            if (platform.FinalStageFromImage is null)
+            if (platform.FinalStageFromImage is null || Options.SkipPlatformCheck)
             {
                 return;
             }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
@@ -24,6 +24,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public string? SourceRepoPrefix { get; set; }
         public string? GetInstalledPackagesScriptPath { get; set; }
         public IDictionary<string, string> BuildArgs { get; set; } = new Dictionary<string, string>();
+        public bool SkipPlatformCheck { get; set; }
     }
 
     public class BuildOptionsBuilder : DockerRegistryOptionsBuilder
@@ -57,6 +58,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                             "Path to the default script file that outputs list of installed packages"),
                         CreateDictionaryOption("build-arg", nameof(BuildOptions.BuildArgs),
                             "Build argument to pass to the Dockerfiles (<name>=<value>)"),
+                        CreateOption<bool>("skip-platform-check", nameof(BuildOptions.SkipPlatformCheck),
+                            "Skips validation that ensures the Dockerfile's base image's platform matches the manifest configuration"),
                     });
 
         public override IEnumerable<Argument> GetCliArguments() =>


### PR DESCRIPTION
As part of the work to enable ARM64 support of CBL-Mariner for https://github.com/dotnet/dotnet-docker/issues/3455, it was discovered that the image metadata of Mariner's ARM64 images do not contain the variant field (https://github.com/dotnet/dotnet-docker/issues/3520). This causes the platform architecture validation check to fail: 

https://github.com/dotnet/docker-tools/blob/5eb5824b8370a33482c95facd7a5f0525da48e48/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs#L428-L453

To work around this, I'm adding a build option that allows the validation check to be skipped. As part of the implementation of https://github.com/dotnet/dotnet-docker/issues/3455, this option will be set only for the CBL-Mariner ARM64 build legs.