### PR TITLE
Define version of Image Builder image with Azure CLI installed

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/Dockerfile.az.linux
+++ b/src/Microsoft.DotNet.ImageBuilder/Dockerfile.az.linux
@@ -1,0 +1,29 @@
+ARG PYTHON_VERSION=3.10
+
+# Azure CLI installer
+FROM mcr.microsoft.com/dotnet-buildtools/image-builder:latest AS az-installer
+
+ARG PYTHON_VERSION
+
+# install Azure CLI
+RUN apk add --no-cache \
+        cargo \
+        gcc \
+        libffi-dev \
+        make \
+        musl-dev \
+        openssl-dev \
+        py3-pip \
+        python3-dev~=$PYTHON_VERSION
+
+RUN pip install azure-cli
+
+
+# build final image
+FROM mcr.microsoft.com/dotnet-buildtools/image-builder:latest
+
+ARG PYTHON_VERSION
+RUN apk add python3~=$PYTHON_VERSION
+
+COPY --from=az-installer /usr/bin/az /usr/bin/az
+COPY --from=az-installer /usr/lib/python$PYTHON_VERSION/site-packages /usr/lib/python$PYTHON_VERSION/site-packages

--- a/src/Microsoft.DotNet.ImageBuilder/manifest.json
+++ b/src/Microsoft.DotNet.ImageBuilder/manifest.json
@@ -77,6 +77,44 @@
               }
             }
           ]
+        },
+        {
+          "sharedTags": {
+            "az": {},
+            "$(UniqueId)-az": {}
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "RID_ARCH": "x64",
+                "MANIFEST_TOOL_ARCH": "amd64",
+                "ALPINE_TAG_SUFFIX": ""
+              },
+              "dockerfile": "Dockerfile.az.linux",
+              "os": "linux",
+              "osVersion": "alpine",
+              "tags": {
+                "linux-amd64-az": {},
+                "linux-amd64-$(UniqueId)-az": {}
+              }
+            },
+            {
+              "buildArgs": {
+                "RID_ARCH": "arm64",
+                "MANIFEST_TOOL_ARCH": "arm64",
+                "ALPINE_TAG_SUFFIX": "-arm64v8"
+              },
+              "architecture": "arm64",
+              "dockerfile": "Dockerfile.az.linux",
+              "os": "linux",
+              "osVersion": "alpine",
+              "tags": {
+                "linux-arm64-az": {},
+                "linux-arm64-$(UniqueId)-az": {}
+              },
+              "variant": "v8"
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
In order to implement https://github.com/dotnet/dotnet-docker/issues/4139, we need the ability to authenticate to the internal ACR. This requires the use of the Azure CLI to be able to authenticate into Azure with a certificate.

Installing the Azure CLI adds 1 GB to the image size, a 270% increase over the original image size of Image Builder. The large install size is already tracked by https://github.com/Azure/azure-cli/issues/7387. Given that the use of the Azure CLI is only needed in scenarios to target internal builds, it doesn't seem like a good idea to have it installed for the Image Builder image used everywhere.

With these changes, I've defined a separate image that adds the Azure CLI to the base Image Builder image. This will allow the pipeline runs that target public builds to not be subjected to the very large image size. It will only be relevant for runs that target internal builds.