### PR TITLE
Use async API in ManifestToolService

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/DockerRegistryCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/DockerRegistryCommand.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Threading.Tasks;
 
 #nullable enable
 namespace Microsoft.DotNet.ImageBuilder.Commands
@@ -13,8 +14,17 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     {
         protected void ExecuteWithUser(Action action)
         {
+            ExecuteWithUserAsync(() =>
+            {
+                action();
+                return Task.CompletedTask;
+            });
+        }
+
+        protected Task ExecuteWithUserAsync(Func<Task> action)
+        {
             Options.CredentialsOptions.Credentials.TryGetValue(Manifest.Registry ?? "", out RegistryCredentials? credentials);
-            DockerHelper.ExecuteWithUser(action, credentials?.Username, credentials?.Password, Manifest.Registry, Options.IsDryRun);
+            return DockerHelper.ExecuteWithUserAsync(action, credentials?.Username, credentials?.Password, Manifest.Registry, Options.IsDryRun);
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 using Newtonsoft.Json;
 using Docker = Microsoft.DotNet.ImageBuilder.Models.Docker;
@@ -25,6 +26,16 @@ namespace Microsoft.DotNet.ImageBuilder
 
         public static void ExecuteWithUser(Action action, string? username, string? password, string? server, bool isDryRun)
         {
+            ExecuteWithUserAsync(() =>
+            {
+                action();
+                return Task.CompletedTask;
+            },
+            username, password, server, isDryRun).GetAwaiter().GetResult();
+        }
+
+        public static async Task ExecuteWithUserAsync(Func<Task> action, string? username, string? password, string? server, bool isDryRun)
+        {
             bool loggedIn = false;
             if (username is not null && password is not null && server is not null)
             {
@@ -34,7 +45,7 @@ namespace Microsoft.DotNet.ImageBuilder
 
             try
             {
-                action();
+                await action();
             }
             finally
             {

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerService.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 
 #nullable enable
@@ -24,7 +25,7 @@ namespace Microsoft.DotNet.ImageBuilder
             _manifestToolService = manifestToolService ?? throw new ArgumentNullException(nameof(manifestToolService));
         }
 
-        public string? GetImageDigest(string image, bool isDryRun)
+        public async Task<string?> GetImageDigestAsync(string image, bool isDryRun)
         {
             IEnumerable<string> digests = DockerHelper.GetImageDigests(image, isDryRun);
 
@@ -34,7 +35,7 @@ namespace Microsoft.DotNet.ImageBuilder
                 return null;
             }
 
-            string digestSha = _manifestToolService.GetManifestDigestSha(ManifestMediaType.Any, image, isDryRun);
+            string digestSha = await _manifestToolService.GetManifestDigestShaAsync(ManifestMediaType.Any, image, isDryRun);
 
             if (digestSha is null)
             {
@@ -54,7 +55,8 @@ namespace Microsoft.DotNet.ImageBuilder
             return digest;
         }
 
-        public IEnumerable<string> GetImageManifestLayers(string image, bool isDryRun) => _manifestToolService.GetImageLayers(image, isDryRun);
+        public Task<IEnumerable<string>> GetImageManifestLayersAsync(string image, bool isDryRun) =>
+            _manifestToolService.GetImageLayersAsync(image, isDryRun);
 
         public void PullImage(string image, string? platform, bool isDryRun) => DockerHelper.PullImage(image, platform, isDryRun);
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/IDockerService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/IDockerService.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 
 #nullable enable
@@ -15,9 +16,9 @@ namespace Microsoft.DotNet.ImageBuilder
 
         void PullImage(string image, string? platform, bool isDryRun);
 
-        string? GetImageDigest(string image, bool isDryRun);
+        Task<string?> GetImageDigestAsync(string image, bool isDryRun);
 
-        IEnumerable<string> GetImageManifestLayers(string image, bool isDryRun);
+        Task<IEnumerable<string>> GetImageManifestLayersAsync(string image, bool isDryRun);
 
         void PushImage(string tag, bool isDryRun);
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/IManifestToolService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/IManifestToolService.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.DotNet.ImageBuilder
@@ -9,6 +10,6 @@ namespace Microsoft.DotNet.ImageBuilder
     public interface IManifestToolService
     {
         void PushFromSpec(string manifestFile, bool isDryRun);
-        JArray Inspect(string image, bool isDryRun);
+        Task<JArray> InspectAsync(string image, bool isDryRun);
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/LockHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/LockHelper.cs
@@ -69,7 +69,7 @@ namespace Microsoft.DotNet.ImageBuilder
         }
 
         public static async Task<TValue> DoubleCheckedLockLookupAsync<TKey, TValue>(
-            this SemaphoreSlim semaphore, IDictionary<TKey, TValue> dictionary, TKey key, Func<Task<TValue>> getValue)
+            this SemaphoreSlim semaphore, IDictionary<TKey, TValue> dictionary, TKey key, Func<Task<TValue>> getValue, Func<TValue, bool> addToDictionary = null)
         {
             if (!dictionary.TryGetValue(key, out TValue value))
             {
@@ -78,7 +78,11 @@ namespace Microsoft.DotNet.ImageBuilder
                     if (!dictionary.TryGetValue(key, out value))
                     {
                         value = await getValue();
-                        dictionary.Add(key, value);
+
+                        if (addToDictionary is null || addToDictionary(value))
+                        {
+                            dictionary.Add(key, value);
+                        }
                     }
                 });
             }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ManifestToolService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ManifestToolService.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel.Composition;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -21,15 +22,15 @@ namespace Microsoft.DotNet.ImageBuilder
             ExecuteHelper.ExecuteWithRetry("manifest-tool", $"push from-spec {manifestFile}", isDryRun);
         }
 
-        public JArray Inspect(string image, bool isDryRun)
+        public Task<JArray> InspectAsync(string image, bool isDryRun)
         {
             string output = ExecuteHelper.ExecuteWithRetry("manifest-tool", $"inspect {image} --raw", isDryRun);
             if (isDryRun)
             {
-                return new JArray();
+                return Task.FromResult(new JArray());
             }
 
-            return JsonConvert.DeserializeObject<JArray>(output);
+            return Task.FromResult(JsonConvert.DeserializeObject<JArray>(output));
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ManifestToolServiceExtensions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ManifestToolServiceExtensions.cs
@@ -5,15 +5,16 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.DotNet.ImageBuilder
 {
     public static class ManifestToolServiceExtensions
     {
-        public static IEnumerable<string> GetImageLayers(this IManifestToolService manifestToolService, string tag, bool isDryRun)
+        public static async Task<IEnumerable<string>> GetImageLayersAsync(this IManifestToolService manifestToolService, string tag, bool isDryRun)
         {
-            IEnumerable<JObject> tagManifests = manifestToolService.Inspect(tag, isDryRun).OfType<JObject>();
+            IEnumerable<JObject> tagManifests = (await manifestToolService.InspectAsync(tag, isDryRun)).OfType<JObject>();
 
             int manifestCount = tagManifests.Count();
             if (manifestCount != 1)
@@ -25,10 +26,10 @@ namespace Microsoft.DotNet.ImageBuilder
             return tagManifests.First()["Layers"].ToObject<List<string>>();
         }
 
-        public static string GetManifestDigestSha(
+        public static async Task<string> GetManifestDigestShaAsync(
             this IManifestToolService manifestToolService, ManifestMediaType mediaType, string tag, bool isDryRun)
         {
-            IEnumerable<JObject> tagManifests = manifestToolService.Inspect(tag, isDryRun).OfType<JObject>();
+            IEnumerable<JObject> tagManifests = (await manifestToolService.InspectAsync(tag, isDryRun)).OfType<JObject>();
             string digest;
 
             bool hasSupportedMediaType = false;

--- a/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
@@ -60,32 +60,32 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Mock<IDockerService> dockerServiceMock = CreateDockerServiceMock();
 
                 dockerServiceMock
-                    .Setup(o => o.GetImageDigest($"{runtimeDepsRepo}:{tag}", false))
-                    .Returns(runtimeDepsDigest);
+                    .Setup(o => o.GetImageDigestAsync($"{runtimeDepsRepo}:{tag}", false))
+                    .ReturnsAsync(runtimeDepsDigest);
 
                 dockerServiceMock
-                    .Setup(o => o.GetImageDigest($"{runtimeRepo}:{tag}", false))
-                    .Returns(runtimeDigest);
+                    .Setup(o => o.GetImageDigestAsync($"{runtimeRepo}:{tag}", false))
+                    .ReturnsAsync(runtimeDigest);
 
                 dockerServiceMock
-                    .Setup(o => o.GetImageDigest($"{aspnetRepo}:{tag}", false))
-                    .Returns(aspnetDigest);
+                    .Setup(o => o.GetImageDigestAsync($"{aspnetRepo}:{tag}", false))
+                    .ReturnsAsync(aspnetDigest);
 
                 dockerServiceMock
-                    .Setup(o => o.GetImageDigest(baseImageTag, false))
-                    .Returns(baseImageDigest);
+                    .Setup(o => o.GetImageDigestAsync(baseImageTag, false))
+                    .ReturnsAsync(baseImageDigest);
 
                 dockerServiceMock
-                    .Setup(o => o.GetImageManifestLayers($"{runtimeDepsRepo}:{tag}", false))
-                    .Returns(runtimeDepsLayers);
+                    .Setup(o => o.GetImageManifestLayersAsync($"{runtimeDepsRepo}:{tag}", false))
+                    .ReturnsAsync(runtimeDepsLayers);
 
                 dockerServiceMock
-                    .Setup(o => o.GetImageManifestLayers($"{runtimeRepo}:{tag}", false))
-                    .Returns(runtimeLayers);
+                    .Setup(o => o.GetImageManifestLayersAsync($"{runtimeRepo}:{tag}", false))
+                    .ReturnsAsync(runtimeLayers);
 
                 dockerServiceMock
-                    .Setup(o => o.GetImageManifestLayers($"{aspnetRepo}:{tag}", false))
-                    .Returns(aspnetLayers);
+                    .Setup(o => o.GetImageManifestLayersAsync($"{aspnetRepo}:{tag}", false))
+                    .ReturnsAsync(aspnetLayers);
 
                 string[] runtimeDepsInstalledPackages =
                 {
@@ -345,16 +345,16 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Mock<IDockerService> dockerServiceMock = CreateDockerServiceMock();
 
             dockerServiceMock
-                .Setup(o => o.GetImageDigest($"{runtimeDepsRepo}:{tag}", false))
-                .Returns(runtimeDepsDigest);
+                .Setup(o => o.GetImageDigestAsync($"{runtimeDepsRepo}:{tag}", false))
+                .ReturnsAsync(runtimeDepsDigest);
 
             dockerServiceMock
-                .Setup(o => o.GetImageDigest(baseImageTag, false))
-                .Returns(baseImageDigest);
+                .Setup(o => o.GetImageDigestAsync(baseImageTag, false))
+                .ReturnsAsync(baseImageDigest);
 
             dockerServiceMock
-                .Setup(o => o.GetImageManifestLayers($"{runtimeDepsRepo}:{tag}", false))
-                .Returns(runtimeDepsLayers);
+                .Setup(o => o.GetImageManifestLayersAsync($"{runtimeDepsRepo}:{tag}", false))
+                .ReturnsAsync(runtimeDepsLayers);
 
             string[] runtimeDepsInstalledPackages =
             {
@@ -494,12 +494,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Mock<IDockerService> dockerServiceMock = CreateDockerServiceMock();
 
             dockerServiceMock
-                .Setup(o => o.GetImageDigest($"{runtimeRepo}:{tag}", false))
-                .Returns(runtimeDigest);
+                .Setup(o => o.GetImageDigestAsync($"{runtimeRepo}:{tag}", false))
+                .ReturnsAsync(runtimeDigest);
 
             dockerServiceMock
-                .Setup(o => o.GetImageDigest(baseImageTag, false))
-                .Returns(baseImageDigest);
+                .Setup(o => o.GetImageDigestAsync(baseImageTag, false))
+                .ReturnsAsync(baseImageDigest);
 
             DateTime createdDate = DateTime.Now;
 
@@ -873,8 +873,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Mock<IDockerService> dockerServiceMock = CreateDockerServiceMock();
 
             dockerServiceMock
-                .Setup(o => o.GetImageDigest($"{runtimeDepsRepo}:{tag}", false))
-                .Returns(runtimeDepsDigest);
+                .Setup(o => o.GetImageDigestAsync($"{runtimeDepsRepo}:{tag}", false))
+                .ReturnsAsync(runtimeDepsDigest);
 
             DateTime createdDate = DateTime.Now;
 
@@ -1025,8 +1025,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsDigest, $"{runtimeDepsRepo}:{tag}", false), Times.Once);
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsDigest, $"{runtimeDepsRepo}:{newTag}", false), Times.Once);
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsDigest, $"{runtimeDepsRepo}:shared", false), Times.Once);
-            dockerServiceMock.Verify(o => o.GetImageManifestLayers($"{runtimeDepsRepo}:{tag}", false), Times.Once);
-            dockerServiceMock.Verify(o => o.GetImageManifestLayers($"{runtimeDepsRepo}:{newTag}", false), Times.Once);
+            dockerServiceMock.Verify(o => o.GetImageManifestLayersAsync($"{runtimeDepsRepo}:{tag}", false), Times.Once);
+            dockerServiceMock.Verify(o => o.GetImageManifestLayersAsync($"{runtimeDepsRepo}:{newTag}", false), Times.Once);
             dockerServiceMock.Verify(o => o.PushImage($"{runtimeDepsRepo}:{tag}", false));
             dockerServiceMock.Verify(o => o.PushImage($"{runtimeDepsRepo}:{newTag}", false));
             dockerServiceMock.Verify(o => o.PushImage($"{runtimeDepsRepo}:shared", false));
@@ -1052,8 +1052,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Mock<IDockerService> dockerServiceMock = CreateDockerServiceMock();
                 const string digest = "runtime@sha256:c74364a9f125ca612f9a67e4a0551937b7a37c82fabb46172c4867b73edd638c";
                 dockerServiceMock
-                    .Setup(o => o.GetImageDigest("runtime:runtime", false))
-                    .Returns(digest);
+                    .Setup(o => o.GetImageDigestAsync("runtime:runtime", false))
+                    .ReturnsAsync(digest);
 
                 const string runtimeRelativeDir = "1.0/runtime/os";
                 Directory.CreateDirectory(Path.Combine(tempFolderContext.Path, runtimeRelativeDir));
@@ -1229,24 +1229,24 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Mock<IDockerService> dockerServiceMock = CreateDockerServiceMock();
 
             dockerServiceMock
-                .Setup(o => o.GetImageDigest($"{runtimeDepsRepoQualified}:{tag}", false))
-                .Returns(runtimeDepsDigest);
+                .Setup(o => o.GetImageDigestAsync($"{runtimeDepsRepoQualified}:{tag}", false))
+                .ReturnsAsync(runtimeDepsDigest);
 
             dockerServiceMock
-                .Setup(o => o.GetImageDigest($"{overridePrefix}{runtimeDepsRepo}:{tag}", false))
-                .Returns(runtimeDepsDigest);
+                .Setup(o => o.GetImageDigestAsync($"{overridePrefix}{runtimeDepsRepo}:{tag}", false))
+                .ReturnsAsync(runtimeDepsDigest);
 
             dockerServiceMock
-                .Setup(o => o.GetImageDigest($"{runtimeRepoQualified}:{tag}", false))
-                .Returns(runtimeDigest);
+                .Setup(o => o.GetImageDigestAsync($"{runtimeRepoQualified}:{tag}", false))
+                .ReturnsAsync(runtimeDigest);
 
             dockerServiceMock
-               .Setup(o => o.GetImageDigest($"{overridePrefix}{runtimeRepo}:{tag}", false))
-               .Returns(runtimeDigest);
+               .Setup(o => o.GetImageDigestAsync($"{overridePrefix}{runtimeRepo}:{tag}", false))
+               .ReturnsAsync(runtimeDigest);
 
             dockerServiceMock
-                .Setup(o => o.GetImageDigest(baseImageTag, false))
-                .Returns(runtimeDepsBaseImageDigest);
+                .Setup(o => o.GetImageDigestAsync(baseImageTag, false))
+                .ReturnsAsync(runtimeDepsBaseImageDigest);
 
             DateTime createdDate = DateTime.Now;
 
@@ -1546,24 +1546,24 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Mock<IDockerService> dockerServiceMock = CreateDockerServiceMock();
 
             dockerServiceMock
-                .Setup(o => o.GetImageDigest($"{runtimeDepsRepo}:{linuxTag}", false))
-                .Returns(runtimeDepsLinuxDigest);
+                .Setup(o => o.GetImageDigestAsync($"{runtimeDepsRepo}:{linuxTag}", false))
+                .ReturnsAsync(runtimeDepsLinuxDigest);
 
             dockerServiceMock
-                .Setup(o => o.GetImageDigest($"{runtimeDepsRepo}:{windowsTag}", false))
-                .Returns(runtimeDepsWindowsDigest);
+                .Setup(o => o.GetImageDigestAsync($"{runtimeDepsRepo}:{windowsTag}", false))
+                .ReturnsAsync(runtimeDepsWindowsDigest);
 
             dockerServiceMock
-                .Setup(o => o.GetImageDigest($"{runtimeDeps2Repo}:{linuxTag}", false))
-                .Returns(runtimeDeps2Digest);
+                .Setup(o => o.GetImageDigestAsync($"{runtimeDeps2Repo}:{linuxTag}", false))
+                .ReturnsAsync(runtimeDeps2Digest);
 
             dockerServiceMock
-                .Setup(o => o.GetImageDigest(linuxBaseImageTag, false))
-                .Returns(runtimeDepsLinuxBaseImageDigest);
+                .Setup(o => o.GetImageDigestAsync(linuxBaseImageTag, false))
+                .ReturnsAsync(runtimeDepsLinuxBaseImageDigest);
 
             dockerServiceMock
-                .Setup(o => o.GetImageDigest(windowsBaseImageTag, false))
-                .Returns(runtimeDepsWindowsBaseImageDigest);
+                .Setup(o => o.GetImageDigestAsync(windowsBaseImageTag, false))
+                .ReturnsAsync(runtimeDepsWindowsBaseImageDigest);
 
             DateTime createdDate = DateTime.Now;
 
@@ -1794,8 +1794,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             Assert.Equal(expectedOutput, actualOutput);
 
-            dockerServiceMock.Verify(o => o.GetImageDigest(linuxBaseImageTag, false), Times.Once);
-            dockerServiceMock.Verify(o => o.GetImageDigest(windowsBaseImageTag, false), Times.Once);
+            dockerServiceMock.Verify(o => o.GetImageDigestAsync(linuxBaseImageTag, false), Times.Once);
+            dockerServiceMock.Verify(o => o.GetImageDigestAsync(windowsBaseImageTag, false), Times.Once);
             dockerServiceMock.Verify(o => o.PullImage(linuxBaseImageTag, "linux/amd64", false), Times.Once);
             dockerServiceMock.Verify(o => o.PullImage(windowsBaseImageTag, "windows/amd64", false), Times.Once);
             dockerServiceMock.Verify(o => o.PullImage(runtimeDepsLinuxDigest, null, false), Times.Once);
@@ -1805,9 +1805,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsLinuxDigest, $"{runtimeDeps2Repo}:{linuxTag}", false), Times.Once);
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsWindowsDigest, $"{runtimeDepsRepo}:{windowsTag}", false), Times.Once);
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsWindowsDigest, $"{runtimeDepsRepo}:shared", false), Times.Once);
-            dockerServiceMock.Verify(o => o.GetImageManifestLayers($"{runtimeDepsRepo}:{linuxTag}", false), Times.Once);
-            dockerServiceMock.Verify(o => o.GetImageManifestLayers($"{runtimeDepsRepo}:{windowsTag}", false), Times.Once);
-            dockerServiceMock.Verify(o => o.GetImageManifestLayers($"{runtimeDeps2Repo}:{linuxTag}", false), Times.Once);
+            dockerServiceMock.Verify(o => o.GetImageManifestLayersAsync($"{runtimeDepsRepo}:{linuxTag}", false), Times.Once);
+            dockerServiceMock.Verify(o => o.GetImageManifestLayersAsync($"{runtimeDepsRepo}:{windowsTag}", false), Times.Once);
+            dockerServiceMock.Verify(o => o.GetImageManifestLayersAsync($"{runtimeDeps2Repo}:{linuxTag}", false), Times.Once);
             dockerServiceMock.Verify(o => o.PushImage($"{runtimeDepsRepo}:{linuxTag}", false));
             dockerServiceMock.Verify(o => o.PushImage($"{runtimeDepsRepo}:{windowsTag}", false));
             dockerServiceMock.Verify(o => o.PushImage($"{runtimeDeps2Repo}:{linuxTag}", false));
