### PR TITLE
Update public pool name for image size validation template

### DIFF
--- a/eng/common/templates/jobs/validate-image-sizes.yml
+++ b/eng/common/templates/jobs/validate-image-sizes.yml
@@ -39,7 +39,10 @@ jobs:
       dockerClientOS: linux
       validationMode: integrity
 - job: WindowsPerfTests
-  pool: Docker-2022-${{ variables['System.TeamProject'] }}
+  ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
+    pool: Docker2022-Public
+  ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+    pool: Docker-2022-Internal
   workspace:
     clean: all
   steps:


### PR DESCRIPTION
Fixes a pool name that was missed in https://github.com/dotnet/docker-tools/pull/1050