### PR TITLE
Remove extra commit to AzDO versions repo

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoOptions.cs
@@ -12,23 +12,19 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     public class PublishImageInfoOptions : ImageInfoOptions, IGitOptionsHost
     {
         public GitOptions GitOptions { get; set; } = new GitOptions();
-        public AzdoOptions AzdoOptions { get; set; } = new AzdoOptions();
     }
 
     public class PublishImageInfoOptionsBuilder : ImageInfoOptionsBuilder
     {
-        private readonly AzdoOptionsBuilder _azdoOptionsBuilder = new AzdoOptionsBuilder();
         private readonly GitOptionsBuilder _gitOptionsBuilder = GitOptionsBuilder.BuildWithDefaults();
 
         public override IEnumerable<Option> GetCliOptions() =>
             base.GetCliOptions()
-                .Concat(_gitOptionsBuilder.GetCliOptions())
-                .Concat(_azdoOptionsBuilder.GetCliOptions());
+                .Concat(_gitOptionsBuilder.GetCliOptions());
 
         public override IEnumerable<Argument> GetCliArguments() =>
             base.GetCliArguments()
-                .Concat(_gitOptionsBuilder.GetCliArguments())
-                .Concat(_azdoOptionsBuilder.GetCliArguments());
+                .Concat(_gitOptionsBuilder.GetCliArguments());
     }
 }
 #nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/tests/PublishImageInfoCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/PublishImageInfoCommandTests.cs
@@ -189,7 +189,6 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 PublishImageInfoCommand command = new PublishImageInfoCommand(gitServiceMock.Object, Mock.Of<ILoggerService>());
                 command.Options.ImageInfoPath = file;
                 command.Options.GitOptions = gitOptions;
-                command.Options.AzdoOptions = azdoOptions;
                 command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
 
                 File.WriteAllText(Path.Combine(tempFolderContext.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));
@@ -381,7 +380,6 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 PublishImageInfoCommand command = new PublishImageInfoCommand(gitServiceMock.Object, Mock.Of<ILoggerService>());
                 command.Options.ImageInfoPath = file;
                 command.Options.GitOptions = gitOptions;
-                command.Options.AzdoOptions = azdoOptions;
                 command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
 
                 File.WriteAllText(Path.Combine(tempFolderContext.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));
@@ -423,7 +421,6 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Mock<Network> networkMock = Mock.Get(repositoryMock.Object.Network);
 
             networkMock.Verify(o => o.Push(It.IsAny<Branch>(), It.IsAny<PushOptions>()));
-            networkMock.Verify(o => o.Push(It.IsAny<Remote>(), It.IsAny<string>(), It.IsAny<PushOptions>()));
         }
 
         private static Mock<IRepository> GetRepositoryMock()


### PR DESCRIPTION
This updates the `publishImageInfo` command to remove the logic which makes the commit to the AzDO versions repo. This is part of the work to implement #986 which will solely rely on the GitHub versions repo. This means that the need to make the same commit to the AzDO repo is no longer needed.