@@ -1849,20 +1849,20 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Mock<IDockerService> dockerServiceMock = CreateDockerServiceMock();
 
             dockerServiceMock
-                .Setup(o => o.GetImageDigest($"{runtimeDepsRepo}:{tag}", false))
-                .Returns(runtimeDepsDigest);
+                .Setup(o => o.GetImageDigestAsync($"{runtimeDepsRepo}:{tag}", false))
+                .ReturnsAsync(runtimeDepsDigest);
 
             dockerServiceMock
-                .Setup(o => o.GetImageDigest($"{runtimeDeps2Repo}:{tag}", false))
-                .Returns(runtimeDeps2Digest);
+                .Setup(o => o.GetImageDigestAsync($"{runtimeDeps2Repo}:{tag}", false))
+                .ReturnsAsync(runtimeDeps2Digest);
 
             dockerServiceMock
-                .Setup(o => o.GetImageDigest($"{runtimeDeps3Repo}:{tag}", false))
-                .Returns(runtimeDeps3Digest);
+                .Setup(o => o.GetImageDigestAsync($"{runtimeDeps3Repo}:{tag}", false))
+                .ReturnsAsync(runtimeDeps3Digest);
 
             dockerServiceMock
-                .Setup(o => o.GetImageDigest(baseImageTag, false))
-                .Returns(runtimeDepsBaseImageDigest);
+                .Setup(o => o.GetImageDigestAsync(baseImageTag, false))
+                .ReturnsAsync(runtimeDepsBaseImageDigest);
 
             DateTime createdDate = DateTime.Now;
 
