### PR TITLE
Allow passing docker secret mounts through ImageBuilder

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -76,7 +76,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
                 await PublishImageInfoAsync();
             });
-            
+
             WriteBuildSummary();
             WriteBuiltImagesToOutputVar();
         }
@@ -272,7 +272,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     {
                         // Tag the built images with the shared tags as well as the platform tags.
                         // Some tests and image FROM instructions depend on these tags.
-                        
+
                         IEnumerable<TagInfo> allTagInfos = platform.Tags
                             .Concat(image.SharedTags)
                             .ToList();
@@ -446,12 +446,23 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             {
                 InvokeBuildHook("pre-build", platform.BuildContextPath);
 
+                IEnumerable<string> additionalArgs = new List<string>();
+
+                if (Options.SecretInfo != null)
+                {
+                    foreach ((string Id, string Src) secretInfo in Options.SecretInfo)
+                    {
+                        additionalArgs = additionalArgs.Append($"--secret id={secretInfo.Id},src={secretInfo.Src}");
+                    }
+                }
+
                 string? buildOutput = _dockerService.BuildImage(
                     dockerfilePath,
                     platform.BuildContextPath,
                     platform.PlatformLabel,
                     allTags,
                     GetBuildArgs(platform),
+                    additionalArgs,
                     Options.IsRetryEnabled,
                     Options.IsDryRun);
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -446,23 +446,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             {
                 InvokeBuildHook("pre-build", platform.BuildContextPath);
 
-                IEnumerable<string> additionalArgs = new List<string>();
-
-                if (Options.SecretInfo != null)
-                {
-                    foreach ((string Id, string Src) secretInfo in Options.SecretInfo)
-                    {
-                        additionalArgs = additionalArgs.Append($"--secret id={secretInfo.Id},src={secretInfo.Src}");
-                    }
-                }
-
                 string? buildOutput = _dockerService.BuildImage(
                     dockerfilePath,
                     platform.BuildContextPath,
                     platform.PlatformLabel,
                     allTags,
                     GetBuildArgs(platform),
-                    additionalArgs,
+                    Options.SecretInfo,
                     Options.IsRetryEnabled,
                     Options.IsDryRun);
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -452,7 +452,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     platform.PlatformLabel,
                     allTags,
                     GetBuildArgs(platform),
-                    Options.SecretInfo,
+                    Options.SecretInfos,
                     Options.IsRetryEnabled,
                     Options.IsDryRun);
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public ServicePrincipalOptions ServicePrincipal { get; set; } = new();
         public string? Subscription { get; set; }
         public string? ResourceGroup { get; set; }
-        public IEnumerable<(string Id, string Src)>? SecretInfo { get; set; }
+        public IEnumerable<(string Id, string Src)> SecretInfo { get; set; } = Enumerable.Empty<(string Id, string Src)>();
     }
 
     public class BuildOptionsBuilder : DockerRegistryOptionsBuilder

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public ServicePrincipalOptions ServicePrincipal { get; set; } = new();
         public string? Subscription { get; set; }
         public string? ResourceGroup { get; set; }
-        public IEnumerable<(string Id, string Src)> SecretInfo { get; set; } = Enumerable.Empty<(string Id, string Src)>();
+        public IEnumerable<(string Id, string Src)> SecretInfos { get; set; } = Enumerable.Empty<(string Id, string Src)>();
     }
 
     public class BuildOptionsBuilder : DockerRegistryOptionsBuilder
@@ -76,7 +76,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                             "Azure subscription to operate on"),
                         CreateOption<string>("acr-resource-group", nameof(BuildOptions.ResourceGroup),
                             "Azure resource group to operate on"),
-                        CreateTupleMultiOption("secret", nameof(BuildOptions.SecretInfo),
+                        CreateTupleMultiOption("secret", nameof(BuildOptions.SecretInfos),
                             "Secret to mount into the Docker build command", "id", "src")
                     });
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
@@ -29,6 +29,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public ServicePrincipalOptions ServicePrincipal { get; set; } = new();
         public string? Subscription { get; set; }
         public string? ResourceGroup { get; set; }
