### PR TITLE
Upgrade manifest tool to 2.0.6

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/Dockerfile.linux
+++ b/src/Microsoft.DotNet.ImageBuilder/Dockerfile.linux
@@ -26,17 +26,21 @@ RUN dotnet publish ./src/Microsoft.DotNet.ImageBuilder.csproj -c Release -o out 
 # build runtime image
 FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-alpine$ALPINE_TAG_SUFFIX
 
-ARG MANIFEST_TOOL_ARCH=amd64
-
 # install tooling
 RUN apk add --no-cache \
         docker \
         git
 
 # install manifest-tool
-RUN wget -O /usr/local/bin/manifest-tool \
-        "https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-$MANIFEST_TOOL_ARCH" \
-    && chmod +x /usr/local/bin/manifest-tool
+ARG MANIFEST_TOOL_ARCH=amd64
+RUN manifestToolVersion="2.0.6" \
+    && wget -O binaries-manifest-tool.tar.gz \
+        "https://github.com/estesp/manifest-tool/releases/download/v$manifestToolVersion/binaries-manifest-tool-$manifestToolVersion.tar.gz" \
+    && echo "4d8a502f2d3b82a50cfde65274ff6df7ef6fe441dc65b96b595a70cc64ece5bc  binaries-manifest-tool.tar.gz" | sha256sum -c - \
+    && tar -zxf binaries-manifest-tool.tar.gz -C /usr/local/bin manifest-tool-linux-$MANIFEST_TOOL_ARCH \
+    && mv /usr/local/bin/manifest-tool-linux-$MANIFEST_TOOL_ARCH /usr/local/bin/manifest-tool \
+    && chmod +x /usr/local/bin/manifest-tool \
+    && rm binaries-manifest-tool.tar.gz
 
 # install image-builder
 WORKDIR /image-builder

--- a/src/Microsoft.DotNet.ImageBuilder/Dockerfile.windows
+++ b/src/Microsoft.DotNet.ImageBuilder/Dockerfile.windows
@@ -15,13 +15,23 @@ RUN dotnet restore -r win-x64 ./src/Microsoft.DotNet.ImageBuilder.csproj
 COPY . ./
 RUN dotnet publish ./src/Microsoft.DotNet.ImageBuilder.csproj -c Release -o out -r win-x64 --no-restore --self-contained
 
-RUN pwsh -Command `
+# install manifest-tool
+RUN pwsh -Command " `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
+        $manifestToolVersion = '2.0.6'; `
         Invoke-WebRequest `
             -UseBasicParsing `
-            -Uri "https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-windows-amd64.exe" `
-            -OutFile out/manifest-tool.exe;
+            -Uri "https://github.com/estesp/manifest-tool/releases/download/v$manifestToolVersion/binaries-manifest-tool-$manifestToolVersion.tar.gz" `
+            -OutFile binaries-manifest-tool.tar.gz; `
+        $sha = '4d8a502f2d3b82a50cfde65274ff6df7ef6fe441dc65b96b595a70cc64ece5bc'; `
+        if ((Get-FileHash binaries-manifest-tool.tar.gz -Algorithm sha256).Hash -ne $sha) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        tar -zxf binaries-manifest-tool.tar.gz -C out manifest-tool-windows-amd64.exe; `
+        Move-Item out/manifest-tool-windows-amd64.exe out/manifest-tool.exe; `
+        Remove-Item binaries-manifest-tool.tar.gz;"
 
 # build runtime image
 FROM mcr.microsoft.com/windows/$WINDOWS_BASE


### PR DESCRIPTION
This required an adjustment to the installation method because the release assets for the manifest tool no longer include each separate executable per platform. There's no just a single tarball which contains the executables for all the platforms. So that gets downloaded and we extract just what we need from it.

Also added checksum validation.

Fixes https://github.com/dotnet/docker-tools/issues/1065