### PR TITLE
Allow passing custom linuxAmd64Pool as object and not just string

### DIFF
--- a/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
@@ -14,7 +14,7 @@ parameters:
   windowsAmdBuildJobTimeout: 60
   windowsAmdTestJobTimeout: 60
   linuxAmdBuildJobTimeout: 60
-  linuxAmd64Pool: ""
+  linuxAmd64Pool: null
   buildMatrixType: platformDependencyGraph
   testMatrixType: platformVersionedOs
 
@@ -62,7 +62,7 @@ stages:
       - group: DotNet-AllOrgs-Darc-Pats
 
     linuxAmd64Pool:
-      ${{ if ne(parameters.linuxAmd64Pool, '') }}:
+      ${{ if parameters.linuxAmd64Pool }}:
         ${{ parameters.linuxAmd64Pool }}
       ${{ elseif eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
         vmImage: $(defaultLinuxAmd64PoolImage)


### PR DESCRIPTION
This lets you specify the pool as
```
pool:
  name: foo
  demands: bar
```
instead of just 
```
pool: foobar
```
Which is needed to facilitate passing a custom 1es hosted pool in the buildtools prereqs repo for this PR. https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/901