@@ -2089,9 +2089,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             dockerServiceMock.Verify(o => o.PullImage(runtimeDepsDigest, null, false));
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsDigest, $"{runtimeDepsRepo}:{tag}", false));
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsDigest, $"{runtimeDeps2Repo}:{tag}", false));
-            dockerServiceMock.Verify(o => o.GetImageManifestLayers($"{runtimeDepsRepo}:{tag}", false), Times.Once);
-            dockerServiceMock.Verify(o => o.GetImageManifestLayers($"{runtimeDeps2Repo}:{tag}", false), Times.Once);
-            dockerServiceMock.Verify(o => o.GetImageManifestLayers($"{runtimeDeps3Repo}:{tag}", false), Times.Once);
+            dockerServiceMock.Verify(o => o.GetImageManifestLayersAsync($"{runtimeDepsRepo}:{tag}", false), Times.Once);
+            dockerServiceMock.Verify(o => o.GetImageManifestLayersAsync($"{runtimeDeps2Repo}:{tag}", false), Times.Once);
+            dockerServiceMock.Verify(o => o.GetImageManifestLayersAsync($"{runtimeDeps3Repo}:{tag}", false), Times.Once);
             dockerServiceMock.Verify(o => o.PushImage($"{runtimeDepsRepo}:{tag}", false));
             dockerServiceMock.Verify(o => o.PushImage($"{runtimeDeps2Repo}:{tag}", false));
             dockerServiceMock.Verify(o => o.PushImage($"{runtimeDeps3Repo}:{tag}", false));
