### PR TITLE
Add base image subscription for dotnet-buildtools-prereqs-docker

### DIFF
--- a/eng/check-base-image-subscriptions.json
+++ b/eng/check-base-image-subscriptions.json
@@ -93,5 +93,27 @@
       "id": 374,
       "pathVariable": "imageBuilder.pathArgs"
     }
+  },
+  {
+    "manifest": {
+      "owner": "dotnet",
+      "repo": "dotnet-buildtools-prereqs-docker",
+      "branch": "main",
+      "path": "manifest.json",
+      "variables": {
+        "FloatingTagSuffix": "",
+        "UniqueId": ""
+      }
+    },
+    "imageInfo": {
+      "owner": "dotnet",
+      "repo": "versions",
+      "branch": "main",
+      "path": "build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-main.json"
+    },
+    "pipelineTrigger": {
+      "id": 1183,
+      "pathVariable": "imageBuilder.pathArgs"
+    }
   }
 ]


### PR DESCRIPTION
This adds a subscription for the main branch of https://github.com/dotnet/dotnet-buildtools-prereqs-docker to participate in the auto-rebuild system. This ensures images from the branch will periodically be checked to ensure they are up-to-date wrt to their base image.

The variables (`FloatingTagSuffix` and `UniqueId`) that are set here are referenced by the manifest in that repo. They need to be defaulted in order to avoid parsing errors. It really doesn't matter what value they have since the logic to check the base image status doesn't rely on the manifest elements which use these variables.