### PR TITLE
Change tagging from parallel to serial

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -533,7 +533,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             }
 
             // Tag the image as if it were locally built so that subsequent built images can reference it
-            Parallel.ForEach(allTags, tag =>
+            foreach (TagInfo tag in allTags)
             {
                 if (!_sourceDigestCopyLocationMapping.TryGetValue(sourceDigest, out string? resolvedSourceDigest))
                 {
@@ -553,7 +553,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 // This is needed in order to prevent a call to the manifest tool to get the digest for these tags
                 // because they haven't yet been pushed to staging by that time.
                 _imageDigestCache.AddDigest(tag.FullyQualifiedName, newDigest);
-            });
+            }
         }
 
         private async Task<string> CopyCachedImage(IEnumerable<TagInfo> allTags, string sourceDigest)


### PR DESCRIPTION
Lately there have been random build timeouts popping up at the point where the `build` command tags cached images. It's not clear what is hanging. It could either be a deadlock of some kind in ImageBuilder's caching code (which seems unlikely since that code hasn't changed) or maybe a new version of Docker that doesn't tolerate parallel tagging operations very well, or maybe something else.

Regardless, this should be fixed by changing the logic to create the tags serially rather than in parallel.