@@ -2106,7 +2106,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     It.IsAny<bool>()));
 
             dockerServiceMock.Verify(o => o.PullImage(baseImageTag, "linux/amd64", false));
-            dockerServiceMock.Verify(o => o.GetImageDigest(It.IsAny<string>(), false));
+            dockerServiceMock.Verify(o => o.GetImageDigestAsync(It.IsAny<string>(), false));
             dockerServiceMock.Verify(o => o.GetCreatedDate(It.IsAny<string>(), false));
             dockerServiceMock.Verify(o => o.GetImageArch(baseImageTag, false));
 
@@ -2135,16 +2135,16 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Mock<IDockerService> dockerServiceMock = CreateDockerServiceMock();
 
             dockerServiceMock
-                .Setup(o => o.GetImageDigest($"{runtimeDepsRepo}:{tag}", false))
-                .Returns(runtimeDepsDigest);
+                .Setup(o => o.GetImageDigestAsync($"{runtimeDepsRepo}:{tag}", false))
+                .ReturnsAsync(runtimeDepsDigest);
 
             dockerServiceMock
-                .Setup(o => o.GetImageDigest($"{runtimeDeps2Repo}:{tag}", false))
-                .Returns(runtimeDepsDigest);
+                .Setup(o => o.GetImageDigestAsync($"{runtimeDeps2Repo}:{tag}", false))
+                .ReturnsAsync(runtimeDepsDigest);
 
             dockerServiceMock
-                .Setup(o => o.GetImageDigest(baseImageTag, false))
-                .Returns(runtimeDepsBaseImageDigest);
+                .Setup(o => o.GetImageDigestAsync(baseImageTag, false))
+                .ReturnsAsync(runtimeDepsBaseImageDigest);
 
             DateTime createdDate = DateTime.Now;
 
@@ -2305,11 +2305,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             }
 
             dockerServiceMock.Verify(o => o.PullImage(baseImageTag, "linux/amd64", false));
-            dockerServiceMock.Verify(o => o.GetImageDigest(baseImageTag, false));
-            dockerServiceMock.Verify(o => o.GetImageDigest($"{runtimeDepsRepo}:{tag}", false));
-            dockerServiceMock.Verify(o => o.GetImageDigest($"{runtimeDeps2Repo}:{tag}", false));
-            dockerServiceMock.Verify(o => o.GetImageManifestLayers($"{runtimeDepsRepo}:{tag}", false), Times.Once);
-            dockerServiceMock.Verify(o => o.GetImageManifestLayers($"{runtimeDeps2Repo}:{tag}", false), Times.Once);
+            dockerServiceMock.Verify(o => o.GetImageDigestAsync(baseImageTag, false));
+            dockerServiceMock.Verify(o => o.GetImageDigestAsync($"{runtimeDepsRepo}:{tag}", false));
+            dockerServiceMock.Verify(o => o.GetImageDigestAsync($"{runtimeDeps2Repo}:{tag}", false));
+            dockerServiceMock.Verify(o => o.GetImageManifestLayersAsync($"{runtimeDepsRepo}:{tag}", false), Times.Once);
+            dockerServiceMock.Verify(o => o.GetImageManifestLayersAsync($"{runtimeDeps2Repo}:{tag}", false), Times.Once);
             dockerServiceMock.Verify(o => o.GetCreatedDate(It.IsAny<string>(), false));
             dockerServiceMock.Verify(o => o.GetImageArch(baseImageTag, false));
 