+        public IEnumerable<(string Id, string Src)>? SecretInfo { get; set; }
     }
 
     public class BuildOptionsBuilder : DockerRegistryOptionsBuilder
@@ -75,6 +76,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                             "Azure subscription to operate on"),
                         CreateOption<string>("acr-resource-group", nameof(BuildOptions.ResourceGroup),
                             "Azure resource group to operate on"),
+                        CreateTupleMultiOption("secret", nameof(BuildOptions.SecretInfo),
+                            "Secret to mount into the Docker build command", "id", "src")
                     });
 
         public override IEnumerable<Argument> GetCliArguments() =>

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CliHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CliHelper.cs
@@ -43,6 +43,48 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 AllowMultipleArgumentsPerToken = false
             };
 
+        public static Option<(string, string)[]> CreateTupleMultiOption(string alias, string propertyName, string description, string key1, string key2) =>
+            new Option<(string, string)[]>(
+                FormatAlias(alias),
+                description: description,
+                parseArgument: argResult =>
+                {
+                    return argResult.Tokens
+                        .Select(token =>
+                            token.Value
+                            .Split(',')
+                            .Select(s => s.ParseKeyValuePair('='))
+                        )
+                        .Select(kvp => {
+                            (string Key, string Value)[] kvpArray = kvp.ToArray();
+
+                            if (kvpArray.Count() != 2) {
+                                throw new ArgumentException($"Invalid format for {propertyName} option. Expected format: {key1}=value1,{key2}=value2");
+                            }
+
+                            string value1;
+                            string value2;
+
+                            if (kvpArray[0].Key == key1 && kvpArray[1].Key == key2) {
+                                value1 = kvpArray[0].Value;
+                                value2 = kvpArray[1].Value;
+                            } else if (kvpArray[0].Key == key2 && kvpArray[1].Key == key1) {
+                                value1 = kvpArray[1].Value;
+                                value2 = kvpArray[0].Value;
+                            } else {
+                                throw new ArgumentException($"Invalid format for {propertyName} option. Expected format: {key1}=value1,{key2}=value2");
+                            }
+
+                            return (value1, value2);
+                        })
+                        .ToArray();
+                }
+            )
+            {
+                Name = propertyName,
+                AllowMultipleArgumentsPerToken = false,
+            };
+
         public static Option<Dictionary<string, string>> CreateDictionaryOption(string alias, string propertyName, string description) =>
             CreateDictionaryOption(alias, propertyName, description, val => val);
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerService.cs
@@ -78,6 +78,7 @@ namespace Microsoft.DotNet.ImageBuilder
             string platform,
             IEnumerable<string> tags,
             IDictionary<string, string?> buildArgs,
