### PR TITLE
Image caching redesign

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
@@ -26,17 +26,26 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public IDictionary<string, string> BuildArgs { get; set; } = new Dictionary<string, string>();
         public bool SkipPlatformCheck { get; set; }
         public string? OutputVariableName { get; set; }
+        public ServicePrincipalOptions ServicePrincipal { get; set; } = new();
+        public string? Subscription { get; set; }
+        public string? ResourceGroup { get; set; }
     }
 
     public class BuildOptionsBuilder : DockerRegistryOptionsBuilder
     {
         private readonly ManifestFilterOptionsBuilder _manifestFilterOptionsBuilder = new();
         private readonly BaseImageOverrideOptionsBuilder _baseImageOverrideOptionsBuilder = new();
+        private readonly ServicePrincipalOptionsBuilder _servicePrincipalOptionsBuilder =
+            ServicePrincipalOptionsBuilder.Build()
+                .WithClientId("acr-client-id", description: "ACR service principal client ID")
+                .WithSecret("acr-password", description: "ACR service principal's password")
+                .WithTenant("acr-tenant", description: "ACR service principal's tenant");
 
         public override IEnumerable<Option> GetCliOptions() =>
             base.GetCliOptions()
                 .Concat(_manifestFilterOptionsBuilder.GetCliOptions())
                 .Concat(_baseImageOverrideOptionsBuilder.GetCliOptions())
+                .Concat(_servicePrincipalOptionsBuilder.GetCliOptions())
                 .Concat(
                     new Option[]
                     {
@@ -62,12 +71,17 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                             "Skips validation that ensures the Dockerfile's base image's platform matches the manifest configuration"),
                         CreateOption<string>("digests-out-var", nameof(BuildOptions.OutputVariableName),
                             "Azure DevOps variable name to use for outputting the list of built image digests"),
+                        CreateOption<string>("acr-subscription", nameof(BuildOptions.Subscription),
+                            "Azure subscription to operate on"),
+                        CreateOption<string>("acr-resource-group", nameof(BuildOptions.ResourceGroup),
+                            "Azure resource group to operate on"),
                     });
 
         public override IEnumerable<Argument> GetCliArguments() =>
             base.GetCliArguments()
                 .Concat(_manifestFilterOptionsBuilder.GetCliArguments())
-                .Concat(_baseImageOverrideOptionsBuilder.GetCliArguments());
+                .Concat(_baseImageOverrideOptionsBuilder.GetCliArguments())
+                .Concat(_servicePrincipalOptionsBuilder.GetCliArguments());
     }
 }
 #nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesOptions.cs
@@ -22,6 +22,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
     public class CleanAcrImagesOptionsBuilder : CliOptionsBuilder
     {
+        private readonly ServicePrincipalOptionsBuilder _servicePrincipalOptionsBuilder =
+            ServicePrincipalOptionsBuilder.BuildWithDefaults();
+
         private const CleanAcrImagesAction DefaultCleanAcrImagesAction = CleanAcrImagesAction.PruneDangling;
         private const int DefaultAge = 30;
 
@@ -33,7 +36,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         new Argument<string>(nameof(CleanAcrImagesOptions.RepoName),
                             "Name of repo to target (wildcard chars * and ? supported)"),
                     })
-                .Concat(ServicePrincipalOptions.GetCliArguments())
+                .Concat(_servicePrincipalOptionsBuilder.GetCliArguments())
                 .Concat(
                     new Argument[]
                     {
@@ -46,14 +49,16 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     });
 
         public override IEnumerable<Option> GetCliOptions() =>