@@ -2339,16 +2339,16 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Mock<IDockerService> dockerServiceMock = CreateDockerServiceMock();
 
             dockerServiceMock
-                .Setup(o => o.GetImageDigest($"{runtimeDepsRepo}:{tag}", false))
-                .Returns(runtimeDepsDigest);
+                .Setup(o => o.GetImageDigestAsync($"{runtimeDepsRepo}:{tag}", false))
+                .ReturnsAsync(runtimeDepsDigest);
 
             dockerServiceMock
-                .Setup(o => o.GetImageDigest($"{runtimeDeps2Repo}:{tag}", false))
-                .Returns(runtimeDepsDigest);
+                .Setup(o => o.GetImageDigestAsync($"{runtimeDeps2Repo}:{tag}", false))
+                .ReturnsAsync(runtimeDepsDigest);
 
             dockerServiceMock
-                .Setup(o => o.GetImageDigest(baseImageTag, false))
-                .Returns(runtimeDepsBaseImageDigest);
+                .Setup(o => o.GetImageDigestAsync(baseImageTag, false))
+                .ReturnsAsync(runtimeDepsBaseImageDigest);
 
             DateTime createdDate = DateTime.Now;
 
@@ -2547,11 +2547,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             }
 
             dockerServiceMock.Verify(o => o.PullImage(baseImageTag, "linux/amd64", false));
-            dockerServiceMock.Verify(o => o.GetImageDigest(baseImageTag, false));
-            dockerServiceMock.Verify(o => o.GetImageDigest($"{runtimeDepsRepo}:{tag}", false));
-            dockerServiceMock.Verify(o => o.GetImageDigest($"{runtimeDeps2Repo}:{tag}", false));
-            dockerServiceMock.Verify(o => o.GetImageManifestLayers($"{runtimeDepsRepo}:{tag}", false), Times.Once);
-            dockerServiceMock.Verify(o => o.GetImageManifestLayers($"{runtimeDeps2Repo}:{tag}", false), Times.Once);
+            dockerServiceMock.Verify(o => o.GetImageDigestAsync(baseImageTag, false));
+            dockerServiceMock.Verify(o => o.GetImageDigestAsync($"{runtimeDepsRepo}:{tag}", false));
+            dockerServiceMock.Verify(o => o.GetImageDigestAsync($"{runtimeDeps2Repo}:{tag}", false));
+            dockerServiceMock.Verify(o => o.GetImageManifestLayersAsync($"{runtimeDepsRepo}:{tag}", false), Times.Once);
+            dockerServiceMock.Verify(o => o.GetImageManifestLayersAsync($"{runtimeDeps2Repo}:{tag}", false), Times.Once);
             dockerServiceMock.Verify(o => o.GetCreatedDate(It.IsAny<string>(), false));
             dockerServiceMock.Verify(o => o.GetImageArch(baseImageTag, false));
 
@@ -2580,12 +2580,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Mock<IDockerService> dockerServiceMock = CreateDockerServiceMock();
 
             dockerServiceMock
-                .Setup(o => o.GetImageDigest($"{runtimeDepsRepo}:{tag}", false))
-                .Returns(runtimeDepsDigest);
+                .Setup(o => o.GetImageDigestAsync($"{runtimeDepsRepo}:{tag}", false))
+                .ReturnsAsync(runtimeDepsDigest);
 
             dockerServiceMock
-                .Setup(o => o.GetImageDigest(baseImageTag, false))
-                .Returns(runtimeDepsLinuxBaseImageDigest);
+                .Setup(o => o.GetImageDigestAsync(baseImageTag, false))
+                .ReturnsAsync(runtimeDepsLinuxBaseImageDigest);
 
             DateTime createdDate = DateTime.Now;
 
@@ -2734,14 +2734,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             Assert.Equal(expectedOutput, actualOutput);
 
-            dockerServiceMock.Verify(o => o.GetImageDigest(baseImageTag, false), Times.Once);
+            dockerServiceMock.Verify(o => o.GetImageDigestAsync(baseImageTag, false), Times.Once);
             dockerServiceMock.Verify(o => o.PullImage(baseImageTag, "linux/amd64", false), Times.Once);
             dockerServiceMock.Verify(o => o.PullImage(runtimeDepsDigest, null, false), Times.Once);
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsDigest, $"{runtimeDepsRepo}:{tag}", false), Times.Once);
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsDigest, $"{runtimeDepsRepo}:{newTag}", false), Times.Once);
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsDigest, $"{runtimeDepsRepo}:shared", false), Times.Once);
-            dockerServiceMock.Verify(o => o.GetImageManifestLayers($"{runtimeDepsRepo}:{tag}", false), Times.Once);
-            dockerServiceMock.Verify(o => o.GetImageManifestLayers($"{runtimeDepsRepo}:{newTag}", false), Times.Once);
+            dockerServiceMock.Verify(o => o.GetImageManifestLayersAsync($"{runtimeDepsRepo}:{tag}", false), Times.Once);
+            dockerServiceMock.Verify(o => o.GetImageManifestLayersAsync($"{runtimeDepsRepo}:{newTag}", false), Times.Once);
             dockerServiceMock.Verify(o => o.PushImage($"{runtimeDepsRepo}:{tag}", false));
             dockerServiceMock.Verify(o => o.PushImage($"{runtimeDepsRepo}:{newTag}", false));
             dockerServiceMock.Verify(o => o.PushImage($"{runtimeDepsRepo}:shared", false));
@@ -2779,15 +2779,15 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Mock<IDockerService> dockerServiceMock = CreateDockerServiceMock();
 
             dockerServiceMock
-                .Setup(o => o.GetImageDigest($"{runtimeDepsRepo}:{tag}", false))
-                .Returns(runtimeDepsLinuxDigest);
+                .Setup(o => o.GetImageDigestAsync($"{runtimeDepsRepo}:{tag}", false))
+                .ReturnsAsync(runtimeDepsLinuxDigest);
             dockerServiceMock
-                .Setup(o => o.GetImageDigest($"{runtimeDeps2Repo}:{tag}", false))
-                .Returns(runtimeDeps2Digest);
+                .Setup(o => o.GetImageDigestAsync($"{runtimeDeps2Repo}:{tag}", false))
+                .ReturnsAsync(runtimeDeps2Digest);
 
             dockerServiceMock
-                .Setup(o => o.GetImageDigest(baseImageTag, false))
-                .Returns(runtimeDepsLinuxBaseImageDigest);
+                .Setup(o => o.GetImageDigestAsync(baseImageTag, false))
+                .ReturnsAsync(runtimeDepsLinuxBaseImageDigest);
 
             DateTime createdDate = DateTime.Now;
 
@@ -2979,14 +2979,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             dockerServiceMock.Verify(o => o.PullImage(runtimeDepsLinuxDigest, null, false), Times.Once);
             dockerServiceMock.Verify(o => o.PullImage(baseImageTag, "linux/amd64", false), Times.Once);
