### PR TITLE
Flow publish repo prefix to wait for MCR image ingestion

### DIFF
--- a/eng/common/templates/steps/wait-for-mcr-image-ingestion.yml
+++ b/eng/common/templates/steps/wait-for-mcr-image-ingestion.yml
@@ -12,6 +12,7 @@ steps:
     '$(mcrStatus.servicePrincipalPassword)'
     '$(mcrStatus.servicePrincipalTenant)'
     --manifest '$(manifest)'
+    --repo-prefix '$(publishRepoPrefix)'
     --min-queue-time '${{ parameters.minQueueTime }}'
     --timeout '$(mcrImageIngestionTimeout)'
     $(manifestVariables)


### PR DESCRIPTION
The changes from https://github.com/dotnet/docker-tools/pull/1049 fixed the implementation of the `waitForMcrImageIngestion` command to use the `--repo-prefix` option. These changes update the pipeline to pass that option to the command when it's invoked in the publish pipeline.