### PR TITLE
Pipeline support for internal .NET builds

### DIFF
--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -99,6 +99,7 @@ jobs:
       --git-path '$(gitHubImageInfoVersionsPath)'
       $(dryRunArg)
       $(imageBuilder.commonCmdArgs)
+    condition: and(succeeded(), eq(variables['publishImageInfo'], 'true'))
     displayName: Publish Image Info
   - script: >
       $(runImageBuilderCmd) ingestKustoImageInfo

--- a/eng/common/templates/jobs/test-images-linux-client.yml
+++ b/eng/common/templates/jobs/test-images-linux-client.yml
@@ -5,6 +5,7 @@ parameters:
   testJobTimeout: 60
   preBuildValidation: false
   internalProjectName: null
+  customInitSteps: []
 
 jobs:
 - job: ${{ parameters.name }}
@@ -22,3 +23,4 @@ jobs:
     parameters:
       preBuildValidation: ${{ parameters.preBuildValidation }}
       internalProjectName: ${{ parameters.internalProjectName }}
+      customInitSteps: ${{ parameters.customInitSteps }}

--- a/eng/common/templates/jobs/test-images-windows-client.yml
+++ b/eng/common/templates/jobs/test-images-windows-client.yml
@@ -4,6 +4,7 @@ parameters:
   matrix: {}
   testJobTimeout: 60
   internalProjectName: null
+  customInitSteps: []
 
 jobs:
 - job: ${{ parameters.name }}
@@ -17,3 +18,4 @@ jobs:
   - template: ../steps/test-images-windows-client.yml
     parameters:
       internalProjectName: ${{ parameters.internalProjectName }}
+      customInitSteps: ${{ parameters.customInitSteps }}

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -4,6 +4,7 @@ parameters:
   buildMatrixCustomBuildLegGroupArgs: ""
   testMatrixCustomBuildLegGroupArgs: ""
   customBuildInitSteps: []
+  customTestInitSteps: []
   customPublishInitSteps: []
   customPublishVariables: []
   
@@ -53,6 +54,7 @@ stages:
       testJobTimeout: ${{ parameters.linuxAmdTestJobTimeout }}
       preBuildValidation: true
       internalProjectName: ${{ parameters.internalProjectName }}
+      customInitSteps: ${{ parameters.customTestInitSteps }}
   - template: ../jobs/copy-base-images.yml
     parameters:
       name: CopyBaseImages
@@ -205,6 +207,7 @@ stages:
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.LinuxAmd64']
         testJobTimeout: ${{ parameters.linuxAmdTestJobTimeout }}
         internalProjectName: ${{ parameters.internalProjectName }}
+        customInitSteps: ${{ parameters.customTestInitSteps }}
     - template: ../jobs/test-images-linux-client.yml
       parameters:
         name: Linux_arm64
@@ -212,6 +215,7 @@ stages:
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.LinuxArm64']
         testJobTimeout: ${{ parameters.linuxArmTestJobTimeout }}
         internalProjectName: ${{ parameters.internalProjectName }}
+        customInitSteps: ${{ parameters.customTestInitSteps }}
     - template: ../jobs/test-images-linux-client.yml
       parameters:
         name: Linux_arm32
@@ -219,6 +223,7 @@ stages:
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.LinuxArm32']
         testJobTimeout: ${{ parameters.linuxArmTestJobTimeout }}
         internalProjectName: ${{ parameters.internalProjectName }}
+        customInitSteps: ${{ parameters.customTestInitSteps }}
     - template: ../jobs/test-images-windows-client.yml
       parameters:
         name: Windows1809_amd64
@@ -226,6 +231,7 @@ stages:
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.Windows1809Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
         internalProjectName: ${{ parameters.internalProjectName }}
+        customInitSteps: ${{ parameters.customTestInitSteps }}
     - template: ../jobs/test-images-windows-client.yml
       parameters:
         name: Windows20H2_amd64
@@ -233,6 +239,7 @@ stages:
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.Windows20H2Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
         internalProjectName: ${{ parameters.internalProjectName }}
+        customInitSteps: ${{ parameters.customTestInitSteps }}
     - template: ../jobs/test-images-windows-client.yml
       parameters:
         name: Windows2022_amd64
@@ -240,6 +247,7 @@ stages:
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.WindowsLtsc2022Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
         internalProjectName: ${{ parameters.internalProjectName }}
