### PR TITLE
Remove base image override for Alpine

### DIFF
--- a/eng/pipelines/check-base-image-updates.yml
+++ b/eng/pipelines/check-base-image-updates.yml
@@ -21,4 +21,4 @@ jobs:
   parameters:
     jobName: CheckBaseImages_BuildTools
     subscriptionsPath: eng/check-base-image-subscriptions-buildtools.json
-    customGetStaleImagesArgs: --base-override-regex '^((alpine|centos|debian|fedora|ubuntu):.+)' --base-override-sub '$(overrideRegistry)/$1'
+    customGetStaleImagesArgs: --base-override-regex '^((centos|debian|fedora|ubuntu):.+)' --base-override-sub '$(overrideRegistry)/$1'


### PR DESCRIPTION
This applies the corresponding change from https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/789. This is needed so that we target the correct image name when checking base image updates for the https://github.com/dotnet/dotnet-buildtools-prereqs-docker repo.