### PR TITLE
Update package dependencies

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
@@ -8,21 +8,25 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.14.1" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.12.0" />
     <PackageReference Include="Cottle" Version="2.0.7" />
     <PackageReference Include="GiGraph.Dot" Version="2.0.1" />
     <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
     <PackageReference Include="Microsoft.Azure.Kusto.Ingest" Version="11.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.38.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.0.1" />
     <PackageReference Include="Microsoft.DotNet.Git.IssueManager" Version="6.0.0-beta.22351.1" />
     <PackageReference Include="Microsoft.DotNet.VersionTools" Version="6.0.0-beta.22351.1" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.3.0" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.170.0" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.14" />
     <PackageReference Include="Polly" Version="7.2.3" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
-    <PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
+    <PackageReference Include="System.ComponentModel.Composition" Version="7.0.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
     <PackageReference Include="YamlDotNet" Version="12.0.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
There were component governance alerts for some NuGet packages that weren't directly referenced. These have been explicitly added to get the latest patched version:
* Azure.Storage.Blobs
  * Root dependency: Microsoft.Azure.Kusto.Ingest
* Azure.Storage.Queues
  * Root dependency: Microsoft.Azure.Kusto.Ingest
* Microsoft.Data.SqlClient
  * Root dependency: Microsoft.Azure.Kusto.Ingest
* System.Data.SqlClient
  * Root dependency: Microsoft.TeamFoundationServer.Client

I've also updated other packages that had newer versions available.