### PR TITLE
Pin Alpine version to 3.17

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/Dockerfile.linux
+++ b/src/Microsoft.DotNet.ImageBuilder/Dockerfile.linux
@@ -24,7 +24,7 @@ RUN dotnet publish ./src/Microsoft.DotNet.ImageBuilder.csproj -c Release -o out 
 
 
 # build runtime image
-FROM mcr.microsoft.com/dotnet/runtime-deps:7.0-alpine$ALPINE_TAG_SUFFIX
+FROM mcr.microsoft.com/dotnet/runtime-deps:7.0-alpine3.17$ALPINE_TAG_SUFFIX
 
 # install tooling
 RUN apk add --no-cache \


### PR DESCRIPTION
ImageBuilder is incompatible with Alpine 3.18 until #1161 is addressed, since Alpine 3.18 contains Docker version 23.x, which sets buildkit/buildx as the default. Also see #1159 