### PR TITLE
Fixes to better support tag override

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -657,7 +657,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             string trimmed = TrimInternallyOwnedRegistryAndRepoPrefix(fromImage);
             if (trimmed == fromImage)
             {
-                return trimmed;
+                return Options.BaseImageOverrideOptions.ApplyBaseImageOverride(trimmed);
             }
             else
             {

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
@@ -137,8 +137,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 {
                     foundImageInfo = true;
                     string? fromImage = platform.FinalStageFromImage;
-                    string currentDigest;
-
                     if (fromImage is null)
                     {
                         _loggerService.WriteMessage(
@@ -146,7 +144,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         break;
                     }
 
-                    currentDigest = await LockHelper.DoubleCheckedLockLookupAsync(_imageDigestsLock, _imageDigests, fromImage,
+                    fromImage = Options.BaseImageOverrideOptions.ApplyBaseImageOverride(fromImage);
+
+                    string currentDigest = await LockHelper.DoubleCheckedLockLookupAsync(_imageDigestsLock, _imageDigests, fromImage,
                         async () =>
                         {
                             string digest = await _manifestToolService.GetManifestDigestShaAsync(fromImage, Options.CredentialsOptions, Options.IsDryRun);

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesOptions.cs
@@ -20,6 +20,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public string VariableName { get; set; } = string.Empty;
 
         public RegistryCredentialsOptions CredentialsOptions { get; set; } = new RegistryCredentialsOptions();
+
+        public BaseImageOverrideOptions BaseImageOverrideOptions { get; set; } = new();
+
     }
 
     public class GetStaleImagesOptionsBuilder : CliOptionsBuilder
@@ -28,14 +31,15 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private readonly ManifestFilterOptionsBuilder _manifestFilterOptionsBuilder = new();
         private readonly SubscriptionOptionsBuilder _subscriptionOptionsBuilder = new();
         private readonly RegistryCredentialsOptionsBuilder _registryCredentialsOptionsBuilder = new();
-
+        private readonly BaseImageOverrideOptionsBuilder _baseImageOverrideOptionsBuilder = new();
 
         public override IEnumerable<Option> GetCliOptions() =>
             base.GetCliOptions()
                 .Concat(_subscriptionOptionsBuilder.GetCliOptions())
                 .Concat(_manifestFilterOptionsBuilder.GetCliOptions())
                 .Concat(_gitOptionsBuilder.GetCliOptions())
-                .Concat(_registryCredentialsOptionsBuilder.GetCliOptions());
+                .Concat(_registryCredentialsOptionsBuilder.GetCliOptions())
+                .Concat(_baseImageOverrideOptionsBuilder.GetCliOptions());
 
         public override IEnumerable<Argument> GetCliArguments() =>
             base.GetCliArguments()


### PR DESCRIPTION
The changes from https://github.com/dotnet/docker-tools/pull/1031 are incomplete when it comes to the scenario of checking for whether an update to the base image exists. When the Dockerfile's base tag is being overridden, we want to compare against the digest of the tag that has the override applied, not the tag that's defined in the Dockerfile.

This requires a change to the `GetStaleBaseImagesCommand` using the same pattern that was used for the other commands in https://github.com/dotnet/docker-tools/pull/1031. It simply applies the override, if applicable, when it needs to look up the digest value that gets compared to the digest from the image info file.

Similarly, `BuildCommand` also needs to be updated so that it outputs the correct base image digest when generating the image info file. Again, it just needs get the digest of the image tag that has the override applied.