### PR TITLE
Fix matrix generation to prevent duplicate build of Dockerfile

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/DockerfileHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/DockerfileHelper.cs
@@ -2,16 +2,22 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.IO;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests.Helpers
 {
     public static class DockerfileHelper
     {
-        public static string CreateDockerfile(string relativeDirectory, TempFolderContext context, string fromTag = "base")
+        public static string CreateDockerfile(string relativeDirectory, TempFolderContext context, string fromTag1 = "base", string fromTag2 = null)
         {
             string relativeDockerfilePath = PathHelper.NormalizePath(Path.Combine(relativeDirectory, "Dockerfile"));
-            CreateFile(relativeDockerfilePath, context, $"FROM {fromTag}");
+            string contents = $"FROM {fromTag1}";
+            if (fromTag2 is not null)
+            {
+                contents += $"{Environment.NewLine}FROM {fromTag2}";
+            }
+            CreateFile(relativeDockerfilePath, context, contents);
             return relativeDockerfilePath;
         }
 


### PR DESCRIPTION
Builds in the nightly branch of https://github.com/dotnet/dotnet-docker are currently broken due to the Dockerfile in src\runtime-deps\6.0\cbl-mariner2.0-distroless\amd64 being built by multiple jobs (same applies to other architectures). Because it's built by multiple jobs we have two distinct images that are tagged the same way. This leads to issues during publish due to the dependency on the information in the image-info.json file which is expecting a certain digest to exist for an image.

This began to occur after the introduction of https://github.com/dotnet/dotnet-docker/pull/3882. But the issue only manifests when both 6.0 and 7.0 have cache misses for the CBL-Mariner 2.0 Dockerfiles. If you get a cache hit for 6.0 and not for 7.0 things will be fine because we're not producing a duplicate image across multiple build jobs; only one build job actually ends up building the relevant images.

This issue stems from the build matrix that gets generated:

```
src-runtime-deps-6.0-cbl-mariner2.0-graph:
  imageBuilderPaths:
    --path src/runtime-deps/6.0/cbl-mariner2.0/amd64
    --path src/runtime/6.0/cbl-mariner2.0/amd64
    --path src/aspnet/6.0/cbl-mariner2.0/amd64
    --path src/sdk/6.0/cbl-mariner2.0/amd64
    --path src/monitor/6.1/cbl-mariner/amd64
    --path src/monitor/6.2/cbl-mariner/amd64
    --path src/monitor/6.2/cbl-mariner-distroless/amd64
    --path src/aspnet/6.0/cbl-mariner2.0-distroless/amd64
    --path src/runtime/6.0/cbl-mariner2.0-distroless/amd64
    --path src/runtime-deps/6.0/cbl-mariner2.0-distroless/amd64
  legName: linuxamd64src-runtime-deps-6.0-cbl-mariner2.0-graph
  osType: linux
  architecture: amd64
  osVersions: --os-version cbl-mariner2.0 --os-version cbl-mariner2.0-distroless

src-runtime-deps-7.0-cbl-mariner2.0-graph:
  imageBuilderPaths:
    --path src/runtime-deps/7.0/cbl-mariner2.0/amd64
    --path src/runtime/7.0/cbl-mariner2.0/amd64
    --path src/aspnet/7.0/cbl-mariner2.0/amd64
    --path src/sdk/7.0/cbl-mariner2.0/amd64
    --path src/monitor/7.0/cbl-mariner/amd64
    --path src/monitor/7.0/cbl-mariner-distroless/amd64
    --path src/aspnet/7.0/cbl-mariner2.0-distroless/amd64
    --path src/runtime/7.0/cbl-mariner2.0-distroless/amd64
    --path src/runtime-deps/6.0/cbl-mariner2.0-distroless/amd64
  legName: linuxamd64src-runtime-deps-7.0-cbl-mariner2.0-graph
  osType: linux
  architecture: amd64
  osVersions: --os-version cbl-mariner2.0 --os-version cbl-mariner2.0-distroless
```

You can see in the last path that's listed for both jobs is `src/runtime-deps/6.0/cbl-mariner2.0-distroless/amd64`. That's a shared Dockerfile used between both 6.0 and 7.0.

The introduction of the distroless Mariner Dockerfiles for .NET Monitor caused an interesting shift in the image graph due to its dependency on both the full Mariner sdk and distroless Mariner aspnet. This caused the image graph to be constructed in such a way that exposed a flaw in the logic of the matrix generation that made an assumption about which Dockerfiles to consider when consolidating subgraphs together that shared the same Dockerfiles. It assumed that only the first platform listed in the subgraph needed to be checked because that would be the "root". But that assumption fails with the way the subgraph is constructed now with .NET Monitor involved. With .NET Monitor, its dependencies get added to the end of the subgraph, one of which is `src/runtime-deps/6.0/cbl-mariner2.0-distroless/amd64`. So that platform wasn't getting checked when consolidating the subgraphs.

This has been fixed by now iterating through each platform of the subgraph to check for matching platforms in other subgraphs. The assumption that only the first platform is relevant has been completely removed.

This change then produces a single leg that builds everything:

```
src-runtime-deps-6.0-cbl-mariner2.0-graph:
  imageBuilderPaths:
    --path src/runtime-deps/6.0/cbl-mariner2.0/amd64
    --path src/runtime/6.0/cbl-mariner2.0/amd64
    --path src/aspnet/6.0/cbl-mariner2.0/amd64
    --path src/sdk/6.0/cbl-mariner2.0/amd64
    --path src/monitor/6.2/cbl-mariner-distroless/amd64
    --path src/aspnet/6.0/cbl-mariner2.0-distroless/amd64
    --path src/runtime/6.0/cbl-mariner2.0-distroless/amd64
    --path src/runtime-deps/6.0/cbl-mariner2.0-distroless/amd64
    --path src/runtime-deps/7.0/cbl-mariner2.0/amd64
    --path src/runtime/7.0/cbl-mariner2.0/amd64
    --path src/aspnet/7.0/cbl-mariner2.0/amd64
    --path src/sdk/7.0/cbl-mariner2.0/amd64
    --path src/monitor/7.0/cbl-mariner-distroless/amd64
    --path src/aspnet/7.0/cbl-mariner2.0-distroless/amd64
    --path src/runtime/7.0/cbl-mariner2.0-distroless/amd64
  legName: linuxamd64src-runtime-deps-6.0-cbl-mariner2.0-graph
  osType: linux
  architecture: amd64
  osVersions: --os-version cbl-mariner2.0 --os-version cbl-mariner2.0-distroless
```


In addition, a validation check was added to ensure that we don't end up having multiple build jobs being generated that are building the same Dockerfile. Having this at the time the new .NET Monitor Dockerfiles were added would have alerted us to an issue much sooner.