### PR TITLE
Pass Dockerfile paths to to test script

### DIFF
--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -60,6 +60,7 @@ stages:
         # values aren't actually used for the pre-build tests.
         - powershell: |
             echo "##vso[task.setvariable variable=productVersion]"
+            echo "##vso[task.setvariable variable=imageBuilderPaths]"
             echo "##vso[task.setvariable variable=osVersions]"
             echo "##vso[task.setvariable variable=architecture]"
           displayName: Initialize Test Variables

--- a/eng/common/templates/steps/parse-test-arg-arrays.yml
+++ b/eng/common/templates/steps/parse-test-arg-arrays.yml
@@ -4,8 +4,12 @@ steps:
     $osVersionsDisplayName = '$(osVersions)' -Replace '--os-version ', '' -Replace ' ', '/'
 
     # Defines a PowerShell snippet in string-form that can be used to initialize an array of the OS versions
-    $osVersionsArrayInitStr="@('" + $($osVersionsDisplayName -Replace "/", "', '") + "')"
+    $osVersionsArrayInitStr = "@('" + $($osVersionsDisplayName -Replace "/", "', '") + "')"
     
     echo "##vso[task.setvariable variable=osVersionsDisplayName]$osVersionsDisplayName"
     echo "##vso[task.setvariable variable=osVersionsArrayInitStr]$osVersionsArrayInitStr"
-  displayName: Parse OS Versions
+
+    # Defines a PowerShell snippet in string-form that can be used to initialize an array of the image builder paths
+    $pathInitStr = "@('" + $('$(imageBuilderPaths)' -Replace '--path', '' -Replace " ", "', '") + "')"
+    echo "##vso[task.setvariable variable=imageBuilderPathsArrayInitStr]$pathInitStr"
+  displayName: Parse Test Arg Arrays

--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -50,7 +50,7 @@ steps:
       parameters:
         targetPath: $(Build.ArtifactStagingDirectory)
         condition: ${{ parameters.condition }}
-- template: parse-os-versions.yml
+- template: parse-test-arg-arrays.yml
 - powershell: >
     $(test.init);
     docker exec
@@ -58,7 +58,7 @@ steps:
     $(testRunner.container)
     pwsh
     -Command "$(testScriptPath)
-    -Version '$(productVersion)'
+    -Paths $(imageBuilderPathsArrayInitStr)
     -OSVersions $(osVersionsArrayInitStr)
     -Architecture '$(architecture)'
     $(optionalTestArgs)"

--- a/eng/common/templates/steps/test-images-windows-client.yml
+++ b/eng/common/templates/steps/test-images-windows-client.yml
@@ -33,11 +33,11 @@ steps:
     parameters:
       targetPath: $(Build.ArtifactStagingDirectory)
       condition: ${{ parameters.condition }}
-- template: parse-os-versions.yml
+- template: parse-test-arg-arrays.yml
 - powershell: >
     $(test.init);
     $(testScriptPath)
-    -Version '$(productVersion)'
+    -Paths $(imageBuilderPathsArrayInitStr)
     -OSVersions $(osVersionsArrayInitStr)
     $(optionalTestArgs)
   displayName: Test Images

--- a/eng/tests/pipeline-validation/run-tests.ps1
+++ b/eng/tests/pipeline-validation/run-tests.ps1
@@ -8,6 +8,7 @@
 param(
     [string]$Version,
     [string]$Architecture,
+    [string[]]$Paths,
     [string[]]$OSVersions,
     [string]$Registry,
     [string]$RepoPrefix,


### PR DESCRIPTION
Updates the pipeline to pass the set of Dockerfile paths to the test script instead of the product version. More details on this at https://github.com/dotnet/dotnet-docker/pull/4207.

Related to https://github.com/dotnet/dotnet-docker/issues/4185