-            base.GetCliOptions().Concat(
-                new Option[]
-                {
-                    CreateOption("action", nameof(CleanAcrImagesOptions.Action),
-                        EnumHelper.GetHelpTextOptions(DefaultCleanAcrImagesAction), DefaultCleanAcrImagesAction),
-                    CreateOption("age", nameof(CleanAcrImagesOptions.Age),
-                        $"Minimum age (days) of repo or images to be deleted (default: {DefaultAge})", DefaultAge)
-                });
+            base.GetCliOptions()
+                .Concat(_servicePrincipalOptionsBuilder.GetCliOptions())
+                .Concat(
+                    new Option[]
+                    {
+                        CreateOption("action", nameof(CleanAcrImagesOptions.Action),
+                            EnumHelper.GetHelpTextOptions(DefaultCleanAcrImagesAction), DefaultCleanAcrImagesAction),
+                        CreateOption("age", nameof(CleanAcrImagesOptions.Age),
+                            $"Minimum age (days) of repo or images to be deleted (default: {DefaultAge})", DefaultAge)
+                    });
     }
 
     public enum CleanAcrImagesAction

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyBaseImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyBaseImagesCommand.cs
@@ -8,7 +8,6 @@ using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Azure.Management.ContainerRegistry.Fluent.Models;
-using Microsoft.DotNet.ImageBuilder.Services;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
 
 #nullable enable
@@ -21,8 +20,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         [ImportingConstructor]
         public CopyBaseImagesCommand(
-            IAzureManagementFactory azureManagementFactory, ILoggerService loggerService, IGitService gitService)
-            : base(azureManagementFactory, loggerService)
+            ICopyImageService copyImageService, ILoggerService loggerService, IGitService gitService)
+            : base(copyImageService, loggerService)
         {
             _gitService = gitService;
         }
@@ -71,7 +70,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             IEnumerable<Task> copyImageTasks = manifests
                 .SelectMany(manifest => GetFromImages(manifest))
                 .Distinct()
-                .Select(fromImage => CopyImageAsync(fromImage, GetBaseRegistryName(fullRegistryName)));
+                .Select(fromImage => CopyImageAsync(fromImage, fullRegistryName));
 
             await Task.WhenAll(copyImageTasks);
         }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyImagesCommand.cs
@@ -2,16 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Threading.Tasks;
-using Microsoft.Azure.Management.ContainerRegistry.Fluent;
 using Microsoft.Azure.Management.ContainerRegistry.Fluent.Models;
-using Microsoft.Azure.Management.Fluent;
-using Microsoft.Azure.Management.ResourceManager.Fluent;
-using Microsoft.Azure.Management.ResourceManager.Fluent.Authentication;
-using Microsoft.DotNet.ImageBuilder.Services;
-using Microsoft.Rest.Azure;
-using ImportSource = Microsoft.Azure.Management.ContainerRegistry.Fluent.Models.ImportSource;
 
 #nullable enable
 namespace Microsoft.DotNet.ImageBuilder.Commands
