### PR TITLE
Use new CBL Mariner 2.0 based testrunner image

### DIFF
--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -2,5 +2,5 @@ variables:
   imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2265396
   imageNames.imageBuilder: $(imageNames.imageBuilderName)
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
-  imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-bullseye-slim-docker-testrunner
+  imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner2.0-docker-testrunner
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)


### PR DESCRIPTION
Follow up from https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/918