### PR TITLE
Fix repo reference in az Dockerfile

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/Dockerfile.az.linux
+++ b/src/Microsoft.DotNet.ImageBuilder/Dockerfile.az.linux
@@ -1,8 +1,9 @@
+ARG REPO=mcr.microsoft.com/dotnet-buildtools/image-builder
 ARG PYTHON_VERSION=3.10
 ARG ARCH=amd64
 
 # Azure CLI installer
-FROM mcr.microsoft.com/dotnet-buildtools/image-builder:linux-$ARCH AS az-installer
+FROM $REPO:linux-$ARCH AS az-installer
 
 ARG PYTHON_VERSION
 
@@ -21,7 +22,7 @@ RUN pip install azure-cli
 
 
 # build final image
-FROM mcr.microsoft.com/dotnet-buildtools/image-builder:linux-$ARCH
+FROM $REPO:linux-$ARCH
 
 ARG PYTHON_VERSION
 RUN apk add python3~=$PYTHON_VERSION

--- a/src/Microsoft.DotNet.ImageBuilder/manifest.json
+++ b/src/Microsoft.DotNet.ImageBuilder/manifest.json
@@ -2,6 +2,7 @@
   "registry": "mcr.microsoft.com",
   "repos": [
     {
+      "id": "image-builder",
       "name": "dotnet-buildtools/image-builder",
       "images": [
         {
@@ -86,6 +87,7 @@
           "platforms": [
             {
               "buildArgs": {
+                "REPO": "$(Repo:image-builder)",
                 "RID_ARCH": "x64",
                 "ARCH": "amd64",
                 "ALPINE_TAG_SUFFIX": ""
@@ -100,6 +102,7 @@
             },
             {
               "buildArgs": {
+                "REPO": "$(Repo:image-builder)",
                 "RID_ARCH": "arm64",
                 "ARCH": "arm64",
                 "ALPINE_TAG_SUFFIX": "-arm64v8"


### PR DESCRIPTION
The build for the changes from https://github.com/dotnet/docker-tools/pull/1068 is failing because of the `--registry-override` option that is used. (This didn't fail in the PR build because that option is not used for the build.) The Dockerfile.az.linux file had hardcoded the image names it referenced in its `FROM` instructions. In conjunction with the `--registry-override` option, it caused Image Builder to rewrite the file to apply the override. But it generated a `FROM` instruction like this: `FROM dotnetdocker.azurecr.io/dotnet-buildtools/image-builder:linux-$ARCHAS az-installer`. Note the lack of a space between `$ARCH` and `AS`. This isn't valid syntax so the build failed.

We shouldn't be having the Dockerfile be rewritten with the registry option. We want to keep the exact version that exists in the repo. To fix this, we can replace the repo reference in the Dockerfile with a reference to an `ARG` that is dynamically set within the manifest file. This follows the same convention that is used in the manifest of https://github.com/dotnet/dotnet-docker.