### PR TITLE
Fix readme generation to support publish scenario

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/ReadmeHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ReadmeHelper.cs
@@ -7,6 +7,7 @@ namespace Microsoft.DotNet.ImageBuilder
     public static class ReadmeHelper
     {
         private const string TagsSectionHeader = "# Full Tag Listing";
+        private const string EndOfGeneratedTagsMarker = "<!--End of generated tags-->";
 
         public static string UpdateTagsListing(string readme, string tagsListing)
         {
@@ -15,8 +16,29 @@ namespace Microsoft.DotNet.ImageBuilder
 
             string targetLineEnding = readme.GetLineEndingFormat();
 
-            readme = readme.Replace(TagsSectionHeader,
-                $"{TagsSectionHeader}{targetLineEnding}{targetLineEnding}{tagsListing}");
+            // We need to account for two readme scenarios:
+            //   1. Readmes hosted in the repo
+            //   2. Readmes published to mcrdocs
+            // The first scenario is simple because it just places the generated tag listing after the tag listing header.
+            // The second scenario is the tricky one because we start with a fully populated readme and we need to strip
+            // out the tag listing and include marker text for MCR's tooling to insert its own tag listing. In order to
+            // determine which portion of text needs to be stripped out we rely on an "End of generated tags" marker comment
+            // in the readme. So we strip out everything starting after the tag listing header and up to the marker comment.
+            // Both scenarios can be solved with this single algorithm.
+
+            int fullTagListingHeaderIndex = readme.IndexOf(TagsSectionHeader);
+            if (fullTagListingHeaderIndex >= 0)
+            {
+                int endOfFullTagListingHeaderIndex = readme.IndexOf(TagsSectionHeader) + TagsSectionHeader.Length;
+                int endOfGeneratedTagsIndex = readme.IndexOf(EndOfGeneratedTagsMarker) + EndOfGeneratedTagsMarker.Length;
+
+                readme =
+                    readme.Substring(0, endOfFullTagListingHeaderIndex) +
+                    targetLineEnding +
+                    targetLineEnding +
+                    tagsListing +
+                    readme.Substring(endOfGeneratedTagsIndex);
+            }
 
             return readme;
         }


### PR DESCRIPTION
The changes in https://github.com/dotnet/docker-tools/pull/1001 broke the readme publish scenario. In that scenario, it takes the existing readme from the repo and strips out the tag listing to be replaced by marker text that MCR's tooling replaces with its own tag listing. But that changes from https://github.com/dotnet/docker-tools/pull/1001, broke the logic which strips out the tag listing. So it ended up producing a two tag listings.

This is fixed by adding back the comment marker to the readme so that the logic in ImageBuilder can correctly identify the section which needs to be stripped out.