@@ -20,63 +12,22 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         where TOptions : CopyImagesOptions, new()
         where TOptionsBuilder : CopyImagesOptionsBuilder, new()
     {
-        public CopyImagesCommand(IAzureManagementFactory azureManagementFactory, ILoggerService loggerService)
+        private readonly ICopyImageService _copyImageService;
+
+        public CopyImagesCommand(ICopyImageService copyImageService, ILoggerService loggerService)
         {
-            AzureManagementFactory = azureManagementFactory;
+            _copyImageService = copyImageService;
             LoggerService = loggerService;
         }
 
-        public IAzureManagementFactory AzureManagementFactory { get; }
         public ILoggerService LoggerService { get; }
 
-        protected string GetBaseRegistryName(string registry) => registry.TrimEnd(".azurecr.io");
-
-        protected async Task ImportImageAsync(string destTagName, string destRegistryName, string srcTagName,
-            string? srcRegistryName = null, string? srcResourceId = null, ImportSourceCredentials? sourceCredentials = null)
-        {
-            AzureCredentials credentials = SdkContext.AzureCredentialsFactory.FromServicePrincipal(
-                Options.ServicePrincipal.ClientId,
-                Options.ServicePrincipal.Secret,
-                Options.ServicePrincipal.Tenant,
-                AzureEnvironment.AzureGlobalCloud);
-            IAzure azure = AzureManagementFactory.CreateAzureManager(credentials, Options.Subscription);
-
-            ImportImageParametersInner importParams = new ImportImageParametersInner()
-            {
-                Mode = "Force",
-                Source = new ImportSource(
-                    srcTagName,
-                    srcResourceId,
-                    srcRegistryName,
-                    sourceCredentials),
-                TargetTags = new string[] { destTagName }
-            };
-
-            LoggerService.WriteMessage($"Importing '{destTagName}' from '{srcTagName}'");
-
-            if (!Options.IsDryRun)
-            {
-                try
-                {
-                    await RetryHelper.GetWaitAndRetryPolicy<Exception>(LoggerService)
-                        .ExecuteAsync(() => azure.ContainerRegistries.Inner.ImportImageAsync(Options.ResourceGroup, destRegistryName, importParams));
-                }
-                catch (Exception e)
-                {
-                    string errorMsg = $"Importing Failure: {destTagName}";
-                    if (e is CloudException cloudException)
-                    {
-                        errorMsg += Environment.NewLine + cloudException.Body.Message;
-                    }
-
-                    errorMsg += Environment.NewLine + e.ToString();
-
-                    LoggerService.WriteMessage(errorMsg);
-
-                    throw;
-                }
-            }
-        }
+        protected Task ImportImageAsync(string destTagName,
+            string destRegistryName, string srcTagName, string? srcRegistryName = null, string? srcResourceId = null,
+            ImportSourceCredentials? sourceCredentials = null) =>
+            _copyImageService.ImportImageAsync(
+                Options.Subscription, Options.ResourceGroup, Options.ServicePrincipal, new string[] { destTagName }, destRegistryName,
+                srcTagName, srcRegistryName, srcResourceId, sourceCredentials, Options.IsDryRun);
     }
 }
 #nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyImagesOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyImagesOptions.cs
@@ -21,16 +21,19 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
     public class CopyImagesOptionsBuilder : ManifestOptionsBuilder
     {
-        private readonly ManifestFilterOptionsBuilder _manifestFilterOptionsBuilder =
-               new ManifestFilterOptionsBuilder();
+        private readonly ManifestFilterOptionsBuilder _manifestFilterOptionsBuilder = new();
+        private readonly ServicePrincipalOptionsBuilder _servicePrincipalOptionsBuilder =
+            ServicePrincipalOptionsBuilder.BuildWithDefaults();
 
         public override IEnumerable<Option> GetCliOptions() =>
-            base.GetCliOptions().Concat(_manifestFilterOptionsBuilder.GetCliOptions());
+            base.GetCliOptions()
+                .Concat(_manifestFilterOptionsBuilder.GetCliOptions())
+                .Concat(_servicePrincipalOptionsBuilder.GetCliOptions());
 
         public override IEnumerable<Argument> GetCliArguments() =>
             base.GetCliArguments()
                 .Concat(_manifestFilterOptionsBuilder.GetCliArguments())
-                .Concat(ServicePrincipalOptions.GetCliArguments())
+                .Concat(_servicePrincipalOptionsBuilder.GetCliArguments())
                 .Concat(
                     new Argument[]
                     {

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/IngestKustoImageInfoOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/IngestKustoImageInfoOptions.cs
@@ -23,10 +23,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     public class IngestKustoImageInfoOptionsBuilder : ImageInfoOptionsBuilder
     {
         private readonly ManifestFilterOptionsBuilder _manifestFilterOptionsBuilder = new();
+        private readonly ServicePrincipalOptionsBuilder _servicePrincipalOptionsBuilder =
+            ServicePrincipalOptionsBuilder.BuildWithDefaults();
 
         public override IEnumerable<Option> GetCliOptions() =>
             base.GetCliOptions()
-                .Concat(_manifestFilterOptionsBuilder.GetCliOptions());
+                .Concat(_manifestFilterOptionsBuilder.GetCliOptions())
+                .Concat(_servicePrincipalOptionsBuilder.GetCliOptions());
 
         public override IEnumerable<Argument> GetCliArguments() =>
             base.GetCliArguments()
@@ -40,7 +43,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         new Argument<string>(nameof(IngestKustoImageInfoOptions.LayerTable), "The layer table to ingest the data to"),
                     }
                 )
-                .Concat(ServicePrincipalOptions.GetCliArguments());
+                .Concat(_servicePrincipalOptionsBuilder.GetCliArguments());
     }
 }
 #nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ServicePrincipalOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ServicePrincipalOptions.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.CommandLine;
