### PR TITLE
Use "docker manifest" command instead of manifest-tool

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/Dockerfile.linux
+++ b/src/Microsoft.DotNet.ImageBuilder/Dockerfile.linux
@@ -31,17 +31,6 @@ RUN apk add --no-cache \
         docker \
         git
 
-# install manifest-tool
-ARG ARCH=amd64
-RUN manifestToolVersion="2.0.6" \
-    && wget -O binaries-manifest-tool.tar.gz \
-        "https://github.com/estesp/manifest-tool/releases/download/v$manifestToolVersion/binaries-manifest-tool-$manifestToolVersion.tar.gz" \
-    && echo "4d8a502f2d3b82a50cfde65274ff6df7ef6fe441dc65b96b595a70cc64ece5bc  binaries-manifest-tool.tar.gz" | sha256sum -c - \
-    && tar -zxf binaries-manifest-tool.tar.gz -C /usr/local/bin manifest-tool-linux-$ARCH \
-    && mv /usr/local/bin/manifest-tool-linux-$ARCH /usr/local/bin/manifest-tool \
-    && chmod +x /usr/local/bin/manifest-tool \
-    && rm binaries-manifest-tool.tar.gz
-
 # install image-builder
 WORKDIR /image-builder
 COPY --from=build-env /image-builder/out ./

--- a/src/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.sln
+++ b/src/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.sln
@@ -9,7 +9,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{E9980342-4B07-48DD-8FA3-0E73F98BD0EA}"
 	ProjectSection(SolutionItems) = preProject
 		.dockerignore = .dockerignore
-		Dockerfile = Dockerfile
+		Dockerfile.az.linux = Dockerfile.az.linux
+		Dockerfile.linux = Dockerfile.linux
 		Dockerfile.nanoserver = Dockerfile.nanoserver
 		NuGet.config = NuGet.config
 	EndProjectSection

--- a/src/Microsoft.DotNet.ImageBuilder/manifest.json
+++ b/src/Microsoft.DotNet.ImageBuilder/manifest.json
@@ -14,7 +14,6 @@
             {
               "buildArgs": {
                 "RID_ARCH": "x64",
-                "ARCH": "amd64",
                 "ALPINE_TAG_SUFFIX": ""
               },
               "dockerfile": "Dockerfile.linux",
@@ -28,7 +27,6 @@
             {
               "buildArgs": {
                 "RID_ARCH": "arm64",
-                "ARCH": "arm64",
                 "ALPINE_TAG_SUFFIX": "-arm64v8"
               },
               "architecture": "arm64",

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerServiceCache.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerServiceCache.cs
@@ -46,6 +46,9 @@ namespace Microsoft.DotNet.ImageBuilder
         public void CreateTag(string image, string tag, bool isDryRun) =>
             _inner.CreateTag(image, tag, isDryRun);
 
+        public void CreateManifestList(string manifestListTag, IEnumerable<string> images, bool isDryRun) =>
+            _inner.CreateManifestList(manifestListTag, images, isDryRun);
+
         public DateTime GetCreatedDate(string image, bool isDryRun) =>
             _createdDateCache.GetOrAdd(image, _ => _inner.GetCreatedDate(image, isDryRun));
 
@@ -73,6 +76,9 @@ namespace Microsoft.DotNet.ImageBuilder
 
         public void PushImage(string tag, bool isDryRun) =>
             _inner.PushImage(tag, isDryRun);
+
+        public void PushManifestList(string tag, bool isDryRun) =>
+            _inner.PushManifestList(tag, isDryRun);
     }
 }
 #nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/IDockerService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/IDockerService.cs
@@ -22,7 +22,11 @@ namespace Microsoft.DotNet.ImageBuilder
 
         void PushImage(string tag, bool isDryRun);
 
+        void PushManifestList(string manifestListTag, bool isDryRun);
+
         void CreateTag(string image, string tag, bool isDryRun);
+
+        void CreateManifestList(string manifestListTag, IEnumerable<string> images, bool isDryRun);
 
         string? BuildImage(
             string dockerfilePath,

--- a/src/Microsoft.DotNet.ImageBuilder/src/IManifestService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/IManifestService.cs
@@ -8,7 +8,6 @@ namespace Microsoft.DotNet.ImageBuilder
 {
     public interface IManifestService
     {
-        void PushFromSpec(string manifestFile, bool isDryRun);
         Task<ManifestQueryResult> GetManifestAsync(string image, IRegistryCredentialsHost credsHost, bool isDryRun);
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ManifestService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ManifestService.cs
@@ -21,13 +21,6 @@ namespace Microsoft.DotNet.ImageBuilder
             _httpClient = httpClientProvider.GetRegistryClient();
         }
 
-        public void PushFromSpec(string manifestFile, bool isDryRun)
-        {
-            // ExecuteWithRetry because the manifest-tool fails periodically while communicating
-            // with the Docker Registry.
-            ExecuteHelper.ExecuteWithRetry("manifest-tool", $"push from-spec {manifestFile}", isDryRun);
-        }
-
         public Task<ManifestQueryResult> GetManifestAsync(string image, IRegistryCredentialsHost credsHost, bool isDryRun)
         {
             if (isDryRun)


### PR DESCRIPTION
Due to the behavior described in #1084, these changes remove the usage of the manifest-tool and instead make use of the `docker manifest` command. While this is technically an experimental feature, it's been that way for years and is widely used. I think the use of this command also puts us in a better position to be supported.

Making use of the `docker manifest push` command always causes the manifest to be pushed even if it already exists. This is the behavior that we need and fixes #1084.

The usage patterns are different between the two such that it required a bit of code rejiggering to spit out the commands we need. The manifest-tool was capable of creating and pushing multiple manifest list tags in one command. The `docker manifest` command requires an individual command invocation for each manifest list tag to be created and again to be pushed. Since we have a lot of manifest list tags, this results in a lot of command executions. But on average, all of these commands seem to be able to be executed in 1m 30s for all the content that we have in the nightly branch.