+            IEnumerable<string> additionalArgs,
             bool isRetryEnabled,
             bool isDryRun)
         {
@@ -87,7 +88,9 @@ namespace Microsoft.DotNet.ImageBuilder
                 .Select(buildArg => $" --build-arg {buildArg.Key}={buildArg.Value}");
             string buildArgsString = string.Join(string.Empty, buildArgList);
 
-            string dockerArgs = $"build --platform {platform} {tagArgs} -f {dockerfilePath}{buildArgsString} {buildContextPath}";
+            string additionalArgsString = string.Join(' ', additionalArgs);
+
+            string dockerArgs = $"build --platform {platform} {tagArgs} {additionalArgsString} -f {dockerfilePath} {buildArgsString} {buildContextPath}";
 
             Dictionary<string, string> envVars = new Dictionary<string, string>
             {

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerService.cs
@@ -78,7 +78,7 @@ namespace Microsoft.DotNet.ImageBuilder
             string platform,
             IEnumerable<string> tags,
             IDictionary<string, string?> buildArgs,
-            IEnumerable<string> additionalArgs,
+            IEnumerable<(string Id, string Src)> secretInfos,
             bool isRetryEnabled,
             bool isDryRun)
         {
@@ -88,9 +88,11 @@ namespace Microsoft.DotNet.ImageBuilder
                 .Select(buildArg => $" --build-arg {buildArg.Key}={buildArg.Value}");
             string buildArgsString = string.Join(string.Empty, buildArgList);
 
-            string additionalArgsString = string.Join(' ', additionalArgs);
+            IEnumerable<string> secretArgs = secretInfos
+                .Select(secretInfo => $"--secret id={secretInfo.Id},src={secretInfo.Src}");
+            string secretArgsString = string.Join(' ', secretArgs);
 
-            string dockerArgs = $"build --platform {platform} {tagArgs} {additionalArgsString} -f {dockerfilePath} {buildArgsString} {buildContextPath}";
+            string dockerArgs = $"build --platform {platform} {tagArgs} {secretArgsString} -f {dockerfilePath} {buildArgsString} {buildContextPath}";
 
             Dictionary<string, string> envVars = new Dictionary<string, string>
             {

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerServiceCache.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerServiceCache.cs
@@ -37,8 +37,8 @@ namespace Microsoft.DotNet.ImageBuilder
 
         public string? BuildImage(
             string dockerfilePath, string buildContextPath, string platform, IEnumerable<string> tags,
-            IDictionary<string, string?> buildArgs, IEnumerable<string> additionalArgs, bool isRetryEnabled, bool isDryRun) =>
-            _inner.BuildImage(dockerfilePath, buildContextPath, platform, tags, buildArgs, additionalArgs, isRetryEnabled, isDryRun);
+            IDictionary<string, string?> buildArgs, IEnumerable<(string Id, string Src)> secretInfos, bool isRetryEnabled, bool isDryRun) =>
+            _inner.BuildImage(dockerfilePath, buildContextPath, platform, tags, buildArgs, secretInfos, isRetryEnabled, isDryRun);
 
         public (Architecture Arch, string? Variant) GetImageArch(string image, bool isDryRun) =>
             _architectureCache.GetOrAdd(image, _ =>_inner.GetImageArch(image, isDryRun));

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerServiceCache.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerServiceCache.cs
@@ -37,8 +37,8 @@ namespace Microsoft.DotNet.ImageBuilder
 
         public string? BuildImage(
             string dockerfilePath, string buildContextPath, string platform, IEnumerable<string> tags,
-            IDictionary<string, string?> buildArgs, bool isRetryEnabled, bool isDryRun) =>
-            _inner.BuildImage(dockerfilePath, buildContextPath, platform, tags, buildArgs, isRetryEnabled, isDryRun);
+            IDictionary<string, string?> buildArgs, IEnumerable<string> additionalArgs, bool isRetryEnabled, bool isDryRun) =>
+            _inner.BuildImage(dockerfilePath, buildContextPath, platform, tags, buildArgs, additionalArgs, isRetryEnabled, isDryRun);
 
         public (Architecture Arch, string? Variant) GetImageArch(string image, bool isDryRun) =>
             _architectureCache.GetOrAdd(image, _ =>_inner.GetImageArch(image, isDryRun));
@@ -61,10 +61,10 @@ namespace Microsoft.DotNet.ImageBuilder
 
         public long GetImageSize(string image, bool isDryRun) =>
             _imageSizeCache.GetOrAdd(image, _ => _inner.GetImageSize(image, isDryRun));
-        
+
         public bool LocalImageExists(string tag, bool isDryRun) =>
             _localImageExistsCache.GetOrAdd(tag, _ => _inner.LocalImageExists(tag, isDryRun));
-        
+
         public void PullImage(string image, string? platform, bool isDryRun)
         {
             _pulledImages.GetOrAdd(image, _ =>

--- a/src/Microsoft.DotNet.ImageBuilder/src/IDockerService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/IDockerService.cs
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.ImageBuilder
             string platform,
             IEnumerable<string> tags,
             IDictionary<string, string?> buildArgs,
-            IEnumerable<string> additionalArgs,
+            IEnumerable<(string Id, string Src)> secretInfos,
             bool isRetryEnabled,
             bool isDryRun);
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/IDockerService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/IDockerService.cs
@@ -34,6 +34,7 @@ namespace Microsoft.DotNet.ImageBuilder
             string platform,
             IEnumerable<string> tags,
             IDictionary<string, string?> buildArgs,
+            IEnumerable<string> additionalArgs,
             bool isRetryEnabled,
             bool isDryRun);
 

--- a/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
@@ -43,12 +43,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             string runtimeDepsDigest = $"{runtimeDepsRepo}@sha256:c74364a9f125ca612f9a67e4a0551937b7a37c82fabb46172c4867b73edd638c";
             string runtimeDigest = $"{runtimeRepo}@sha256:adc914a9f125ca612f9a67e4a0551937b7a37c82fabb46172c4867b73ed99227";
             string aspnetDigest = $"{aspnetRepo}@sha256:781914a9f125ca612f9a67e4a0551937b7a37c82fabb46172c4867b73ed0045a";
-            IEnumerable<string> runtimeDepsLayers = new [] { 
+            IEnumerable<string> runtimeDepsLayers = new [] {
                 "sha256:777b2c648970480f50f5b4d0af8f9a8ea798eea43dbcf40ce4a8c7118736bdcf",
                 "sha256:b9dfc8eed8d66f1eae8ffe46be9a26fe047a7f6554e9dbc2df9da211e59b4786" };
-            IEnumerable<string> runtimeLayers = 
+            IEnumerable<string> runtimeLayers =
                 runtimeDepsLayers.Concat(new [] { "sha256:466982335a8bacfe63b8f75a2e8c6484dfa7f7e92197550643b3c1457fa445b4" });
-            IEnumerable<string> aspnetLayers = 
+            IEnumerable<string> aspnetLayers =
                 runtimeLayers.Concat(new [] { "sha256:d305fbfc4bd0d9f38662e979dced9831e3b5e4d85442397a8ec0a0e7bcf5458b"});
             const string tag = "tag";
             const string localTag = "localtag";
@@ -522,6 +522,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         TagInfo.GetFullyQualifiedName(repoName, sharedTag)
                     },
                     It.IsAny<IDictionary<string, string>>(),
+                    It.IsAny<IEnumerable<string>>(),
                     It.IsAny<bool>(),
                     It.IsAny<bool>()));
 