+using static Microsoft.DotNet.ImageBuilder.Commands.CliHelper;
 
 #nullable enable
 namespace Microsoft.DotNet.ImageBuilder.Commands
@@ -15,14 +16,63 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public string Secret { get; set; } = string.Empty;
 
         public string Tenant { get; set; } = string.Empty;
+    }
 
-        public static IEnumerable<Argument> GetCliArguments() =>
-            new Argument[]
+    public class ServicePrincipalOptionsBuilder
+    {
+        private readonly List<Option> _options = new();
+        private readonly List<Argument> _arguments = new();
+
+        private ServicePrincipalOptionsBuilder()
+        {
+        }
+
+        public static ServicePrincipalOptionsBuilder Build() => new();
+
+        public static ServicePrincipalOptionsBuilder BuildWithDefaults() =>
+            Build()
+                .WithClientId(isRequired: true)
+                .WithSecret(isRequired: true)
+                .WithTenant(isRequired: true);
+
+        public ServicePrincipalOptionsBuilder WithClientId(
+            string alias = "sp-client-id",
+            bool isRequired = false,
+            string? defaultValue = null,
+            string description = "Client ID of service principal") =>
+            AddSymbol(alias, nameof(ServicePrincipalOptions.ClientId), isRequired, defaultValue, description);
+
+        public ServicePrincipalOptionsBuilder WithSecret(
+            string alias = "sp-secret",
+            bool isRequired = false,
+            string? defaultValue = null,
+            string description = "Secret of service principal") =>
+            AddSymbol(alias, nameof(ServicePrincipalOptions.Secret), isRequired, defaultValue, description);
+
+        public ServicePrincipalOptionsBuilder WithTenant(
+            string alias = "sp-tenant",
+            bool isRequired = false,
+            string? defaultValue = null,
+            string description = "Tenant of service principal") =>
+            AddSymbol(alias, nameof(ServicePrincipalOptions.Tenant), isRequired, defaultValue, description);
+
+        public IEnumerable<Option> GetCliOptions() => _options;
+
+        public IEnumerable<Argument> GetCliArguments() => _arguments;
+
+        private ServicePrincipalOptionsBuilder AddSymbol<T>(string alias, string propertyName, bool isRequired, T? defaultValue, string description)
+        {
+            if (isRequired)
             {
-                new Argument<string>(nameof(ClientId), "Client ID of service principal"),
-                new Argument<string>(nameof(Secret), "Secret of service principal"),
-                new Argument<string>(nameof(Tenant), "Tenant of service principal"),
-            };
+                _arguments.Add(new Argument<T>(propertyName, description));
+            }
+            else
+            {
+                _options.Add(CreateOption<T>(alias, propertyName, description, defaultValue is null ? default! : defaultValue));
+            }
+
+            return this;
+        }
     }
 }
 #nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/WaitForMcrDocIngestionOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/WaitForMcrDocIngestionOptions.cs
@@ -24,6 +24,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
     public class WaitForMcrDocIngestionOptionsBuilder : CliOptionsBuilder
     {
+        private readonly ServicePrincipalOptionsBuilder _servicePrincipalOptionsBuilder =
+            ServicePrincipalOptionsBuilder.BuildWithDefaults();
+
         private static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(5);
         private static readonly TimeSpan DefaultRequeryDelay = TimeSpan.FromSeconds(10);
 
@@ -36,10 +39,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                             "Git commit digest of the readme changes")
                     }
                 )
-                .Concat(ServicePrincipalOptions.GetCliArguments());
+                .Concat(_servicePrincipalOptionsBuilder.GetCliArguments());
 
         public override IEnumerable<Option> GetCliOptions() =>
             base.GetCliOptions()
