### PR TITLE
Revert "Switch Windows Server 2022 CI legs to 1ES hosted pools (#1163)"

### DIFF
--- a/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
@@ -82,10 +82,4 @@ stages:
         name: Docker-Linux-Arm-Internal
     windows2016Pool: Docker-2016-${{ variables['System.TeamProject'] }}
     windows1809Pool: Docker-1809-${{ variables['System.TeamProject'] }}
-    windows2022Pool:
-      ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
-        name: NetCore-Public
-        demands: ImageOverride -equals 1es-windows-2022-open
-      ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
-        name: NetCore1ESPool-Svc-Internal
-        demands: ImageOverride -equals 1es-windows-2022
+    windows2022Pool: Docker-2022-${{ variables['System.TeamProject'] }}


### PR DESCRIPTION
Docker-2022* pools seem to be in working order now. We can switch back from 1ES hosted pools. Here is an example run that uses agents from the Docker-2022-Internal pool - [pipeline run [internal link]](https://dev.azure.com/dnceng/internal/_build/results?buildId=2230872&view=logs&s=6884a131-87da-5381-61f3-d7acc3b91d76&j=758d7417-7473-52bb-e4e7-358533cf3cc7)

This reverts commit 08cf0d9476e1bcf72ba44f7275090bd59435b7e5.

Fixes #1164 