@@ -628,6 +629,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     It.IsAny<List<string>>(),
                     It.Is<Dictionary<string, string>>(
                         args => args.Count == 3 && args["arg1"] == "val1" && args["arg2"] == "val2b" && args["arg3"] == "val3"),
+                    It.IsAny<IEnumerable<string>>(),
                     It.IsAny<bool>(),
                     It.IsAny<bool>()));
         }
@@ -690,6 +692,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         TagInfo.GetFullyQualifiedName(repoName, sharedTag)
                     },
                     It.IsAny<IDictionary<string, string>>(),
+                    It.IsAny<IEnumerable<string>>(),
                     It.IsAny<bool>(),
                     It.IsAny<bool>()));
 
@@ -885,7 +888,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 o.BuildImage(
                     PathHelper.NormalizePath(Path.Combine(tempFolderContext.Path, runtimeDepsLinuxDockerfileRelativePath)),
                     It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<IDictionary<string, string>>(),
-                    It.IsAny<bool>(), It.IsAny<bool>()),
+                    It.IsAny<IEnumerable<string>>(), It.IsAny<bool>(), It.IsAny<bool>()),
                 Times.Never);
 
             VerifyImportImage(copyImageServiceMock, command,
@@ -958,7 +961,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Mock<IDockerService> dockerServiceMock = CreateDockerServiceMock("Pulling from");
 
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
-            
+
             const string runtimeRelativeDir = "1.0/runtime/os";
             Directory.CreateDirectory(Path.Combine(tempFolderContext.Path, runtimeRelativeDir));
             string dockerfileRelativePath = PathHelper.NormalizePath(Path.Combine(runtimeRelativeDir, "Dockerfile"));
@@ -1524,7 +1527,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     }
                 }
             };
-          
+
             ImageArtifactDetails sourceImageArtifactDetails = new ImageArtifactDetails
             {
                 Repos = sourceRepos.ToList()
@@ -1676,7 +1679,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             dockerServiceMock.Verify(o =>
                 o.BuildImage(
                     It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>(),
-                    It.IsAny<IDictionary<string, string>>(), It.IsAny<bool>(), It.IsAny<bool>()),
+                    It.IsAny<IDictionary<string, string>>(), It.IsAny<IEnumerable<string>>(), It.IsAny<bool>(), It.IsAny<bool>()),
                 Times.Never);
 
             dockerServiceMock.VerifyNoOtherCalls();
