### PR TITLE
Upgrade package dependencies

### DIFF
--- a/eng/src/file-pusher/file-pusher.csproj
+++ b/eng/src/file-pusher/file-pusher.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.VersionTools" Version="6.0.0-beta.21275.4" />
+    <PackageReference Include="Microsoft.DotNet.VersionTools" Version="6.0.0-beta.22351.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
     <PackageReference Include="System.Diagnostics.TextWriterTraceListener" Version="4.3.0" />

--- a/eng/src/yaml-updater/yaml-updater.csproj
+++ b/eng/src/yaml-updater/yaml-updater.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
     <PackageReference Include="System.Diagnostics.TextWriterTraceListener" Version="4.3.0" />
-    <PackageReference Include="YamlDotNet" Version="9.1.4" />
+    <PackageReference Include="YamlDotNet" Version="11.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -11,14 +11,14 @@
     <PackageReference Include="Cottle" Version="2.0.7" />
     <PackageReference Include="GiGraph.Dot" Version="1.6.3" />
     <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
-    <PackageReference Include="Microsoft.Azure.Kusto.Ingest" Version="9.4.1" />
-    <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.38.0" />
-    <PackageReference Include="Microsoft.DotNet.Git.IssueManager" Version="6.0.0-beta.21275.4" />
-    <PackageReference Include="Microsoft.DotNet.VersionTools" Version="6.0.0-beta.21275.4" />
+    <PackageReference Include="Microsoft.Azure.Kusto.Ingest" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.38.1" />
+    <PackageReference Include="Microsoft.DotNet.Git.IssueManager" Version="6.0.0-beta.22351.1" />
+    <PackageReference Include="Microsoft.DotNet.VersionTools" Version="6.0.0-beta.22351.1" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.170.0" />
-    <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.13" />
-    <PackageReference Include="Polly" Version="7.2.2" />
+    <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.14" />
+    <PackageReference Include="Polly" Version="7.2.3" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
     <PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />

--- a/src/Microsoft.DotNet.ImageBuilder/tests/Microsoft.DotNet.ImageBuilder.Tests.csproj
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/Microsoft.DotNet.ImageBuilder.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -6,10 +6,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Moq" Version="4.12.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Moq" Version="4.18.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updates the projects in this repo to reference the latest versions of their package dependencies. The only one not included in this is [System.CommandLine](https://github.com/dotnet/docker-tools/issues/1019) which has breaking changes that need to be accounted for.