### PR TITLE
Don't merge components between builds

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
@@ -224,7 +224,7 @@ namespace Microsoft.DotNet.ImageBuilder
                 }
                 else if (typeof(IList<Component>).IsAssignableFrom(property.PropertyType))
                 {
-                    MergeLists<Component>(property, srcObj, targetObj, options);
+                    ReplaceValue(property, srcObj, targetObj);
                 }
                 else
                 {


### PR DESCRIPTION
When Image Builder publishes image info files, it's accumulating image component data between builds. For example, a recent [build of Alpine images](https://github.com/dotnet/versions/commit/58cb965e90283925ca2d44d8db6fdd429039a686) picked up a new version of busybox. The image info file now shows that there are two versions of busybox contained in an image: 1.33.1-r6 and 1.33.1-r7. This is because of the merge behavior when updating image info files. It preserved the version from a previous build and added the new version to the list. This is incorrect behavior. The list of components should be completely replaced, not merged.

I've updated the logic in Image Builder to handle this correctly.