### PR TITLE
Add openssl1.1-compat to imagebuilder dockerfile

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/Dockerfile.linux
+++ b/src/Microsoft.DotNet.ImageBuilder/Dockerfile.linux
@@ -28,6 +28,7 @@ FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-alpine$ALPINE_TAG_SUFFIX
 
 # install tooling
 RUN apk add --no-cache \
+        openssl1.1-compat \
         docker \
         git
 


### PR DESCRIPTION
We recently [moved the floating Alpine Linux tags from 3.16 to 3.17](https://github.com/dotnet/dotnet-docker/issues/4264). Per [Alpine Linux 3.17 release notes](https://alpinelinux.org/posts/Alpine-3.17.0-released.html), the default version of OpenSSL is changed from 1.1 to 3.0. For `libgit2sharp` to function, we need to add the `openssl1.1-compat` package as recommended by the Alpine Linux release notes.

Fixes https://github.com/dotnet/docker-tools/issues/1105