### PR TITLE
Add pipeline support for internal PR builds

### DIFF
--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -91,7 +91,7 @@ jobs:
       # all we need is for that value to be in a PowerShell variable, we can get that by the fact that AzDO automatically creates
       # the environment variable for us.
       $imageBuilderBuildArgs = "$env:IMAGEBUILDERBUILDARGS $(imageBuilder.queueArgs) --image-info-output-path $(artifactsPath)/$(legName)-image-info.json"
-      if ($env:SYSTEM_TEAMPROJECT -eq "${{ parameters.internalProjectName }}") {
+      if ($env:SYSTEM_TEAMPROJECT -eq "${{ parameters.internalProjectName }}" -and $env:BUILD_REASON -ne "PullRequest") {
         $imageBuilderBuildArgs = "$imageBuilderBuildArgs --registry-override $(acr.server) --repo-prefix $(stagingRepoPrefix) --source-repo-prefix $(mirrorRepoPrefix) --push --registry-creds ""$(acr.server)=$(acr.userName);$(acr.password)"""
       }
 
@@ -119,7 +119,7 @@ jobs:
   - publish: $(Build.ArtifactStagingDirectory)/$(legName)-image-info.json
     artifact: $(legName)-image-info-$(System.JobAttempt)
     displayName: Publish Image Info File Artifact
-  - ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+  - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
       # Define the task here to load it into the agent so that we can invoke the tool manually
     - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
       inputs:
@@ -152,12 +152,12 @@ jobs:
         }
       displayName: Generate SBOMs
       condition: and(succeeded(), ne(variables['BuildImages.builtImages'], ''))
-  - ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
+  - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
     - template: ${{ format('../steps/test-images-{0}-client.yml', parameters.dockerClientOS) }}
       parameters:
         condition: ne(variables.testScriptPath, '')
   - template: ${{ format('../steps/cleanup-docker-{0}.yml', parameters.dockerClientOS) }}
-  - ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+  - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
     - publish: $(sbomDirectory)
       artifact: $(legName)-sboms
       displayName: Publish SBOM

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -172,7 +172,7 @@ stages:
 ################################################################################
 # Test Images
 ################################################################################
-- ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+- ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
   - stage: Test
     dependsOn: Post_Build
     condition: "
@@ -249,9 +249,9 @@ stages:
 # Publish Images
 ################################################################################
 - stage: Publish
-  ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+  ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
     dependsOn: Test
