### PR TITLE
Use custom templates for 1ES Pipeline Templates

### DIFF
--- a/eng/common/templates/1es-official.yml
+++ b/eng/common/templates/1es-official.yml
@@ -1,0 +1,48 @@
+# When extending this template, pipelines using a repository resource containing versions files for image caching must
+# do the following:
+#
+# - Do not rely on any source code from the versions repo so as to not circumvent SDL and CG guidelines
+# - The versions repo resource must be named `InternalVersionsRepo` or `PublicVersionsRepo` to avoid SDL scans
+# - The versions repo must be checked out to `$(Build.SourcesDirectory)/versions` to avoid CG scans
+#
+# If the pipeline is not using a separate repository resource, ensure that there is no source code checked out in
+# `$(Build.SourcesDirectory)/versions`, as it will not be scanned.
+#
+# The `cgDryRun` parameter will run CG but not submit the results, for testing purposes.
+
+parameters:
+- name: cgDryRun
+  type: boolean
+  default: false
+- name: stages
+  type: stageList
+  default: []
+  # 1ES Pipeline Template parameters
+- name: pool
+  type: object
+  default:
+    name: NetCore1ESPool-Internal
+    image: 1es-windows-2022
+    os: windows
+
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool: ${{ parameters.pool }}
+    sdl:
+      componentgovernance:
+        ignoreDirectories: $(Build.SourcesDirectory)/versions
+        whatIf: ${{ parameters.cgDryRun }}
+        showAlertLink: true
+      sourceRepositoriesToScan:
+        exclude:
+        - repository: InternalVersionsRepo
+        - repository: PublicVersionsRepo
+    stages: ${{ parameters.stages }}

--- a/eng/common/templates/1es-unofficial.yml
+++ b/eng/common/templates/1es-unofficial.yml
@@ -1,0 +1,51 @@
+# This unofficial template will always run CG in "what if" mode, which will not submit results to the CG. SDL tools may
+# also be disabled for testing purposes.
+#
+# When extending this template, pipelines using a repository resource containing versions files for image caching must
+# do the following:
+#
+# - Do not rely on any source code from the versions repo so as to not circumvent SDL and CG guidelines
+# - The versions repo resource must be named `InternalVersionsRepo` or `PublicVersionsRepo` to avoid SDL scans
+# - The versions repo must be checked out to `$(Build.SourcesDirectory)/versions` to avoid CG scans
+#
+# If the pipeline is not using a separate repository resource, ensure that there is no source code checked out in
+# `$(Build.SourcesDirectory)/versions`, as it will not be scanned.
+
+parameters:
+- name: disableSDL
+  type: boolean
+  default: false
+  displayName: Disable SDL
+- name: stages
+  type: stageList
+  default: []
+  # 1ES Pipeline Template parameters
+- name: pool
+  type: object
+  default:
+    name: NetCore1ESPool-Internal
+    image: 1es-windows-2022
+    os: windows
+
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool: ${{ parameters.pool }}
+    sdl:
+      enableAllTools: ${{ not(parameters.disableSDL) }}
+      componentgovernance:
+        ignoreDirectories: $(Build.SourcesDirectory)/versions
+        whatIf: true
+        showAlertLink: true
+      sourceRepositoriesToScan:
+        exclude:
+        - repository: InternalVersionsRepo
+        - repository: PublicVersionsRepo
+    stages: ${{ parameters.stages }}

--- a/eng/pipelines/cg-detection.yml
+++ b/eng/pipelines/cg-detection.yml
@@ -6,25 +6,23 @@ trigger:
     - main
 pr: none
 
+parameters:
+# Setting cgDryRun will run CG but not submit the results
+- name: cgDryRun
+  type: boolean
+  default: false
+  displayName: CG Dry Run
+
 variables:
 - template: /eng/pipelines/templates/variables/common.yml@self
+# Skip CG detection (for debugging project builds, etc.)
 - name: skipComponentGovernanceDetection
   value: false
-resources:
-  repositories:
-  - repository: 1ESPipelineTemplates
-    type: git
-    name: 1ESPipelineTemplates/1ESPipelineTemplates
-    ref: refs/tags/release
+
 extends:
-  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  template: /eng/common/templates/1es-official.yml@self
   parameters:
