### PR TITLE
Added ContextPath property to platform model.

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/Platform.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/Platform.cs
@@ -73,6 +73,12 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Manifest
             )]
         public string? Variant { get; set; }
 
+        [Description(
+            "Relative path to set for the 'docker build' context. If not provided the " +
+            "Dockerfile directory will be used."
+            )]
+        public string? ContextPath { get; set; }
+
         public Platform()
         {
         }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
@@ -57,8 +57,16 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
 
             string dockerfileWithBaseDir = Path.Combine(baseDirectory, model.ResolveDockerfilePath(baseDirectory));
             DockerfilePath = PathHelper.NormalizePath(dockerfileWithBaseDir);
-            BuildContextPath = PathHelper.NormalizePath(Path.GetDirectoryName(dockerfileWithBaseDir));
             DockerfilePathRelativeToManifest = PathHelper.TrimPath(baseDirectory, DockerfilePath);
+
+            if(model.ContextPath != null)
+            {
+                BuildContextPath = PathHelper.NormalizePath(Path.Combine(baseDirectory, model.ContextPath));
+            }
+            else 
+            {
+                BuildContextPath = PathHelper.NormalizePath(Path.GetDirectoryName(dockerfileWithBaseDir));
+            }
 
             if (model.DockerfileTemplate != null)
             {


### PR DESCRIPTION
Started using this to handle building our library of internal docker images (it's great) and came across a use case that we have, that was unsupported. 

We have a lot of common resources (such as internal CAs, Kerberos configs, appsec tools, and so on) so we have some shared contexts between multiple images for these resources. I've added a property that can be used to override the context path at the platform level to another path relative to the repo. If not specified, it uses the default logic using the Dockerfile directory.

Thought this might be useful for others.