### PR TITLE
Show correct repo name in publish notification

### DIFF
--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -129,6 +129,7 @@ jobs:
       '$(gitHubNotificationsRepoInfo.accessToken)'
       '$(gitHubNotificationsRepoInfo.org)'
       '$(gitHubNotificationsRepoInfo.repo)'
+      --repo-prefix '$(publishRepoPrefix)'
       --task "Copy Images"
       --task "Publish Manifest"
       --task "Wait for Image Ingestion"


### PR DESCRIPTION
Changes were made in https://github.com/dotnet/docker-tools/pull/1018 to include the correct fully-qualified repo name in the publish notification body. Specifically, it used the value of the `--repo-prefix` option when constructing the repo name. That logic is all correct. The problem is that the `--epo-prefix` option isn't being set when calling the command from the pipeline. This change fixes that.