### PR TITLE
Add Paths parameter for ImageBuilder test script

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/run-tests.ps1
+++ b/src/Microsoft.DotNet.ImageBuilder/run-tests.ps1
@@ -8,6 +8,7 @@
 param(
     [string]$Version,
     [string]$Architecture,
+    [string[]]$Paths,
     [string[]]$OSVersions,
     [string]$Registry,
     [string]$RepoPrefix,


### PR DESCRIPTION
ImageBuilder tests are failing to run from the pipeline because the pipeline is attempting to pass a `-Paths` parameter (from https://github.com/dotnet/docker-tools/pull/1082) but the script wasn't updated to include that parameter.

I've updated the script to have the parameter. It's not consumed at all because the tests aren't specific to a particular Dockerfile.