### PR TITLE
Remove Fedora from base image override

### DIFF
--- a/eng/pipelines/check-base-image-updates.yml
+++ b/eng/pipelines/check-base-image-updates.yml
@@ -21,4 +21,4 @@ jobs:
   parameters:
     jobName: CheckBaseImages_BuildTools
     subscriptionsPath: eng/check-base-image-subscriptions-buildtools.json
-    customGetStaleImagesArgs: --base-override-regex '^((centos|debian|fedora|ubuntu):.+)' --base-override-sub '$(overrideRegistry)/$1'
+    customGetStaleImagesArgs: --base-override-regex '^((centos|debian|ubuntu):.+)' --base-override-sub '$(overrideRegistry)/$1'


### PR DESCRIPTION
Accounts for the change that was made in https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/887. Without this change, the builds to check for base images updates is blocked.