### PR TITLE
Manually enable BuildKit in TestRunner container

### DIFF
--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -33,7 +33,8 @@ steps:
     docker run -t -d
     -v /var/run/docker.sock:/var/run/docker.sock
     -v $(Build.ArtifactStagingDirectory):$(artifactsPath)
-    -e RUNNING_TESTS_IN_CONTAINER=true 
+    -e DOCKER_BUILDKIT=1
+    -e RUNNING_TESTS_IN_CONTAINER=true
     --name $(testRunner.container)
     $(imageNames.testRunner.withrepo)
   displayName: Start Test Runner Container


### PR DESCRIPTION
This change was made some time ago in the dotnet-docker main repo but never backported to eng/common, so it got overwritten and caused more problems. Original change: https://github.com/dotnet/dotnet-docker/commit/f2cad09f84ea4f2035c15d57fcd4272ce5fdf174

The [new Mariner testrunner container](https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/918) has an older version of Docker that doesn't have BuildKit enabled by default. This should make it use BuildKit by default.