### PR TITLE
Remove certain instances of Docker image cleanup

### DIFF
--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -181,7 +181,7 @@ jobs:
             -PackageVersion '$(Build.BuildNumber)' `
             -ManifestDirPath $sbomChildDir `
             -DockerImagesToScan $_ `
-            -Verbosity Information 
+            -Verbosity Information
         }
       displayName: Generate SBOMs
       condition: and(succeeded(), ne(variables['BuildImages.builtImages'], ''))
@@ -189,7 +189,6 @@ jobs:
     - template: /eng/common/templates/jobs/${{ format('../steps/test-images-{0}-client.yml', parameters.dockerClientOS) }}@self
       parameters:
         condition: ne(variables.testScriptPath, '')
-  - template: /eng/common/templates/jobs/${{ format('../steps/cleanup-docker-{0}.yml', parameters.dockerClientOS) }}@self
   - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
     - template: /eng/common/templates/steps/publish-artifact.yml@self
       parameters:

--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -76,6 +76,8 @@ jobs:
       echo "##vso[task.setvariable variable=baseContainerRepoPath]$baseContainerRepoPath"
     displayName: Set Base Container Repo Path
   - template: /eng/common/templates/jobs/${{ format('../steps/init-docker-{0}.yml', parameters.dockerClientOS) }}@self
+    parameters:
+      cleanupDocker: true
   - ${{ parameters.customInitSteps }}
   - template: /eng/common/templates/steps/set-image-info-path-var.yml@self
     parameters:

--- a/eng/common/templates/jobs/copy-base-images.yml
+++ b/eng/common/templates/jobs/copy-base-images.yml
@@ -16,4 +16,3 @@ jobs:
       additionalOptions: ${{ parameters.additionalOptions }}
       publicProjectName: ${{ parameters.publicProjectName }}
       continueOnError: true
-  - template: /eng/common/templates/steps/cleanup-docker-linux.yml@self

--- a/eng/common/templates/jobs/copy-base-images.yml
+++ b/eng/common/templates/jobs/copy-base-images.yml
@@ -10,8 +10,6 @@ jobs:
   pool: ${{ parameters.pool }}
   steps:
   - template: /eng/common/templates/steps/init-docker-linux.yml@self
-    parameters:
-      cleanupDocker: false
   - ${{ parameters.customInitSteps }}
   - template: /eng/common/templates/steps/copy-base-images.yml@self
     parameters:

--- a/eng/common/templates/jobs/copy-base-images.yml
+++ b/eng/common/templates/jobs/copy-base-images.yml
@@ -10,6 +10,8 @@ jobs:
   pool: ${{ parameters.pool }}
   steps:
   - template: /eng/common/templates/steps/init-docker-linux.yml@self
+    parameters:
+      cleanupDocker: false
   - ${{ parameters.customInitSteps }}
   - template: /eng/common/templates/steps/copy-base-images.yml@self
     parameters:

--- a/eng/common/templates/jobs/generate-matrix.yml
+++ b/eng/common/templates/jobs/generate-matrix.yml
@@ -12,8 +12,6 @@ jobs:
   steps:
   - template: /eng/common/templates/steps/retain-build.yml@self
   - template: /eng/common/templates/steps/init-docker-linux.yml@self
-    parameters:
-      cleanupDocker: false
   - template: /eng/common/templates/steps/validate-branch.yml@self
     parameters:
       internalProjectName: ${{ parameters.internalProjectName }}

--- a/eng/common/templates/jobs/generate-matrix.yml
+++ b/eng/common/templates/jobs/generate-matrix.yml
@@ -12,6 +12,8 @@ jobs:
   steps:
   - template: /eng/common/templates/steps/retain-build.yml@self
   - template: /eng/common/templates/steps/init-docker-linux.yml@self
+    parameters:
+      cleanupDocker: false
   - template: /eng/common/templates/steps/validate-branch.yml@self
     parameters:
       internalProjectName: ${{ parameters.internalProjectName }}
@@ -38,4 +40,3 @@ jobs:
       $(additionalGenerateBuildMatrixOptions)
     displayName: Generate ${{ parameters.matrixType }} Matrix
     name: matrix
-  - template: /eng/common/templates/steps/cleanup-docker-linux.yml@self

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -25,6 +25,8 @@ jobs:
   steps:
   - template: /eng/common/templates/steps/retain-build.yml@self
   - template: /eng/common/templates/steps/init-docker-linux.yml@self
+    parameters:
+      cleanupDocker: false
   - pwsh: |
       $azdoOrgName = Split-Path -Leaf $Env:SYSTEM_COLLECTIONURI
       echo "##vso[task.setvariable variable=azdoOrgName]$azdoOrgName"

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -25,8 +25,6 @@ jobs:
   steps:
   - template: /eng/common/templates/steps/retain-build.yml@self
   - template: /eng/common/templates/steps/init-docker-linux.yml@self
-    parameters:
-      cleanupDocker: false
   - pwsh: |
       $azdoOrgName = Split-Path -Leaf $Env:SYSTEM_COLLECTIONURI
       echo "##vso[task.setvariable variable=azdoOrgName]$azdoOrgName"

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -154,4 +154,3 @@ jobs:
       $(imageBuilder.commonCmdArgs)
     displayName: Post Publish Notification
     condition: and(always(), eq(variables['publishNotificationsEnabled'], 'true'))
-  - template: /eng/common/templates/steps/cleanup-docker-linux.yml@self

--- a/eng/common/templates/jobs/wait-for-ingestion.yml
+++ b/eng/common/templates/jobs/wait-for-ingestion.yml
@@ -24,4 +24,3 @@ jobs:
     parameters:
       commitDigest: $(readmeCommitDigest)
       condition: and(succeeded(), ne(variables['readmeCommitDigest'], ''))
-  - template: ../steps/cleanup-docker-linux.yml

--- a/eng/common/templates/jobs/wait-for-ingestion.yml
+++ b/eng/common/templates/jobs/wait-for-ingestion.yml
@@ -4,6 +4,8 @@ jobs:
     vmImage: $(defaultLinuxAmd64PoolImage)
   steps:
   - template: ../steps/init-docker-linux.yml
+    parameters:
+      cleanupDocker: false
   - template: ../steps/download-build-artifact.yml
     parameters:
       targetPath: $(Build.ArtifactStagingDirectory)

--- a/eng/common/templates/jobs/wait-for-ingestion.yml
+++ b/eng/common/templates/jobs/wait-for-ingestion.yml
@@ -4,8 +4,6 @@ jobs:
     vmImage: $(defaultLinuxAmd64PoolImage)
   steps:
   - template: ../steps/init-docker-linux.yml
-    parameters:
-      cleanupDocker: false
   - template: ../steps/download-build-artifact.yml
     parameters:
       targetPath: $(Build.ArtifactStagingDirectory)

--- a/eng/common/templates/steps/init-docker-linux.yml
+++ b/eng/common/templates/steps/init-docker-linux.yml
@@ -1,7 +1,7 @@
 parameters:
   setupImageBuilder: true
   setupTestRunner: false
-  cleanupDocker: true
+  cleanupDocker: false
   condition: true
 
 steps:

--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -9,7 +9,7 @@ steps:
   parameters:
     setupImageBuilder: false
     setupTestRunner: true
-    cleanupDocker: ${{ and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}
+    cleanupDocker: ${{ and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest'), eq(parameters.preBuildValidation, 'false')) }}
     condition: ${{ parameters.condition }}
 - ${{ parameters.customInitSteps }}
 - script: |
@@ -96,7 +96,3 @@ steps:
   displayName: Cleanup TestRunner Container
   condition: and(always(), ${{ parameters.condition }})
   continueOnError: true
-- ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: /eng/common/templates/steps/cleanup-docker-linux.yml@self
-    parameters:
-      condition: ${{ parameters.condition }}

--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -9,6 +9,8 @@ steps:
   parameters:
     setupImageBuilder: false
     setupTestRunner: true
+    # Clean only up when we're running an internal build, not a PR, and not doing pre-build validation.
+    # i.e. when we're building something important.
     cleanupDocker: ${{ and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest'), eq(parameters.preBuildValidation, 'false')) }}
     condition: ${{ parameters.condition }}
 - ${{ parameters.customInitSteps }}

--- a/eng/common/templates/steps/test-images-windows-client.yml
+++ b/eng/common/templates/steps/test-images-windows-client.yml
@@ -18,7 +18,7 @@ steps:
 - powershell: |
     if ("${{ variables['System.TeamProject'] }}" -eq "${{ parameters.internalProjectName }}" -and "${{ variables['Build.Reason'] }}" -ne "PullRequest") {
       $optionalTestArgs="$optionalTestArgs -PullImages -Registry $env:ACR_SERVER -RepoPrefix $env:STAGINGREPOPREFIX -ImageInfoPath $(artifactsPath)/image-info.json"
-    } 
+    }
     if ($env:REPOTESTARGS) {
       $optionalTestArgs += " $env:REPOTESTARGS"
     }
@@ -58,7 +58,3 @@ steps:
     mergeTestResults: true
     publishRunAttachments: true
     testRunTitle: $(productVersion) $(osVersionsDisplayName) amd64
-- ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: /eng/common/templates/steps/cleanup-docker-windows.yml@self
-    parameters:
-      condition: ${{ parameters.condition }}

--- a/eng/common/templates/steps/test-images-windows-client.yml
+++ b/eng/common/templates/steps/test-images-windows-client.yml
@@ -7,6 +7,7 @@ steps:
 - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
   - template: /eng/common/templates/steps/init-docker-windows.yml@self
     parameters:
+      cleanupDocker: true
       setupImageBuilder: false
       condition: ${{ parameters.condition }}
   - powershell: >

--- a/eng/common/templates/steps/validate-image-sizes.yml
+++ b/eng/common/templates/steps/validate-image-sizes.yml
@@ -2,7 +2,7 @@ parameters:
   dockerClientOS: null
   architecture: "*"
   validationMode: "all"
-  
+
 steps:
   - template: ${{ format('../steps/init-docker-{0}.yml', parameters.dockerClientOS) }}
   - powershell: >
@@ -11,4 +11,3 @@ steps:
       -ValidationMode:${{ parameters.validationMode }}
       -PullImages
     displayName: Run Image Size Tests
-  - template: ${{ format('../steps/cleanup-docker-{0}.yml', parameters.dockerClientOS) }}

--- a/eng/common/templates/steps/validate-image-sizes.yml
+++ b/eng/common/templates/steps/validate-image-sizes.yml
@@ -5,6 +5,9 @@ parameters:
 
 steps:
   - template: ${{ format('../steps/init-docker-{0}.yml', parameters.dockerClientOS) }}
+    parameters:
+      # Get some disk space back, pipeline run time is not a concern here
+      cleanupDocker: true
   - powershell: >
       ./tests/performance/Validate-ImageSize.ps1
       -ImageBuilderCustomArgs "--architecture '${{ parameters.architecture }}'"

--- a/eng/pipelines/cleanup-acr-images-custom.yml
+++ b/eng/pipelines/cleanup-acr-images-custom.yml
@@ -16,4 +16,3 @@ jobs:
       action: $(action)
       age: $(age)
       customArgs: $(customArgs)
-  - template: ../common/templates/steps/cleanup-docker-linux.yml

--- a/eng/pipelines/cleanup-acr-images-custom.yml
+++ b/eng/pipelines/cleanup-acr-images-custom.yml
@@ -10,6 +10,8 @@ jobs:
     vmImage: $(defaultLinuxAmd64PoolImage)
   steps:
   - template: ../common/templates/steps/init-docker-linux.yml
+    parameters:
+      cleanupDocker: false
   - template: ../common/templates/steps/clean-acr-images.yml
     parameters:
       repo: $(repo)

--- a/eng/pipelines/cleanup-acr-images-custom.yml
+++ b/eng/pipelines/cleanup-acr-images-custom.yml
@@ -10,8 +10,6 @@ jobs:
     vmImage: $(defaultLinuxAmd64PoolImage)
   steps:
   - template: ../common/templates/steps/init-docker-linux.yml
-    parameters:
-      cleanupDocker: false
   - template: ../common/templates/steps/clean-acr-images.yml
     parameters:
       repo: $(repo)

--- a/eng/pipelines/cleanup-acr-images.yml
+++ b/eng/pipelines/cleanup-acr-images.yml
@@ -18,8 +18,6 @@ jobs:
     vmImage: $(defaultLinuxAmd64PoolImage)
   steps:
   - template: ../common/templates/steps/init-docker-linux.yml
-    parameters:
-      cleanupDocker: false
   - template: ../common/templates/steps/clean-acr-images.yml
     parameters:
       repo: "build-staging/*"

--- a/eng/pipelines/cleanup-acr-images.yml
+++ b/eng/pipelines/cleanup-acr-images.yml
@@ -44,4 +44,3 @@ jobs:
   #     repo: "mirror/*"
   #     action: pruneDangling
   #     age: 0
-  - template: ../common/templates/steps/cleanup-docker-linux.yml

--- a/eng/pipelines/cleanup-acr-images.yml
+++ b/eng/pipelines/cleanup-acr-images.yml
@@ -18,6 +18,8 @@ jobs:
     vmImage: $(defaultLinuxAmd64PoolImage)
   steps:
   - template: ../common/templates/steps/init-docker-linux.yml
+    parameters:
+      cleanupDocker: false
   - template: ../common/templates/steps/clean-acr-images.yml
     parameters:
       repo: "build-staging/*"

--- a/eng/pipelines/templates/jobs/check-base-image-updates.yml
+++ b/eng/pipelines/templates/jobs/check-base-image-updates.yml
@@ -42,4 +42,3 @@ jobs:
       --subscriptions-path ${{ parameters.subscriptionsPath }}
       --image-paths "$(GetStaleImages.staleImagePaths)"
     displayName: Queue Build for Stale Images
-  - template: /eng/common/templates/steps/cleanup-docker-linux.yml@self

--- a/eng/pipelines/templates/jobs/check-base-image-updates.yml
+++ b/eng/pipelines/templates/jobs/check-base-image-updates.yml
@@ -11,6 +11,8 @@ jobs:
     os: linux
   steps:
   - template: /eng/common/templates/steps/init-docker-linux.yml@self
+    parameters:
+      cleanupDocker: false
   - template: /eng/common/templates/steps/copy-base-images.yml@self
     parameters:
       additionalOptions: "--subscriptions-path '${{ parameters.subscriptionsPath }}'"

--- a/eng/pipelines/templates/jobs/check-base-image-updates.yml
+++ b/eng/pipelines/templates/jobs/check-base-image-updates.yml
@@ -11,8 +11,6 @@ jobs:
     os: linux
   steps:
   - template: /eng/common/templates/steps/init-docker-linux.yml@self
-    parameters:
-      cleanupDocker: false
   - template: /eng/common/templates/steps/copy-base-images.yml@self
     parameters:
       additionalOptions: "--subscriptions-path '${{ parameters.subscriptionsPath }}'"


### PR DESCRIPTION
Part of #1213 

These changes are intended to...

Remove the Docker cleanup step:
- From the end of pipeline runs
- Before pre-build validation and matrix generation

Leave the cleanup step:
- Before building any images
- Before mirroring/pulling any base images 

Test run (still running at time of submission, but it's been through a few iterations): https://dev.azure.com/dnceng/internal/_build/results?buildId=2412187&view=results