### PR TITLE
Run copyBaseImages with path filtering

### DIFF
--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -67,7 +67,7 @@ stages:
     parameters:
       name: CopyBaseImages
       pool: ${{ parameters.linuxAmd64Pool }}
-      additionalOptions: "--manifest '$(manifest)' $(manifestVariables)"
+      additionalOptions: "--manifest '$(manifest)' $(imageBuilder.pathArgs) $(manifestVariables)"
       publicProjectName: ${{ parameters.publicProjectName }}
       customInitSteps: ${{ parameters.customCopyBaseImagesInitSteps}}
   - template: ../jobs/generate-matrix.yml


### PR DESCRIPTION
As a result of making broad sets of changes in the https://github.com/dotnet/dotnet-buildtools-prereqs-docker repo that cause a large set of the associated pipelines to be run simultaneously, we're seeing errors in the "Copy Base Images" stage of the pipeline.

```
Operation registries-7ec13324-6d01-4aa8-8d59-451229c80f57 failed. Resource /subscriptions/941d4baa-5ef2-462e-b4b1-505791294610/resourceGroups/DotnetContainers/providers/Microsoft.ContainerRegistry/registries/dotnetdocker Invalid message 429 Too Many Requests Too Many Requests (HAP429).

Microsoft.Rest.Azure.CloudException: Long running operation failed with status 'BadRequest'.
   at Microsoft.Rest.ClientRuntime.Azure.LRO.LROPollState`2.CheckErrorStatusAndThrowAsync(HttpRequestMessage request, HttpResponseMessage response)
   at Microsoft.Rest.ClientRuntime.Azure.LRO.LROPollState`2.GetRawAsync(Dictionary`2 customHeaders, CancellationToken cancellationToken)
   at Microsoft.Rest.ClientRuntime.Azure.LRO.LROPollState`2.UpdateResourceFromPollingUri(Dictionary`2 customHeaders, CancellationToken cancellationToken)
   at Microsoft.Rest.ClientRuntime.Azure.LRO.LROPollState`2.Poll(Dictionary`2 customHeaders, CancellationToken cancellationToken)
   at Microsoft.Rest.ClientRuntime.Azure.LRO.AzureLRO`2.StartPollingAsync()
   at Microsoft.Rest.ClientRuntime.Azure.LRO.AzureLRO`2.BeginLROAsync()
   at Microsoft.Rest.Azure.AzureClientExtensions.GetLongRunningOperationResultAsync[TBody,THeader](IAzureClient client, AzureOperationResponse`2 response, Dictionary`2 customHeaders, CancellationToken cancellationToken)
   at Microsoft.Rest.Azure.AzureClientExtensions.GetLongRunningOperationResultAsync[TBody](IAzureClient client, AzureOperationResponse`1 response, Dictionary`2 customHeaders, CancellationToken cancellationToken)
   at Microsoft.Rest.Azure.AzureClientExtensions.GetLongRunningOperationResultAsync(IAzureClient client, AzureOperationResponse response, Dictionary`2 customHeaders, CancellationToken cancellationToken)
   at Microsoft.Rest.Azure.AzureClientExtensions.GetPostOrDeleteOperationResultAsync(IAzureClient client, AzureOperationResponse response, Dictionary`2 customHeaders, CancellationToken cancellationToken)
   at Microsoft.Azure.Management.ContainerRegistry.Fluent.RegistriesOperations.ImportImageWithHttpMessagesAsync(String resourceGroupName, String registryName, ImportImageParametersInner parameters, Dictionary`2 customHeaders, CancellationToken cancellationToken)
   at Microsoft.Azure.Management.ContainerRegistry.Fluent.RegistriesOperationsExtensions.ImportImageAsync(IRegistriesOperations operations, String resourceGroupName, String registryName, ImportImageParametersInner parameters, CancellationToken cancellationToken)
   at Polly.AsyncPolicy.<>c__DisplayClass40_0.<<ImplementationAsync>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at Polly.Retry.AsyncRetryEngine.ImplementationAsync[TResult](Func`3 action, Context context, CancellationToken cancellationToken, ExceptionPredicates shouldRetryExceptionPredicates, ResultPredicates`1 shouldRetryResultPredicates, Func`5 onRetryAsync, Int32 permittedRetryCount, IEnumerable`1 sleepDurationsEnumerable, Func`4 sleepDurationProvider, Boolean continueOnCapturedContext)
   at Polly.AsyncPolicy.ExecuteAsync(Func`3 action, Context context, CancellationToken cancellationToken, Boolean continueOnCapturedContext)
   at Microsoft.DotNet.ImageBuilder.Commands.CopyImagesCommand`2.ImportImageAsync(String destTagName, String destRegistryName, String srcTagName, String srcRegistryName, String srcResourceId, ImportSourceCredentials sourceCredentials) in /image-builder/src/Commands/CopyImagesCommand.cs:line 79
Unhandled exception: Microsoft.Rest.Azure.CloudException: Long running operation failed with status 'BadRequest'.
   at Microsoft.Rest.ClientRuntime.Azure.LRO.LROPollState`2.CheckErrorStatusAndThrowAsync(HttpRequestMessage request, HttpResponseMessage response)
   at Microsoft.Rest.ClientRuntime.Azure.LRO.LROPollState`2.GetRawAsync(Dictionary`2 customHeaders, CancellationToken cancellationToken)
   at Microsoft.Rest.ClientRuntime.Azure.LRO.LROPollState`2.UpdateResourceFromPollingUri(Dictionary`2 customHeaders, CancellationToken cancellationToken)
   at Microsoft.Rest.ClientRuntime.Azure.LRO.LROPollState`2.Poll(Dictionary`2 customHeaders, CancellationToken cancellationToken)
   at Microsoft.Rest.ClientRuntime.Azure.LRO.AzureLRO`2.StartPollingAsync()
   at Microsoft.Rest.ClientRuntime.Azure.LRO.AzureLRO`2.BeginLROAsync()
   at Microsoft.Rest.Azure.AzureClientExtensions.GetLongRunningOperationResultAsync[TBody,THeader](IAzureClient client, AzureOperationResponse`2 response, Dictionary`2 customHeaders, CancellationToken cancellationToken)
   at Microsoft.Rest.Azure.AzureClientExtensions.GetLongRunningOperationResultAsync[TBody](IAzureClient client, AzureOperationResponse`1 response, Dictionary`2 customHeaders, CancellationToken cancellationToken)
   at Microsoft.Rest.Azure.AzureClientExtensions.GetLongRunningOperationResultAsync(IAzureClient client, AzureOperationResponse response, Dictionary`2 customHeaders, CancellationToken cancellationToken)
   at Microsoft.Rest.Azure.AzureClientExtensions.GetPostOrDeleteOperationResultAsync(IAzureClient client, AzureOperationResponse response, Dictionary`2 customHeaders, CancellationToken cancellationToken)
   at Microsoft.Azure.Management.ContainerRegistry.Fluent.RegistriesOperations.ImportImageWithHttpMessagesAsync(String resourceGroupName, String registryName, ImportImageParametersInner parameters, Dictionary`2 customHeaders, CancellationToken cancellationToken)
   at Microsoft.Azure.Management.ContainerRegistry.Fluent.RegistriesOperationsExtensions.ImportImageAsync(IRegistriesOperations operations, String resourceGroupName, String registryName, ImportImageParametersInner parameters, CancellationToken cancellationToken)
   at Polly.AsyncPolicy.<>c__DisplayClass40_0.<<ImplementationAsync>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at Polly.Retry.AsyncRetryEngine.ImplementationAsync[TResult](Func`3 action, Context context, CancellationToken cancellationToken, ExceptionPredicates shouldRetryExceptionPredicates, ResultPredicates`1 shouldRetryResultPredicates, Func`5 onRetryAsync, Int32 permittedRetryCount, IEnumerable`1 sleepDurationsEnumerable, Func`4 sleepDurationProvider, Boolean continueOnCapturedContext)
   at Polly.AsyncPolicy.ExecuteAsync(Func`3 action, Context context, CancellationToken cancellationToken, Boolean continueOnCapturedContext)
   at Microsoft.DotNet.ImageBuilder.Commands.CopyImagesCommand`2.ImportImageAsync(String destTagName, String destRegistryName, String srcTagName, String srcRegistryName, String srcResourceId, ImportSourceCredentials sourceCredentials) in /image-builder/src/Commands/CopyImagesCommand.cs:line 79
   at Microsoft.DotNet.ImageBuilder.Commands.CopyBaseImagesCommand.ExecuteAsync() in /image-builder/src/Commands/CopyBaseImagesCommand.cs:line 77
```

The key piece of information out of all that is `429 Too Many Requests`. Retry logic is running, but it ends up not being enough of a delay to reset the rate limiting.

This error exposed a flaw in how the pipeline is configured though. Each pipeline is filtered to only build a specific subset of the paths in the repo. However, _all_ of the pipelines are attempting to copy _all_ of the images, not just the images relevant to what that pipeline is going to be building. In other words, the pipeline that builds Alpine Dockerfiles is attempting to copy Alpine, Ubuntu, Debian, CentOS, etc. So you can see how all of these pipelines attempting to copy all of these images and all at about the same time would lead to this issue.

The fix is very simple. We just need to ensure that the path args that are used to filter what gets built are also passed to the `copyBaseImages` command. That ensures that the pipeline will only copy the images that are base images for what it will be building.