@@ -1988,6 +1991,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     It.IsAny<string>(),
                     It.IsAny<IEnumerable<string>>(),
                     It.IsAny<IDictionary<string, string>>(),
+                    It.IsAny<IEnumerable<string>>(),
                     It.IsAny<bool>(),
                     It.IsAny<bool>()));
 
@@ -2200,6 +2204,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         It.IsAny<string>(),
                         new string[] { expectedTag },
                         It.IsAny<IDictionary<string, string>>(),
+                        It.IsAny<IEnumerable<string>>(),
                         It.IsAny<bool>(),
                         It.IsAny<bool>()),
                     Times.Once);
@@ -2445,6 +2450,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         It.IsAny<string>(),
                         new string[] { expectedTag },
                         It.IsAny<IDictionary<string, string>>(),
+                        It.IsAny<IEnumerable<string>>(),
                         It.IsAny<bool>(),
                         It.IsAny<bool>()),
                     Times.Once);
@@ -2658,7 +2664,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             dockerServiceMock.Verify(o =>
                 o.BuildImage(
                     PathHelper.NormalizePath(Path.Combine(tempFolderContext.Path, runtimeDepsLinuxDockerfileRelativePath)),
-                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<IDictionary<string, string>>(),
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<IEnumerable<string>>(),
                     It.IsAny<bool>(), It.IsAny<bool>()),
                 Times.Never);
 
@@ -2921,7 +2927,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             dockerServiceMock.Verify(o =>
                 o.BuildImage(
                     It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>(),
-                    It.IsAny<IDictionary<string, string>>(), It.IsAny<bool>(), It.IsAny<bool>()),
+                    It.IsAny<IDictionary<string, string>>(), It.IsAny<IEnumerable<string>>(), It.IsAny<bool>(), It.IsAny<bool>()),
                 Times.Never);
             dockerServiceMock.Verify(o => o.GetCreatedDate(It.IsAny<string>(), false));
 
@@ -3017,7 +3023,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     .Setup(o => o.GetImageDigestAsync($"{RegistryOverride}/{RepoPrefix}{AspnetRepo}:{Tag}", It.IsAny<IRegistryCredentialsHost>(), false))
                     .ReturnsAsync(callCount => callCount > 0 ? $"{RegistryOverride}/{RepoPrefix}{AspnetRepo}@{AspnetDigest}" : null);
             }
-            
+
             dockerServiceMock
                 .Setup(o => o.GetImageDigestAsync(mirrorBaseTag, It.IsAny<IRegistryCredentialsHost>(), false))
                 .ReturnsAsync(mirrorBaseImageDigest);
@@ -3283,6 +3289,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     It.IsAny<string>(),
                     It.IsAny<IEnumerable<string>>(),
                     It.IsAny<IDictionary<string, string>>(),
+                    It.IsAny<IEnumerable<string>>(),
                     It.IsAny<bool>(),
                     It.IsAny<bool>()));
 
@@ -3313,7 +3320,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             }
 
             dockerServiceMock.Verify(o => o.GetImageDigestAsync(mirrorBaseTag, It.IsAny<IRegistryCredentialsHost>(), false));
-            
+
             dockerServiceMock.Verify(o => o.GetImageDigestAsync($"{RegistryOverride}/{RepoPrefix}{AspnetRepo}:{Tag}", It.IsAny<IRegistryCredentialsHost>(), false));
 
             if (!hasCachedImage)
@@ -3321,7 +3328,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 dockerServiceMock.Verify(o => o.PushImage($"{RegistryOverride}/{RepoPrefix}{RuntimeDepsRepo}:{Tag}", false));
                 dockerServiceMock.Verify(o => o.PushImage($"{RegistryOverride}/{RepoPrefix}{RuntimeRepo}:{Tag}", false));
             }
-            
+
             dockerServiceMock.Verify(o => o.PushImage($"{RegistryOverride}/{RepoPrefix}{AspnetRepo}:{Tag}", false));
 
             dockerServiceMock.Verify(o => o.GetCreatedDate($"{RegistryOverride}/{RepoPrefix}{RuntimeDepsRepo}:{Tag}", false));
