### PR TITLE
Compensate for varying .NET install location from manifest task

### DIFF
--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -129,11 +129,20 @@ jobs:
     - powershell: |
         $images = "$(BuildImages.builtImages)"
         if (-not $images) { return 0 }
-        $taskDir = $(Get-ChildItem -Recurse -Directory -Filter "ManifestGeneratorTask*" -Path '$(Agent.WorkFolder)').FullName
+        # There can be leftover versions of the task left on the agent if it's not fresh. So find the latest version.
+        $taskDir = $(Get-ChildItem -Recurse -Directory -Filter "ManifestGeneratorTask*" -Path '$(Agent.WorkFolder)')[-1].FullName
         $manifestToolDllPath = $(Get-ChildItem -Recurse -File -Filter "Microsoft.ManifestTool.dll" -Path $taskDir).FullName
-        $dotnetDir = $(Get-ChildItem -Recurse -Directory -Filter "*dotnet-*" -Path "$(Agent.ToolsDirectory)").FullName
 
-        # If the manifest tool installed its own version of .NET use that; otherwise it's reusing an existing install of .NET
+        # Check whether the manifest task installed its own version of .NET.
+        # To be more robust, we'll handle varying implementations that it's had.
+        # First check for a dotnet folder in the task location
+        $dotnetDir = $(Get-ChildItem -Recurse -Directory -Filter "dotnet-*" -Path $taskDir).FullName
+        if (-not $dotnetDir) {
+          # If it's not there, check in the agent tools location
+          $dotnetDir = $(Get-ChildItem -Recurse -Directory -Filter "*dotnet-*" -Path "$(Agent.ToolsDirectory)").FullName
+        }
+
+        # If the manifest task installed its own version of .NET use that; otherwise it's reusing an existing install of .NET
         # which is executable by default.
         if ($dotnetDir) {
           $dotnetPath = "$dotnetDir/dotnet"


### PR DESCRIPTION
The change to the manifest AzDO task that made the changes in https://github.com/dotnet/docker-tools/pull/1045 necessary have been rolled back. That rollback now means the changes in https://github.com/dotnet/docker-tools/pull/1045 cause build failures because it's attempting to look for the .NET install location in the wrong directory.

I've updated the script to handle either scenario. This allows it to be more robust and at least handle either of these conditions. The team which owns this AzDO task do intend to add roll out there changes again. They were testing it temporarily.