### PR TITLE
Support build retention in pipeline template

### DIFF
--- a/eng/common/Retain-Build.ps1
+++ b/eng/common/Retain-Build.ps1
@@ -1,0 +1,43 @@
+# Adapted from https://github.com/dotnet/arcade/blob/main/eng/common/retain-build.ps1
+Param(
+    [Parameter(Mandatory = $true)][int] $BuildId,
+    [Parameter(Mandatory = $true)][string] $AzdoOrgUri, 
+    [Parameter(Mandatory = $true)][string] $AzdoProject,
+    [Parameter(Mandatory = $true)][string] $Token
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+function Get-AzDOHeaders(
+    [string] $Token) {
+    $base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(":${Token}"))
+    $headers = @{"Authorization" = "Basic $base64AuthInfo" }
+    return $headers
+}
+
+function Update-BuildRetention(
+    [string] $AzdoOrgUri,
+    [string] $AzdoProject,
+    [int] $BuildId,
+    [string] $Token) {
+    $headers = Get-AzDOHeaders -Token $Token
+    $requestBody = "{
+        `"keepForever`": `"true`"
+    }"
+
+    $requestUri = "${AzdoOrgUri}/${AzdoProject}/_apis/build/builds/${BuildId}?api-version=6.0"
+    Write-Host "Attempting to retain build using the following URI: ${requestUri} ..."
+
+    try {
+        Invoke-RestMethod -Uri $requestUri -Method Patch -Body $requestBody -Header $headers -contentType "application/json"
+        Write-Host "Updated retention settings for build ${BuildId}."
+    }
+    catch {
+        Write-Host "##[error] Failed to update retention settings for build: $($_.Exception.Response.StatusDescription)"
+        exit 1
+    }
+}
+
+Update-BuildRetention -AzdoOrgUri $AzdoOrgUri -AzdoProject $AzdoProject -BuildId $BuildId -Token $Token
+exit 0

--- a/eng/common/templates/jobs/generate-matrix.yml
+++ b/eng/common/templates/jobs/generate-matrix.yml
@@ -10,6 +10,7 @@ jobs:
 - job: ${{ parameters.name }}
   pool: ${{ parameters.pool }}
   steps:
+  - template: ../steps/retain-build.yml
   - template: ../steps/init-docker-linux.yml
   - template: ../steps/validate-branch.yml
     parameters:

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -18,6 +18,7 @@ jobs:
     value: $(Build.Repository.Name)
   - ${{ parameters.customPublishVariables }}
   steps:
+  - template: ../steps/retain-build.yml
   - template: ../steps/init-docker-linux.yml
   - pwsh: |
       $azdoOrgName = Split-Path -Leaf $Env:SYSTEM_COLLECTIONURI

--- a/eng/common/templates/steps/retain-build.yml
+++ b/eng/common/templates/steps/retain-build.yml
@@ -1,0 +1,9 @@
+steps:
+- powershell: >
+    $(engCommonPath)/Retain-Build.ps1
+    -BuildId $(Build.BuildId)
+    -AzdoOrgUri '$(System.CollectionUri)'
+    -AzdoProject '$(System.TeamProject)'
+    -Token '$(System.AccessToken)'
+  displayName: Enable permanent build retention
+  condition: and(succeeded(), eq(variables.retainBuild, 'true'))


### PR DESCRIPTION
This updates the pipeline template to support [build retention](#973) for official builds. By default, build retention is not enabled. Any pipeline that wants to enable it needs to be set with a `retainBuild` variable set to `true`.

The pipeline can run any stage independently. So a given build may end up executing only one of those stages. But we'd want to be able to retain any build, regardless of which stage it is running. In order to do that the build step used to retain the build is executed across all of the stages to ensure that it will be retained. If multiple stages run in a build, the step which retains the build essentially becomes a no-op after the first stage has run the step.

Fixes #973