### PR TITLE
Fix regex for FROM image overwrite

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -834,7 +834,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     RepoInfo repo = Manifest.FilteredRepos.First(r => r.FullModelName == fromRepo);
                     string newFromImage = DockerHelper.ReplaceRepo(fromImage, repo.QualifiedName);
                     _loggerService.WriteMessage($"Replacing FROM `{fromImage}` with `{newFromImage}`");
-                    Regex fromRegex = new Regex($@"FROM\s+{Regex.Escape(fromImage)}[^\S\r\n]*");
+                    Regex fromRegex = new Regex($@"FROM\s+{Regex.Escape(fromImage)}[^\s\r\n]*");
                     dockerfileContents = fromRegex.Replace(dockerfileContents, $"FROM {newFromImage}");
                     updateDockerfile = true;
                 }


### PR DESCRIPTION
The changes from https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/754 caused a failure in the internal build:

```
Error response from daemon: dockerfile parse error line 1: FROM requires either one or three arguments
```

This occurs because Image Builder is incorrectly rewriting the Dockerfile to target the locally built tag instead of the public MCR tag. It ends up replacing the whitespace between the end of the tag and the `AS` keyword, producing this `FROM` instruction: `FROM dotnetdocker.azurecr.io/build-staging/2090449/dotnet-buildtools/prereqs:ubuntu-20.04-crossdeps-localAS binutils`. Notice there's no space before `AS`. This is invalid syntax and causes the error to occur.

This is fixed by using the correct character class in the Regex which does the string replacement. The string its search to replace should stop before hitting any whitespace (`\s`) but it was using the non-whitespace character class (`\S`).