### PR TITLE
Support for generating multiple repo readmes

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateReadmesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateReadmesCommand.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 (manifest) => manifest.ReadmeTemplatePath,
                 (manifest) => manifest.ReadmePath,
                 (manifest, templatePath, indent) => GetTemplateState(manifest, templatePath, indent),
-                nameof(Models.Manifest.Manifest.ReadmeTemplate),
+                nameof(Readme.TemplatePath),
                 ArtifactName);
 
             // Generate Repo Readmes

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateReadmesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateReadmesCommand.cs
@@ -4,12 +4,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.CommandLine;
 using System.ComponentModel.Composition;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Cottle;
+using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
@@ -46,13 +46,15 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             // Generate Repo Readmes
             await GenerateArtifactsAsync(
-                Manifest.FilteredRepos,
-                (repo) => repo.ReadmeTemplatePath,
-                (repo) => repo.ReadmePath,
-                (repo, templatePath, indent) => GetTemplateState(repo, templatePath, indent),
-                nameof(Models.Manifest.Repo.ReadmeTemplate),
+                Manifest.FilteredRepos
+                    .Select(repo => repo.Readmes.Select(readme => (repo, readme)))
+                    .SelectMany(repoReadme => repoReadme),
+                ((RepoInfo repo, Readme readme) context) => context.readme.TemplatePath,
+                ((RepoInfo repo, Readme readme) context) => context.readme.Path,
+                ((RepoInfo repo, Readme readme) context, string templatePath, string indent) => GetTemplateState(context.repo, templatePath, indent),
+                nameof(Readme.TemplatePath),
                 ArtifactName,
-                (readme, repo) => UpdateTagsListing(readme, repo));
+                (string readmeContent, (RepoInfo repo, Readme readme) context) => UpdateTagsListing(readmeContent, context.repo));
 
             ValidateArtifacts();
         }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsCommand.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
 using Microsoft.DotNet.VersionTools.Automation;
 using Microsoft.DotNet.VersionTools.Automation.GitHubApi;
