### PR TITLE
Allow literal special characters in ImageBuilder args

### DIFF
--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -84,7 +84,13 @@ jobs:
     condition: eq(variables.imageBuilderBuildArgs, '')
     displayName: Initialize Image Builder Build Args
   - powershell: |
-      $imageBuilderBuildArgs = "$(imageBuilderBuildArgs) $(imageBuilder.queueArgs) --image-info-output-path $(artifactsPath)/$(legName)-image-info.json"
+      # Reference the existing imageBuilderBuildArgs variable as an environment variable rather than injecting it directly
+      # with the $(imageBuilderBuildArgs) syntax. This is to avoid issues where the string may contain single quotes $ chars
+      # which really mess up assigning to a variable. It would require assigning the string with single quotes but also needing
+      # to escape the single quotes that are in the string which would need to be done outside the context of PowerShell. Since
+      # all we need is for that value to be in a PowerShell variable, we can get that by the fact that AzDO automatically creates
+      # the environment variable for us.
+      $imageBuilderBuildArgs = "$env:IMAGEBUILDERBUILDARGS $(imageBuilder.queueArgs) --image-info-output-path $(artifactsPath)/$(legName)-image-info.json"
       if ($env:SYSTEM_TEAMPROJECT -eq "${{ parameters.internalProjectName }}") {
         $imageBuilderBuildArgs = "$imageBuilderBuildArgs --registry-override $(acr.server) --repo-prefix $(stagingRepoPrefix) --source-repo-prefix $(mirrorRepoPrefix) --push --registry-creds ""$(acr.server)=$(acr.userName);$(acr.password)"""
       }


### PR DESCRIPTION
This fixes the pipeline logic to reference the ImageBuilder args variable in a way that supports it containing special characters like `'` and `$` without resolving them in the context of PowerShell. This is related to https://github.com/dotnet/docker-tools/pull/1031 where the substitution pattern to be used will contain a sub-string like `$1`. Such a value needs to remain unresolved by PowerShell.