### PR TITLE
Update libgit2sharp and remove dependency on libssl 1.1 compat libraries

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/Dockerfile.linux
+++ b/src/Microsoft.DotNet.ImageBuilder/Dockerfile.linux
@@ -23,8 +23,7 @@ FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-alpine
 # install tooling
 RUN apk add --no-cache \
         docker \
-        git \
-        openssl1.1-compat
+        git
 
 # install image-builder
 WORKDIR /image-builder

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
@@ -43,18 +43,18 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             try
             {
                 _loggerService.WriteSubheading("Cloning GitHub repo");
+
+                CloneOptions cloneOptions = new() { BranchName = Options.GitOptions.Branch };
+                cloneOptions.FetchOptions.CredentialsProvider = (url, user, cred) => new UsernamePasswordCredentials
+                {
+                    Username = Options.GitOptions.AuthToken,
+                    Password = string.Empty
+                };
+
                 using IRepository repo =_gitService.CloneRepository(
                     $"https://github.com/{Options.GitOptions.Owner}/{Options.GitOptions.Repo}",
                     repoPath,
-                    new CloneOptions
-                    {
-                        BranchName = Options.GitOptions.Branch,
-                        CredentialsProvider = (url, user, cred) => new UsernamePasswordCredentials
-                        {
-                            Username = Options.GitOptions.AuthToken,
-                            Password = string.Empty
-                        }
-                    });
+                    cloneOptions);
 
                 Uri imageInfoPathIdentifier = GitHelper.GetBlobUrl(Options.GitOptions);
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Azure.Storage.Queues" Version="12.16.0" />
     <PackageReference Include="Cottle" Version="2.0.10" />
     <PackageReference Include="GiGraph.Dot" Version="2.0.1" />
-    <PackageReference Include="LibGit2Sharp" Version="0.27.2" />
+    <PackageReference Include="LibGit2Sharp" Version="0.29.0" />
     <PackageReference Include="Microsoft.Azure.Kusto.Ingest" Version="11.3.4" />
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.38.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.3" />


### PR DESCRIPTION
Fixes build error due to upgrade to Alpine 3.19.

Related: https://github.com/dotnet/dotnet-docker/pull/5202