### PR TITLE
Revert "Allow passing custom linuxAmd64Pool as object and not just string (#1155)"

### DIFF
--- a/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
@@ -14,7 +14,7 @@ parameters:
   windowsAmdBuildJobTimeout: 60
   windowsAmdTestJobTimeout: 60
   linuxAmdBuildJobTimeout: 60
-  linuxAmd64Pool: null
+  linuxAmd64Pool: ""
   buildMatrixType: platformDependencyGraph
   testMatrixType: platformVersionedOs
 
@@ -62,7 +62,7 @@ stages:
       - group: DotNet-AllOrgs-Darc-Pats
 
     linuxAmd64Pool:
-      ${{ if parameters.linuxAmd64Pool }}:
+      ${{ if ne(parameters.linuxAmd64Pool, '') }}:
         ${{ parameters.linuxAmd64Pool }}
       ${{ elseif eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
         vmImage: $(defaultLinuxAmd64PoolImage)


### PR DESCRIPTION

This reverts commit eca722a715f22bde9e3925e2f8ce83390ceba2a0.

It was actually not necessary as can be seen in [this public pipeline run](https://dev.azure.com/dnceng-public/public/_build/results?buildId=332276&view=logs&j=9aada89a-2e24-5acb-2807-6900158b9cce) which successfully gets the correct 1ES hosted pool, even when overriding the `linuxAmd64Pool` default string (`""`).