### PR TITLE
Support customization of imageBuilderBuildArgs

### DIFF
--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -25,6 +25,7 @@ jobs:
   variables:
     imageBuilderDockerRunExtraOptions: $(build.imageBuilderDockerRunExtraOptions)
     versionsRepoPath: versions
+    imageBuilderBuildArgs: $[variables.imageBuilderBuildArgs] # set to empty if not defined
     ${{ if eq(parameters.noCache, false) }}:
       versionsBasePath: $(versionsRepoPath)/
       pipelineDisabledCache: false
@@ -80,7 +81,7 @@ jobs:
     parameters:
       publicSourceBranch: $(publicSourceBranch)
   - powershell: |
-      $imageBuilderBuildArgs = "$(imageBuilder.queueArgs) --image-info-output-path $(artifactsPath)/$(legName)-image-info.json"
+      $imageBuilderBuildArgs = "$(imageBuilderBuildArgs) $(imageBuilder.queueArgs) --image-info-output-path $(artifactsPath)/$(legName)-image-info.json"
       if ($env:SYSTEM_TEAMPROJECT -eq "${{ parameters.internalProjectName }}") {
         $imageBuilderBuildArgs = "$imageBuilderBuildArgs --registry-override $(acr.server) --repo-prefix $(stagingRepoPrefix) --source-repo-prefix $(mirrorRepoPrefix) --push --registry-creds ""$(acr.server)=$(acr.userName);$(acr.password)"""
       }

--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -79,7 +79,7 @@ jobs:
   - template: ../steps/set-image-info-path-var.yml
     parameters:
       publicSourceBranch: $(publicSourceBranch)
-  - script: echo "##vso[task.setvariable variable=imageBuilderBuildArgs]"
+  - powershell: echo "##vso[task.setvariable variable=imageBuilderBuildArgs]"
     condition: eq(variables.imageBuilderBuildArgs, '')
     displayName: Initialize Image Builder Build Args
   - powershell: |

--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -25,7 +25,7 @@ jobs:
   variables:
     imageBuilderDockerRunExtraOptions: $(build.imageBuilderDockerRunExtraOptions)
     versionsRepoPath: versions
-    imageBuilderBuildArgs: $[variables.imageBuilderBuildArgs] # set to empty if not defined
+    imageBuilderBuildArgs: $[variables['imageBuilderBuildArgs']]
     ${{ if eq(parameters.noCache, false) }}:
       versionsBasePath: $(versionsRepoPath)/
       pipelineDisabledCache: false

--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -25,7 +25,6 @@ jobs:
   variables:
     imageBuilderDockerRunExtraOptions: $(build.imageBuilderDockerRunExtraOptions)
     versionsRepoPath: versions
-    imageBuilderBuildArgs: $[variables['imageBuilderBuildArgs']]
     ${{ if eq(parameters.noCache, false) }}:
       versionsBasePath: $(versionsRepoPath)/
       pipelineDisabledCache: false
@@ -80,6 +79,9 @@ jobs:
   - template: ../steps/set-image-info-path-var.yml
     parameters:
       publicSourceBranch: $(publicSourceBranch)
+  - script: echo "##vso[task.setvariable variable=imageBuilderBuildArgs]"
+    condition: eq(variables.imageBuilderBuildArgs, '')
+    displayName: Initialize Image Builder Build Args
   - powershell: |
       $imageBuilderBuildArgs = "$(imageBuilderBuildArgs) $(imageBuilder.queueArgs) --image-info-output-path $(artifactsPath)/$(legName)-image-info.json"
       if ($env:SYSTEM_TEAMPROJECT -eq "${{ parameters.internalProjectName }}") {


### PR DESCRIPTION
This allows pipelines to customize the `imageBuilderBuildArgs` variable that gets passed as an argument to the `build` command of Image Builder.

This is specifically necessary to support https://github.com/dotnet/dotnet-docker/issues/3455, allowing it to inject a `--skip-platform-check` option to the build arguments for Arm64 build legs (see https://github.com/dotnet/docker-tools/pull/974).