### PR TITLE
Fix dotnet path usage with SBOM manifest tool

### DIFF
--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -131,7 +131,16 @@ jobs:
         if (-not $images) { return 0 }
         $taskDir = $(Get-ChildItem -Recurse -Directory -Filter "ManifestGeneratorTask*" -Path '$(Agent.WorkFolder)').FullName
         $manifestToolDllPath = $(Get-ChildItem -Recurse -File -Filter "Microsoft.ManifestTool.dll" -Path $taskDir).FullName
-        $dotnetDir = $(Get-ChildItem -Recurse -Directory -Filter "dotnet-*" -Path $taskDir).FullName
+        $dotnetDir = $(Get-ChildItem -Recurse -Directory -Filter "*dotnet-*" -Path "$(Agent.ToolsDirectory)").FullName
+
+        # If the manifest tool installed its own version of .NET use that; otherwise it's reusing an existing install of .NET
+        # which is executable by default.
+        if ($dotnetDir) {
+          $dotnetPath = "$dotnetDir/dotnet"
+        }
+        else {
+          $dotnetPath = "dotnet"
+        }
 
         # Call the manifest tool for each image to produce seperate SBOMs
         # Manifest tool docs: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/secure-supply-chain/custom-sbom-generation-workflows
@@ -140,7 +149,7 @@ jobs:
           $formattedImageName = $_.Replace('$(acr.server)/$(stagingRepoPrefix)', "").Replace('/', '_').Replace(':', '_');
           $sbomChildDir = "$(sbomDirectory)/$formattedImageName";
           New-Item -Type Directory -Path $sbomChildDir > $null;
-          & "$dotnetDir/dotnet" "$manifestToolDllPath" `
+          & $dotnetPath "$manifestToolDllPath" `
             Generate `
             -BuildDropPath '$(Build.ArtifactStagingDirectory)' `
             -BuildComponentPath '$(Agent.BuildDirectory)' `


### PR DESCRIPTION
An update to the SBOM manifest tool build task caused a build break. Our script logic is not finding the dotnet directory that was expected to be installed by the tool.

The task for the tool was updated with these changes: https://github.com/microsoft/dropvalidator/pull/523. This caused the task to attempt to use an existing .NET installation on the build agent as long as it was compatible. If not, it install its own. In addition, when it does install its own, the path is different than what our script was expecting.

I've updated the script to compensate for all these conditions. It will first check to see if the tool installed its own version of .NET. If it did, it will target that installation. If not, it will expect that the agent has the compatible version of .NET already installed and use that.