+                .Concat(_servicePrincipalOptionsBuilder.GetCliOptions())
                 .Concat(
                     new Option[]
                     {

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/WaitForMcrImageIngestionOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/WaitForMcrImageIngestionOptions.cs
@@ -26,6 +26,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
     public class WaitForMcrImageIngestionOptionsBuilder : ManifestOptionsBuilder
     {
+        private readonly ServicePrincipalOptionsBuilder _servicePrincipalOptionsBuilder =
+            ServicePrincipalOptionsBuilder.BuildWithDefaults();
+
         private static readonly TimeSpan DefaultWaitTimeout = TimeSpan.FromMinutes(20);
         private static readonly TimeSpan DefaultRequeryDelay = TimeSpan.FromSeconds(10);
 
@@ -38,10 +41,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                             "Path to image info file")
                     }
                 )
-                .Concat(ServicePrincipalOptions.GetCliArguments());
+                .Concat(_servicePrincipalOptionsBuilder.GetCliArguments());
 
         public override IEnumerable<Option> GetCliOptions() =>
             base.GetCliOptions()
+                .Concat(_servicePrincipalOptionsBuilder.GetCliOptions())
                 .Concat(
                     new Option[]
                     {

--- a/src/Microsoft.DotNet.ImageBuilder/src/CopyImageService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/CopyImageService.cs
@@ -1,0 +1,100 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Azure.Management.ContainerRegistry.Fluent;
+using Microsoft.Azure.Management.ContainerRegistry.Fluent.Models;
+using Microsoft.Azure.Management.Fluent;
+using Microsoft.Azure.Management.ResourceManager.Fluent;
+using Microsoft.Azure.Management.ResourceManager.Fluent.Authentication;
+using Microsoft.DotNet.ImageBuilder.Commands;
+using Microsoft.DotNet.ImageBuilder.Services;
+using Microsoft.Rest.Azure;
+using ImportSource = Microsoft.Azure.Management.ContainerRegistry.Fluent.Models.ImportSource;
+
+namespace Microsoft.DotNet.ImageBuilder;
+
+#nullable enable
+public interface ICopyImageService
+{
+    Task ImportImageAsync(
+        string subscription, string resourceGroup, ServicePrincipalOptions servicePrincipalOptions, string[] destTagNames,
+        string destRegistryName, string srcTagName, string? srcRegistryName = null, string? srcResourceId = null,
+        ImportSourceCredentials? sourceCredentials = null, bool isDryRun = false);
+}
+
+[Export(typeof(ICopyImageService))]
+public class CopyImageService : ICopyImageService
+{
+    private readonly IAzureManagementFactory _azureManagementFactory;
+    private readonly ILoggerService _loggerService;
+
+    [ImportingConstructor]
+    public CopyImageService(IAzureManagementFactory azureManagementFactory, ILoggerService loggerService)
+    {
+        _azureManagementFactory = azureManagementFactory;
+        _loggerService = loggerService;
+    }
+
+    private static string GetBaseRegistryName(string registry) => registry.TrimEnd(".azurecr.io");
+
+    public static string GetResourceId(string subscription, string resourceGroup, string registry) =>
+        $"/subscriptions/{subscription}/resourceGroups/{resourceGroup}/providers" +
+                $"/Microsoft.ContainerRegistry/registries/{GetBaseRegistryName(registry)}";
+
+    public async Task ImportImageAsync(
+        string subscription, string resourceGroup, ServicePrincipalOptions servicePrincipalOptions, string[] destTagNames,
+        string destRegistryName, string srcTagName, string? srcRegistryName = null, string? srcResourceId = null,
+        ImportSourceCredentials? sourceCredentials = null, bool isDryRun = false)
+    {
+        destRegistryName = GetBaseRegistryName(destRegistryName);
+
+        AzureCredentials credentials = SdkContext.AzureCredentialsFactory.FromServicePrincipal(
+            servicePrincipalOptions.ClientId,
+            servicePrincipalOptions.Secret,
+            servicePrincipalOptions.Tenant,
+            AzureEnvironment.AzureGlobalCloud);
+        IAzure azure = _azureManagementFactory.CreateAzureManager(credentials, subscription);
+
+        ImportImageParametersInner importParams = new()
+        {
+            Mode = "Force",
+            Source = new ImportSource(
+                srcTagName,
+                srcResourceId,
+                srcRegistryName,
+                sourceCredentials),
+            TargetTags = destTagNames
+        };
+
+        string formattedDestTagNames = string.Join(", ", destTagNames.Select(tag => $"'{DockerHelper.GetImageName(destRegistryName, tag)}'").ToArray());
+        _loggerService.WriteMessage($"Importing {formattedDestTagNames} from '{DockerHelper.GetImageName(srcRegistryName, srcTagName)}'");
+
+        if (!isDryRun)
+        {
+            try
+            {
+                await RetryHelper.GetWaitAndRetryPolicy<Exception>(_loggerService)
+                    .ExecuteAsync(() => azure.ContainerRegistries.Inner.ImportImageAsync(resourceGroup, destRegistryName, importParams));
+            }
+            catch (Exception e)
+            {
+                string errorMsg = $"Importing Failure: {formattedDestTagNames}";
+                if (e is CloudException cloudException)
+                {
+                    errorMsg += Environment.NewLine + cloudException.Body.Message;
+                }
+
+                errorMsg += Environment.NewLine + e.ToString();
+
+                _loggerService.WriteMessage(errorMsg);
+
+                throw;
+            }
+        }
+    }
+}
+#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
@@ -149,14 +149,21 @@ namespace Microsoft.DotNet.ImageBuilder
 
         public static string GetDigestString(string repo, string sha) => $"{repo}@{sha}";
 
-        public static string GetImageName(string registry, string repo, string? tag = null, string? digest = null)
+        public static string GetImageName(string? registry, string repo, string? tag = null, string? digest = null)
         {
             if (tag != null && digest != null)
             {
                 throw new InvalidOperationException($"Invalid to provide both the {nameof(tag)} and {nameof(digest)} arguments.");
             }
 
-            string imageName = $"{registry}/{repo}";
+            string imageName = registry ?? string.Empty;
+            if (imageName.Length > 0)
+            {
+                imageName += $"/";
+            }
+
+            imageName += repo;
+
             if (tag != null)
             {
                 return $"{imageName}:{tag}";

--- a/src/Microsoft.DotNet.ImageBuilder/tests/CopyAcrImagesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/CopyAcrImagesCommandTests.cs
@@ -40,7 +40,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Mock<IAzureManagementFactory> azureManagementFactoryMock =
                     AzureHelper.CreateAzureManagementFactoryMock(subscriptionId, azure);
 
-                CopyAcrImagesCommand command = new CopyAcrImagesCommand(azureManagementFactoryMock.Object, Mock.Of<ILoggerService>());
+                Mock<ICopyImageService> copyImageServiceMock = new();
+
+                CopyAcrImagesCommand command = new(copyImageServiceMock.Object, Mock.Of<ILoggerService>());
                 command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
                 command.Options.Subscription = subscriptionId;
                 command.Options.ResourceGroup = "my resource group";
@@ -103,15 +105,21 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
                 foreach (string expectedTag in expectedTags)
                 {
-                    registriesOperationsMock
-                        .Verify(o => o.ImportImageWithHttpMessagesAsync(
+                    copyImageServiceMock.Verify(o =>
+                        o.ImportImageAsync(
+                            subscriptionId,
                             command.Options.ResourceGroup,
+                            It.IsAny<ServicePrincipalOptions>(),
+                            new string[] { expectedTag },
                             manifest.Registry,
-                            It.Is<ImportImageParametersInner>(parameters =>
-                                VerifyImportImageParameters(parameters, new List<string> { expectedTag })),
-                            It.IsAny<Dictionary<string, List<string>>>(),
-                            It.IsAny<CancellationToken>()));
+                            expectedTag,
+                            null,
+                            CopyImageService.GetResourceId(subscriptionId, command.Options.ResourceGroup, manifest.Registry),
+                            null,
+                            false));
                 }
+
+                copyImageServiceMock.VerifyNoOtherCalls();
             }
         }
 
@@ -130,9 +138,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Mock<IAzureManagementFactory> azureManagementFactoryMock =
                     AzureHelper.CreateAzureManagementFactoryMock(subscriptionId, azure);
 
-                Mock<IEnvironmentService> environmentServiceMock = new Mock<IEnvironmentService>();
+                Mock<IEnvironmentService> environmentServiceMock = new();
+                Mock<ICopyImageService> copyImageServiceMock = new();
 
-                CopyAcrImagesCommand command = new CopyAcrImagesCommand(azureManagementFactoryMock.Object, Mock.Of<ILoggerService>());
+                CopyAcrImagesCommand command = new CopyAcrImagesCommand(copyImageServiceMock.Object, Mock.Of<ILoggerService>());
                 command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
                 command.Options.Subscription = subscriptionId;
                 command.Options.ResourceGroup = "my resource group";
@@ -207,15 +216,21 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
                 foreach (string expectedTag in expectedTags)
                 {
-                    registriesOperationsMock
-                        .Verify(o => o.ImportImageWithHttpMessagesAsync(
+                    copyImageServiceMock.Verify(o =>
+                        o.ImportImageAsync(
+                            subscriptionId,
                             command.Options.ResourceGroup,
+                            It.IsAny<ServicePrincipalOptions>(),
+                            new string[] { expectedTag },
                             manifest.Registry,
-                            It.Is<ImportImageParametersInner>(parameters =>
-                                VerifyImportImageParameters(parameters, new List<string> { expectedTag })),
-                            It.IsAny<Dictionary<string, List<string>>>(),
-                            It.IsAny<CancellationToken>()));
+                            expectedTag,
+                            null,
+                            CopyImageService.GetResourceId(subscriptionId, command.Options.ResourceGroup, manifest.Registry),
+                            null,
+                            false));
                 }
+
+                copyImageServiceMock.VerifyNoOtherCalls();
             }
         }
 
