### PR TITLE
Move 1ES PT image definition inside internal project conditional

### DIFF
--- a/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
@@ -56,7 +56,7 @@ stages:
 
     internalVersionsRepoRef: InternalVersionsRepo
     publicVersionsRepoRef: PublicVersionsRepo
-    
+
     ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
       customPublishVariables:
       - group: DotNet-AllOrgs-Darc-Pats
@@ -71,25 +71,25 @@ stages:
         name: NetCore1ESPool-Internal
         image: 1es-ubuntu-2204
         os: linux
-    
+
     # Linux Arm64
     linuxArm64Pool:
-      image: Mariner-2-Docker-ARM64
       os: linux
       hostArchitecture: Arm64
       ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
         name: Docker-Linux-Arm-Public
       ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+        image: Mariner-2-Docker-ARM64
         name: Docker-Linux-Arm-Internal
 
     # Linux Arm32
     linuxArm32Pool:
-      image: Mariner-2-Docker-ARM64
       os: linux
       hostArchitecture: Arm64
       ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
         name: Docker-Linux-Arm-Public
       ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+        image: Mariner-2-Docker-ARM64
         name: Docker-Linux-Arm-Internal
 
     # Windows Server 2016


### PR DESCRIPTION
From the expanded yaml I downloaded from our PR validation pipeline, this code used to expand to: 
```
    pool:
      image: Mariner-2-Docker-ARM64
      os: linux
      hostArchitecture: Arm64
      name: Docker-Linux-Arm-Public
```
This is invalid since the only image in that pool is `Ubuntu-20.04-Docker-ARM64`. Azure DevOps silently ignores incorrect image name requests, making this YAML misleading.

Related: https://github.com/dotnet/docker-tools/pull/1215#discussion_r1529470841

Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2408331&view=results