### PR TITLE
Use separate base check subscription for buildtools-prereqs repo

### DIFF
--- a/eng/check-base-image-subscriptions-buildtools.json
+++ b/eng/check-base-image-subscriptions-buildtools.json
@@ -1,0 +1,24 @@
+[
+  {
+    "manifest": {
+      "owner": "dotnet",
+      "repo": "dotnet-buildtools-prereqs-docker",
+      "branch": "main",
+      "path": "manifest.json",
+      "variables": {
+        "FloatingTagSuffix": "",
+        "UniqueId": ""
+      }
+    },
+    "imageInfo": {
+      "owner": "dotnet",
+      "repo": "versions",
+      "branch": "main",
+      "path": "build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-main.json"
+    },
+    "pipelineTrigger": {
+      "id": 1183,
+      "pathVariable": "imageBuilder.pathArgs"
+    }
+  }
+]

--- a/eng/check-base-image-subscriptions.json
+++ b/eng/check-base-image-subscriptions.json
@@ -93,27 +93,5 @@
       "id": 374,
       "pathVariable": "imageBuilder.pathArgs"
     }
-  },
-  {
-    "manifest": {
-      "owner": "dotnet",
-      "repo": "dotnet-buildtools-prereqs-docker",
-      "branch": "main",
-      "path": "manifest.json",
-      "variables": {
-        "FloatingTagSuffix": "",
-        "UniqueId": ""
-      }
-    },
-    "imageInfo": {
-      "owner": "dotnet",
-      "repo": "versions",
-      "branch": "main",
-      "path": "build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-main.json"
-    },
-    "pipelineTrigger": {
-      "id": 1183,
-      "pathVariable": "imageBuilder.pathArgs"
-    }
   }
 ]

--- a/eng/pipelines/check-base-image-updates.yml
+++ b/eng/pipelines/check-base-image-updates.yml
@@ -15,5 +15,10 @@ variables:
 jobs:
 - template: templates/jobs/check-base-image-updates.yml
   parameters:
-    jobName: Build
+    jobName: CheckBaseImages
     subscriptionsPath: eng/check-base-image-subscriptions.json
+- template: templates/jobs/check-base-image-updates.yml
+  parameters:
+    jobName: CheckBaseImages_BuildTools
+    subscriptionsPath: eng/check-base-image-subscriptions-buildtools.json
+    customGetStaleImagesArgs: --base-override-regex '^((alpine|centos|debian|fedora|ubuntu):.+)' --base-override-sub '$(overrideRegistry)/$1'


### PR DESCRIPTION
The changes from https://github.com/dotnet/docker-tools/pull/1075 are incomplete. They are causing base image diffs for all the images that we use from the internal MS mirror. This is because we're not applying the same base image override regex that is used in https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/6124dd8d705e266effaffcbb5eca10d9278df8d2/eng/pipelines/steps/set-base-image-override-options.yml#L13.

But applying that regex should only be done for the images in that repo. We don't want to apply it to other repos for which there are base image check subscriptions. To handle that, I've split off the subscription for https://github.com/dotnet/dotnet-buildtools-prereqs-docker into its own subscription file and a separate job configures it to be used.