### PR TITLE
Use a default Linux pool for non-sdl tasks

### DIFF
--- a/eng/common/templates/1es-official.yml
+++ b/eng/common/templates/1es-official.yml
@@ -17,8 +17,13 @@ parameters:
 - name: stages
   type: stageList
   default: []
-  # 1ES Pipeline Template parameters
 - name: pool
+  type: object
+  default:
+    name: NetCore1ESPool-Internal
+    image: 1es-ubuntu-2204
+    os: linux
+- name: sourceAnalysisPool
   type: object
   default:
     name: NetCore1ESPool-Internal
@@ -45,4 +50,5 @@ extends:
         exclude:
         - repository: InternalVersionsRepo
         - repository: PublicVersionsRepo
+      sourceAnalysisPool: ${{ parameters.sourceAnalysisPool }}
     stages: ${{ parameters.stages }}


### PR DESCRIPTION
Fixes https://github.com/dotnet/dotnet-docker/issues/5399

This is a point-in-time fix, which is why I hard-coded the default pool. All of the hard-coded pool and images names should be re-evaluated as part of https://github.com/dotnet/docker-tools/issues/1227