@@ -3337,7 +3344,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 dockerServiceMock.Verify(o => o.GetImageArch(mirrorBaseTag, false));
                 dockerServiceMock.Verify(o => o.GetImageArch($"{RegistryOverride}/{RepoPrefix}{RuntimeDepsRepo}:{Tag}", false));
             }
-            
+
             dockerServiceMock.Verify(o => o.GetImageArch($"{RegistryOverride}/{RepoPrefix}{RuntimeRepo}:{Tag}", false));
 
             dockerServiceMock.VerifyNoOtherCalls();
@@ -3428,6 +3435,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     It.IsAny<string>(),
                     It.IsAny<IEnumerable<string>>(),
                     It.IsAny<IDictionary<string, string>>(),
+                    It.IsAny<IEnumerable<string>>(),
                     It.IsAny<bool>(),
                     It.IsAny<bool>()));
 
@@ -3571,6 +3579,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     It.IsAny<string>(),
                     It.IsAny<IEnumerable<string>>(),
                     It.IsAny<IDictionary<string, string>>(),
+                    It.IsAny<IEnumerable<string>>(),
                     It.IsAny<bool>(),
                     It.IsAny<bool>()));
 
@@ -3603,6 +3612,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         It.IsAny<string>(),
                         It.IsAny<IEnumerable<string>>(),
                         It.IsAny<IDictionary<string, string>>(),
+                        It.IsAny<IEnumerable<string>>(),
                         It.IsAny<bool>(),
                         It.IsAny<bool>()))
                 .Returns(buildOutput ?? string.Empty);

--- a/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
@@ -651,8 +651,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             BuildCommand command = new(dockerServiceMock.Object, Mock.Of<ILoggerService>(), Mock.Of<IGitService>(),
                 Mock.Of<IProcessService>(), Mock.Of<ICopyImageService>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
-            command.Options.SecretInfo = command.Options.SecretInfo.Append(("SecretId1", "SecretValue1"));
-            command.Options.SecretInfo = command.Options.SecretInfo.Append(("SecretId2", "SecretValue2"));
+            command.Options.SecretInfos = command.Options.SecretInfos.Append(("SecretId1", "SecretValue1"));
+            command.Options.SecretInfos = command.Options.SecretInfos.Append(("SecretId2", "SecretValue2"));
 
             Platform platform = CreatePlatform(
                 DockerfileHelper.CreateDockerfile("1.0/runtime/os", tempFolderContext, baseImageTag),

--- a/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
@@ -522,7 +522,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         TagInfo.GetFullyQualifiedName(repoName, sharedTag)
                     },
                     It.IsAny<IDictionary<string, string>>(),
-                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<IEnumerable<(string Id, string Src)>>(),
                     It.IsAny<bool>(),
                     It.IsAny<bool>()));
 
@@ -629,7 +629,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     It.IsAny<List<string>>(),
                     It.Is<Dictionary<string, string>>(
                         args => args.Count == 3 && args["arg1"] == "val1" && args["arg2"] == "val2b" && args["arg3"] == "val3"),
-                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<IEnumerable<(string Id, string Src)>>(),
                     It.IsAny<bool>(),
                     It.IsAny<bool>()));
         }
@@ -692,7 +692,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         TagInfo.GetFullyQualifiedName(repoName, sharedTag)
                     },
                     It.IsAny<IDictionary<string, string>>(),
-                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<IEnumerable<(string Id, string Src)>>(),
                     It.IsAny<bool>(),
                     It.IsAny<bool>()));
 
@@ -888,7 +888,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 o.BuildImage(
                     PathHelper.NormalizePath(Path.Combine(tempFolderContext.Path, runtimeDepsLinuxDockerfileRelativePath)),
                     It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<IDictionary<string, string>>(),
-                    It.IsAny<IEnumerable<string>>(), It.IsAny<bool>(), It.IsAny<bool>()),
+                    It.IsAny<IEnumerable<(string Id, string Src)>>(), It.IsAny<bool>(), It.IsAny<bool>()),
                 Times.Never);
 
             VerifyImportImage(copyImageServiceMock, command,
@@ -1679,7 +1679,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             dockerServiceMock.Verify(o =>
                 o.BuildImage(
                     It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>(),
-                    It.IsAny<IDictionary<string, string>>(), It.IsAny<IEnumerable<string>>(), It.IsAny<bool>(), It.IsAny<bool>()),
+                    It.IsAny<IDictionary<string, string>>(), It.IsAny<IEnumerable<(string Id, string Src)>>(), It.IsAny<bool>(), It.IsAny<bool>()),
                 Times.Never);
 
             dockerServiceMock.VerifyNoOtherCalls();
