### PR TITLE
Remove infra related to Windows Server 20H2

### DIFF
--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -35,8 +35,6 @@ parameters:
     vmImage: $(defaultWindows2016PoolImage)
   windows1809Pool:
     vmImage: $(defaultWindows1809PoolImage)
-  windows20H2Pool:
-    vmImage: $(defaultWindows20H2PoolImage)
   windows2022Pool:
     vmImage: $(defaultWindows2022PoolImage)
 
@@ -125,19 +123,6 @@ stages:
       name: Windows1809_amd64
       pool: ${{ parameters.windows1809Pool }}
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.Windows1809Amd64']
-      dockerClientOS: windows
-      buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
-      customInitSteps: ${{ parameters.customBuildInitSteps }}
-      noCache: ${{ parameters.noCache }}
-      internalProjectName: ${{ parameters.internalProjectName }}
-      publicProjectName: ${{ parameters.publicProjectName }}
-      internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
-      publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
-  - template: ../jobs/build-images.yml
-    parameters:
-      name: Windows20H2_amd64
-      pool: ${{ parameters.windows20H2Pool }}
-      matrix: dependencies.GenerateBuildMatrix.outputs['matrix.Windows20H2Amd64']
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
@@ -240,14 +225,6 @@ stages:
         name: Windows1809_amd64
         pool: ${{ parameters.windows1809Pool }}
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.Windows1809Amd64']
-        testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
-        internalProjectName: ${{ parameters.internalProjectName }}
-        customInitSteps: ${{ parameters.customTestInitSteps }}
-    - template: ../jobs/test-images-windows-client.yml
-      parameters:
-        name: Windows20H2_amd64
-        pool: ${{ parameters.windows20H2Pool }}
-        matrix: dependencies.GenerateTestMatrix.outputs['matrix.Windows20H2Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
         internalProjectName: ${{ parameters.internalProjectName }}
         customInitSteps: ${{ parameters.customTestInitSteps }}

--- a/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
@@ -82,5 +82,4 @@ stages:
         name: Docker-Linux-Arm-Internal
     windows2016Pool: Docker-2016-${{ variables['System.TeamProject'] }}
     windows1809Pool: Docker-1809-${{ variables['System.TeamProject'] }}
-    windows20H2Pool: Docker-20H2-${{ variables['System.TeamProject'] }}
     windows2022Pool: Docker-2022-${{ variables['System.TeamProject'] }}

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -51,7 +51,5 @@ variables:
   value: vs2017-win2016
 - name: defaultWindows1809PoolImage
   value: windows-2019
-- name: defaultWindows20H2PoolImage
-  value: null
 - name: defaultWindows2022PoolImage
   value: windows-2022

--- a/src/Microsoft.DotNet.ImageBuilder/manifest.json
+++ b/src/Microsoft.DotNet.ImageBuilder/manifest.json
@@ -66,18 +66,6 @@
             },
             {
               "buildArgs": {
-                "WINDOWS_BASE": "nanoserver:20H2-amd64"
-              },
-              "dockerfile": "Dockerfile.windows",
-              "os": "windows",
-              "osVersion": "nanoserver-20H2",
-              "tags": {
-                "nanoserver-20H2-amd64": {},
-                "nanoserver-20H2-amd64-$(UniqueId)": {}
-              }
-            },
-            {
-              "buildArgs": {
                 "WINDOWS_BASE": "nanoserver:ltsc2022-amd64"
               },
               "dockerfile": "Dockerfile.windows",


### PR DESCRIPTION
This infrastructure no longer needs to be maintained since Windows Server 20H2 is EOL today and we'll not be running any more builds that are based on it.