### PR TITLE
Explicitly install .NET 6 SDK

### DIFF
--- a/eng/common/Install-DotNetSdk.ps1
+++ b/eng/common/Install-DotNetSdk.ps1
@@ -40,16 +40,16 @@ if (!(Test-Path $DotnetInstallScriptPath)) {
     & "$PSScriptRoot/Invoke-WithRetry.ps1" "Invoke-WebRequest 'https://dot.net/v1/$DotnetInstallScript' -OutFile $DotnetInstallScriptPath"
 }
 
-$DotnetChannel = "Current"
+$DotnetChannel = "6.0"
 
 $InstallFailed = $false
 if ($IsRunningOnUnix) {
     & chmod +x $DotnetInstallScriptPath
-    & $DotnetInstallScriptPath --channel $DotnetChannel --version "latest" --install-dir $InstallPath
+    & $DotnetInstallScriptPath --channel $DotnetChannel --install-dir $InstallPath
     $InstallFailed = ($LASTEXITCODE -ne 0)
 }
 else {
-    & $DotnetInstallScriptPath -Channel $DotnetChannel -Version "latest" -InstallDir $InstallPath
+    & $DotnetInstallScriptPath -Channel $DotnetChannel -InstallDir $InstallPath
     $InstallFailed = (-not $?)
 }
 


### PR DESCRIPTION
The script that installs .NET is using the "Current" channel which now defaults to .NET 7. This causes the tests to fail because they are compiled for .NET 6. Updating the script to explicitly install .NET 6 for now. We'll update to .NET 7 later.