+        customInitSteps: ${{ parameters.customTestInitSteps }}
     - template: ../jobs/test-images-windows-client.yml
       parameters:
         name: WindowsLtsc2016_amd64
@@ -247,6 +255,7 @@ stages:
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.WindowsLtsc2016Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
         internalProjectName: ${{ parameters.internalProjectName }}
+        customInitSteps: ${{ parameters.customTestInitSteps }}
 
 ################################################################################
 # Publish Images

--- a/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
@@ -8,6 +8,7 @@ parameters:
   buildMatrixCustomBuildLegGroupArgs: ""
   testMatrixCustomBuildLegGroupArgs: ""
   customBuildInitSteps: []
+  customTestInitSteps: []
   customPublishInitSteps: []
   windowsAmdBuildJobTimeout: 60
   windowsAmdTestJobTimeout: 60
@@ -25,6 +26,7 @@ stages:
     buildMatrixCustomBuildLegGroupArgs: ${{ parameters.buildMatrixCustomBuildLegGroupArgs }}
     testMatrixCustomBuildLegGroupArgs: ${{ parameters.testMatrixCustomBuildLegGroupArgs }}
     customBuildInitSteps: ${{ parameters.customBuildInitSteps }}
+    customTestInitSteps: ${{ parameters.customTestInitSteps }}
     customPublishInitSteps:
     - pwsh: |
         # When reporting the repo name in the publish notification, we don't want to include

--- a/eng/common/templates/steps/set-dry-run.yml
+++ b/eng/common/templates/steps/set-dry-run.yml
@@ -1,10 +1,12 @@
 steps:
-- script: |
+- powershell: |
       # Use dry-run option for certain publish operations if this is not a production build
