### PR TITLE
Fix readme generation to preserve end of generated tags marker comment

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/ReadmeHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ReadmeHelper.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+
 namespace Microsoft.DotNet.ImageBuilder
 {
     public static class ReadmeHelper
@@ -29,14 +31,22 @@ namespace Microsoft.DotNet.ImageBuilder
             int fullTagListingHeaderIndex = readme.IndexOf(TagsSectionHeader);
             if (fullTagListingHeaderIndex >= 0)
             {
-                int endOfFullTagListingHeaderIndex = readme.IndexOf(TagsSectionHeader) + TagsSectionHeader.Length;
+                int endOfFullTagListingHeaderIndex = fullTagListingHeaderIndex + TagsSectionHeader.Length;
                 int endOfGeneratedTagsIndex = readme.IndexOf(EndOfGeneratedTagsMarker) + EndOfGeneratedTagsMarker.Length;
+
+                if (endOfGeneratedTagsIndex < 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Unable to find marker '{EndOfGeneratedTagsMarker}' in the readme content:{Environment.NewLine}{readme}");
+                }
 
                 readme =
                     readme.Substring(0, endOfFullTagListingHeaderIndex) +
                     targetLineEnding +
                     targetLineEnding +
                     tagsListing +
+                    EndOfGeneratedTagsMarker +
+                    targetLineEnding +
                     readme.Substring(endOfGeneratedTagsIndex);
             }
 


### PR DESCRIPTION
The changes in https://github.com/dotnet/dotnet-docker/pull/3784 were incorrect because they didn't preserve the `<!--End of generated tags-->` comment in the generated readme. That causes the publish scenario to not find the marker and end up leaving the original tags listing.

I've fixed this to both preserve the comment and also add validation to check that the marker exists.