### PR TITLE
Revert public pool name changes

### DIFF
--- a/eng/common/templates/jobs/validate-image-sizes.yml
+++ b/eng/common/templates/jobs/validate-image-sizes.yml
@@ -39,10 +39,7 @@ jobs:
       dockerClientOS: linux
       validationMode: integrity
 - job: WindowsPerfTests
-  ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
-    pool: Docker2022-Public
-  ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
-    pool: Docker-2022-Internal
+  pool: Docker-2022-${{ variables['System.TeamProject'] }}
   workspace:
     clean: all
   steps:

--- a/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
@@ -80,21 +80,6 @@ stages:
         name: DotNetCoreDocker-Public
       ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
         name: Docker-Linux-Arm-Internal
-    
-    windows2016Pool:
-      ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
-        name: Docker2016-Public
-      ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
-        name: Docker-2016-Internal
-    
-    windows1809Pool:
-      ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
-        name: Docker1809-Public
-      ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
-        name: Docker-1809-Internal
-    
-    windows2022Pool:
-      ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
-        name: Docker2022-Public
-      ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
-        name: Docker-2022-Internal
+    windows2016Pool: Docker-2016-${{ variables['System.TeamProject'] }}
+    windows1809Pool: Docker-1809-${{ variables['System.TeamProject'] }}
+    windows2022Pool: Docker-2022-${{ variables['System.TeamProject'] }}


### PR DESCRIPTION
The public agent pool names have been changed back to their original name, consistent with the naming pattern of the internal pools.