### PR TITLE
Support dynamic tag values in publish notifications

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerHelper.cs
@@ -169,6 +169,8 @@ namespace Microsoft.DotNet.ImageBuilder
             return imageName;
         }
 
+        public static string GetTagName(string imageName) => imageName[(GetTagOrDigestSeparatorIndex(imageName) + 1)..];
+
         public static string NormalizeRepo(string image)
         {
             string? registry = GetRegistry(image);


### PR DESCRIPTION
For tag names that have dynamically-generated values, the publish notification that gets created is not using the correct value. It's using the value that was generated when loading the manifest to execute the command rather than the value stored in the image info file.

Fixed the logic to use the tag names from the image info file instead.

Fixes #1010