-      dryRunArg=""
-      if [[ "$PUBLISHREPOPREFIX" != "$OFFICIALREPOPREFIX" || "$SYSTEM_TEAMPROJECT" == "$PUBLICPROJECTNAME" ]]; then
-        dryRunArg=" --dry-run"
-      fi
+      $dryRunArg=""
+      if (-not "$(officialRepoPrefixes)".Split(',').Contains("$(publishRepoPrefix)") `
+          -or "$(System.TeamProject)" -eq "$(publicProjectName)")
+      {
+        $dryRunArg=" --dry-run"
+      }
       
       echo "##vso[task.setvariable variable=dryRunArg]$dryRunArg"
   displayName: Set dry-run arg for non-prod

--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -2,6 +2,7 @@ parameters:
   preBuildValidation: false
   internalProjectName: null
   condition: true
+  customInitSteps: []
 
 steps:
 - template: init-docker-linux.yml
@@ -10,6 +11,7 @@ steps:
     setupTestRunner: true
     cleanupDocker: ${{ eq(variables['System.TeamProject'], parameters.internalProjectName) }}
     condition: ${{ parameters.condition }}
+- ${{ parameters.customInitSteps }}
 - script: |
     echo "##vso[task.setvariable variable=testRunner.container]testrunner-$(Build.BuildId)-$(System.JobId)"
 
@@ -48,8 +50,12 @@ steps:
       parameters:
         targetPath: $(Build.ArtifactStagingDirectory)
         condition: ${{ parameters.condition }}
-- script: >
-    docker exec $(testRunner.container) pwsh
+- powershell: >
+    $(test.init);
+    docker exec
+    $(testRunner.options)
+    $(testRunner.container)
+    pwsh
     -File $(testScriptPath)
     -Version '$(productVersion)'
     -OS '$(osVariant)'

--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -57,9 +57,9 @@ steps:
     $(testRunner.container)
     pwsh
     -File $(testScriptPath)
-    -Version '$(productVersion)'
-    -OS '$(osVariant)'
-    -Architecture '$(architecture)'
+    -Version '"$(productVersion)"'
+    -OS '"$(osVariant)"'
+    -Architecture '"$(architecture)"'
     $(optionalTestArgs)
   displayName: Test Images
   condition: and(succeeded(), ${{ parameters.condition }})

--- a/eng/common/templates/steps/test-images-windows-client.yml
+++ b/eng/common/templates/steps/test-images-windows-client.yml
@@ -1,6 +1,7 @@
 parameters:
   internalProjectName: null
   condition: true
+  customInitSteps: []
 
 steps:
 - ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
@@ -13,6 +14,7 @@ steps:
       "cmd /c 'docker login -u $(acr.userName) --password $(acr.password) $(acr.server) 2>&1'"
     displayName: Docker login
     condition: and(succeeded(), ${{ parameters.condition }})
+- ${{ parameters.customInitSteps }}
 - powershell: |
     if ("${{ variables['System.TeamProject'] }}" -eq "${{ parameters.internalProjectName }}") {
       $optionalTestArgs="$optionalTestArgs -PullImages -Registry $env:ACR_SERVER -RepoPrefix $env:STAGINGREPOPREFIX -ImageInfoPath $(artifactsPath)/image-info/image-info.json"
@@ -32,6 +34,7 @@ steps:
       targetPath: $(Build.ArtifactStagingDirectory)
       condition: ${{ parameters.condition }}
 - powershell: >
+    $(test.init);
     $(testScriptPath)
     -Version '$(productVersion)'
     -OS '$(osVariant)'

--- a/eng/common/templates/steps/validate-branch.yml
+++ b/eng/common/templates/steps/validate-branch.yml
@@ -3,11 +3,12 @@ parameters:
 
 steps:
 - ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
-  - script: |
-      if [[ "$OFFICIALBRANCHES" != *\'$SOURCEBRANCH\'* && \
-            "$PUBLISHREPOPREFIX" == "$OFFICIALREPOPREFIX" && \
-            "$OVERRIDEOFFICIALBRANCHVALIDATION" != "true" ]]; then
-          echo "##vso[task.logissue type=error]Official builds must be done from an official branch: $OFFICIALBRANCHES"
-          exit 1
-      fi
+  - powershell: |
+      if (-not "$(officialBranches)".Split(',').Contains("$(sourceBranch)") `
+          -and "$(officialBranches)".Split(',').Contains("$(publishRepoPrefix)") `
+          -and "$(overrideOfficialBranchValidation)" -ne "true")
+      {
+        echo "##vso[task.logissue type=error]Official builds must be done from an official branch: $(officialBranches)"
+        exit 1
+      }
     displayName: Validate Branch

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -34,6 +34,8 @@ variables:
   value: 'mirror/'
 - name: cgBuildGrepArgs
   value: "''"
+- name: test.init
+  value: ""
 
 - name: defaultLinuxAmd64PoolImage
   value: ubuntu-latest

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -5,6 +5,10 @@ variables:
   value: build-staging/$(sourceBuildId)/
 - name: publishReadme
   value: true
+- name: publishImageInfo
+  value: true
+- name: ingestKustoImageInfo
+  value: true
 - name: skipComponentGovernanceDetection
   value: true
 - name: build.imageBuilderDockerRunExtraOptions
@@ -15,8 +19,6 @@ variables:
   value: 2
 - name: imageInfoVariant
   value: ""
-- name: ingestKustoImageInfo
-  value: true
 - name: publishNotificationsEnabled
   value: false
 - name: manifestVariables
@@ -26,8 +28,8 @@ variables:
 - name: mcrDocIngestionTimeout
   value: "00:05:00"
 - name: officialBranches
-  # list multiple branches as "'branch1', 'branch2', etc."
-  value: "'main'"
+  # comma-delimited list of branch names
+  value: main
 - name: mirrorRepoPrefix
   value: 'mirror/'
 - name: cgBuildGrepArgs

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -36,6 +36,8 @@ variables:
   value: "''"
 - name: test.init
   value: ""
+- name: testRunner.options
+  value: ""
 
 - name: defaultLinuxAmd64PoolImage
   value: ubuntu-latest

--- a/eng/common/templates/variables/dotnet/build-test-publish.yml
+++ b/eng/common/templates/variables/dotnet/build-test-publish.yml
@@ -11,8 +11,8 @@ variables:
   value: ./tests/run-tests.ps1
 - name: testResultsDirectory
   value: tests/Microsoft.DotNet.Docker.Tests/TestResults/
-- name: officialRepoPrefix
-  value: public/
+- name: officialRepoPrefixes
+  value: public/,private/internal/
 
 - name: mcrDocsRepoInfo.accessToken
   value: $(BotAccount-dotnet-docker-bot-PAT)


### PR DESCRIPTION
Updates the common pipeline infrastructure in order to enable support for internal .NET builds (related to https://github.com/dotnet/dotnet-docker/issues/2152).

This mainly involves adding more customization points within the pipeline such as being able to inject custom initialization logic before running tests. Another small buy key change is to allow the publishing of the image info file to be disabled by the pipeline via a `publishImageInfo` variable.