### PR TITLE
Support multiple OS versions in tests

### DIFF
--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -54,7 +54,16 @@ stages:
       testJobTimeout: ${{ parameters.linuxAmdTestJobTimeout }}
       preBuildValidation: true
       internalProjectName: ${{ parameters.internalProjectName }}
-      customInitSteps: ${{ parameters.customTestInitSteps }}
+      customInitSteps:
+        - ${{ parameters.customTestInitSteps }}
+        # These variables are normally set by the matrix. Since this test job is not generated
+        # by a matrix, we need to set them manually. They can be set to empty values since their
+        # values aren't actually used for the pre-build tests.
+        - powershell: |
+            echo "##vso[task.setvariable variable=productVersion]"
+            echo "##vso[task.setvariable variable=osVersions]"
+            echo "##vso[task.setvariable variable=architecture]"
+          displayName: Initialize Test Variables
   - template: ../jobs/copy-base-images.yml
     parameters:
       name: CopyBaseImages

--- a/eng/common/templates/steps/parse-os-versions.yml
+++ b/eng/common/templates/steps/parse-os-versions.yml
@@ -1,0 +1,11 @@
+steps:
+- powershell: |
+    # Formats the OS versions in a compact human-readable form (e.g. "os1/os2")
+    $osVersionsDisplayName = '$(osVersions)' -Replace '--os-version ', '' -Replace ' ', '/'
+
+    # Defines a PowerShell snippet in string-form that can be used to initialize an array of the OS versions
+    $osVersionsArrayInitStr="@('" + $($osVersionsDisplayName -Replace "/", "', '") + "')"
+    
+    echo "##vso[task.setvariable variable=osVersionsDisplayName]$osVersionsDisplayName"
+    echo "##vso[task.setvariable variable=osVersionsArrayInitStr]$osVersionsArrayInitStr"
+  displayName: Parse OS Versions

--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -50,17 +50,18 @@ steps:
       parameters:
         targetPath: $(Build.ArtifactStagingDirectory)
         condition: ${{ parameters.condition }}
+- template: parse-os-versions.yml
 - powershell: >
     $(test.init);
     docker exec
     $(testRunner.options)
     $(testRunner.container)
     pwsh
-    -File $(testScriptPath)
-    -Version '"$(productVersion)"'
-    -OS '"$(osVariant)"'
-    -Architecture '"$(architecture)"'
-    $(optionalTestArgs)
+    -Command "$(testScriptPath)
+    -Version '$(productVersion)'
+    -OSVersions $(osVersionsArrayInitStr)
+    -Architecture '$(architecture)'
+    $(optionalTestArgs)"
   displayName: Test Images
   condition: and(succeeded(), ${{ parameters.condition }})
 - ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
@@ -86,7 +87,7 @@ steps:
     mergeTestResults: true
     publishRunAttachments: true
     ${{ if eq(parameters.preBuildValidation, 'false') }}:
-      testRunTitle: $(productVersion) $(osVariant) $(architecture)
+      testRunTitle: $(productVersion) $(osVersionsDisplayName) $(architecture)
     ${{ if eq(parameters.preBuildValidation, 'true') }}:
       testRunTitle: Pre-Build Validation
 - script: docker rm -f $(testRunner.container)

--- a/eng/common/templates/steps/test-images-windows-client.yml
+++ b/eng/common/templates/steps/test-images-windows-client.yml
@@ -33,11 +33,12 @@ steps:
     parameters:
       targetPath: $(Build.ArtifactStagingDirectory)
       condition: ${{ parameters.condition }}
+- template: parse-os-versions.yml
 - powershell: >
     $(test.init);
     $(testScriptPath)
     -Version '$(productVersion)'
-    -OS '$(osVariant)'
+    -OSVersions $(osVersionsArrayInitStr)
     $(optionalTestArgs)
   displayName: Test Images
   condition: and(succeeded(), ${{ parameters.condition }})
@@ -55,7 +56,7 @@ steps:
     testResultsFiles: '$(testResultsDirectory)/**/*.trx'
     mergeTestResults: true
     publishRunAttachments: true
-    testRunTitle: $(productVersion) $(osVariant) amd64
+    testRunTitle: $(productVersion) $(osVersionsDisplayName) amd64
 - ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
   - template: cleanup-docker-windows.yml
     parameters:

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1824627
+  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1861126
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-buster-slim-docker-testrunner-974165
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/eng/tests/pipeline-validation/run-tests.ps1
+++ b/eng/tests/pipeline-validation/run-tests.ps1
@@ -8,7 +8,7 @@
 param(
     [string]$Version,
     [string]$Architecture,
-    [string]$OS,
+    [string[]]$OSVersions,
     [string]$Registry,
     [string]$RepoPrefix,
     [switch]$DisableHttpVerification,

--- a/src/Microsoft.DotNet.ImageBuilder/run-tests.ps1
+++ b/src/Microsoft.DotNet.ImageBuilder/run-tests.ps1
@@ -8,7 +8,7 @@
 param(
     [string]$Version,
     [string]$Architecture,
-    [string]$OS,
+    [string[]]$OSVersions,
     [string]$Registry,
     [string]$RepoPrefix,
     [switch]$DisableHttpVerification,


### PR DESCRIPTION
These are changes to support a fix for https://github.com/dotnet/dotnet-docker/issues/3870. The issue there is that we're excluding distroless Mariner images from being tested in jobs where both Mariner and distroless Mariner images were built (e.g. PR builds).

In order to fix this, the intention is to make use of the data we have available in the generated matrix. It includes an `osVersions` field which specifies the set of OS versions represented by the Dockerfile paths it has included to be built/tested in matrix job. In the case of this scenario, that field contains both "cbl-mariner2.0" and "cbl-mariner2.0-distroless", for example. By passing both of these values to the `run-tests.ps1` script, it can correctly include both of those image types to be in its testing.

This is a breaking change with the contract between the common pipeline and the test script because it changes the name and type of the OS parameter.