-    pool:
-      name: NetCore1ESPool-Internal
-      image: 1es-windows-2022
-      os: windows
-    customBuildTags:
-    - ES365AIMigrationTooling
+    cgDryRun: ${{ parameters.cgDryRun }}
     stages:
     - stage: CgDetection
       displayName: CG Detection

--- a/eng/pipelines/check-base-image-updates.yml
+++ b/eng/pipelines/check-base-image-updates.yml
@@ -11,21 +11,10 @@ schedules:
 
 variables:
 - template: /eng/pipelines/templates/variables/common.yml@self
-resources:
-  repositories:
-  - repository: 1ESPipelineTemplates
-    type: git
-    name: 1ESPipelineTemplates/1ESPipelineTemplates
-    ref: refs/tags/release
+
 extends:
-  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  template: /eng/common/templates/1es-official.yml@self
   parameters:
-    pool:
-      name: NetCore1ESPool-Internal
-      image: 1es-windows-2022
-      os: windows
-    customBuildTags:
-    - ES365AIMigrationTooling
     stages:
     - stage: CheckBaseImages
       displayName: Check Base Images

--- a/eng/pipelines/dotnet-buildtools-image-builder-official.yml
+++ b/eng/pipelines/dotnet-buildtools-image-builder-official.yml
@@ -6,27 +6,14 @@ trigger:
   paths:
     include:
     - src/*
-
 pr: none
 
 variables:
 - template: /eng/pipelines/templates/variables/image-builder.yml@self
 
-resources:
-  repositories:
-  - repository: 1ESPipelineTemplates
-    type: git
-    name: 1ESPipelineTemplates/1ESPipelineTemplates
-    ref: refs/tags/release
 extends:
-  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  template: /eng/common/templates/1es-official.yml@self
   parameters:
-    pool:
-      name: NetCore1ESPool-Internal
-      image: 1es-windows-2022
-      os: windows
-    customBuildTags:
-    - ES365AIMigrationTooling
     stages:
     - template: /eng/common/templates/stages/dotnet/build-test-publish-repo.yml@self
       parameters:

--- a/eng/pipelines/dotnet-docker-tools-eng-validation.yml
+++ b/eng/pipelines/dotnet-docker-tools-eng-validation.yml
@@ -12,22 +12,9 @@ trigger:
 variables:
 - template: /eng/pipelines/templates/variables/eng-validation.yml@self
 
-resources:
-  repositories:
-  - repository: 1ESPipelineTemplates
-    type: git
-    name: 1ESPipelineTemplates/1ESPipelineTemplates
-    ref: refs/tags/release
-
 extends:
-  template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
+  template: /eng/common/templates/1es-unofficial.yml@self
   parameters:
-    pool:
-      name: NetCore1ESPool-Internal
-      image: 1es-windows-2022
-      os: windows
-    customBuildTags:
-    - ES365AIMigrationTooling
     stages:
     - template: /eng/common/templates/stages/dotnet/build-test-publish-repo.yml@self
       parameters:

--- a/eng/pipelines/upload-file.yml
+++ b/eng/pipelines/upload-file.yml
@@ -14,21 +14,10 @@ parameters:
 
 variables:
 - template: /eng/pipelines/templates/variables/common.yml@self
-resources:
-  repositories:
-  - repository: 1ESPipelineTemplates
-    type: git
-    name: 1ESPipelineTemplates/1ESPipelineTemplates
-    ref: refs/tags/release
+
 extends:
-  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  template: /eng/common/templates/1es-official.yml@self
   parameters:
-    pool:
-      name: NetCore1ESPool-Internal
-      image: 1es-windows-2022
-      os: windows
-    customBuildTags:
-    - ES365AIMigrationTooling
     stages:
     - stage: UploadFile
       displayName: Upload File


### PR DESCRIPTION
This PR:
- Should fix https://github.com/dotnet/dotnet-docker/issues/5332
  - It's hard to validate that it actually fixes this. However I've got a totally green build from dotnet-docker-nightly-playground [here](https://dev.azure.com/dnceng/internal/_build/results?buildId=2427926&view=results) [internal link]. I think it is ignoring the /versions directory correctly.
- Reduces lots of duplication
- Centralizes the location where we define which pool we use for SDL stages
  - We could probably do better with the definition. I put it in a parameter, since parameters let you hold arbitrary yaml objects. However we could just inline the whole thing and put all the values in variables.