### PR TITLE
Refactor skipComponentGovernanceDetection variable handling

### DIFF
--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -1,8 +1,3 @@
-parameters:
-  # CG is disabled by default because projects are built within Dockerfiles and CG step do not scan artifacts
-  # that are built within Dockerfiles. A separate CG pipeline exists for this reason.
-  skipComponentGovernanceDetectionValue: true
-
 variables:
 - template: /eng/common/templates/variables/docker-images.yml@self
 - template: /eng/common/templates/variables/common-paths.yml@self
@@ -14,8 +9,10 @@ variables:
   value: true
 - name: ingestKustoImageInfo
   value: true
+  # CG is disabled by default because projects are built within Dockerfiles and CG step do not scan artifacts
+  # that are built within Dockerfiles. A separate CG pipeline exists for this reason.
 - name: skipComponentGovernanceDetection
-  value: $(skipComponentGovernanceDetectionValue)
+  value: false
 - name: build.imageBuilderDockerRunExtraOptions
   value: ""
 - name: imageBuilderDockerRunExtraOptions

--- a/eng/pipelines/cg-detection.yml
+++ b/eng/pipelines/cg-detection.yml
@@ -8,8 +8,8 @@ pr: none
 
 variables:
 - template: /eng/pipelines/templates/variables/common.yml@self
-  parameters:
-    skipComponentGovernanceDetectionValue: false
+- name: skipComponentGovernanceDetection
+  value: false
 resources:
   repositories:
   - repository: 1ESPipelineTemplates


### PR DESCRIPTION
Refactoring how the skipComponentGovernanceDetection variable is overridden.  The pattern I added in  https://github.com/dotnet/docker-tools/pull/1218 was silly.  This new pattern is the existing pattern used for other common variables.

Test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2405705&view=results (Microsoft internal link)