### PR TITLE
Fix CG Build in dependent repos by removing variable in CG pipeline template

### DIFF
--- a/eng/common/templates/jobs/cg-detection.yml
+++ b/eng/common/templates/jobs/cg-detection.yml
@@ -4,12 +4,12 @@ jobs:
     vmImage: $(defaultLinuxAmd64PoolImage)
   steps:
   - powershell: >
-      ./eng/common/Install-DotNetSdk.ps1 $(dotnetInstallDir)
+      ./eng/common/Install-DotNetSdk.ps1 /usr/share/.dotnet
     displayName: Run Dotnet Install Script
   - task: CodeQL3000Init@0
     displayName: CodeQL Initialize
   - script: >
-      find . -name '*.csproj' | grep $(cgBuildGrepArgs) | xargs -n 1 $(dotnetInstallDir)/dotnet build
+      find . -name '*.csproj' | grep $(cgBuildGrepArgs) | xargs -n 1 /usr/share/.dotnet/dotnet build
     displayName: Build Projects
   - task: CodeQL3000Finalize@0
     displayName: CodeQL Finalize


### PR DESCRIPTION
The solution in https://github.com/dotnet/docker-tools/pull/1194 worked, however when that flowed to other repos they didn't have a definition for the $(dotnetInstallDir) variable. Since it's only used in this file for this purpose, I just inlined it.