### PR TITLE
Fix publish notification branch name

### DIFF
--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -16,6 +16,11 @@ jobs:
       $(imageBuilder.queueArgs)
   - name: publishNotificationRepoName
     value: $(Build.Repository.Name)
+  - name: branchName
+    ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/') }}:
+      value: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
+    ${{ if startsWith(variables['Build.SourceBranch'], 'refs/pull/') }}:
+      value: $[ replace(variables['System.PullRequest.SourceBranch'], 'refs/heads/', '') ]
   - ${{ parameters.customPublishVariables }}
   steps:
   - template: ../steps/retain-build.yml
@@ -120,7 +125,7 @@ jobs:
   - script: >
       $(runImageBuilderCmd) postPublishNotification
       '$(publishNotificationRepoName)'
-      '$(Build.SourceBranchName)'
+      '$(branchName)'
       '$(artifactsPath)/image-info.json'
       $(Build.BuildId)
       '$(System.AccessToken)'


### PR DESCRIPTION
When publishing from a branch with forward slashes, the branch name that gets output in the publish notification contains only the last portion of the branch name. For example, a branch name like `internal/private/nightly` will have its branch name appear in the publish notification issue as `nightly`. This is how the predefined $(Build.SourceBranchName) variable works (see https://github.com/Microsoft/azure-pipelines-agent/issues/838). In order to get the full branch name, we need to use `Build.SourceBranch` but that also includes `/refs/heads` so we strip that out.