-            dockerServiceMock.Verify(o => o.GetImageDigest(baseImageTag, false), Times.Once);
+            dockerServiceMock.Verify(o => o.GetImageDigestAsync(baseImageTag, false), Times.Once);
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsLinuxDigest, $"{runtimeDepsRepo}:{tag}", false), Times.Once);
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsLinuxDigest, $"{runtimeDepsRepo}:shared", false), Times.Once);
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsLinuxDigest, $"{runtimeDeps2Repo}:{tag}", false), Times.Once);
             dockerServiceMock.Verify(o => o.CreateTag(runtimeDepsLinuxDigest, $"{runtimeDeps2Repo}:{newTag}", false), Times.Once);
-            dockerServiceMock.Verify(o => o.GetImageManifestLayers($"{runtimeDepsRepo}:{tag}", false), Times.Once);
-            dockerServiceMock.Verify(o => o.GetImageManifestLayers($"{runtimeDeps2Repo}:{tag}", false), Times.Once);
-            dockerServiceMock.Verify(o => o.GetImageManifestLayers($"{runtimeDeps2Repo}:{newTag}", false), Times.Once);
+            dockerServiceMock.Verify(o => o.GetImageManifestLayersAsync($"{runtimeDepsRepo}:{tag}", false), Times.Once);
+            dockerServiceMock.Verify(o => o.GetImageManifestLayersAsync($"{runtimeDeps2Repo}:{tag}", false), Times.Once);
+            dockerServiceMock.Verify(o => o.GetImageManifestLayersAsync($"{runtimeDeps2Repo}:{newTag}", false), Times.Once);
             dockerServiceMock.Verify(o => o.PushImage($"{runtimeDepsRepo}:{tag}", false));
             dockerServiceMock.Verify(o => o.PushImage($"{runtimeDeps2Repo}:{tag}", false));
             dockerServiceMock.Verify(o => o.PushImage($"{runtimeDeps2Repo}:{newTag}", false));
@@ -3039,49 +3039,49 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             if (hasCachedImage)
             {
                 dockerServiceMock
-                    .Setup(o => o.GetImageDigest($"{Registry}/{RuntimeDepsRepo}:{Tag}", false))
-                    .Returns($"{Registry}/{RuntimeDepsRepo}@{RuntimeDepsDigest}");
+                    .Setup(o => o.GetImageDigestAsync($"{Registry}/{RuntimeDepsRepo}:{Tag}", false))
+                    .ReturnsAsync($"{Registry}/{RuntimeDepsRepo}@{RuntimeDepsDigest}");
 
                 dockerServiceMock
-                    .Setup(o => o.GetImageDigest($"{Registry}/{RuntimeRepo}:{Tag}", false))
-                    .Returns($"{Registry}/{RuntimeRepo}@{RuntimeDigest}");
+                    .Setup(o => o.GetImageDigestAsync($"{Registry}/{RuntimeRepo}:{Tag}", false))
+                    .ReturnsAsync($"{Registry}/{RuntimeRepo}@{RuntimeDigest}");
 
                 dockerServiceMock
-                    .Setup(o => o.GetImageDigest($"{Registry}/{AspnetRepo}:{Tag}", false))
-                    .Returns($"{Registry}/{AspnetRepo}@{AspnetDigest}");
+                    .Setup(o => o.GetImageDigestAsync($"{Registry}/{AspnetRepo}:{Tag}", false))
+                    .ReturnsAsync($"{Registry}/{AspnetRepo}@{AspnetDigest}");
 
                 dockerServiceMock
-                    .Setup(o => o.GetImageDigest($"{RegistryOverride}/{RepoPrefix}{RuntimeDepsRepo}:{Tag}", false))
-                    .Returns($"{RegistryOverride}/{RuntimeDepsRepo}@{RuntimeDepsDigest}");
+                    .Setup(o => o.GetImageDigestAsync($"{RegistryOverride}/{RepoPrefix}{RuntimeDepsRepo}:{Tag}", false))
+                    .ReturnsAsync($"{RegistryOverride}/{RuntimeDepsRepo}@{RuntimeDepsDigest}");
 
                 dockerServiceMock
-                    .Setup(o => o.GetImageDigest($"{RegistryOverride}/{RepoPrefix}{RuntimeRepo}:{Tag}", false))
-                    .Returns($"{RegistryOverride}/{RuntimeRepo}@{RuntimeDigest}");
+                    .Setup(o => o.GetImageDigestAsync($"{RegistryOverride}/{RepoPrefix}{RuntimeRepo}:{Tag}", false))
+                    .ReturnsAsync($"{RegistryOverride}/{RuntimeRepo}@{RuntimeDigest}");
 
                 dockerServiceMock
-                    .Setup(o => o.GetImageDigest($"{RegistryOverride}/{RepoPrefix}{AspnetRepo}:{Tag}", false))
-                    .Returns($"{RegistryOverride}/{AspnetRepo}@{AspnetDigest}");
+                    .Setup(o => o.GetImageDigestAsync($"{RegistryOverride}/{RepoPrefix}{AspnetRepo}:{Tag}", false))
+                    .ReturnsAsync($"{RegistryOverride}/{AspnetRepo}@{AspnetDigest}");
             }
             else
             {
                 // Locally built images will not have a digest until they get pushed. So don't return a digest until
                 // the appropriate request.
                 dockerServiceMock
-                    .Setup(o => o.GetImageDigest($"{RegistryOverride}/{RepoPrefix}{RuntimeDepsRepo}:{Tag}", false))
-                    .Returns(callCount => callCount > 2 ? $"{RegistryOverride}/{RepoPrefix}{RuntimeDepsRepo}@{RuntimeDepsDigest}" : null);
+                    .Setup(o => o.GetImageDigestAsync($"{RegistryOverride}/{RepoPrefix}{RuntimeDepsRepo}:{Tag}", false))
+                    .ReturnsAsync(callCount => callCount > 2 ? $"{RegistryOverride}/{RepoPrefix}{RuntimeDepsRepo}@{RuntimeDepsDigest}" : null);
 
                 dockerServiceMock
-                    .Setup(o => o.GetImageDigest($"{RegistryOverride}/{RepoPrefix}{RuntimeRepo}:{Tag}", false))
-                    .Returns(callCount => callCount > 1 ? $"{RegistryOverride}/{RepoPrefix}{RuntimeRepo}@{RuntimeDigest}" : null);
+                    .Setup(o => o.GetImageDigestAsync($"{RegistryOverride}/{RepoPrefix}{RuntimeRepo}:{Tag}", false))
+                    .ReturnsAsync(callCount => callCount > 1 ? $"{RegistryOverride}/{RepoPrefix}{RuntimeRepo}@{RuntimeDigest}" : null);
 
                 dockerServiceMock
-                    .Setup(o => o.GetImageDigest($"{RegistryOverride}/{RepoPrefix}{AspnetRepo}:{Tag}", false))
-                    .Returns(callCount => callCount > 0 ? $"{RegistryOverride}/{RepoPrefix}{AspnetRepo}@{AspnetDigest}" : null);
+                    .Setup(o => o.GetImageDigestAsync($"{RegistryOverride}/{RepoPrefix}{AspnetRepo}:{Tag}", false))
+                    .ReturnsAsync(callCount => callCount > 0 ? $"{RegistryOverride}/{RepoPrefix}{AspnetRepo}@{AspnetDigest}" : null);
             }
             
             dockerServiceMock
