### PR TITLE
Add display name support for generic Ubuntu

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
@@ -238,6 +238,10 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
                 {
                     displayName = FormatVersionableOsName(os, name => "openSUSE Leap");
                 }
+                else if (os.Contains("ubuntu"))
+                {
+                    displayName = FormatVersionableOsName(os, name => "Ubuntu");
+                }
                 else
                 {
                     throw new NotSupportedException($"The OS version '{os}' is not supported.");


### PR DESCRIPTION
Add display name support for versionless Ubuntu so that an OS version of `ubuntu` or `ubuntu-chiseled` is displayed as `Ubuntu`.