@@ -1991,7 +1991,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     It.IsAny<string>(),
                     It.IsAny<IEnumerable<string>>(),
                     It.IsAny<IDictionary<string, string>>(),
-                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<IEnumerable<(string Id, string Src)>>(),
                     It.IsAny<bool>(),
                     It.IsAny<bool>()));
 
@@ -2204,7 +2204,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         It.IsAny<string>(),
                         new string[] { expectedTag },
                         It.IsAny<IDictionary<string, string>>(),
-                        It.IsAny<IEnumerable<string>>(),
+                        It.IsAny<IEnumerable<(string Id, string Src)>>(),
                         It.IsAny<bool>(),
                         It.IsAny<bool>()),
                     Times.Once);
@@ -2450,7 +2450,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         It.IsAny<string>(),
                         new string[] { expectedTag },
                         It.IsAny<IDictionary<string, string>>(),
-                        It.IsAny<IEnumerable<string>>(),
+                        It.IsAny<IEnumerable<(string Id, string Src)>>(),
                         It.IsAny<bool>(),
                         It.IsAny<bool>()),
                     Times.Once);
@@ -2664,7 +2664,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             dockerServiceMock.Verify(o =>
                 o.BuildImage(
                     PathHelper.NormalizePath(Path.Combine(tempFolderContext.Path, runtimeDepsLinuxDockerfileRelativePath)),
-                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<IEnumerable<(string Id, string Src)>>(),
                     It.IsAny<bool>(), It.IsAny<bool>()),
                 Times.Never);
 
@@ -2927,7 +2927,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             dockerServiceMock.Verify(o =>
                 o.BuildImage(
                     It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>(),
-                    It.IsAny<IDictionary<string, string>>(), It.IsAny<IEnumerable<string>>(), It.IsAny<bool>(), It.IsAny<bool>()),
+                    It.IsAny<IDictionary<string, string>>(), It.IsAny<IEnumerable<(string Id, string Src)>>(), It.IsAny<bool>(), It.IsAny<bool>()),
                 Times.Never);
             dockerServiceMock.Verify(o => o.GetCreatedDate(It.IsAny<string>(), false));
 
@@ -3289,7 +3289,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     It.IsAny<string>(),
                     It.IsAny<IEnumerable<string>>(),
                     It.IsAny<IDictionary<string, string>>(),
-                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<IEnumerable<(string Id, string Src)>>(),
                     It.IsAny<bool>(),
                     It.IsAny<bool>()));
 
@@ -3435,7 +3435,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     It.IsAny<string>(),
                     It.IsAny<IEnumerable<string>>(),
                     It.IsAny<IDictionary<string, string>>(),
-                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<IEnumerable<(string Id, string Src)>>(),
                     It.IsAny<bool>(),
                     It.IsAny<bool>()));
 
@@ -3579,7 +3579,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     It.IsAny<string>(),
                     It.IsAny<IEnumerable<string>>(),
                     It.IsAny<IDictionary<string, string>>(),
-                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<IEnumerable<(string Id, string Src)>>(),
                     It.IsAny<bool>(),
                     It.IsAny<bool>()));
 
@@ -3612,7 +3612,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         It.IsAny<string>(),
                         It.IsAny<IEnumerable<string>>(),
                         It.IsAny<IDictionary<string, string>>(),
-                        It.IsAny<IEnumerable<string>>(),
+                        It.IsAny<IEnumerable<(string Id, string Src)>>(),
                         It.IsAny<bool>(),
                         It.IsAny<bool>()))
                 .Returns(buildOutput ?? string.Empty);


### PR DESCRIPTION
I tried to make the new CliHelper Option and the build command arguments more general. I'm working on the tests now.