### PR TITLE
Break publish notifications up into comments

### DIFF
--- a/eng/common/Install-DotNetSdk.ps1
+++ b/eng/common/Install-DotNetSdk.ps1
@@ -40,7 +40,7 @@ if (!(Test-Path $DotnetInstallScriptPath)) {
     & "$PSScriptRoot/Invoke-WithRetry.ps1" "Invoke-WebRequest 'https://dot.net/v1/$DotnetInstallScript' -OutFile $DotnetInstallScriptPath"
 }
 
-$DotnetChannel = "7.0"
+$DotnetChannel = "8.0"
 
 $InstallFailed = $false
 if ($IsRunningOnUnix) {

--- a/src/Microsoft.DotNet.ImageBuilder/Dockerfile.linux
+++ b/src/Microsoft.DotNet.ImageBuilder/Dockerfile.linux
@@ -2,29 +2,23 @@
 #     docker build -t image-builder .
 #     docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v <local path to build>:/repo -w /repo image-builder <image-build args>
 
-ARG ALPINE_TAG_SUFFIX=""
-
 # build Microsoft.DotNet.ImageBuilder
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build-env
-
-ARG RID_ARCH=x64
-# The rid must be version-specific to workaround a libgit2sharp issue (see https://github.com/dotnet/dotnet-docker/pull/2111)
-ARG RID=alpine.3.14-${RID_ARCH}
-
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build-env
+ARG TARGETARCH
 WORKDIR /image-builder
 
 # restore packages before copying entire source - provides optimizations when rebuilding
 COPY NuGet.config ./
 COPY src/Microsoft.DotNet.ImageBuilder.csproj ./src/
-RUN dotnet restore -r $RID ./src/Microsoft.DotNet.ImageBuilder.csproj
+RUN dotnet restore -a $TARGETARCH ./src/Microsoft.DotNet.ImageBuilder.csproj
 
 # copy everything else and publish
 COPY . ./
-RUN dotnet publish ./src/Microsoft.DotNet.ImageBuilder.csproj -c Release -o out -r $RID --no-restore --self-contained
+RUN dotnet publish -a $TARGETARCH ./src/Microsoft.DotNet.ImageBuilder.csproj -o out --no-restore
 
 
 # build runtime image
-FROM mcr.microsoft.com/dotnet/runtime-deps:7.0-alpine$ALPINE_TAG_SUFFIX
+FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-alpine
 
 # install tooling
 RUN apk add --no-cache \

--- a/src/Microsoft.DotNet.ImageBuilder/Dockerfile.windows
+++ b/src/Microsoft.DotNet.ImageBuilder/Dockerfile.windows
@@ -1,9 +1,10 @@
 # escape=`
 
 ARG WINDOWS_BASE
+ARG WINDOWS_SDK
 
 # build Microsoft.DotNet.ImageBuilder
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:8.0-$WINDOWS_SDK AS build-env
 WORKDIR /image-builder
 
 # restore packages before copying entire source - provides optimizations when rebuilding

--- a/src/Microsoft.DotNet.ImageBuilder/manifest.json
+++ b/src/Microsoft.DotNet.ImageBuilder/manifest.json
@@ -33,19 +33,21 @@
             },
             {
               "buildArgs": {
-                "WINDOWS_BASE": "servercore:ltsc2016-amd64"
+                "WINDOWS_BASE": "servercore:ltsc2019-amd64",
+                "WINDOWS_SDK": "windowsservercore-ltsc2019"
               },
               "dockerfile": "Dockerfile.windows",
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2019",
               "tags": {
-                "windowsservercore-ltsc2016-amd64": {},
-                "windowsservercore-ltsc2016-amd64-$(UniqueId)": {}
+                "windowsservercore-ltsc2019-amd64": {},
+                "windowsservercore-ltsc2019-amd64-$(UniqueId)": {}
               }
             },
             {
               "buildArgs": {
-                "WINDOWS_BASE": "nanoserver:1809-amd64"
+                "WINDOWS_BASE": "nanoserver:1809-amd64",
+                "WINDOWS_SDK": "nanoserver-1809"
               },
               "dockerfile": "Dockerfile.windows",
               "os": "windows",
@@ -57,7 +59,8 @@
             },
             {
               "buildArgs": {
-                "WINDOWS_BASE": "nanoserver:ltsc2022-amd64"
+                "WINDOWS_BASE": "nanoserver:ltsc2022-amd64",
+                "WINDOWS_SDK": "nanoserver-ltsc2022"
               },
               "dockerfile": "Dockerfile.windows",
               "os": "windows",

--- a/src/Microsoft.DotNet.ImageBuilder/manifest.json
+++ b/src/Microsoft.DotNet.ImageBuilder/manifest.json
@@ -33,15 +33,15 @@
             },
             {
               "buildArgs": {
-                "WINDOWS_BASE": "servercore:ltsc2019-amd64",
+                "WINDOWS_BASE": "servercore:ltsc2016-amd64",
                 "WINDOWS_SDK": "windowsservercore-ltsc2019"
               },
               "dockerfile": "Dockerfile.windows",
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2019",
               "tags": {
-                "windowsservercore-ltsc2019-amd64": {},
-                "windowsservercore-ltsc2019-amd64-$(UniqueId)": {}
+                "windowsservercore-ltsc2016-amd64": {},
+                "windowsservercore-ltsc2016-amd64-$(UniqueId)": {}
               }
             },
             {

--- a/src/Microsoft.DotNet.ImageBuilder/manifest.json
+++ b/src/Microsoft.DotNet.ImageBuilder/manifest.json
@@ -34,7 +34,7 @@
             {
               "buildArgs": {
                 "WINDOWS_BASE": "servercore:ltsc2016-amd64",
-                "WINDOWS_SDK": "windowsservercore-ltsc2019"
+                "WINDOWS_SDK": "nanoserver-1809"
               },
               "dockerfile": "Dockerfile.windows",
               "os": "windows",

--- a/src/Microsoft.DotNet.ImageBuilder/manifest.json
+++ b/src/Microsoft.DotNet.ImageBuilder/manifest.json
@@ -12,10 +12,6 @@
           },
           "platforms": [
             {
-              "buildArgs": {
-                "RID_ARCH": "x64",
-                "ALPINE_TAG_SUFFIX": ""
-              },
               "dockerfile": "Dockerfile.linux",
               "os": "linux",
               "osVersion": "alpine",
@@ -25,10 +21,6 @@
               }
             },
             {
-              "buildArgs": {
-                "RID_ARCH": "arm64",
-                "ALPINE_TAG_SUFFIX": "-arm64v8"
-              },
               "architecture": "arm64",
               "dockerfile": "Dockerfile.linux",
               "os": "linux",

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PostPublishNotificationCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PostPublishNotificationCommand.cs
@@ -235,7 +235,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             {
                 return Enumerable.Empty<string>();
             }
-            
+
             ImageArtifactDetails imageArtifactDetails = ImageInfoHelper.LoadFromFile(Options.ImageInfoPath, Manifest);
 
             List<(string digestSha, string repo, IEnumerable<string> tags)> imageInfos = new();
@@ -268,20 +268,20 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             IEnumerable<string> imagesMarkdown = new List<string>();
             foreach (IGrouping<string, (string digestSha, string repo, IEnumerable<string> tags)> imageInfoRepoGroup in imageInfosByRepo)
             {
-                StringBuilder stringBuilder = new StringBuilder();
+                StringBuilder imageRepoMarkdown = new();
                 string repo = imageInfoRepoGroup.Key;
                 string fullyQualifiedRepo = $"{Manifest.Registry}/{Options.RepoPrefix}{repo}";
-                stringBuilder.AppendLine($"### {fullyQualifiedRepo}");
-                stringBuilder.AppendLine();
+                imageRepoMarkdown.AppendLine($"### {fullyQualifiedRepo}");
+                imageRepoMarkdown.AppendLine();
                 foreach ((string digestSha, string _, IEnumerable<string> tags) in imageInfoRepoGroup.OrderBy(group => group.digestSha))
                 {
-                    stringBuilder.AppendLine($"* {digestSha}");
+                    imageRepoMarkdown.AppendLine($"* {digestSha}");
                     foreach (string tag in tags.OrderBy(tag => tag))
                     {
-                        stringBuilder.AppendLine($"  * {tag}");
+                        imageRepoMarkdown.AppendLine($"  * {tag}");
                     }
                 }
-                imagesMarkdown = imagesMarkdown.Append(stringBuilder.ToString());
+                imagesMarkdown = imagesMarkdown.Append(imageRepoMarkdown.ToString());
             }
 
             return imagesMarkdown;

--- a/src/Microsoft.DotNet.ImageBuilder/src/INotificationService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/INotificationService.cs
@@ -5,11 +5,19 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
+#nullable enable
 namespace Microsoft.DotNet.ImageBuilder
 {
     public interface INotificationService
     {
         Task<Uri> PostAsync(
-            string title, string description, IEnumerable<string> labels, string repoUrl, string gitHubAccessToken, bool isDryRun);
+            string title,
+            string description,
+            IEnumerable<string> labels,
+            string repoUrl,
+            string gitHubAccessToken,
+            bool isDryRun,
+            IEnumerable<string>? comments = null);
     }
 }
+#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <PublishTrimmed>False</PublishTrimmed>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Microsoft.DotNet.ImageBuilder</RootNamespace>
   </PropertyGroup>
 
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Azure.Kusto.Ingest" Version="11.3.1" />
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.38.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.1" />
-    <PackageReference Include="Microsoft.DotNet.Git.IssueManager" Version="6.0.0-beta.22351.1" />
+    <PackageReference Include="Microsoft.DotNet.Git.IssueManager" Version="9.0.0-beta.23513.3" />
     <PackageReference Include="Microsoft.DotNet.VersionTools" Version="6.0.0-beta.22351.1" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.3.0" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.205.1" />

--- a/src/Microsoft.DotNet.ImageBuilder/src/NotificationService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/NotificationService.cs
@@ -4,9 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Git.IssueManager;
 
+#nullable enable
 namespace Microsoft.DotNet.ImageBuilder
 {
     [Export(typeof(INotificationService))]
@@ -21,7 +23,13 @@ namespace Microsoft.DotNet.ImageBuilder
         }
 
         public async Task<Uri> PostAsync(
-            string title, string description, IEnumerable<string> labels, string repoUrl, string gitHubAccessToken, bool isDryRun)
+            string title,
+            string description,
+            IEnumerable<string> labels,
+            string repoUrl,
+            string gitHubAccessToken,
+            bool isDryRun,
+            IEnumerable<string>? comments = null)
         {
             IssueManager issueManager = new(gitHubAccessToken);
 
@@ -32,6 +40,14 @@ namespace Microsoft.DotNet.ImageBuilder
             }
 
             Uri issueUrl = new($"{repoUrl}/issues/{issueId}");
