### PR TITLE
Define default values for common variables

### DIFF
--- a/eng/common/templates/jobs/generate-matrix.yml
+++ b/eng/common/templates/jobs/generate-matrix.yml
@@ -10,6 +10,7 @@ jobs:
 - job: ${{ parameters.name }}
   pool: ${{ parameters.pool }}
   steps:
+  - script: echo $(acr.servicePrincipalTenant)
   - template: /eng/common/templates/steps/retain-build.yml@self
   - template: /eng/common/templates/steps/init-docker-linux.yml@self
   - template: /eng/common/templates/steps/validate-branch.yml@self

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -55,3 +55,11 @@ variables:
   value: windows-2019
 - name: defaultWindows2022PoolImage
   value: windows-2022
+
+# Define these as placeholder values to allow string validation to succeed since we don't have the
+# variable group with the actual values in public builds. For internal builds, the variable group
+# will cause these values to be overridden with the real values.
+- name: acr.servicePrincipalTenant
+  value: 00000000-0000-0000-0000-000000000000
+- name: acr.subscription
+  value: 00000000-0000-0000-0000-000000000000

--- a/eng/pipelines/dotnet-docker-tools-eng-validation-pr.yml
+++ b/eng/pipelines/dotnet-docker-tools-eng-validation-pr.yml
@@ -11,12 +11,6 @@ trigger: none
 
 variables:
 - template: templates/variables/eng-validation.yml
-# Define these as placeholder values to allow string validation to succeed since we don't have the
-# variable group with the actual values in public builds.
-- name: acr.servicePrincipalTenant
-  value: 00000000-0000-0000-0000-000000000000
-- name: acr.subscription
-  value: 00000000-0000-0000-0000-000000000000
 
 stages:
 - template: ../common/templates/stages/dotnet/build-test-publish-repo.yml


### PR DESCRIPTION
The changes that were applied in https://github.com/dotnet/docker-tools/pull/1251/commits/6c89f3faa08770f2b757d7e70818bee0c474b724 to fix https://github.com/dotnet/docker-tools/issues/1254 aren't sufficient. Public builds for other pipelines also run into the same issue (https://github.com/dotnet/docker-tools/issues/1256).

I've moved these variables to the common variable template so that all pipelines can make use of these values. They will still be overridden by any variable which consumes the variable group that has these actual values.