-                .Setup(o => o.GetImageDigest(mirrorBaseTag, false))
-                .Returns(mirrorBaseImageDigest);
+                .Setup(o => o.GetImageDigestAsync(mirrorBaseTag, false))
+                .ReturnsAsync(mirrorBaseImageDigest);
 
             DateTime createdDate = DateTime.Now.ToUniversalTime();
             dockerServiceMock
@@ -3349,13 +3349,13 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             }
             else
             {
-                dockerServiceMock.Verify(o => o.GetImageDigest($"{RegistryOverride}/{RepoPrefix}{RuntimeDepsRepo}:{Tag}", false));
-                dockerServiceMock.Verify(o => o.GetImageDigest($"{RegistryOverride}/{RepoPrefix}{RuntimeRepo}:{Tag}", false));
+                dockerServiceMock.Verify(o => o.GetImageDigestAsync($"{RegistryOverride}/{RepoPrefix}{RuntimeDepsRepo}:{Tag}", false));
+                dockerServiceMock.Verify(o => o.GetImageDigestAsync($"{RegistryOverride}/{RepoPrefix}{RuntimeRepo}:{Tag}", false));
             }
 
-            dockerServiceMock.Verify(o => o.GetImageDigest(mirrorBaseTag, false));
+            dockerServiceMock.Verify(o => o.GetImageDigestAsync(mirrorBaseTag, false));
             
-            dockerServiceMock.Verify(o => o.GetImageDigest($"{RegistryOverride}/{RepoPrefix}{AspnetRepo}:{Tag}", false));
+            dockerServiceMock.Verify(o => o.GetImageDigestAsync($"{RegistryOverride}/{RepoPrefix}{AspnetRepo}:{Tag}", false));
 
             dockerServiceMock.Verify(o => o.PushImage($"{RegistryOverride}/{RepoPrefix}{RuntimeDepsRepo}:{Tag}", false));
             dockerServiceMock.Verify(o => o.PushImage($"{RegistryOverride}/{RepoPrefix}{RuntimeRepo}:{Tag}", false));
@@ -3365,9 +3365,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             dockerServiceMock.Verify(o => o.GetCreatedDate($"{RegistryOverride}/{RepoPrefix}{RuntimeRepo}:{Tag}", false));
             dockerServiceMock.Verify(o => o.GetCreatedDate($"{RegistryOverride}/{RepoPrefix}{AspnetRepo}:{Tag}", false));
 
-            dockerServiceMock.Verify(o => o.GetImageManifestLayers($"{RegistryOverride}/{RepoPrefix}{RuntimeDepsRepo}:{Tag}", false));
-            dockerServiceMock.Verify(o => o.GetImageManifestLayers($"{RegistryOverride}/{RepoPrefix}{RuntimeRepo}:{Tag}", false));
-            dockerServiceMock.Verify(o => o.GetImageManifestLayers($"{RegistryOverride}/{RepoPrefix}{AspnetRepo}:{Tag}", false));
+            dockerServiceMock.Verify(o => o.GetImageManifestLayersAsync($"{RegistryOverride}/{RepoPrefix}{RuntimeDepsRepo}:{Tag}", false));
+            dockerServiceMock.Verify(o => o.GetImageManifestLayersAsync($"{RegistryOverride}/{RepoPrefix}{RuntimeRepo}:{Tag}", false));
+            dockerServiceMock.Verify(o => o.GetImageManifestLayersAsync($"{RegistryOverride}/{RepoPrefix}{AspnetRepo}:{Tag}", false));
 
             if (!hasCachedImage)
             {
@@ -3408,12 +3408,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             }
 
             dockerServiceMock
-                .Setup(o => o.GetImageDigest($"{baseImageRepoPrefix}/{RuntimeRepo}:{Tag}", false))
-                .Returns($"{baseImageRepoPrefix}/{RuntimeRepo}@{RuntimeDigest}");
+                .Setup(o => o.GetImageDigestAsync($"{baseImageRepoPrefix}/{RuntimeRepo}:{Tag}", false))
+                .ReturnsAsync($"{baseImageRepoPrefix}/{RuntimeRepo}@{RuntimeDigest}");
 
             dockerServiceMock
-                .Setup(o => o.GetImageDigest($"{RegistryOverride}/{SamplesRepo}:{Tag}", false))
-                .Returns($"{RegistryOverride}/{SamplesRepo}@{SampleDigest}");
+                .Setup(o => o.GetImageDigestAsync($"{RegistryOverride}/{SamplesRepo}:{Tag}", false))
+                .ReturnsAsync($"{RegistryOverride}/{SamplesRepo}@{SampleDigest}");
 
             string sampleDockerfileRelativePath = DockerfileHelper.CreateDockerfile(
                 "1.0/samples/os", tempFolderContext, $"{baseImageRegistry}/{RuntimeRepo}:{Tag}");
@@ -3467,11 +3467,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     It.IsAny<bool>()));
 
             dockerServiceMock.Verify(o => o.PullImage($"{baseImageRepoPrefix}/{RuntimeRepo}:{Tag}", "linux/amd64", false));
-            dockerServiceMock.Verify(o => o.GetImageDigest($"{baseImageRepoPrefix}/{RuntimeRepo}:{Tag}", false));
-            dockerServiceMock.Verify(o => o.GetImageDigest($"{RegistryOverride}/{SamplesRepo}:{Tag}", false));
+            dockerServiceMock.Verify(o => o.GetImageDigestAsync($"{baseImageRepoPrefix}/{RuntimeRepo}:{Tag}", false));
+            dockerServiceMock.Verify(o => o.GetImageDigestAsync($"{RegistryOverride}/{SamplesRepo}:{Tag}", false));
             dockerServiceMock.Verify(o => o.PushImage($"{RegistryOverride}/{SamplesRepo}:{Tag}", false));
             dockerServiceMock.Verify(o => o.GetCreatedDate($"{RegistryOverride}/{SamplesRepo}:{Tag}", false));
-            dockerServiceMock.Verify(o => o.GetImageManifestLayers($"{RegistryOverride}/{SamplesRepo}:{Tag}", false));
+            dockerServiceMock.Verify(o => o.GetImageManifestLayersAsync($"{RegistryOverride}/{SamplesRepo}:{Tag}", false));
 
             if (isExternallyOwnedBaseImage)
             {

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
@@ -668,7 +668,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 context.Verify(expectedPathsBySubscription);
 
                 context.ManifestToolServiceMock
-                    .Verify(o => o.Inspect(baseImage, false), Times.Once);
+                    .Verify(o => o.InspectAsync(baseImage, false), Times.Once);
             }
         }
 