+
+            if (comments != null)
+            {
+                foreach (string comment in comments)
+                {
+                    string _ = await issueManager.CreateNewIssueCommentAsync(repoUrl, issueId, comment);
+                }
+            }
 
             _loggerService.WriteSubheading("POSTED NOTIFICATION:");
             _loggerService.WriteMessage($"Issue URL: {issueUrl}");

--- a/src/Microsoft.DotNet.ImageBuilder/src/NotificationService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/NotificationService.cs
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.ImageBuilder
         {
             IssueManager issueManager = new(gitHubAccessToken);
 
-            Uri issueUrl = new("https://github.com/404");
+            Uri? issueUrl = null;
             if (!isDryRun)
             {
                 int issueId = await issueManager.CreateNewIssueAsync(repoUrl, title, description, labels: labels);
@@ -50,7 +50,7 @@ namespace Microsoft.DotNet.ImageBuilder
             }
 
             _loggerService.WriteSubheading("POSTED NOTIFICATION:");
-            _loggerService.WriteMessage($"Issue URL: {issueUrl}");
+            _loggerService.WriteMessage($"Issue URL: {issueUrl?.ToString() ?? "N/A"}");
             _loggerService.WriteMessage($"Title: {title}");
             _loggerService.WriteMessage($"Labels: {string.Join(", ", labels)}");
             _loggerService.WriteMessage($"Description:");

--- a/src/Microsoft.DotNet.ImageBuilder/src/NotificationService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/NotificationService.cs
@@ -56,17 +56,18 @@ namespace Microsoft.DotNet.ImageBuilder
             _loggerService.WriteMessage($"Description:");
             _loggerService.WriteMessage($"====BEGIN DESCRIPTION MARKDOWN===");
             _loggerService.WriteMessage(description);
+            _loggerService.WriteMessage($"====END DESCRIPTION MARKDOWN===");
 
             if (comments != null)
             {
+                _loggerService.WriteMessage($"====BEGIN COMMENTS MARKDOWN===");
                 for (int i = 0; i < comments.Count(); i++)
                 {
                     _loggerService.WriteMessage($"====COMMENT {i + 1} MARKDOWN===");
                     _loggerService.WriteMessage(comments.ElementAt(i));
                 }
+                _loggerService.WriteMessage($"====END COMMENTS MARKDOWN===");
             }
-
-            _loggerService.WriteMessage($"====END DESCRIPTION MARKDOWN===");
 
             return issueUrl;
         }

