### PR TITLE
Use git clone instead of download repo zip

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/GitHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/GitHelper.cs
@@ -97,28 +97,5 @@ namespace Microsoft.DotNet.ImageBuilder
                 return null;
             }
         }
-
-        public static async Task<string> DownloadAndExtractGitRepoArchiveAsync(
-            HttpClient httpClient, IGitHubBranchRef branchRef, ILoggerService loggerService)
-        {
-            string uniqueName = $"{branchRef.Owner}-{branchRef.Repo}-{branchRef.Branch}";
-            string extractPath = Path.Combine(Path.GetTempPath(), uniqueName);
-            Uri repoContentsUrl = GetArchiveUrl(branchRef);
-            string zipPath = Path.Combine(Path.GetTempPath(), $"{uniqueName}.zip");
-            byte[] bytes = await RetryHelper.GetWaitAndRetryPolicy<Exception>(loggerService)
-                .ExecuteAsync(() => httpClient.GetByteArrayAsync(repoContentsUrl));
-            File.WriteAllBytes(zipPath, bytes);
-
-            try
-            {
-                ZipFile.ExtractToDirectory(zipPath, extractPath);
-            }
-            finally
-            {
-                File.Delete(zipPath);
-            }
-
-            return Path.Combine(extractPath, $"{branchRef.Repo}-{branchRef.Branch}");
-        }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/CopyBaseImagesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/CopyBaseImagesCommandTests.cs
@@ -35,10 +35,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Mock<IAzureManagementFactory> azureManagementFactoryMock =
                 AzureHelper.CreateAzureManagementFactoryMock(subscriptionId, azure);
 
-            Mock<IEnvironmentService> environmentServiceMock = new Mock<IEnvironmentService>();
+            Mock<IEnvironmentService> environmentServiceMock = new();
 
-            CopyBaseImagesCommand command = new CopyBaseImagesCommand(
-                azureManagementFactoryMock.Object, Mock.Of<ILoggerService>(), Mock.Of<IHttpClientProvider>());
+            CopyBaseImagesCommand command = new(
+                azureManagementFactoryMock.Object, Mock.Of<ILoggerService>(), Mock.Of<IGitService>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.Subscription = subscriptionId;
             command.Options.ResourceGroup = "my resource group";
@@ -137,7 +137,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Mock<IEnvironmentService> environmentServiceMock = new();
 
             CopyBaseImagesCommand command = new(
-                azureManagementFactoryMock.Object, Mock.Of<ILoggerService>(), Mock.Of<IHttpClientProvider>());
+                azureManagementFactoryMock.Object, Mock.Of<ILoggerService>(), Mock.Of<IGitService>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.Subscription = subscriptionId;
             command.Options.ResourceGroup = "my resource group";


### PR DESCRIPTION
In order to add a subscription to the https://github.com/dotnet/dotnet-buildtools-prereqs-docker repo to participate in auto-rebuilding whenever a base image updates, there are some changes necessary in Image Builder related to its loading of those subscriptions from the https://github.com/dotnet/docker-tools/blob/main/eng/check-base-image-subscriptions.json file.

The dotnet-buildtools-prereqs-docker repo makes use of `System:DockerfileGitCommitSha` variable in its manifests. This variable cannot be computed when Image Builder attempts to load the repo's subscription. That's because the way in which Image Builder gets the repo's code is by downloading the repo zip file from GitHub. The extracted contents of that zip file do not contain a `.git` folder and so the code which retrieves the commit SHA for files fails because that information isn't there.

In order to fix this, Image Builder needs to clone the repo instead of just downloading the zip file.

Another issue that was found was the deletion of this cloned repo. It requires using the `FileHelper.ForceDeleteDirectory` method because there are readonly files in the repo that need to be changed to writable in order to delete them. But that method didn't properly handle symlinks in the repo which show up as directories. So with the `DirectoryInfo.GetFileSystemInfos` method, .NET attempts to enumerate the contents of these as if they are a directory which fails. By rewriting the code to use primitives, it's possible to filter those symlinks out.