### PR TITLE
Update GetOSDisplayName to exclude -distroless

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
@@ -294,15 +294,21 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             }
         }
 
-        private static (string Name, string Version) GetOsVersionInfo(string osVersion)
+        private static (string Name, string Version) GetOsVersionInfo(string os)
         {
-            int versionIndex = osVersion.IndexOfAny(new char[] { '1', '2', '3', '4', '5', '6', '7', '8', '9', '0' });
-            if (versionIndex != -1)
-            {
-                return (osVersion.Substring(0, versionIndex), osVersion.Substring(versionIndex));
-            }
+            // Regex matches an os name ending in a non-numeric or decimal character and up to
+            // a 3 part version number. Any additional characters are dropped (e.g. -distroless).
+            Regex versionRegex = new Regex(@"(?<name>.+[^0-9\.])(?<version>\d+(\.\d*){0,2})");
+            Match match = versionRegex.Match(os);
 
-            return (osVersion, string.Empty);
+            if (match.Success)
+            {
+                return (match.Groups["name"].Value, match.Groups["version"].Value);
+            }
+            else
+            {
+                return (os, string.Empty);
+            }
         }
 
 

--- a/src/Microsoft.DotNet.ImageBuilder/tests/PlatformInfoTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/PlatformInfoTests.cs
@@ -23,9 +23,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         [InlineData("bionic", "Ubuntu 18.04")]
         [InlineData("disco", "Ubuntu 19.04")]
         [InlineData("focal", "Ubuntu 20.04")]
+        [InlineData("jammy", "Ubuntu 22.04")]
+        [InlineData("jammy-chiseled", "Ubuntu 22.04")]
         [InlineData("alpine3.12", "Alpine 3.12")]
         [InlineData("centos8", "Centos 8")]
         [InlineData("fedora32", "Fedora 32")]
+        [InlineData("cbl-mariner2.0", "CBL-Mariner 2.0")]
+        [InlineData("azurelinux3.0", "Azure Linux 3.0")]
+        [InlineData("azurelinux3.0-distroless", "Azure Linux 3.0")]
         public void GetOSDisplayName_Linux(string osVersion, string expectedDisplayName)
         {
             ValidateGetOSDisplayName(OS.Linux, osVersion, expectedDisplayName);


### PR DESCRIPTION
Fixes #1248 

In addition to the tests added here, I did regenerated the readmes in the dotnet-docker nightly branch and manually verified the changes.