--- a/src/Microsoft.DotNet.ImageBuilder/src/NotificationService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/NotificationService.cs
@@ -33,20 +33,20 @@ namespace Microsoft.DotNet.ImageBuilder
         {
             IssueManager issueManager = new(gitHubAccessToken);
 
-            int issueId = 0;
+            Uri issueUrl = new("https://github.com/404");
             if (!isDryRun)
             {
-                issueId = await issueManager.CreateNewIssueAsync(repoUrl, title, description, labels: labels);
-            }
+                int issueId = await issueManager.CreateNewIssueAsync(repoUrl, title, description, labels: labels);
+                issueUrl = new($"{repoUrl}/issues/{issueId}");
 
-            Uri issueUrl = new($"{repoUrl}/issues/{issueId}");
-
-            if (comments != null)
-            {
-                foreach (string comment in comments)
+                if (comments != null)
                 {
-                    string _ = await issueManager.CreateNewIssueCommentAsync(repoUrl, issueId, comment);
+                    foreach (string comment in comments)
+                    {
+                        string _ = await issueManager.CreateNewIssueCommentAsync(repoUrl, issueId, comment);
+                    }
                 }
+
             }
 
             _loggerService.WriteSubheading("POSTED NOTIFICATION:");
@@ -56,6 +56,16 @@ namespace Microsoft.DotNet.ImageBuilder
             _loggerService.WriteMessage($"Description:");
             _loggerService.WriteMessage($"====BEGIN DESCRIPTION MARKDOWN===");
             _loggerService.WriteMessage(description);
+
+            if (comments != null)
+            {
+                for (int i = 0; i < comments.Count(); i++)
+                {
+                    _loggerService.WriteMessage($"====COMMENT {i + 1} MARKDOWN===");
+                    _loggerService.WriteMessage(comments.ElementAt(i));
+                }
+            }
+
             _loggerService.WriteMessage($"====END DESCRIPTION MARKDOWN===");
 
             return issueUrl;

--- a/src/Microsoft.DotNet.ImageBuilder/tests/Microsoft.DotNet.ImageBuilder.Tests.csproj
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/Microsoft.DotNet.ImageBuilder.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.ImageBuilder/tests/QueueBuildCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/QueueBuildCommandTests.cs
@@ -502,10 +502,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             /// <param name="inProgressBuilds">The set of in-progress builds that should be configured.</param>
             /// <param name="allBuilds">The set of failed builds that should be configured.</param>
             public TestContext(
-            Subscription[] subscriptions,
-            IEnumerable<IEnumerable<SubscriptionImagePaths>> allSubscriptionImagePaths,
-            PagedList<WebApi.Build> inProgressBuilds,
-            PagedList<WebApi.Build> allBuilds)
+                Subscription[] subscriptions,
+                IEnumerable<IEnumerable<SubscriptionImagePaths>> allSubscriptionImagePaths,
+                PagedList<WebApi.Build> inProgressBuilds,
+                PagedList<WebApi.Build> allBuilds)
             {
                 this.allSubscriptionImagePaths = allSubscriptionImagePaths;
                 this.inProgressBuilds = inProgressBuilds;
@@ -549,7 +549,13 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             {
                 _notificationServiceMock
                     .Verify(o => o.PostAsync(
-                        It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), $"https://github.com/{GitOwner}/{GitRepo}", GitAccessToken, It.IsAny<bool>()),
+                            It.IsAny<string>(),
+                            It.IsAny<string>(),
+                            It.IsAny<IEnumerable<string>>(),
+                            $"https://github.com/{GitOwner}/{GitRepo}",
+                            GitAccessToken,
+                            It.IsAny<bool>(),
+                            It.IsAny<IEnumerable<string>>()),
                         Times.Exactly(notificationPostCallCount));
 
                 if (!isQueuedBuildExpected)


### PR DESCRIPTION
Fixes https://github.com/dotnet/docker-tools/issues/1162

New Arcade packages target .NET 8.0, so I needed to upgrade ImageBuilder to .NET 8 as well. Took the opportunity to make the Dockerfile multi-platform as well (I have been using this modified Dockerfile for some time to test ImageBuilder in arm64 CI anyways). And as far as I could tell, the LibGit2Sharp issues are all closed so I removed the RID weirdness.

I tested this manually by pointing at a private repo of mine.