### PR TITLE
Fix official repo prefix for internal repo

### DIFF
--- a/eng/common/templates/variables/dotnet/build-test-publish.yml
+++ b/eng/common/templates/variables/dotnet/build-test-publish.yml
@@ -12,7 +12,7 @@ variables:
 - name: testResultsDirectory
   value: tests/Microsoft.DotNet.Docker.Tests/TestResults/
 - name: officialRepoPrefixes
-  value: public/,private/internal/
+  value: public/,internal/private/
 
 - name: mcrDocsRepoInfo.accessToken
   value: $(BotAccount-dotnet-docker-bot-PAT)


### PR DESCRIPTION
The repo prefix for the internal repo is defined incorrectly in the `officialRepoPrefixes` variable. This causes the build to use the `--dry-run` option in the publish stage when attempting to publish to the internal repo. That's not what we want.

Updated with the correct repo name.