### PR TITLE
Allow base image tags to be overriden

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BaseImageOverrideOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BaseImageOverrideOptions.cs
@@ -1,0 +1,65 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.Linq;
+using System.Text.RegularExpressions;
+using static Microsoft.DotNet.ImageBuilder.Commands.CliHelper;
+
+namespace Microsoft.DotNet.ImageBuilder.Commands;
+
+/// <summary>
+/// Defines options that allow the caller to configure whether and how base image tags defined in a Dockerfile
+/// are to be overriden.
+/// </summary>
+/// This allows for images to be sourced from a different location than described in the Dockerfile.
+/// For example, the Build command implements this by pulling an image from the overriden location, retagging it with the
+/// tag used in the Dockerfile, and continue with the rest of the build.<remarks>
+/// </remarks>
+#nullable enable
+public class BaseImageOverrideOptions
+{
+    public const string BaseOverrideRegexName = "base-override-regex";
+    public const string BaseOverrideSubName = "base-override-sub";
+
+    public string? RegexPattern { get; set; }
+
+    public string? Substitution { get; set; }
+
+    public void Validate()
+    {
+        if ((RegexPattern is null) != (Substitution is null))
+        {
+            throw new InvalidOperationException(
+                $"The '{BaseOverrideRegexName}' and '{BaseOverrideSubName}' options must both be set.");
+        }
+    }
+
+    public string ApplyBaseImageOverride(string imageName)
+    {
+        if (RegexPattern is not null && Substitution is not null)
+        {
+            return Regex.Replace(imageName, RegexPattern, Substitution);
+        }
+
+        return imageName;
+    }
+}
+
+public class BaseImageOverrideOptionsBuilder
+{
+    public IEnumerable<Option> GetCliOptions() =>
+        new Option[]
+        {
+            CreateOption<string?>(BaseImageOverrideOptions.BaseOverrideRegexName, nameof(BaseImageOverrideOptions.RegexPattern),
+                    $"Regular expression identifying base image tags to apply string substitution to (requires {BaseImageOverrideOptions.BaseOverrideSubName} to be set)"),
+                CreateOption<string?>(BaseImageOverrideOptions.BaseOverrideSubName, nameof(BaseImageOverrideOptions.Substitution),
+                    $"Regular expression substitution that overrides a matching base image tag (requires {BaseImageOverrideOptions.BaseOverrideRegexName} to be set)")
+        };
+
+    public IEnumerable<Argument> GetCliArguments() => Enumerable.Empty<Argument>();
+}
+
+#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -48,6 +48,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         public override async Task ExecuteAsync()
         {
+            Options.BaseImageOverrideOptions.Validate();
+
             if (Options.ImageInfoOutputPath != null)
             {
                 _imageArtifactDetails = new ImageArtifactDetails();
@@ -628,6 +630,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         /// </remarks>
         private string GetFromImageTag(string fromImage, string? registry)
         {
+            fromImage = Options.BaseImageOverrideOptions.ApplyBaseImageOverride(fromImage);
+
             if ((registry is not null && DockerHelper.IsInRegistry(fromImage, registry)) ||
                 DockerHelper.IsInRegistry(fromImage, Manifest.Model.Registry)
                 || Options.SourceRepoPrefix is null)

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
@@ -12,7 +12,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     public class BuildOptions : DockerRegistryOptions, IFilterableOptions
     {
-        public ManifestFilterOptions FilterOptions { get; set; } = new ManifestFilterOptions();
+        public ManifestFilterOptions FilterOptions { get; set; } = new();
+        public BaseImageOverrideOptions BaseImageOverrideOptions { get; set; } = new();
 
         public bool IsPushEnabled { get; set; }
         public bool IsRetryEnabled { get; set; }
@@ -29,12 +30,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
     public class BuildOptionsBuilder : DockerRegistryOptionsBuilder
     {
-        private readonly ManifestFilterOptionsBuilder _manifestFilterOptionsBuilder =
-            new ManifestFilterOptionsBuilder();
+        private readonly ManifestFilterOptionsBuilder _manifestFilterOptionsBuilder = new();
+        private readonly BaseImageOverrideOptionsBuilder _baseImageOverrideOptionsBuilder = new();
 
         public override IEnumerable<Option> GetCliOptions() =>
             base.GetCliOptions()
                 .Concat(_manifestFilterOptionsBuilder.GetCliOptions())
+                .Concat(_baseImageOverrideOptionsBuilder.GetCliOptions())
                 .Concat(
                     new Option[]
                     {
@@ -64,7 +66,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         public override IEnumerable<Argument> GetCliArguments() =>
             base.GetCliArguments()
-                .Concat(_manifestFilterOptionsBuilder.GetCliArguments());
+                .Concat(_manifestFilterOptionsBuilder.GetCliArguments())
+                .Concat(_baseImageOverrideOptionsBuilder.GetCliArguments());
     }
 }
 #nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyBaseImagesOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyBaseImagesOptions.cs
@@ -11,26 +11,30 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     public class CopyBaseImagesOptions : CopyImagesOptions
     {
-        public RegistryCredentialsOptions CredentialsOptions { get; set; } = new RegistryCredentialsOptions();
+        public RegistryCredentialsOptions CredentialsOptions { get; set; } = new();
 
-        public SubscriptionOptions SubscriptionOptions { get; set; } = new SubscriptionOptions();
+        public SubscriptionOptions SubscriptionOptions { get; set; } = new();
+
+        public BaseImageOverrideOptions BaseImageOverrideOptions { get; set; } = new();
     }
 
     public class CopyBaseImagesOptionsBuilder : CopyImagesOptionsBuilder
     {
-        private readonly RegistryCredentialsOptionsBuilder _registryCredentialsOptionsBuilder =
-            new RegistryCredentialsOptionsBuilder();
-        private readonly SubscriptionOptionsBuilder _subscriptionOptionsBuilder = new SubscriptionOptionsBuilder();
+        private readonly RegistryCredentialsOptionsBuilder _registryCredentialsOptionsBuilder = new();
+        private readonly SubscriptionOptionsBuilder _subscriptionOptionsBuilder = new();
+        private readonly BaseImageOverrideOptionsBuilder _baseImageOverrideOptionsBuilder = new();
 
         public override IEnumerable<Option> GetCliOptions() =>
             base.GetCliOptions()
                 .Concat(_registryCredentialsOptionsBuilder.GetCliOptions())
-                .Concat(_subscriptionOptionsBuilder.GetCliOptions());
+                .Concat(_subscriptionOptionsBuilder.GetCliOptions())
+                .Concat(_baseImageOverrideOptionsBuilder.GetCliOptions());
 
         public override IEnumerable<Argument> GetCliArguments() =>
             base.GetCliArguments()
                 .Concat(_registryCredentialsOptionsBuilder.GetCliArguments())
-                .Concat(_subscriptionOptionsBuilder.GetCliArguments());
+                .Concat(_subscriptionOptionsBuilder.GetCliArguments())
+                .Concat(_baseImageOverrideOptionsBuilder.GetCliArguments());
     }
 }
 #nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestOptions.cs
@@ -13,6 +13,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     public abstract class ManifestOptions : Options, IManifestOptionsInfo
     {
+        public const string RegistryOverrideName = "registry-override";
+
         public string Manifest { get; set; } = string.Empty;
         public string? RegistryOverride { get; set; }
         public IEnumerable<string> Repos { get; set; } = Enumerable.Empty<string>();
@@ -45,7 +47,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 {
                     CreateOption("manifest", nameof(ManifestOptions.Manifest),
                         "Path to json file which describes the repo", "manifest.json"),
-                    CreateOption<string?>("registry-override", nameof(ManifestOptions.RegistryOverride),
+                    CreateOption<string?>(ManifestOptions.RegistryOverrideName, nameof(ManifestOptions.RegistryOverride),
                         "Alternative registry which overrides the manifest"),
                     CreateMultiOption<string>("repo", nameof(ManifestOptions.Repos),
                         "Repos to operate on (Default is all)"),


### PR DESCRIPTION
There's a need to be able to pull the base images that our Dockerfiles are dependent on from a registry location other than the Docker Hub registry. But we still want to maintain our Dockerfile content as-is to allow the community to make use of them with the canonical source of these base images.

This can be implemented in a build by pulling from the overridden location, tagging it with the same tag referenced by the Dockerfile, and proceeding with the rest of the build as usual. This allows us to keep the Dockerfile unchanged but still allows us to make use of a base image from a different source.

By ensuring that images from the overridden location are the same images that exist on Docker Hub, we can maintain our commitment to the community that the images we publish are effectively based on the location described by the Dockerfiles.

This is implemented by providing two command options: `base-override-regex` and `base-override-sub`. When used together, these options allow a caller to specify a regex that, when matched on a base image tag, will replace it with the substitution pattern. This provides a dynamic way for callers to customize how the base image tag should be overridden. It's consumed by `CopyBaseImagesCommand`, to allow images from the overridden location to be mirrored to our ACR, and `BuildCommand`, to do the retagging logic described earlier.