### PR TITLE
Fix matrix generation to handle graph consolidation with duplicated platforms

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
@@ -65,8 +65,17 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
                     if (subgraphsByRootDockerfilePath.TryGetValue(key, out List<PlatformInfo>? commonSubgraph))
                     {
-                        commonSubgraph.AddRange(subgraph);
-                        subgraphsToDelete.Add(subgraph);
+                        // In some cases it is possible to have distinct PlatformInfo instances with the same Dockerfile path.
+                        // This happens in the scenario where a Dockerfile path is duplicated/redefined in a separate image such
+                        // as the case for Debian images that are contained both in the 6.0 multi-arch tag as well as
+                        // the 6.0-bullseye-slim multi-arch tag. To account for that scenario we need to look up by Dockerfile path
+                        // but also ensure that we're not getting the same subgraph that we're currently processing. That prevents us
+                        // from getting the duplicated platform that exists within the same subgraph.
+                        if (commonSubgraph != subgraph)
+                        {
+                            commonSubgraph.AddRange(subgraph);
+                            subgraphsToDelete.Add(subgraph);
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
The changes from https://github.com/dotnet/docker-tools/pull/1023 resulted in the following exception when generating the platformVersionedOs matrix type for https://github.com/dotnet/dotnet-docker:
```
Unhandled exception: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
 ---> System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
   at Microsoft.DotNet.ImageBuilder.Commands.GenerateBuildMatrixCommand.ConsolidateSubgraphs(IEnumerable`1 subgraphs, Func`2 getKey) in /image-builder/src/Commands/GenerateBuildMatrixCommand.cs:line 60
   at Microsoft.DotNet.ImageBuilder.Commands.GenerateBuildMatrixCommand.AddVersionedOsLegs(BuildMatrixInfo matrix, IGrouping`2 platformGrouping) in /image-builder/src/Commands/GenerateBuildMatrixCommand.cs:line 263
   at Microsoft.DotNet.ImageBuilder.Commands.GenerateBuildMatrixCommand.GenerateMatrixInfo() in /image-builder/src/Commands/GenerateBuildMatrixCommand.cs:line 423
   at Microsoft.DotNet.ImageBuilder.Commands.GenerateBuildMatrixCommand.ExecuteAsync() in /image-builder/src/Commands/GenerateBuildMatrixCommand.cs:line 46
   at Microsoft.DotNet.ImageBuilder.Commands.Command`2.<GetCliCommand>b__9_0(TOptions options) in /image-builder/src/Commands/Command.TOptions.cs:line 46
```

This is due to incorrect handling of duplicated platforms within the manifest. Those are platforms which are redefined in the manifest in order to associate a Dockerfile with different manifest images. This allows a given Dockerfile to be assigned different multi-arch tags such as `6.0` and `6.0-bullseye-slim`. The matrix generation logic assumed that a given subgraph wouldn't have distinct platforms that share the same Dockerfile path. But that's not true for this scenario. So that lead to an attempt to modify the subgraph that was currently being processed.

The fix is to simply check that the subgraph is not the same subgraph being processed. That will prevent it from being modified. It doesn't need to be modified in that case.