### PR TITLE
Split base image subscriptions

### DIFF
--- a/eng/check-base-image-subscriptions.json
+++ b/eng/check-base-image-subscriptions.json
@@ -24,25 +24,6 @@
     "manifest": {
       "owner": "dotnet",
       "repo": "dotnet-docker",
-      "branch": "main",
-      "path": "manifest.json"
-    },
-    "imageInfo": {
-      "owner": "dotnet",
-      "repo": "versions",
-      "branch": "main",
-      "path": "build-info/docker/image-info.dotnet-dotnet-docker-main.json"
-    },
-    "pipelineTrigger": {
-      "id": 373,
-      "pathVariable": "imageBuilder.pathArgs"
-    },
-    "osType": "linux"
-  },
-  {
-    "manifest": {
-      "owner": "dotnet",
-      "repo": "dotnet-docker",
       "branch": "nightly",
       "path": "manifest.json"
     },
@@ -57,24 +38,6 @@
       "pathVariable": "imageBuilder.pathArgs"
     },
     "osType": "linux"
-  },
-  {
-    "manifest": {
-      "owner": "dotnet",
-      "repo": "dotnet-docker",
-      "branch": "main",
-      "path": "manifest.samples.json"
-    },
-    "imageInfo": {
-      "owner": "dotnet",
-      "repo": "versions",
-      "branch": "main",
-      "path": "build-info/docker/image-info.dotnet-dotnet-docker-main-samples.json"
-    },
-    "pipelineTrigger": {
-      "id": 376,
-      "pathVariable": "imageBuilder.pathArgs"
-    }
   },
   {
     "manifest": {

--- a/eng/check-base-image-subscriptions2.json
+++ b/eng/check-base-image-subscriptions2.json
@@ -1,0 +1,39 @@
+[
+  {
+    "manifest": {
+      "owner": "dotnet",
+      "repo": "dotnet-docker",
+      "branch": "main",
+      "path": "manifest.json"
+    },
+    "imageInfo": {
+      "owner": "dotnet",
+      "repo": "versions",
+      "branch": "main",
+      "path": "build-info/docker/image-info.dotnet-dotnet-docker-main.json"
+    },
+    "pipelineTrigger": {
+      "id": 373,
+      "pathVariable": "imageBuilder.pathArgs"
+    },
+    "osType": "linux"
+  },
+  {
+    "manifest": {
+      "owner": "dotnet",
+      "repo": "dotnet-docker",
+      "branch": "main",
+      "path": "manifest.samples.json"
+    },
+    "imageInfo": {
+      "owner": "dotnet",
+      "repo": "versions",
+      "branch": "main",
+      "path": "build-info/docker/image-info.dotnet-dotnet-docker-main-samples.json"
+    },
+    "pipelineTrigger": {
+      "id": 376,
+      "pathVariable": "imageBuilder.pathArgs"
+    }
+  }
+]

--- a/eng/pipelines/check-base-image-updates.yml
+++ b/eng/pipelines/check-base-image-updates.yml
@@ -11,43 +11,14 @@ schedules:
 
 variables:
 - template: templates/variables/common.yml
-- name: checkBaseImageSubscriptionsPath
-  value: eng/check-base-image-subscriptions.json
 
 jobs:
-- job: Build
-  pool:
-    vmImage: $(defaultLinuxAmd64PoolImage)
-  steps:
-  - template: ../common/templates/steps/init-docker-linux.yml
-  - template: ../common/templates/steps/copy-base-images.yml
-    parameters:
-      additionalOptions: "--subscriptions-path '$(checkBaseImageSubscriptionsPath)'"
-      publicProjectName: ${{ variables.publicProjectName }}
-  - script: >
-      $(runImageBuilderCmd)
-      getStaleImages
-      $(dotnetDockerBot.userName)
-      $(dotnetDockerBot.email)
-      $(BotAccount-dotnet-docker-bot-PAT)
-      staleImagePaths
-      --subscriptions-path $(checkBaseImageSubscriptionsPath)
-      --os-type '*'
-      --architecture '*'
-      --registry-creds '$(acr.server)=$(acr.userName);$(acr.password)'
-      $(dockerHubRegistryCreds)
-    displayName: Get Stale Images
-    name: GetStaleImages
-  - script: >
-      $(runImageBuilderCmd)
-      queueBuild
-      $(System.AccessToken)
-      dnceng
-      internal
-      --git-token '$(BotAccount-dotnet-docker-bot-PAT)'
-      --git-owner 'dotnet'
-      --git-repo '$(internalGitHubRepo)'
-      --subscriptions-path $(checkBaseImageSubscriptionsPath)
-      --image-paths "$(GetStaleImages.staleImagePaths)"
-    displayName: Queue Build for Stale Images
-  - template: ../common/templates/steps/cleanup-docker-linux.yml
+- template: templates/jobs/check-base-image-updates.yml
+  parameters:
+    jobName: Build
+    subscriptionsPath: eng/check-base-image-subscriptions.json
+    customGetStaleImagesArgs: --base-override-regex '.*\/(ubuntu:.+)' --base-override-sub 'ubuntu.azurecr.io/$1'
+- template: templates/jobs/check-base-image-updates.yml
+  parameters:
+    jobName: Build2
+    subscriptionsPath: eng/check-base-image-subscriptions2.json

--- a/eng/pipelines/check-base-image-updates.yml
+++ b/eng/pipelines/check-base-image-updates.yml
@@ -18,6 +18,8 @@ jobs:
     jobName: Build
     subscriptionsPath: eng/check-base-image-subscriptions.json
     customGetStaleImagesArgs: --base-override-regex '.*\/(ubuntu:.+)' --base-override-sub 'ubuntu.azurecr.io/$1'
+# Run a separate job for a different set of subscriptions that's configured to not use the base override
+# See https://github.com/dotnet/docker-tools/pull/1038
 - template: templates/jobs/check-base-image-updates.yml
   parameters:
     jobName: Build2

--- a/eng/pipelines/templates/jobs/check-base-image-updates.yml
+++ b/eng/pipelines/templates/jobs/check-base-image-updates.yml
@@ -1,0 +1,43 @@
+parameters:
+  jobName: null
+  subscriptionsPath: null
+  customGetStaleImagesArgs: ""
+
+jobs:
+- job: ${{ parameters.jobName }}
+  pool:
+    vmImage: $(defaultLinuxAmd64PoolImage)
+  steps:
+  - template: ../../../common/templates/steps/init-docker-linux.yml
+  - template: ../../../common/templates/steps/copy-base-images.yml
+    parameters:
+      additionalOptions: "--subscriptions-path '${{ parameters.subscriptionsPath }}'"
+      publicProjectName: ${{ variables.publicProjectName }}
+  - script: >
+      $(runImageBuilderCmd)
+      getStaleImages
+      $(dotnetDockerBot.userName)
+      $(dotnetDockerBot.email)
+      $(BotAccount-dotnet-docker-bot-PAT)
+      staleImagePaths
+      ${{ parameters.customGetStaleImagesArgs }}
+      --subscriptions-path ${{ parameters.subscriptionsPath }}
+      --os-type '*'
+      --architecture '*'
+      --registry-creds '$(acr.server)=$(acr.userName);$(acr.password)'
+      $(dockerHubRegistryCreds)
+    displayName: Get Stale Images
+    name: GetStaleImages
+  - script: >
+      $(runImageBuilderCmd)
+      queueBuild
+      $(System.AccessToken)
+      dnceng
+      internal
+      --git-token '$(BotAccount-dotnet-docker-bot-PAT)'
+      --git-owner 'dotnet'
+      --git-repo '$(internalGitHubRepo)'
+      --subscriptions-path ${{ parameters.subscriptionsPath }}
+      --image-paths "$(GetStaleImages.staleImagePaths)"
+    displayName: Queue Build for Stale Images
+  - template: ../../../common/templates/steps/cleanup-docker-linux.yml


### PR DESCRIPTION
The changes in https://github.com/dotnet/dotnet-docker/pull/3971 require a corresponding change in the execution of the `getStaleImages` command. That command needs to have the same `--base-override-regex` and `--base-override-sub` options in order to correctly interpret the image digests that would be written to the image info file by those builds (see https://github.com/dotnet/docker-tools/pull/1034).

However, we can't make that change in all cases of when the `getStaleImages` command is called. We want to evaluate the changes from https://github.com/dotnet/dotnet-docker/pull/3971 in the nightly branch before rolling out to main. Since the `getStaleImages` command applies to all subscriptions defined in https://github.com/dotnet/docker-tools/blob/main/eng/check-base-image-subscriptions.json, that would mean the tag override options would get applied to checks in the dotnet-docker/main branch as well. That would cause diffs to be detected in the base image digest because that branch isn't yet configured to use the tag override. And those diffs would cause rebuild attempts; not what we want.

To avoid that, we need to split apart the subscriptions to limit the scope of where the new tag override options are applied. I've refactored the pipeline to have run two jobs in parallel that run the same logic, but parameterized in order to use different command options and to target different subscription files. The subscriptions for the dotnet-docker/main branch have been split into a separate subscription file. This allows the tag override options to not be applied for the secondary subscription file.

This PR needs to be merged in conjunction with https://github.com/dotnet/dotnet-docker/pull/3971 to ensure that image info content is kept in sync.