### PR TITLE
Remove dependency on Azure Fluent package

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/BasicAuthenticationCredentials.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/BasicAuthenticationCredentials.cs
@@ -4,9 +4,5 @@
 namespace Microsoft.DotNet.ImageBuilder;
 
 #nullable enable
-public class BasicAuthenticationCredentials(string userName, string password)
-{
-    public string UserName { get; } = userName;
-    public string Password { get; } = password;
-}
+public record struct BasicAuthenticationCredentials(string UserName, string Password);
 #nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/BasicAuthenticationCredentials.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/BasicAuthenticationCredentials.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.ImageBuilder;
+
+#nullable enable
+public class BasicAuthenticationCredentials(string userName, string password)
+{
+    public string UserName { get; } = userName;
+    public string Password { get; } = password;
+}
+#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/ManifestService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ManifestService.cs
@@ -5,7 +5,6 @@
 using System.ComponentModel.Composition;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
-using Microsoft.Rest;
 
 #nullable enable
 namespace Microsoft.DotNet.ImageBuilder
@@ -35,11 +34,7 @@ namespace Microsoft.DotNet.ImageBuilder
             // Lookup the credentials, if any, for the registry where the image is located
             if (credsHost.Credentials.TryGetValue(imageName.Registry!, out RegistryCredentials? registryCreds))
             {
-                basicAuthCreds = new BasicAuthenticationCredentials
-                {
-                    UserName = registryCreds.Username,
-                    Password = registryCreds.Password
-                };
+                basicAuthCreds = new BasicAuthenticationCredentials(registryCreds.Username, registryCreds.Password);
             }
 
             // Docker Hub's registry has a separate host name for its API

--- a/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
@@ -17,7 +17,6 @@
     <PackageReference Include="GiGraph.Dot" Version="2.0.1" />
     <PackageReference Include="LibGit2Sharp" Version="0.29.0" />
     <PackageReference Include="Microsoft.Azure.Kusto.Ingest" Version="11.3.4" />
-    <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.38.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.3" />
     <PackageReference Include="Microsoft.DotNet.Git.IssueManager" Version="9.0.0-beta.24123.3" />
     <PackageReference Include="Microsoft.DotNet.VersionTools" Version="9.0.0-beta.24151.5" />

--- a/src/Microsoft.DotNet.ImageBuilder/src/RegistryHttpClient.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/RegistryHttpClient.cs
@@ -6,12 +6,10 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Security.Authentication;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Rest;
-using Microsoft.Rest.Azure.Authentication;
-using Microsoft.Rest.Serialization;
 using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.ImageBuilder;
@@ -98,11 +96,14 @@ public class RegistryHttpClient : HttpClient
 
             try
             {
-                return SafeJsonConvert.DeserializeObject<OAuthToken>(tokenContent);
+                return JsonConvert.DeserializeObject<OAuthToken>(tokenContent) ??
+                    throw new JsonSerializationException(
+                        $"Unable to deserialize the response.{Environment.NewLine}{Environment.NewLine}Content:{Environment.NewLine}{tokenContent}"); ;
             }
             catch (JsonException e)
             {
-                throw new SerializationException("Unable to deserialize the response.", tokenContent, e);
+                throw new JsonSerializationException(
+                    $"Unable to deserialize the response.{Environment.NewLine}{Environment.NewLine}Content:{Environment.NewLine}{tokenContent}", e);
             }
         }
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/RegistryServiceClient.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/RegistryServiceClient.cs
@@ -2,13 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Text;
 using System.Text.Json.Nodes;
-using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Rest;
 using Microsoft.VisualStudio.Services.Common;
 
 namespace Microsoft.DotNet.ImageBuilder;
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.ImageBuilder;
 /// <summary>
 /// Client used for querying the REST API of container registries.
 /// </summary>
