### PR TITLE
Add workaround for incorrect BuildKit file caching behavior

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerService.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.IO;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
@@ -88,6 +89,13 @@ namespace Microsoft.DotNet.ImageBuilder
             string buildArgsString = string.Join(string.Empty, buildArgList);
 
             string dockerArgs = $"build --platform {platform} {tagArgs} -f {dockerfilePath}{buildArgsString} {buildContextPath}";
+
+            // Workaround for https://github.com/moby/buildkit/issues/1368
+            // BuildKit caches Dockerfiles based on file size and timestamp.
+            // In case we need to build two Dockerfiles that are the same size,
+            // we need to set the timestamp manually so that we build the
+            // correct Dockerfile.
+            File.SetLastWriteTimeUtc(dockerfilePath, DateTime.UtcNow);
 
             if (isRetryEnabled)
             {


### PR DESCRIPTION
This fixes the issue that we saw for patch Tuesday where the wrong Dockerfile was cached for some 7.0 runtime Dockerfiles.

Please see https://github.com/moby/buildkit/issues/1368

It's fixed in Docker version 23, but the bug is in the agent code and not the client, so we would have to wait until our build agents are updated.