### PR TITLE
Fix CG build by installing newer .NET version

### DIFF
--- a/eng/common/templates/jobs/cg-detection.yml
+++ b/eng/common/templates/jobs/cg-detection.yml
@@ -3,10 +3,13 @@ jobs:
   pool:
     vmImage: $(defaultLinuxAmd64PoolImage)
   steps:
+  - powershell: >
+      ./eng/common/Install-DotNetSdk.ps1 $(dotnetInstallDir)
+    displayName: Run Dotnet Install Script
   - task: CodeQL3000Init@0
     displayName: CodeQL Initialize
   - script: >
-      find . -name '*.csproj' | grep $(cgBuildGrepArgs) | xargs -n 1 dotnet build
+      find . -name '*.csproj' | grep $(cgBuildGrepArgs) | xargs -n 1 $(dotnetInstallDir)/dotnet build
     displayName: Build Projects
   - task: CodeQL3000Finalize@0
     displayName: CodeQL Finalize

--- a/eng/pipelines/cg-detection.yml
+++ b/eng/pipelines/cg-detection.yml
@@ -15,6 +15,8 @@ variables:
   parameters:
     TSAEnabled: ${{ parameters.TSAEnabled }}
 - template: templates/variables/common.yml
+- name: dotnetInstallDir
+  value: /usr/share/.dotnet
 
 jobs:
 - template: ../common/templates/jobs/cg-detection.yml


### PR DESCRIPTION
The `ubuntu-latest` Azure DevOps Pools [don't have .NET 8 yet](https://github.com/actions/runner-images/blob/1687f31a3b1ce5f61a7e1e9a4ca23d22ba6e2f7c/images/linux/Ubuntu2204-Readme.md) so they can't build our .NET 8 projects. This fixes the CG pipeline by installing the .NET version we use to build. 