### PR TITLE
Only download image-info artifact for test setup

### DIFF
--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -20,7 +20,7 @@ steps:
       optionalTestArgs="$optionalTestArgs -TestCategories pre-build"
     else
       if [ "${{ variables['System.TeamProject'] }}" == "${{ parameters.internalProjectName }}" ] && [ "${{ variables['Build.Reason'] }}" != "PullRequest" ]; then
-        optionalTestArgs="$optionalTestArgs -PullImages -Registry $(acr.server) -RepoPrefix $(stagingRepoPrefix) -ImageInfoPath $(artifactsPath)/image-info/image-info.json"
+        optionalTestArgs="$optionalTestArgs -PullImages -Registry $(acr.server) -RepoPrefix $(stagingRepoPrefix) -ImageInfoPath $(artifactsPath)/image-info.json"
       fi
       if [ "$REPOTESTARGS" != "" ]; then
         optionalTestArgs="$optionalTestArgs $REPOTESTARGS"
@@ -49,6 +49,7 @@ steps:
     - template: ../steps/download-build-artifact.yml
       parameters:
         targetPath: $(Build.ArtifactStagingDirectory)
+        artifactName: image-info
         condition: ${{ parameters.condition }}
 - template: parse-test-arg-arrays.yml
 - powershell: >

--- a/eng/common/templates/steps/test-images-windows-client.yml
+++ b/eng/common/templates/steps/test-images-windows-client.yml
@@ -17,7 +17,7 @@ steps:
 - ${{ parameters.customInitSteps }}
 - powershell: |
     if ("${{ variables['System.TeamProject'] }}" -eq "${{ parameters.internalProjectName }}" -and "${{ variables['Build.Reason'] }}" -ne "PullRequest") {
-      $optionalTestArgs="$optionalTestArgs -PullImages -Registry $env:ACR_SERVER -RepoPrefix $env:STAGINGREPOPREFIX -ImageInfoPath $(artifactsPath)/image-info/image-info.json"
+      $optionalTestArgs="$optionalTestArgs -PullImages -Registry $env:ACR_SERVER -RepoPrefix $env:STAGINGREPOPREFIX -ImageInfoPath $(artifactsPath)/image-info.json"
     } 
     if ($env:REPOTESTARGS) {
       $optionalTestArgs += " $env:REPOTESTARGS"
@@ -32,6 +32,7 @@ steps:
   - template: ../steps/download-build-artifact.yml
     parameters:
       targetPath: $(Build.ArtifactStagingDirectory)
+      artifactName: image-info
       condition: ${{ parameters.condition }}
 - template: parse-test-arg-arrays.yml
 - powershell: >


### PR DESCRIPTION
Test jobs are unnecessarily downloading all pipeline artifacts when they actually only need the image-info artifact. This can cause a fairly significant amount of time to execute in some cases, especially on the Arm machines.

This is fixed by explicitly setting the desired artifact name: `image-info`.

Fixes #749