### PR TITLE
Fix build matrix graph generation to include grandparents in calculation

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/GraphExtensions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/GraphExtensions.cs
@@ -31,26 +31,30 @@ namespace Microsoft.DotNet.ImageBuilder
 
             foreach (T item in source)
             {
-                if (!nodes.TryGetValue(item, out Node<T> itemNode))
-                {
-                    itemNode = new Node<T>() { Item = item };
-                    nodes.Add(item, itemNode);
-                }
-
-                foreach (T parent in getParents(item))
-                {
-                    if (!nodes.TryGetValue(parent, out Node<T> parentNode))
-                    {
-                        parentNode = new Node<T>() { Item = parent };
-                        nodes.Add(parent, parentNode);
-                    }
-
-                    parentNode.Children.Add(itemNode);
-                    itemNode.Parents.Add(parentNode);
-                }
+                CreateNode(item, nodes, getParents);
             }
 
             return nodes.Values.ToList();
+        }
+
+        private static Node<T> CreateNode<T>(T item, Dictionary<T, Node<T>> nodes, Func<T, IEnumerable<T>> getParents)
+        {
+            if (nodes.TryGetValue(item, out Node<T> itemNode))
+            {
+                return itemNode;
+            }
+
+            itemNode = new Node<T>() { Item = item };
+            nodes.Add(item, itemNode);
+
+            foreach (T parent in getParents(item))
+            {
+                Node<T> parentNode = CreateNode(parent, nodes, getParents);
+                parentNode.Children.Add(itemNode);
+                itemNode.Parents.Add(parentNode);
+            }
+
+            return itemNode;
         }
 
         private static void AddSubgraphNode<T>(HashSet<Node<T>> subgraph, Node<T> node, List<Node<T>> unvisitedNodes)

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
@@ -697,9 +697,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// https://github.com/dotnet/docker-tools/issues/1141
         /// </remarks>
         [Theory]
-        [InlineData(false, false, "--path 1.0/runtime/os/Dockerfile --path 1.0/aspnet/os-composite/Dockerfile --path 1.0/aspnet/os/Dockerfile")]
-        [InlineData(true, false, "--path 1.0/aspnet/os/Dockerfile --path 1.0/aspnet/os-composite/Dockerfile")]
-        [InlineData(true, true, "--path 1.0/aspnet/os-composite/Dockerfile")]
+        [InlineData(false, false, "--path 1.0/runtime/os/Dockerfile --path 1.0/aspnet/os-composite/Dockerfile --path 1.0/aspnet/os/Dockerfile --path 1.0/sdk/os/Dockerfile")]
+        [InlineData(true, false, "--path 1.0/aspnet/os/Dockerfile --path 1.0/aspnet/os-composite/Dockerfile --path 1.0/sdk/os/Dockerfile")]
+        [InlineData(true, true, "--path 1.0/aspnet/os-composite/Dockerfile --path 1.0/sdk/os/Dockerfile")]
         public void PlatformVersionedOs_CachedParent(bool isRuntimeCached, bool isAspnetCached, string expectedPaths)
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -758,7 +758,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         new Platform[]
                         {
                             CreatePlatform(
-                                sdkDockerfilePath = DockerfileHelper.CreateDockerfile("1.0/sdk/os", tempFolderContext, "sdk:tag"),
+                                sdkDockerfilePath = DockerfileHelper.CreateDockerfile("1.0/sdk/os", tempFolderContext, "aspnet:tag"),
                                 new string[] { "tag" })
                         },
                         productVersion: "1.0"))

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
@@ -697,10 +697,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// https://github.com/dotnet/docker-tools/issues/1141
         /// </remarks>
         [Theory]
-        [InlineData(false, false, false, "--path 1.0/runtime/os/Dockerfile --path 1.0/aspnet/os-composite/Dockerfile --path 1.0/aspnet/os/Dockerfile")]
-        [InlineData(true, false, false, "--path 1.0/aspnet/os/Dockerfile --path 1.0/aspnet/os-composite/Dockerfile")]
-        [InlineData(false, false, true, "--path 1.0/runtime/os/Dockerfile --path 1.0/aspnet/os-composite/Dockerfile")]
-        public void PlatformVersionedOs_CachedParent(bool isRuntimeCached, bool isAspnetCompositeCached, bool isAspnetCached, string expectedPaths)
+        [InlineData(false, false, "--path 1.0/runtime/os/Dockerfile --path 1.0/aspnet/os-composite/Dockerfile --path 1.0/aspnet/os/Dockerfile")]
+        [InlineData(true, false, "--path 1.0/aspnet/os/Dockerfile --path 1.0/aspnet/os-composite/Dockerfile")]
+        [InlineData(true, true, "--path 1.0/aspnet/os-composite/Dockerfile")]
+        public void PlatformVersionedOs_CachedParent(bool isRuntimeCached, bool isAspnetCached, string expectedPaths)
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
             GenerateBuildMatrixCommand command = new();
@@ -825,7 +825,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                 ProductVersion = "1.0",
                                 Platforms =
                                 {
-                                    CreateSimplePlatformData(aspnetCompositeDockerfilePath, isCached: isAspnetCompositeCached)
+                                    CreateSimplePlatformData(aspnetCompositeDockerfilePath, isCached: false)
                                 }
                             }
                         }
@@ -840,7 +840,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                 ProductVersion = "1.0",
                                 Platforms =
                                 {
-                                    CreateSimplePlatformData(sdkDockerfilePath, isCached: true)
+                                    CreateSimplePlatformData(sdkDockerfilePath, isCached: false)
                                 }
                             }
                         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/docker-tools/issues/1141

I did not test https://github.com/dotnet/docker-tools/pull/1142 enough and it turns out it was still an issue in some cases. In this case, the PlatformVersionedOS matrix graph generation would create multiple legs for the same OS when we needed to build images with a shared cached parent that were not direct siblings. For example, generating a matrix when we have built both `aspnet` and `aspnet-composite` would end up creating two separate test graphs - one with `[runtime-deps, aspnet-composite]` and the other with `[runtime, aspnet, sdk]` (that's before we filter the images down in a later step).

```mermaid
flowchart TD
    A[runtime-deps] --> B
    A --> E[aspnet-composite]
    B[runtime] --> C
    C[aspnet] --> D[sdk]
```

The issue is that the `CreateNodeList` method didn't include parents-of-parents in its calculation. I changed it to be recursive. We don't need to dig deeper into children because ~~our Dockerfiles don't branch beneath runtime-deps, no children have multiple descendants. However I could be convinced to add walking the children graph to `CreateNodeList`.~~ because parent images that aren't cached imply all their children will also be not cached.

I also added some extra testing to cover this case. I added SDK to the test graph to make it more representative of the actual build but I don't think it makes a difference.