### PR TITLE
Pass required registry creds to ImageBuilder cmds

### DIFF
--- a/eng/common/templates/jobs/copy-base-images.yml
+++ b/eng/common/templates/jobs/copy-base-images.yml
@@ -19,7 +19,7 @@ jobs:
       '$(acr.servicePrincipalTenant)'
       '$(acr.subscription)'
       '$(acr.resourceGroup)'
-      $(mirrorRegistryCreds)
+      $(dockerHubRegistryCreds)
       --repo-prefix $(mirrorRepoPrefix)
       --registry-override '$(acr.server)'
       --os-type 'linux'

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1714271
+  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1728424
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-buster-slim-docker-testrunner-974165
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/eng/common/templates/variables/dotnet/build-test-publish.yml
+++ b/eng/common/templates/variables/dotnet/build-test-publish.yml
@@ -49,5 +49,3 @@ variables:
   value: $(app-DotnetDockerTelemetryIngestion-client-secret)
 - name: mcrStatus.servicePrincipalPassword
   value: $(app-DotnetDockerMcrStatusApi-client-secret)
-- name: acr.password
-  value: $(BotAccount-dotnet-docker-acr-bot-password)

--- a/eng/common/templates/variables/dotnet/common.yml
+++ b/eng/common/templates/variables/dotnet/common.yml
@@ -4,10 +4,12 @@ variables:
   value: public
 - name: internalProjectName
   value: internal
-- name: mirrorRegistryCreds
+- name: dockerHubRegistryCreds
   value: --registry-creds 'docker.io=$(dotnetDockerHubBot.userName);$(BotAccount-dotnet-dockerhub-bot-PAT)'
 - name: acr.servicePrincipalPassword
   value: $(app-dotnetdockerbuild-client-secret)
+- name: acr.password
+  value: $(BotAccount-dotnet-docker-acr-bot-password)
 
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNet-Docker-Common

--- a/eng/pipelines/templates/steps/get-stale-images.yml
+++ b/eng/pipelines/templates/steps/get-stale-images.yml
@@ -16,6 +16,8 @@ steps:
       --subscriptions-path ${{ parameters.subscriptionsPath }}
       --os-type ${{ parameters.osType }}
       --architecture ${{ parameters.architecture }}
+      --registry-creds '$(acr.server)=$(acr.userName);$(acr.password)'
+      $(dockerHubRegistryCreds)
     displayName: Get Stale Images
     name: GetStaleImages
   - template: ${{ format('../../../common/templates/steps/cleanup-docker-{0}.yml', parameters.dockerClientOS) }}


### PR DESCRIPTION
This updates the pipeline to be compatible with the latest version of Image Builder containing the changes in https://github.com/dotnet/docker-tools/pull/998. This required passing registry credentials to the `getStaleImages` command.