### PR TITLE
Build option to output digests of images

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
@@ -25,6 +25,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public string? GetInstalledPackagesScriptPath { get; set; }
         public IDictionary<string, string> BuildArgs { get; set; } = new Dictionary<string, string>();
         public bool SkipPlatformCheck { get; set; }
+        public string? OutputVariableName { get; set; }
     }
 
     public class BuildOptionsBuilder : DockerRegistryOptionsBuilder
@@ -60,6 +61,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                             "Build argument to pass to the Dockerfiles (<name>=<value>)"),
                         CreateOption<bool>("skip-platform-check", nameof(BuildOptions.SkipPlatformCheck),
                             "Skips validation that ensures the Dockerfile's base image's platform matches the manifest configuration"),
+                        CreateOption<string>("output-var", nameof(BuildOptions.OutputVariableName),
+                            "Azure DevOps variable name to use for outputting the list of built image digests"),
                     });
 
         public override IEnumerable<Argument> GetCliArguments() =>

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
@@ -61,7 +61,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                             "Build argument to pass to the Dockerfiles (<name>=<value>)"),
                         CreateOption<bool>("skip-platform-check", nameof(BuildOptions.SkipPlatformCheck),
                             "Skips validation that ensures the Dockerfile's base image's platform matches the manifest configuration"),
-                        CreateOption<string>("output-var", nameof(BuildOptions.OutputVariableName),
+                        CreateOption<string>("digests-out-var", nameof(BuildOptions.OutputVariableName),
                             "Azure DevOps variable name to use for outputting the list of built image digests"),
                     });
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         public Platform Model { get; private set; }
         public IEnumerable<string> OverriddenFromImages { get => _overriddenFromImages; }
         public string FullRepoModelName { get; set; }
-        private string RepoName { get; set; }
+        public string RepoName { get; private set; }
         public IEnumerable<TagInfo> Tags { get; private set; }
         public IDictionary<string, CustomBuildLegGroup> CustomLegGroups { get; private set; } =
             ImmutableDictionary<string, CustomBuildLegGroup>.Empty;


### PR DESCRIPTION
This provides an option to the `build` command to output the list of digests of the images that were built. 

This supports the work of #979 by allowing the pipeline to retrieve this list of digests and provide them as input in order to generate an SBOM for each of the images.