### PR TITLE
Switch Windows Server 2022 CI legs to 1ES hosted pools

### DIFF
--- a/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
@@ -81,13 +81,7 @@ stages:
       ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
         name: Docker-Linux-Arm-Internal
     windows2016Pool: Docker-2016-${{ variables['System.TeamProject'] }}
-    windows1809Pool:
-      ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
-        name: NetCore-Public
-        demands: ImageOverride -equals 1es-windows-2019-open
-      ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
-        name: NetCore1ESPool-Svc-Internal
-        demands: ImageOverride -equals 1es-windows-2019
+    windows1809Pool: Docker-1809-${{ variables['System.TeamProject'] }}
     windows2022Pool:
       ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
         name: NetCore-Public

--- a/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
@@ -81,5 +81,17 @@ stages:
       ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
         name: Docker-Linux-Arm-Internal
     windows2016Pool: Docker-2016-${{ variables['System.TeamProject'] }}
-    windows1809Pool: Docker-1809-${{ variables['System.TeamProject'] }}
-    windows2022Pool: Docker-2022-${{ variables['System.TeamProject'] }}
+    windows1809Pool:
+      ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
+        name: NetCore-Public
+        demands: ImageOverride -equals 1es-windows-2019-open
+      ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+        name: NetCore1ESPool-Svc-Internal
+        demands: ImageOverride -equals 1es-windows-2019
+    windows2022Pool:
+      ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
+        name: NetCore-Public
+        demands: ImageOverride -equals 1es-windows-2022-open
+      ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+        name: NetCore1ESPool-Svc-Internal
+        demands: ImageOverride -equals 1es-windows-2022


### PR DESCRIPTION
This mitigates an issue that we're having with our Server 2022 pools at the moment. I ran some internal tests and noticed no issues using the 1ES hosted pools. We can switch back once our custom pools are functional again.