### PR TITLE
Support custom init steps for CopyBaseImages stage

### DIFF
--- a/eng/common/templates/jobs/copy-base-images.yml
+++ b/eng/common/templates/jobs/copy-base-images.yml
@@ -3,12 +3,14 @@ parameters:
   pool: {}
   additionalOptions: null
   publicProjectName: null
+  customInitSteps: []
   
 jobs:
 - job: ${{ parameters.name }}
   pool: ${{ parameters.pool }}
   steps:
   - template: ../steps/init-docker-linux.yml
+  - ${{ parameters.customInitSteps }}
   - template: ../steps/copy-base-images.yml
     parameters:
       additionalOptions: ${{ parameters.additionalOptions }}

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -3,6 +3,7 @@ parameters:
   testMatrixType: platformVersionedOs
   buildMatrixCustomBuildLegGroupArgs: ""
   testMatrixCustomBuildLegGroupArgs: ""
+  customCopyBaseImagesInitSteps: []
   customBuildInitSteps: []
   customTestInitSteps: []
   customPublishInitSteps: []
@@ -70,6 +71,7 @@ stages:
       pool: ${{ parameters.linuxAmd64Pool }}
       additionalOptions: "--manifest '$(manifest)' $(manifestVariables)"
       publicProjectName: ${{ parameters.publicProjectName }}
+      customInitSteps: ${{ parameters.customCopyBaseImagesInitSteps}}
   - template: ../jobs/generate-matrix.yml
     parameters:
       matrixType: ${{ parameters.buildMatrixType }}

--- a/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
@@ -7,6 +7,7 @@ parameters:
   publicProjectName: null
   buildMatrixCustomBuildLegGroupArgs: ""
   testMatrixCustomBuildLegGroupArgs: ""
+  customCopyBaseImagesInitSteps: []
   customBuildInitSteps: []
   customTestInitSteps: []
   customPublishInitSteps: []
@@ -25,6 +26,7 @@ stages:
     publicProjectName: ${{ parameters.publicProjectName }}
     buildMatrixCustomBuildLegGroupArgs: ${{ parameters.buildMatrixCustomBuildLegGroupArgs }}
     testMatrixCustomBuildLegGroupArgs: ${{ parameters.testMatrixCustomBuildLegGroupArgs }}
+    customCopyBaseImagesInitSteps: ${{ parameters.customCopyBaseImagesInitSteps}}
     customBuildInitSteps: ${{ parameters.customBuildInitSteps }}
     customTestInitSteps: ${{ parameters.customTestInitSteps }}
     customPublishInitSteps:

--- a/eng/common/templates/steps/copy-base-images.yml
+++ b/eng/common/templates/steps/copy-base-images.yml
@@ -15,6 +15,7 @@ steps:
     '$(acr.subscription)'
     '$(acr.resourceGroup)'
     $(dockerHubRegistryCreds)
+    $(customCopyBaseImagesArgs)
     --repo-prefix $(mirrorRepoPrefix)
     --registry-override '$(acr.server)'
     --os-type 'linux'

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -38,6 +38,8 @@ variables:
   value: ""
 - name: testRunner.options
   value: ""
+- name: customCopyBaseImagesArgs
+  value: ""
 
 - name: defaultLinuxAmd64PoolImage
   value: ubuntu-latest


### PR DESCRIPTION
This updates the pipeline to allow custom init steps to be injected for the `CopyBaseImages` stage and to provide additional custom args to the `CopyBaseImages` command. This allows consuming repos to provide the custom args introduced by https://github.com/dotnet/docker-tools/pull/1031.