### PR TITLE
Update NuGet package versions

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateImageGraphCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateImageGraphCommand.cs
@@ -9,12 +9,14 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using GiGraph.Dot.Entities.Attributes.Enums;
 using GiGraph.Dot.Entities.Edges;
 using GiGraph.Dot.Entities.Graphs;
 using GiGraph.Dot.Entities.Nodes;
-using GiGraph.Dot.Entities.Types.Styles;
 using GiGraph.Dot.Extensions;
+using GiGraph.Dot.Types.Arrowheads;
+using GiGraph.Dot.Types.Layout;
+using GiGraph.Dot.Types.Nodes;
+using GiGraph.Dot.Types.Styling;
 using Microsoft.DotNet.ImageBuilder.Models.Docker;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
 
@@ -38,8 +40,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             Logger.WriteHeading("GENERATING IMAGE GRAPH");
 
             DotGraph graph = new DotGraph("ImageGraph", true);
-            graph.Attributes.Layout.Direction = DotLayoutDirection.BottomToTop;
-            graph.Attributes.Font.Color = Color.Black;
+            graph.Layout.Direction = DotLayoutDirection.BottomToTop;
+            graph.Font.Color = Color.Black;
 
             PlatformInfo[] platforms = Manifest.GetFilteredPlatforms().ToArray();
             AddBaseImages(graph, platforms);
@@ -92,10 +94,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             }
 
             DotNode imageNode = new DotNode(primaryTag);
-            imageNode.Attributes.Shape = DotNodeShape.Record;
-            imageNode.Attributes.Color = color;
-            imageNode.Attributes.Label = $"{{{recordBody}}}";
-            imageNode.Attributes.Style.BorderStyle = DotBorderStyle.Solid;
+            imageNode.Shape = DotNodeShape.Record;
+            imageNode.Color = color;
+            imageNode.Label = $"{{{recordBody}}}";
+            imageNode.Style.BorderStyle = DotBorderStyle.Solid;
 
             graph.Nodes.Add(imageNode);
             foreach (string tag in tags)
@@ -119,10 +121,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 if (platform.FinalStageFromImage is not null)
                 {
                     var myEdge = new DotEdge(imageNode.Id, _nodeCache[platform.FinalStageFromImage].Id);
-                    myEdge.Attributes.Head.Arrowhead = DotArrowheadShape.Normal;
-                    myEdge.Attributes.Tail.Arrowhead = DotArrowheadShape.None;
-                    myEdge.Attributes.Color = Color.Black;
-                    myEdge.Attributes.Style.LineStyle = DotLineStyle.Dashed;
+                    myEdge.Head.Arrowhead = DotArrowheadShape.Normal;
+                    myEdge.Tail.Arrowhead = DotArrowheadShape.None;
+                    myEdge.Color = Color.Black;
+                    myEdge.Style.LineStyle = DotLineStyle.Dashed;
                     graph.Edges.Add(myEdge);
                 }
             }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -9,9 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="Cottle" Version="2.0.7" />
-    <PackageReference Include="GiGraph.Dot" Version="1.6.3" />
+    <PackageReference Include="GiGraph.Dot" Version="2.0.1" />
     <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
-    <PackageReference Include="Microsoft.Azure.Kusto.Ingest" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Azure.Kusto.Ingest" Version="11.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.38.1" />
     <PackageReference Include="Microsoft.DotNet.Git.IssueManager" Version="6.0.0-beta.22351.1" />
     <PackageReference Include="Microsoft.DotNet.VersionTools" Version="6.0.0-beta.22351.1" />
@@ -22,6 +22,7 @@
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
     <PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
-    <PackageReference Include="YamlDotNet" Version="11.2.1" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
+    <PackageReference Include="YamlDotNet" Version="12.0.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The NuGet dependency graph of Image Builder included a vulnerable version of `System.Drawing.Common` (4.7.0). This was due to an indirect dependency on an older version of `System.Configuration.ConfigurationManager` that various other packages had. I've fixed this by explicitly adding a dependency on `System.Configuration.ConfigurationManager` that gives us version 6.0.0 of `System.Drawing.Common`.

I've also upgraded other packages to their latest versions.