-internal class RegistryServiceClient : ServiceClient<RegistryServiceClient>
+internal class RegistryServiceClient
 {
     private const string DockerContentDigestHeader = "Docker-Content-Digest";
 
@@ -25,23 +25,23 @@ internal class RegistryServiceClient : ServiceClient<RegistryServiceClient>
     private const string DockerManifestList = "application/vnd.docker.distribution.manifest.list.v2+json";
     private const string OciManifestSchema1 = "application/vnd.oci.image.manifest.v1+json";
     private const string OciManifestList1 = "application/vnd.oci.image.index.v1+json";
-    private static readonly string[] s_manifestMediaTypes = new[]
-    {
+    private static readonly string[] s_manifestMediaTypes =
+    [
         DockerManifestSchema2,
         DockerManifestList,
         OciManifestSchema1,
         OciManifestList1
-    };
+    ];
 
     private readonly BasicAuthenticationCredentials? _credentials;
+    private readonly RegistryHttpClient _httpClient;
 
     public Uri BaseUri { get; }
 
     public RegistryServiceClient(string registry, RegistryHttpClient httpClient, BasicAuthenticationCredentials? credentials)
-        : base(httpClient, disposeHttpClient: false)
     {
         BaseUri = new Uri($"https://{registry}");
-        credentials?.InitializeServiceClient(this);
+        _httpClient = httpClient;
         _credentials = credentials;
     }
 
@@ -69,33 +69,21 @@ internal class RegistryServiceClient : ServiceClient<RegistryServiceClient>
     {
         if (_credentials != null)
         {
-            // This allows the credentials instance to update the request's Authorization header
-            await _credentials.ProcessHttpRequestAsync(request, CancellationToken.None);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Basic",
+                Convert.ToBase64String(Encoding.UTF8.GetBytes(string.Format(
+                    CultureInfo.InvariantCulture,
+                    "{0}:{1}",
+                    _credentials.UserName,
+                    _credentials.Password).ToCharArray())));
         }
 
-        HttpResponseMessage response = await HttpClient.SendAsync(request);
+        HttpResponseMessage response = await _httpClient.SendAsync(request);
         if (!response.IsSuccessStatusCode)
         {
-            if (response.Content is null)
-            {
-                throw new InvalidOperationException($"Response content is null.");
-            }
-
-            string? requestContent = null;
-            if (request.Content is not null)
-            {
-                requestContent = await request.Content.ReadAsStringAsync();
-            }
-
             string errorContent = await response.Content.ReadAsStringAsync();
 
-            throw new HttpOperationException(
-                $"Response status code does not indicate success: {response.StatusCode}. Reason: '{response.ReasonPhrase}'. Error content:{Environment.NewLine}{errorContent}")
-            {
-                Body = errorContent,
-                Request = new HttpRequestMessageWrapper(request, requestContent),
-                Response = new HttpResponseMessageWrapper(response, errorContent)
-            };
+            throw new HttpRequestException(
+                $"Response status code does not indicate success: {response.StatusCode}. Reason: '{response.ReasonPhrase}'. Error content:{Environment.NewLine}{errorContent}");
         }
         response.EnsureSuccessStatusCode();
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/RegistryServiceClient.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/RegistryServiceClient.cs
@@ -73,8 +73,8 @@ internal class RegistryServiceClient
                 Convert.ToBase64String(Encoding.UTF8.GetBytes(string.Format(
                     CultureInfo.InvariantCulture,
                     "{0}:{1}",
-                    _credentials.UserName,
-                    _credentials.Password).ToCharArray())));
+                    _credentials.Value.UserName,
+                    _credentials.Value.Password).ToCharArray())));
         }
 
         HttpResponseMessage response = await _httpClient.SendAsync(request);

--- a/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
@@ -18,7 +18,6 @@ using Newtonsoft.Json;
 using Xunit;
 using Xunit.Abstractions;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
-using ImportSourceCredentials = Microsoft.Azure.Management.ContainerRegistry.Fluent.Models.ImportSourceCredentials;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {


### PR DESCRIPTION
This removes Image Builder's dependency on Microsoft.Azure.Management.Fluent, which is marked as deprecated. The remaining code actually mainly had a dependency on a transitive dependency of Microsoft.Azure.Management.Fluent: Microsoft.Rest.ClientRuntime.

Fixes https://github.com/dotnet/docker-tools/issues/1123