@@ -233,9 +248,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Mock<IAzureManagementFactory> azureManagementFactoryMock =
                 AzureHelper.CreateAzureManagementFactoryMock(subscriptionId, azure);
 
-            Mock<IEnvironmentService> environmentServiceMock = new Mock<IEnvironmentService>();
+            Mock<IEnvironmentService> environmentServiceMock = new();
+            Mock<ICopyImageService> copyImageServiceMock = new();
 
-            CopyAcrImagesCommand command = new CopyAcrImagesCommand(azureManagementFactoryMock.Object, Mock.Of<ILoggerService>());
+            CopyAcrImagesCommand command = new CopyAcrImagesCommand(copyImageServiceMock.Object, Mock.Of<ILoggerService>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.Subscription = subscriptionId;
             command.Options.ResourceGroup = "my resource group";
@@ -322,15 +338,21 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             foreach (string expectedTag in expectedTags)
             {
-                registriesOperationsMock
-                    .Verify(o => o.ImportImageWithHttpMessagesAsync(
-                        command.Options.ResourceGroup,
-                        manifest.Registry,
-                        It.Is<ImportImageParametersInner>(parameters =>
-                            VerifyImportImageParameters(parameters, new List<string> { expectedTag })),
-                        It.IsAny<Dictionary<string, List<string>>>(),
-                        It.IsAny<CancellationToken>()));
+                copyImageServiceMock.Verify(o =>
+                        o.ImportImageAsync(
+                            subscriptionId,
+                            command.Options.ResourceGroup,
+                            It.IsAny<ServicePrincipalOptions>(),
+                            new string[] { expectedTag },
+                            manifest.Registry,
+                            expectedTag,
+                            null,
+                            CopyImageService.GetResourceId(subscriptionId, command.Options.ResourceGroup, manifest.Registry),
+                            null,
+                            false));
             }
+
+            copyImageServiceMock.VerifyNoOtherCalls();
         }
 
         /// <summary>
