### PR TITLE
Add Debian 12 Bullseye to ImageBuilder's platform info

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
@@ -198,6 +198,10 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
                 {
                     displayName = "Debian 11";
                 }
+                else if (os.Contains("bookworm"))
+                {
+                    displayName = "Debian 12";
+                }
                 else if (os.Contains("xenial"))
                 {
                     displayName = "Ubuntu 16.04";


### PR DESCRIPTION
First part of https://github.com/dotnet/dotnet-docker/issues/4322