### PR TITLE
Reference correct runtime-deps image in ImageBuilder Linux Dockerfile

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/Dockerfile.linux
+++ b/src/Microsoft.DotNet.ImageBuilder/Dockerfile.linux
@@ -24,7 +24,7 @@ RUN dotnet publish ./src/Microsoft.DotNet.ImageBuilder.csproj -c Release -o out 
 
 
 # build runtime image
-FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-alpine$ALPINE_TAG_SUFFIX
+FROM mcr.microsoft.com/dotnet/runtime-deps:7.0-alpine$ALPINE_TAG_SUFFIX
 
 # install tooling
 RUN apk add --no-cache \


### PR DESCRIPTION
Fixes https://github.com/dotnet/docker-tools/issues/1113