@@ -97,7 +98,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             string filePath,
             string updatedContent)
         {
-            string gitPath = string.Join('/', Options.GitOptions.Path, repo, filePath);
+            // We only use the filename from the provided file path because all files in the target mcrdocs repo
+            // are located at the root of the repo directory.
+            string gitPath = string.Join('/', Options.GitOptions.Path, repo, Path.GetFileName(filePath));
 
             return new GitObject
             {
@@ -130,7 +133,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             foreach (RepoInfo repo in Manifest.FilteredRepos)
             {
-                readmes.Add(GetReadMeGitObject(GetProductRepoName(repo), repo.ReadmePath, containsTagListing: true));
+                foreach (Readme readme in repo.Readmes)
+                {
+                    readmes.Add(GetReadMeGitObject(GetProductRepoName(repo), readme.Path, containsTagListing: true));
+                }
             }
 
             return readmes.ToArray();

--- a/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -20,7 +20,6 @@
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.13" />
     <PackageReference Include="Polly" Version="7.2.2" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
-    <PackageReference Include="Sprache" Version="2.3.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
     <PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
     <PackageReference Include="YamlDotNet" Version="11.2.1" />

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/Manifest.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/Manifest.cs
@@ -24,15 +24,9 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Manifest
         public string[] Includes { get; set; }
 
         [Description(
-            "Relative path to the GitHub readme Markdown file associated with the manifest. " +
-            "This readme file documents the overall set of Docker repositories described by " +
-            "the manifest.")]
-        public string Readme { get; set; }
-
-        [Description(
-            "Relative path to the template the readme is generated from."
+            "Info about the readme that documents the product family."
             )]
-        public string ReadmeTemplate { get; set; }
+        public Readme Readme { get; set; }
 
         [Description(
             "The location of the Docker registry where the images are to be published."

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/Readme.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/Readme.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.ImageBuilder.Models.Manifest;
+
+#nullable enable
+public class Readme
+{
+    [Description(
+            "Relative path to the GitHub readme Markdown file associated with the " +
+            "repository. This readme file documents the set of Docker images for " +
+            "this repository."
+            )]
+    [JsonProperty(Required = Required.Always)]
+    public string Path { get; set; } = string.Empty;
+
+    [Description(
+            "Relative path to the template the readme is generated from."
+            )]
+    public string? TemplatePath { get; set; }
+
+    public Readme()
+    {
+    }
+
+    public Readme(string path, string? templatePath)
+    {
+        Path = path;
+        TemplatePath = templatePath;
+    }
+}
+#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/Repo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/Repo.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.ComponentModel;
 using Newtonsoft.Json;
 
@@ -43,12 +44,7 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Manifest
             "repository. This readme file documents the set of Docker images for " +
             "this repository."
             )]
-        public string Readme { get; set; }
-
-        [Description(
-            "Relative path to the template the readme is generated from."
-            )]
-        public string ReadmeTemplate { get; set; }
+        public Readme[] Readmes { get; set; } = Array.Empty<Readme>();
 
         public Repo()
         {

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/Repo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/Repo.cs
@@ -40,9 +40,7 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Manifest
         public string Name { get; set; }
 
         [Description(
-            "Relative path to the GitHub readme Markdown file associated with the " +
-            "repository. This readme file documents the set of Docker images for " +
-            "this repository."
+            "Info about the readme that documents the repo."
             )]
         public Readme[] Readmes { get; set; } = Array.Empty<Readme>();
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/ReadmeHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ReadmeHelper.cs
@@ -2,15 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-using Sprache;
-
 namespace Microsoft.DotNet.ImageBuilder
 {
     public static class ReadmeHelper
     {
         private const string TagsSectionHeader = "# Full Tag Listing";
-        private const string EndOfGeneratedTagsMarker = "<!--End of generated tags-->";
 
         public static string UpdateTagsListing(string readme, string tagsListing)
         {
@@ -19,29 +15,10 @@ namespace Microsoft.DotNet.ImageBuilder
 
             string targetLineEnding = readme.GetLineEndingFormat();
 
-            Parser<string> headerParser =
-                from headerPrefix in Parse.String(targetLineEnding + "# ").Text()
-                from label in Parse.AnyChar.Until(Parse.String(targetLineEnding)).Text()
-                select string.Concat(headerPrefix, label, targetLineEnding);
+            readme = readme.Replace(TagsSectionHeader,
+                $"{TagsSectionHeader}{targetLineEnding}{targetLineEnding}{tagsListing}");
 
-            Parser<IEnumerable<char>> endOfGeneratedTagsParser =
-                Parse.String(EndOfGeneratedTagsMarker + targetLineEnding).XOr(headerParser);
-
-            Parser<string> parser =
-                from leadingContent in Parse.AnyChar.Until(Parse.String(TagsSectionHeader + targetLineEnding)).Text()
-                from tagsContent in Parse.AnyChar.Except(endOfGeneratedTagsParser).Many().Text()
-                from endOfGeneratedTags in endOfGeneratedTagsParser.Text()
-                from trailingContent in Parse.AnyChar.Many().Text()
-                select string.Concat(
-                    leadingContent,
-                    TagsSectionHeader,
-                    targetLineEnding,
-                    targetLineEnding,
-                    tagsListing,
-                    endOfGeneratedTags,
-                    trailingContent);
-
-            return parser.Parse(readme);
+            return readme;
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
@@ -82,11 +82,11 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 
             if (model.Readme != null)
             {
-                manifestInfo.ReadmePath = Path.Combine(manifestInfo.Directory, model.Readme);
-            }
-            if (model.ReadmeTemplate != null)
-            {
-                manifestInfo.ReadmeTemplatePath = Path.Combine(manifestInfo.Directory, model.ReadmeTemplate);
+                manifestInfo.ReadmePath = Path.Combine(manifestInfo.Directory, model.Readme.Path);
+                if (model.Readme.TemplatePath != null)
+                {
+                    manifestInfo.ReadmeTemplatePath = Path.Combine(manifestInfo.Directory, model.Readme.TemplatePath);
+                }
             }
 
             IEnumerable<string> repoNames = manifestInfo.AllRepos.Select(repo => repo.QualifiedName).ToArray();

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs
@@ -216,7 +216,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         {
             // Validate that all repos which share the same name also don't have non-empty, conflicting values for the other settings
             IEnumerable<PropertyInfo> propertiesToValidate = typeof(Repo).GetProperties()
-                .Where(prop => prop.Name != nameof(Repo.Images));
+                .Where(prop => prop.Name != nameof(Repo.Images) && prop.Name != nameof(Repo.Readmes));
             foreach (PropertyInfo property in propertiesToValidate)
             {
                 List<string> distinctNonEmptyPropertyValues = grouping
@@ -246,12 +246,9 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
                 McrTagsMetadataTemplate = grouping
                     .Select(repo => repo.McrTagsMetadataTemplate)
                     .FirstOrDefault(val => !string.IsNullOrEmpty(val)),
-                Readme = grouping
-                    .Select(repo => repo.Readme)
-                    .FirstOrDefault(val => !string.IsNullOrEmpty(val)),
-                ReadmeTemplate = grouping
-                    .Select(repo => repo.ReadmeTemplate)
-                    .FirstOrDefault(val => !string.IsNullOrEmpty(val)),
+                Readmes = grouping
+                    .SelectMany(repo => repo.Readmes)
+                    .ToArray(),
                 Images = grouping
                     .SelectMany(repo => repo.Images)
                     .ToArray()

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ModelExtensions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ModelExtensions.cs
@@ -65,12 +65,10 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
                 ValidateRepo(repo, manifestDirectory);
             }
 
-            ValidateFileReference(manifest.Readme, manifestDirectory);
-            ValidateFileReference(manifest.ReadmeTemplate, manifestDirectory);
-
-            if (manifest.ReadmeTemplate != null && manifest.Readme == null)
+            if (manifest.Readme is not null)
             {
-                throw new ValidationException("The manifest must specify a Readme since a ReadmeTemplate is specified");
+                ValidateFileReference(manifest.Readme.Path, manifestDirectory);
+                ValidateFileReference(manifest.Readme.TemplatePath, manifestDirectory);
             }
         }
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ModelExtensions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ModelExtensions.cs
@@ -137,16 +137,9 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 
             foreach (Readme readme in repo.Readmes)
             {
-                string readmeFilename = Path.GetFileName(readme.Path);
-
-
                 ValidateFileReference(readme.Path, manifestDirectory);
                 ValidateFileReference(readme.TemplatePath, manifestDirectory);
 
-                if (readme.TemplatePath != null && readme.Path == null)
-                {
-                    throw new ValidationException($"The repo '{repo.Name}' must specify a Readme since a ReadmeTemplate is specified");
-                }
                 if (repo.McrTagsMetadataTemplate != null && readme.TemplatePath == null)
                 {
                     throw new ValidationException($"The repo '{repo.Name}' must specify a ReadmeTemplate since a McrTagsMetadataTemplate is specified");

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateReadmesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateReadmesCommandTests.cs
@@ -187,8 +187,10 @@ ABC-123";
             }
 
             Repo repo = CreateRepo("dotnet/repo");
-            repo.Readme = RepoReadmePath;
-            repo.ReadmeTemplate = templatePath;
+            repo.Readmes = new[]
+            {
+                new Readme(RepoReadmePath, templatePath)
+            };
             Manifest manifest = CreateManifest(repo);
             manifest.Registry = "mcr.microsoft.com";
             manifest.Readme = ProductFamilyReadmePath;

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateReadmesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateReadmesCommandTests.cs
@@ -193,8 +193,7 @@ ABC-123";
             };
             Manifest manifest = CreateManifest(repo);
             manifest.Registry = "mcr.microsoft.com";
-            manifest.Readme = ProductFamilyReadmePath;
-            manifest.ReadmeTemplate = templatePath;
+            manifest.Readme = new(ProductFamilyReadmePath, templatePath);
 
             string manifestPath = Path.Combine(tempFolderContext.Path, "manifest.json");
             File.WriteAllText(manifestPath, JsonConvert.SerializeObject(manifest));

--- a/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ManifestHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ManifestHelper.cs
@@ -33,14 +33,22 @@ namespace Microsoft.DotNet.ImageBuilder.Tests.Helpers
             string readmeTemplate = null,
             string mcrTagsMetadataTemplate = null)
         {
+            Readme[] readmes = Array.Empty<Readme>();
+            if (readme is not null)
+            {
+                readmes = new[]
+                {
+                    new Readme(readme, readmeTemplate)
+                };
+            }
+
             return new Repo
             {
                 Name = name,
                 Id = name,
                 Images = images,
                 McrTagsMetadataTemplate = mcrTagsMetadataTemplate,
-                Readme = readme,
-                ReadmeTemplate = readmeTemplate
+                Readmes = readmes
             };
         }
 

--- a/src/Microsoft.DotNet.ImageBuilder/tests/PublishMcrDocsCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/PublishMcrDocsCommandTests.cs
@@ -80,8 +80,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         CreatePlatform(CreateDockerfile("1.0/runtime/linux", tempFolderContext), new string[] { "tag" }))
                 }, RepoReadmePath, ReadmeTemplatePath, Path.GetFileName(tagsMetadataTemplatePath)));
             manifest.Registry = "mcr.microsoft.com";
-            manifest.Readme = ProductFamilyReadmePath;
-            manifest.ReadmeTemplate = ReadmeTemplatePath;
+            manifest.Readme = new(ProductFamilyReadmePath, ReadmeTemplatePath);
             repo.Id = "repo";
 
             string manifestPath = Path.Combine(tempFolderContext.Path, "manifest.json");


### PR DESCRIPTION
We need the ability to generate different sets of readmes depending on the site that will be hosting them. For example, readmes for Docker Hub will be different than the MCR portal.

These changes enable that by extending the manifest model for describing readmes.

This JSON snippet example shows the difference in the model, allowing for multiple readmes to be associated with a repo:
```diff
- "readmeTemplate": "eng/readme-templates/README.md",
- "mcrTagsMetadataTemplate": "eng/mcr-tags-metadata-templates/runtime-deps-tags.yml",
+ "readmes": [
+   {
+     "path": "README.runtime-deps.md",
+     "templatePath": "eng/readme-templates/README.md"
+   },
+   {
+     "path": ".mcr/portal/README.runtime-deps.portal.md",
+     "templatePath": "eng/readme-templates/README.mcr.md"
+   }
+ ],
```

An update was also needed in ReadmeHelper to add the tag listing to the readme. While I was in there, I realized the logic could be greatly simplified. Not sure what I was thinking 2 years ago when I wrote that. 🤷‍♂️ That allowed me to get rid of the Sprache dependency.