@@ -1691,8 +1691,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             {
                 Mock<IManifestToolService> manifestToolServiceMock = new Mock<IManifestToolService>();
                 manifestToolServiceMock
-                    .Setup(o => o.Inspect(It.IsAny<string>(), false))
-                    .Returns((string image, bool isDryRun) =>
+                    .Setup(o => o.InspectAsync(It.IsAny<string>(), false))
+                    .ReturnsAsync((string image, bool isDryRun) =>
                         ManifestToolServiceHelper.CreateTagManifest(
                             ManifestToolService.ManifestListMediaType, this.imageDigests[image]));
                 return manifestToolServiceMock;

--- a/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ReturnsExtensions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ReturnsExtensions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Threading.Tasks;
+using Moq;
 using Moq.Language;
 using Moq.Language.Flow;
 
@@ -14,6 +16,13 @@ namespace Microsoft.DotNet.ImageBuilder.Tests.Helpers
         {
             int callCount = 0;
             return returns.Returns(() => valueFunction(++callCount));
+        }
+
+        public static IReturnsResult<TMock> ReturnsAsync<TMock, TResult>(this IReturns<TMock, Task<TResult>> returns, Func<int, TResult> valueFunction)
+            where TMock : class
+        {
+            int callCount = 0;
+            return returns.ReturnsAsync(() => valueFunction(++callCount));
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/ManifestToolServiceExtensionsTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/ManifestToolServiceExtensionsTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
 using Moq;
 using Xunit;
@@ -22,19 +23,19 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         [InlineData("tag2", ManifestMediaType.Manifest, null, typeof(InvalidOperationException))]
         [InlineData("tag2", ManifestMediaType.Any, ManifestListDigest)]
         [InlineData("tag1", (ManifestMediaType)100, null, typeof(ArgumentException))]
-        public void GetManifestDigestSha(string tag, ManifestMediaType mediaType, string expectedDigestSha, Type expectedExceptionType = null)
+        public async Task GetManifestDigestSha(string tag, ManifestMediaType mediaType, string expectedDigestSha, Type expectedExceptionType = null)
         {
             Mock<IManifestToolService> manifestToolService = new Mock<IManifestToolService>();
             manifestToolService
-                .Setup(o => o.Inspect("tag1", false))
-                .Returns(ManifestToolServiceHelper.CreateTagManifest(ManifestToolService.ManifestMediaType, ManifestDigest));
+                .Setup(o => o.InspectAsync("tag1", false))
+                .ReturnsAsync(ManifestToolServiceHelper.CreateTagManifest(ManifestToolService.ManifestMediaType, ManifestDigest));
             manifestToolService
-                .Setup(o => o.Inspect("tag2", false))
-                .Returns(ManifestToolServiceHelper.CreateTagManifest(ManifestToolService.ManifestListMediaType, ManifestListDigest));
+                .Setup(o => o.InspectAsync("tag2", false))
+                .ReturnsAsync(ManifestToolServiceHelper.CreateTagManifest(ManifestToolService.ManifestListMediaType, ManifestListDigest));
 
             if (expectedExceptionType is null)
             {
-                string digestSha = ManifestToolServiceExtensions.GetManifestDigestSha(
+                string digestSha = await ManifestToolServiceExtensions.GetManifestDigestShaAsync(
                     manifestToolService.Object,
                     mediaType,
                     tag,
@@ -43,9 +44,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             }
             else
             {
-                Assert.Throws(expectedExceptionType, () =>
+                await Assert.ThrowsAsync(expectedExceptionType, async () =>
                 {
-                    ManifestToolServiceExtensions.GetManifestDigestSha(
+                    await ManifestToolServiceExtensions.GetManifestDigestShaAsync(
                         manifestToolService.Object,
                         mediaType,
                         tag,

--- a/src/Microsoft.DotNet.ImageBuilder/tests/PublishManifestCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/PublishManifestCommandTests.cs
@@ -30,11 +30,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         {
             Mock<IManifestToolService> manifestToolService = new Mock<IManifestToolService>();
             manifestToolService
-                .Setup(o => o.Inspect("repo1:sharedtag2", false))
-                .Returns(ManifestToolServiceHelper.CreateTagManifest(ManifestToolService.ManifestListMediaType, "digest1"));
+                .Setup(o => o.InspectAsync("repo1:sharedtag2", false))
+                .ReturnsAsync(ManifestToolServiceHelper.CreateTagManifest(ManifestToolService.ManifestListMediaType, "digest1"));
             manifestToolService
-                .Setup(o => o.Inspect("repo2:sharedtag3", false))
-                .Returns(ManifestToolServiceHelper.CreateTagManifest(ManifestToolService.ManifestListMediaType, "digest2"));
+                .Setup(o => o.InspectAsync("repo2:sharedtag3", false))
+                .ReturnsAsync(ManifestToolServiceHelper.CreateTagManifest(ManifestToolService.ManifestListMediaType, "digest2"));
 
             DateTime manifestCreatedDate = DateTime.UtcNow;
             IDateTimeService dateTimeService = Mock.Of<IDateTimeService>(o => o.UtcNow == manifestCreatedDate);
@@ -321,8 +321,8 @@ manifests:
                 });
 
             manifestToolService
-                .Setup(o => o.Inspect(It.IsAny<string>(), false))
-                .Returns(ManifestToolServiceHelper.CreateTagManifest(ManifestToolService.ManifestListMediaType, "digest"));
+                .Setup(o => o.InspectAsync(It.IsAny<string>(), false))
+                .ReturnsAsync(ManifestToolServiceHelper.CreateTagManifest(ManifestToolService.ManifestListMediaType, "digest"));
 
             PublishManifestCommand command = new PublishManifestCommand(
                 manifestToolService.Object, Mock.Of<ILoggerService>(), Mock.Of<IDateTimeService>());
@@ -473,8 +473,8 @@ manifests:
                 });
 
             manifestToolService
-                .Setup(o => o.Inspect(It.IsAny<string>(), false))
-                .Returns(ManifestToolServiceHelper.CreateTagManifest(ManifestToolService.ManifestListMediaType, "digest"));
+                .Setup(o => o.InspectAsync(It.IsAny<string>(), false))
+                .ReturnsAsync(ManifestToolServiceHelper.CreateTagManifest(ManifestToolService.ManifestListMediaType, "digest"));
 
             DateTime manifestCreatedDate = DateTime.UtcNow;
             IDateTimeService dateTimeService = Mock.Of<IDateTimeService>(o => o.UtcNow == manifestCreatedDate);


### PR DESCRIPTION
This is some preliminary work to enable making API calls to container registries. Doing that requires having an async API within the `ManifestToolService` class. I've made that change which then cascaded to other parts of the codebase which I've updated.