### PR TITLE
Refactor ImageBuilder variable name

### DIFF
--- a/eng/common/Get-ImageBuilder.ps1
+++ b/eng/common/Get-ImageBuilder.ps1
@@ -8,8 +8,8 @@ ForEach-Object {
     Set-Variable -Name $parts[0].Trim() -Value $parts[1].Trim() -Scope Global
 }
 
-& docker inspect ${imageNames.imagebuilder} | Out-Null
+& docker inspect ${imageNames.imagebuilderName} | Out-Null
 if (-not $?) {
     Write-Output "Pulling"
-    & $PSScriptRoot/Invoke-WithRetry.ps1 "docker pull ${imageNames.imagebuilder}"
+    & $PSScriptRoot/Invoke-WithRetry.ps1 "docker pull ${imageNames.imagebuilderName}"
 }

--- a/eng/common/Invoke-ImageBuilder.ps1
+++ b/eng/common/Invoke-ImageBuilder.ps1
@@ -66,7 +66,7 @@ try {
         if ($ReuseImageBuilderImage -ne $True) {
             & ./eng/common/Get-ImageBuilder.ps1
             Exec ("docker build -t $imageBuilderImageName --build-arg " `
-                + "IMAGE=${imageNames.imagebuilder} -f eng/common/Dockerfile.WithRepo .")
+                + "IMAGE=${imageNames.imageBuilderName} -f eng/common/Dockerfile.WithRepo .")
         }
 
         $imageBuilderCmd = "docker run --name $imageBuilderContainerName -v /var/run/docker.sock:/var/run/docker.sock $imageBuilderImageName"
@@ -78,7 +78,7 @@ try {
         $imageBuilderCmd = [System.IO.Path]::Combine($imageBuilderFolder, "Microsoft.DotNet.ImageBuilder.exe")
         if (-not (Test-Path -Path "$imageBuilderCmd" -PathType Leaf)) {
             & ./eng/common/Get-ImageBuilder.ps1
-            Exec "docker create --name $imageBuilderContainerName ${imageNames.imagebuilder}"
+            Exec "docker create --name $imageBuilderContainerName ${imageNames.imageBuilderName}"
             $containerCreated = $true
             if (Test-Path -Path $imageBuilderFolder)
             {

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,15 @@
 variables:
-  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:2017609
+  # This variable is updated by automation to reference the latest version of Image Builder
+  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2017609
+  # This variable is referenced by the pipeline when it needs the name of the Image Builder image.
+  # It's defined separately from the imageNames.imageBuilderName variable so that it can be overridden
+  # by the pipeline without possibly causing a cyclic dependency. For example, an overriding pipeline
+  # may want to base the name of the Image Builder image from the original value of the variable. If
+  # there wasn't a separate variable for the name, you couldn't set imageNames.imageBuilder to
+  # $(imageNames.imageBuilder)-<suffix>, for example, because that would create a cyclic dependency. But
+  # you can set imageNames.imageBuilder to $(imageNames.imageBuilderName)-<suffix>.
+  imageNames.imageBuilder: $(imageNames.imageBuilderName)
+
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-buster-slim-docker-testrunner-974165
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/eng/pipelines/update-image-builder-tag.yml
+++ b/eng/pipelines/update-image-builder-tag.yml
@@ -32,7 +32,7 @@ jobs:
   - script: >
       docker run --rm yaml-updater
       ./eng/image-builder-tag-update-config.json
-      variables/imageNames.imageBuilder
+      variables/imageNames.imageBuilderName
       mcr.microsoft.com/dotnet-buildtools/image-builder:$(imageBuilderTag)
       $(dotnetDockerBot.userName)
       $(dotnetDockerBot.email)


### PR DESCRIPTION
This helps to support https://github.com/dotnet/dotnet-docker/issues/4139 by allowing internal build pipelines to override the name of the Image Builder image to use within the pipeline. With the changes in https://github.com/dotnet/docker-tools/pull/1068, a suffix is added to the tag name. This allows the overriding pipeline to be able to set the variable to that new name, and base it on the original name, without introducing a cyclic dependency.