### PR TITLE
Fix YAML parsing in Get-ImageBuilder.ps1

### DIFF
--- a/eng/common/Get-ImageBuilder.ps1
+++ b/eng/common/Get-ImageBuilder.ps1
@@ -2,7 +2,7 @@
 
 # Load common image names
 Get-Content $PSScriptRoot/templates/variables/docker-images.yml |
-Where-Object { $_.Trim() -notlike 'variables:' } |
+Where-Object { $_.Trim().Length -gt 0 -and $_.Trim() -notlike 'variables:' -and $_.Trim() -notlike '# *' } |
 ForEach-Object { 
     $parts = $_.Split(':', 2)
     Set-Variable -Name $parts[0].Trim() -Value $parts[1].Trim() -Scope Global

--- a/eng/common/Get-ImageBuilder.ps1
+++ b/eng/common/Get-ImageBuilder.ps1
@@ -1,11 +1,9 @@
 #!/usr/bin/env pwsh
 
 # Load common image names
-Get-Content $PSScriptRoot/templates/variables/docker-images.yml |
-Where-Object { $_.Trim().Length -gt 0 -and $_.Trim() -notlike 'variables:' -and $_.Trim() -notlike '# *' } |
-ForEach-Object { 
-    $parts = $_.Split(':', 2)
-    Set-Variable -Name $parts[0].Trim() -Value $parts[1].Trim() -Scope Global
+$imageNameVars = & $PSScriptRoot/Get-ImageNameVars.ps1
+foreach ($varName in $imageNameVars.Keys) { 
+    Set-Variable -Name $varName -Value $imageNameVars[$varName] -Scope Global
 }
 
 & docker inspect ${imageNames.imagebuilderName} | Out-Null

--- a/eng/common/Get-ImageNameVars.ps1
+++ b/eng/common/Get-ImageNameVars.ps1
@@ -1,0 +1,12 @@
+# Returns a hashtable of variable name-to-value mapping representing the image name variables
+# used by the common build infrastructure.
+
+$vars = @{}
+Get-Content $PSScriptRoot/templates/variables/docker-images.yml |
+    Where-Object { $_.Trim().Length -gt 0 -and $_.Trim() -notlike 'variables:' -and $_.Trim() -notlike '# *' } |
+    ForEach-Object {
+        $parts = $_.Split(':', 2)
+        $vars[$parts[0].Trim()] = $parts[1].Trim()
+    }
+
+return $vars

--- a/eng/common/Invoke-CleanupDocker.ps1
+++ b/eng/common/Invoke-CleanupDocker.ps1
@@ -7,16 +7,14 @@ docker volume prune -f
 
 # Preserve the tagged Windows base images and the common eng infra images (e.g. ImageBuilder)
 # to avoid the expense of having to repull continuously.
-$engInfraImages = Get-Content $PSScriptRoot/templates/variables/docker-images.yml |
-    Where-Object { $_.Trim() -notlike 'variables:' } |
-    ForEach-Object { $_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[1] }
+$imageNameVars = & $PSScriptRoot/Get-ImageNameVars.ps1
 
-docker images --format "{{.Repository}}:{{.Tag}} {{.ID}}"|
+docker images --format "{{.Repository}}:{{.Tag}} {{.ID}}" |
     Where-Object {
         $localImage = $_
         $localImage.Contains(":<none> ")`
         -Or -Not ($localImage.StartsWith("mcr.microsoft.com/windows")`
-            -Or ($engInfraImages.Where({ $localImage.StartsWith($_) }, 'First').Count -gt 0)) } |
+            -Or ($imageNameVars.Values.Where({ $localImage.StartsWith($_) }, 'First').Count -gt 0)) } |
     ForEach-Object { $_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[1] } |
     Select-Object -Unique |
     ForEach-Object { docker rmi -f $_ }


### PR DESCRIPTION
The changes in https://github.com/dotnet/docker-tools/pull/1070 broke the use of the `Get-ImageBuilder.ps1` script because it's unable to properly parse the `docker-images.yml` file. The YAML file now includes comments and blank lines that need to be filtered out.