@@ -347,9 +369,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Mock<IAzureManagementFactory> azureManagementFactoryMock =
                 AzureHelper.CreateAzureManagementFactoryMock(subscriptionId, azure);
 
-            Mock<IEnvironmentService> environmentServiceMock = new Mock<IEnvironmentService>();
+            Mock<IEnvironmentService> environmentServiceMock = new();
+            Mock<ICopyImageService> copyImageServiceMock = new();
 
-            CopyAcrImagesCommand command = new CopyAcrImagesCommand(azureManagementFactoryMock.Object, Mock.Of<ILoggerService>());
+            CopyAcrImagesCommand command = new CopyAcrImagesCommand(copyImageServiceMock.Object, Mock.Of<ILoggerService>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.Subscription = subscriptionId;
             command.Options.ResourceGroup = "my resource group";
@@ -437,20 +460,21 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             foreach (string expectedTag in expectedTags)
             {
-                registriesOperationsMock
-                    .Verify(o => o.ImportImageWithHttpMessagesAsync(
-                        command.Options.ResourceGroup,
-                        manifest.Registry,
-                        It.Is<ImportImageParametersInner>(parameters =>
-                            VerifyImportImageParameters(parameters, new List<string> { expectedTag })),
-                        It.IsAny<Dictionary<string, List<string>>>(),
-                        It.IsAny<CancellationToken>()));
+                copyImageServiceMock.Verify(o =>
+                        o.ImportImageAsync(
+                            subscriptionId,
+                            command.Options.ResourceGroup,
+                            It.IsAny<ServicePrincipalOptions>(),
+                            new string[] { expectedTag },
+                            manifest.Registry,
+                            It.IsAny<string>(),
+                            null,
+                            CopyImageService.GetResourceId(subscriptionId, command.Options.ResourceGroup, manifest.Registry),
+                            null,
+                            false));
             }
-        }
 
