### PR TITLE
Update file-pusher and yaml-updater dockerfiles to 8.0

### DIFF
--- a/eng/src/file-pusher/Dockerfile
+++ b/eng/src/file-pusher/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile is intended to be built at the root of the repo.
 
 # build image
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build-env
 
 WORKDIR /file-pusher
 
@@ -16,7 +16,7 @@ RUN dotnet publish -c Release -o out --no-restore
 
 
 # runtime image
-FROM mcr.microsoft.com/dotnet/runtime:7.0-alpine
+FROM mcr.microsoft.com/dotnet/runtime:8.0-alpine
 
 # copy file-pusher
 WORKDIR /file-pusher

--- a/eng/src/file-pusher/file-pusher.csproj
+++ b/eng/src/file-pusher/file-pusher.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.VersionTools" Version="6.0.0-beta.22351.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
     <PackageReference Include="System.Diagnostics.TextWriterTraceListener" Version="4.3.0" />
   </ItemGroup>
 

--- a/eng/src/yaml-updater/Dockerfile
+++ b/eng/src/yaml-updater/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile is intended to be built at the root of the repo.
 
 # build image
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build-env
 
 WORKDIR /src
 
@@ -19,7 +19,7 @@ RUN dotnet publish ./yaml-updater/*.csproj -c Release -o out --no-restore
 
 
 # runtime image
-FROM mcr.microsoft.com/dotnet/runtime:7.0-alpine
+FROM mcr.microsoft.com/dotnet/runtime:8.0-alpine
 
 # copy yaml-updater
 WORKDIR /yaml-updater

--- a/eng/src/yaml-updater/yaml-updater.csproj
+++ b/eng/src/yaml-updater/yaml-updater.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
     <PackageReference Include="System.Diagnostics.TextWriterTraceListener" Version="4.3.0" />
     <PackageReference Include="YamlDotNet" Version="13.7.1" />
   </ItemGroup>


### PR DESCRIPTION
This was left out of https://github.com/dotnet/docker-tools/pull/1188 because I searched for `net7.0` and not `7.0` by itself. I will include these files in the checklist I am writing for this procedure. Also downgraded the System.Commandline version to match ImageBuilder after it was updated in error with #1188.

Part of https://github.com/dotnet/docker-tools/issues/1181