### PR TITLE
Migrate eng-validation pipeline to 1ES unofficial template

### DIFF
--- a/eng/pipelines/dotnet-docker-tools-eng-validation.yml
+++ b/eng/pipelines/dotnet-docker-tools-eng-validation.yml
@@ -10,11 +10,27 @@ trigger:
     - test/*
 
 variables:
-- template: templates/variables/eng-validation.yml
+- template: /eng/pipelines/templates/variables/eng-validation.yml@self
 
-stages:
-- template: ../common/templates/stages/dotnet/build-test-publish-repo.yml
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
-    noCache: true
-    internalProjectName: ${{ variables.internalProjectName }}
-    publicProjectName: ${{ variables.publicProjectName }}
+    pool:
+      name: NetCore1ESPool-Internal
+      image: 1es-windows-2022
+      os: windows
+    customBuildTags:
+    - ES365AIMigrationTooling
+    stages:
+    - template: /eng/common/templates/stages/dotnet/build-test-publish-repo.yml@self
+      parameters:
+        noCache: true
+        internalProjectName: ${{ variables.internalProjectName }}
+        publicProjectName: ${{ variables.publicProjectName }}


### PR DESCRIPTION
Fixes https://github.com/dotnet/docker-tools/issues/1220

[Test run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2405709&view=results) (internal link)