-        private static bool VerifyImportImageParameters(ImportImageParametersInner parameters, IList<string> expectedTags)
-        {
-            return TestHelper.CompareLists(expectedTags, parameters.TargetTags);
+            copyImageServiceMock.VerifyNoOtherCalls();
         }
     }
 }


### PR DESCRIPTION
A situation can sometimes occur in image caching scenarios where the cached image is pulled from MAR and pushed to the ACR resulting in a different image digest in ACR than it had in MAR. This causes the incorrect data to exist in the image info which affects caching behavior of subsequent builds. It can also affect the logic for querying MAR's image ingestion status because we'll be querying the expected digest which doesn't exist. The reason we'd be querying for image ingestion status for a cached image is if it was assigned new tags.

This is fixed by changing the workflow for how image caching is done. When a cache hit occurs, this is the current workflow:

1. Pull image from MAR by digest
2. Add desired tags based on ACR staging repo
3. Push tags to ACR

Here is the new workflow:

1. [Import/copy image](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-import-images) from MAR to ACR staging repo for all the desired tags
2. Pull the image from ACR staging repo by digest
3. Add desired tags based on ACR staging repo

This new workflow means that, for cached images, we never pull the image locally and push it to the ACR. We rely on the ACR import logic instead. Hopefully the ACR import logic won't run into this issue of the digest being different. If they do, I would consider it a bug to be logged on ACR. And if it does occur, it will actually be caught much sooner in the pipeline now. Because we pull the image by its expected digest from the staging repo in step 2 above, if it doesn't exist we'll get an error at that point. This is much better than running into the issue during the publish stage when images would have already been published.

Because the image import logic was already implemented by `CopyImagesCommand`, I've factored out that logic into a separate service, `CopyImagesService`, that can be reused by `BuildCommand`. Changes were also necessary to the build options to provide the necessary options (subscription, ACR tenant, etc.) for executing the import operation on the ACR.

Fixes #821 