-  ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
+  ${{ else }}:
     dependsOn: Post_Build
   condition: "
     and(

--- a/eng/common/templates/steps/copy-base-images.yml
+++ b/eng/common/templates/steps/copy-base-images.yml
@@ -4,7 +4,7 @@ parameters:
   continueOnError: false
   
 steps:
-- ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
+- ${{ if or(eq(variables['System.TeamProject'], parameters.publicProjectName), eq(variables['Build.Reason'], 'PullRequest')) }}:
   - template: ../steps/set-dry-run.yml
 - script: >
     $(runImageBuilderCmd)

--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -9,7 +9,7 @@ steps:
   parameters:
     setupImageBuilder: false
     setupTestRunner: true
-    cleanupDocker: ${{ eq(variables['System.TeamProject'], parameters.internalProjectName) }}
+    cleanupDocker: ${{ and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}
     condition: ${{ parameters.condition }}
 - ${{ parameters.customInitSteps }}
 - script: |
@@ -19,7 +19,7 @@ steps:
     if [ "${{ parameters.preBuildValidation }}" == "true" ]; then
       optionalTestArgs="$optionalTestArgs -TestCategories pre-build"
     else
-      if [ "${{ variables['System.TeamProject'] }}" == "${{ parameters.internalProjectName }}" ]; then
+      if [ "${{ variables['System.TeamProject'] }}" == "${{ parameters.internalProjectName }}" ] && [ "${{ variables['Build.Reason'] }}" != "PullRequest" ]; then
         optionalTestArgs="$optionalTestArgs -PullImages -Registry $(acr.server) -RepoPrefix $(stagingRepoPrefix) -ImageInfoPath $(artifactsPath)/image-info/image-info.json"
       fi
       if [ "$REPOTESTARGS" != "" ]; then
@@ -38,7 +38,7 @@ steps:
     $(imageNames.testRunner.withrepo)
   displayName: Start Test Runner Container
   condition: and(succeeded(), ${{ parameters.condition }})
-- ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+- ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
   - script: >
       docker exec $(testRunner.container) pwsh
       -File $(engCommonRelativePath)/Invoke-WithRetry.ps1
@@ -64,7 +64,7 @@ steps:
     $(optionalTestArgs)"
   displayName: Test Images
   condition: and(succeeded(), ${{ parameters.condition }})
-- ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+- ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
   - script: docker exec $(testRunner.container) docker logout $(acr.server)
     displayName: Docker logout
     condition: and(always(), ${{ parameters.condition }})
@@ -94,7 +94,7 @@ steps:
   displayName: Cleanup TestRunner Container
   condition: and(always(), ${{ parameters.condition }})
   continueOnError: true
-- ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+- ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
   - template: cleanup-docker-linux.yml
     parameters:
       condition: ${{ parameters.condition }}

--- a/eng/common/templates/steps/test-images-windows-client.yml
+++ b/eng/common/templates/steps/test-images-windows-client.yml
@@ -4,7 +4,7 @@ parameters:
   customInitSteps: []
 
 steps:
-- ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+- ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
   - template: init-docker-windows.yml
     parameters:
       setupImageBuilder: false
@@ -16,7 +16,7 @@ steps:
     condition: and(succeeded(), ${{ parameters.condition }})
 - ${{ parameters.customInitSteps }}
 - powershell: |
-    if ("${{ variables['System.TeamProject'] }}" -eq "${{ parameters.internalProjectName }}") {
+    if ("${{ variables['System.TeamProject'] }}" -eq "${{ parameters.internalProjectName }}" -and "${{ variables['Build.Reason'] }}" -ne "PullRequest") {
       $optionalTestArgs="$optionalTestArgs -PullImages -Registry $env:ACR_SERVER -RepoPrefix $env:STAGINGREPOPREFIX -ImageInfoPath $(artifactsPath)/image-info/image-info.json"
     } 
     if ($env:REPOTESTARGS) {
@@ -28,7 +28,7 @@ steps:
 - powershell: Get-ChildItem -Path tests -r | Where {$_.Extension -match "trx"} | Remove-Item
   displayName: Cleanup Old Test Results
   condition: and(succeeded(), ${{ parameters.condition }})
-- ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+- ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
   - template: ../steps/download-build-artifact.yml
     parameters:
       targetPath: $(Build.ArtifactStagingDirectory)
@@ -42,7 +42,7 @@ steps:
     $(optionalTestArgs)
   displayName: Test Images
   condition: and(succeeded(), ${{ parameters.condition }})
-- ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+- ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
   - script: docker logout $(acr.server)
     displayName: Docker logout
     condition: and(always(), ${{ parameters.condition }})
@@ -57,7 +57,7 @@ steps:
     mergeTestResults: true
     publishRunAttachments: true
     testRunTitle: $(productVersion) $(osVersionsDisplayName) amd64
-- ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+- ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
   - template: cleanup-docker-windows.yml
     parameters:
       condition: ${{ parameters.condition }}

--- a/eng/common/templates/steps/validate-branch.yml
+++ b/eng/common/templates/steps/validate-branch.yml
@@ -2,7 +2,7 @@ parameters:
   internalProjectName: null
 
 steps:
-- ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+- ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
   - powershell: |
       if (-not "$(officialBranches)".Split(',').Contains("$(sourceBranch)") `
           -and "$(officialBranches)".Split(',').Contains("$(publishRepoPrefix)") `


### PR DESCRIPTION
Due to the changes in https://github.com/dotnet/dotnet-docker/pull/3910, we now have the ability to create internal AzDO PRs that target internal builds of .NET. But we need to be able to run a build for that PR to validate the changes.

Currently the pipeline logic is all based around conditions that check for internal vs public, with no distinction of whether the pipeline was triggered by a PR. That's problematic because we don't want to be executing the same pipeline logic for an internal PR as we would for an internal official build. For example, we don't want to be pushing images to the staging location in the ACR for a PR. We'd want the pipeline to mostly be similar to what a PR build would look like in a public GitHub PR. The main difference would be that it has access to internal secrets.

These changes update the pipeline logic to account for an internal build being triggered from a PR.

Related to https://github.com/dotnet/dotnet-docker/issues/2152 