### PR TITLE
Remove service principal authentication from CopyImages commands

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -581,9 +581,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                                 .Select(tagInfo => DockerHelper.TrimRegistry(tagInfo.FullyQualifiedName))
                                 .ToArray();
             string? srcRegistry = DockerHelper.GetRegistry(sourceDigest);
-            await _copyImageService.ImportImageAsync(Options.Subscription, Options.ResourceGroup,
-                    destTags, Manifest.Registry, DockerHelper.TrimRegistry(sourceDigest, srcRegistry),
-                    srcRegistry);
+            await _copyImageService.ImportImageAsync(
+                Options.Subscription,
+                Options.ResourceGroup,
+                destTags,
+                Manifest.Registry,
+                DockerHelper.TrimRegistry(sourceDigest, srcRegistry),
+                srcRegistry);
 
             // Redefine the source digest to be from the destination of the copy, not the source. The canonical scenario
             // here is to copy the cached image from MCR to the staging location in an ACR. This allows test jobs to always pull

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -582,7 +582,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                                 .ToArray();
             string? srcRegistry = DockerHelper.GetRegistry(sourceDigest);
             await _copyImageService.ImportImageAsync(Options.Subscription, Options.ResourceGroup,
-                    Options.ServicePrincipal, destTags, Manifest.Registry, DockerHelper.TrimRegistry(sourceDigest, srcRegistry),
+                    destTags, Manifest.Registry, DockerHelper.TrimRegistry(sourceDigest, srcRegistry),
                     srcRegistry);
 
             // Redefine the source digest to be from the destination of the copy, not the source. The canonical scenario

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             LoggerService.WriteHeading("COPYING IMAGES");
 
             ResourceIdentifier resourceId = ContainerRegistryResource.CreateResourceIdentifier(
-                Options.Subscription, Options.ResourceGroup, CopyImageService.GetBaseRegistryName(Manifest.Registry));
+                Options.Subscription, Options.ResourceGroup, CopyImageService.GetBaseAcrName(Manifest.Registry));
 
             IEnumerable<Task> importTasks = Manifest.FilteredRepos
                 .Select(repo =>

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyImagesCommand.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             string destRegistryName, string srcTagName, string? srcRegistryName = null, ResourceIdentifier? srcResourceId = null,
             ContainerRegistryImportSourceCredentials? sourceCredentials = null) =>
             _copyImageService.ImportImageAsync(
-                Options.Subscription, Options.ResourceGroup, Options.ServicePrincipal, [destTagName], destRegistryName,
+                Options.Subscription, Options.ResourceGroup, [destTagName], destRegistryName,
                 srcTagName, srcRegistryName, srcResourceId, sourceCredentials, Options.IsDryRun);
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyImagesCommand.cs
@@ -7,28 +7,37 @@ using Azure.Core;
 using Azure.ResourceManager.ContainerRegistry.Models;
 
 #nullable enable
-namespace Microsoft.DotNet.ImageBuilder.Commands
+namespace Microsoft.DotNet.ImageBuilder.Commands;
+
+public abstract class CopyImagesCommand<TOptions, TOptionsBuilder> : ManifestCommand<TOptions, TOptionsBuilder>
+    where TOptions : CopyImagesOptions, new()
+    where TOptionsBuilder : CopyImagesOptionsBuilder, new()
 {
-    public abstract class CopyImagesCommand<TOptions, TOptionsBuilder> : ManifestCommand<TOptions, TOptionsBuilder>
-        where TOptions : CopyImagesOptions, new()
-        where TOptionsBuilder : CopyImagesOptionsBuilder, new()
+    private readonly ICopyImageService _copyImageService;
+
+    public CopyImagesCommand(ICopyImageService copyImageService, ILoggerService loggerService)
     {
-        private readonly ICopyImageService _copyImageService;
-
-        public CopyImagesCommand(ICopyImageService copyImageService, ILoggerService loggerService)
-        {
-            _copyImageService = copyImageService;
-            LoggerService = loggerService;
-        }
-
-        public ILoggerService LoggerService { get; }
-
-        protected Task ImportImageAsync(string destTagName,
-            string destRegistryName, string srcTagName, string? srcRegistryName = null, ResourceIdentifier? srcResourceId = null,
-            ContainerRegistryImportSourceCredentials? sourceCredentials = null) =>
-            _copyImageService.ImportImageAsync(
-                Options.Subscription, Options.ResourceGroup, [destTagName], destRegistryName,
-                srcTagName, srcRegistryName, srcResourceId, sourceCredentials, Options.IsDryRun);
+        _copyImageService = copyImageService;
+        LoggerService = loggerService;
     }
+
+    public ILoggerService LoggerService { get; }
+
+    protected Task ImportImageAsync(
+        string destTagName,
+        string destRegistryName,
+        string srcTagName,
+        string? srcRegistryName = null,
+        ResourceIdentifier? srcResourceId = null,
+        ContainerRegistryImportSourceCredentials? sourceCredentials = null) =>
+            _copyImageService.ImportImageAsync(
+                Options.Subscription,
+                Options.ResourceGroup,
+                [ destTagName ],
+                destRegistryName,
+                srcTagName,
+                srcRegistryName,
+                srcResourceId,
+                sourceCredentials,
+                Options.IsDryRun);
 }
-#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyImagesOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyImagesOptions.cs
@@ -7,35 +7,33 @@ using System.CommandLine;
 using System.Linq;
 
 #nullable enable
-namespace Microsoft.DotNet.ImageBuilder.Commands
+namespace Microsoft.DotNet.ImageBuilder.Commands;
+
+public class CopyImagesOptions : ManifestOptions, IFilterableOptions
 {
-    public class CopyImagesOptions : ManifestOptions, IFilterableOptions
-    {
-        public ManifestFilterOptions FilterOptions { get; set; } = new ManifestFilterOptions();
+    public ManifestFilterOptions FilterOptions { get; set; } = new ManifestFilterOptions();
 
-        public string ResourceGroup { get; set; } = string.Empty;
-        public string Subscription { get; set; } = string.Empty;
-    }
-
-    public class CopyImagesOptionsBuilder : ManifestOptionsBuilder
-    {
-        private readonly ManifestFilterOptionsBuilder _manifestFilterOptionsBuilder = new();
-
-        public override IEnumerable<Option> GetCliOptions() =>
-            base.GetCliOptions()
-                .Concat(_manifestFilterOptionsBuilder.GetCliOptions());
-
-        public override IEnumerable<Argument> GetCliArguments() =>
-            base.GetCliArguments()
-                .Concat(_manifestFilterOptionsBuilder.GetCliArguments())
-                .Concat(
-                    new Argument[]
-                    {
-                        new Argument<string>(nameof(CopyImagesOptions.Subscription),
-                            "Azure subscription to operate on"),
-                        new Argument<string>(nameof(CopyImagesOptions.ResourceGroup),
-                            "Azure resource group to operate on"),
-                    });
-    }
+    public string ResourceGroup { get; set; } = string.Empty;
+    public string Subscription { get; set; } = string.Empty;
 }
-#nullable disable
+
+public class CopyImagesOptionsBuilder : ManifestOptionsBuilder
+{
+    private readonly ManifestFilterOptionsBuilder _manifestFilterOptionsBuilder = new();
+
+    public override IEnumerable<Option> GetCliOptions() =>
+        [
+            ..base.GetCliOptions(),
+            .._manifestFilterOptionsBuilder.GetCliOptions()
+        ];
+
+    public override IEnumerable<Argument> GetCliArguments() =>
+        [
+            ..base.GetCliArguments(),
+            .._manifestFilterOptionsBuilder.GetCliArguments(),
+            new Argument<string>(nameof(CopyImagesOptions.Subscription),
+                "Azure subscription to operate on"),
+            new Argument<string>(nameof(CopyImagesOptions.ResourceGroup),
+                "Azure resource group to operate on"),
+        ];
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyImagesOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyImagesOptions.cs
@@ -15,25 +15,19 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         public string ResourceGroup { get; set; } = string.Empty;
         public string Subscription { get; set; } = string.Empty;
-
-        public ServicePrincipalOptions ServicePrincipal { get; set; } = new ServicePrincipalOptions();
     }
 
     public class CopyImagesOptionsBuilder : ManifestOptionsBuilder
     {
         private readonly ManifestFilterOptionsBuilder _manifestFilterOptionsBuilder = new();
-        private readonly ServicePrincipalOptionsBuilder _servicePrincipalOptionsBuilder =
-            ServicePrincipalOptionsBuilder.BuildWithDefaults();
 
         public override IEnumerable<Option> GetCliOptions() =>
             base.GetCliOptions()
-                .Concat(_manifestFilterOptionsBuilder.GetCliOptions())
-                .Concat(_servicePrincipalOptionsBuilder.GetCliOptions());
+                .Concat(_manifestFilterOptionsBuilder.GetCliOptions());
 
         public override IEnumerable<Argument> GetCliArguments() =>
             base.GetCliArguments()
                 .Concat(_manifestFilterOptionsBuilder.GetCliArguments())
-                .Concat(_servicePrincipalOptionsBuilder.GetCliArguments())
                 .Concat(
                     new Argument[]
                     {

--- a/src/Microsoft.DotNet.ImageBuilder/src/CopyImageService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/CopyImageService.cs
@@ -35,9 +35,7 @@ public class CopyImageService : ICopyImageService
 {
     private readonly ILoggerService _loggerService;
 
-    private ArmClient? _armClient;
-
-    private ArmClient ArmClient => _armClient ??= new ArmClient(new DefaultAzureCredential());
+    private readonly ArmClient _armClient = new(new DefaultAzureCredential());
 
     [ImportingConstructor]
     public CopyImageService(ILoggerService loggerService)
@@ -60,7 +58,7 @@ public class CopyImageService : ICopyImageService
     {
         destAcrName = GetBaseAcrName(destAcrName);
 
-        ContainerRegistryResource registryResource = ArmClient.GetContainerRegistryResource(
+        ContainerRegistryResource registryResource = _armClient.GetContainerRegistryResource(
             ContainerRegistryResource.CreateResourceIdentifier(subscription, resourceGroup, destAcrName));
 
         ContainerRegistryImportSource importSrc = new(srcTagName)

--- a/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
@@ -43,12 +43,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             string runtimeDepsDigest = $"{runtimeDepsRepo}@sha256:c74364a9f125ca612f9a67e4a0551937b7a37c82fabb46172c4867b73edd638c";
             string runtimeDigest = $"{runtimeRepo}@sha256:adc914a9f125ca612f9a67e4a0551937b7a37c82fabb46172c4867b73ed99227";
             string aspnetDigest = $"{aspnetRepo}@sha256:781914a9f125ca612f9a67e4a0551937b7a37c82fabb46172c4867b73ed0045a";
-            IEnumerable<string> runtimeDepsLayers = new [] { 
+            IEnumerable<string> runtimeDepsLayers = new [] {
                 "sha256:777b2c648970480f50f5b4d0af8f9a8ea798eea43dbcf40ce4a8c7118736bdcf",
                 "sha256:b9dfc8eed8d66f1eae8ffe46be9a26fe047a7f6554e9dbc2df9da211e59b4786" };
-            IEnumerable<string> runtimeLayers = 
+            IEnumerable<string> runtimeLayers =
                 runtimeDepsLayers.Concat(new [] { "sha256:466982335a8bacfe63b8f75a2e8c6484dfa7f7e92197550643b3c1457fa445b4" });
-            IEnumerable<string> aspnetLayers = 
+            IEnumerable<string> aspnetLayers =
                 runtimeLayers.Concat(new [] { "sha256:d305fbfc4bd0d9f38662e979dced9831e3b5e4d85442397a8ec0a0e7bcf5458b"});
             const string tag = "tag";
             const string localTag = "localtag";
@@ -958,7 +958,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Mock<IDockerService> dockerServiceMock = CreateDockerServiceMock("Pulling from");
 
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
-            
+
             const string runtimeRelativeDir = "1.0/runtime/os";
             Directory.CreateDirectory(Path.Combine(tempFolderContext.Path, runtimeRelativeDir));
             string dockerfileRelativePath = PathHelper.NormalizePath(Path.Combine(runtimeRelativeDir, "Dockerfile"));
@@ -1524,7 +1524,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     }
                 }
             };
-          
+
             ImageArtifactDetails sourceImageArtifactDetails = new ImageArtifactDetails
             {
                 Repos = sourceRepos.ToList()
@@ -3017,7 +3017,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     .Setup(o => o.GetImageDigestAsync($"{RegistryOverride}/{RepoPrefix}{AspnetRepo}:{Tag}", It.IsAny<IRegistryCredentialsHost>(), false))
                     .ReturnsAsync(callCount => callCount > 0 ? $"{RegistryOverride}/{RepoPrefix}{AspnetRepo}@{AspnetDigest}" : null);
             }
-            
+
             dockerServiceMock
                 .Setup(o => o.GetImageDigestAsync(mirrorBaseTag, It.IsAny<IRegistryCredentialsHost>(), false))
                 .ReturnsAsync(mirrorBaseImageDigest);
@@ -3313,7 +3313,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             }
 
             dockerServiceMock.Verify(o => o.GetImageDigestAsync(mirrorBaseTag, It.IsAny<IRegistryCredentialsHost>(), false));
-            
+
             dockerServiceMock.Verify(o => o.GetImageDigestAsync($"{RegistryOverride}/{RepoPrefix}{AspnetRepo}:{Tag}", It.IsAny<IRegistryCredentialsHost>(), false));
 
             if (!hasCachedImage)
@@ -3321,7 +3321,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 dockerServiceMock.Verify(o => o.PushImage($"{RegistryOverride}/{RepoPrefix}{RuntimeDepsRepo}:{Tag}", false));
                 dockerServiceMock.Verify(o => o.PushImage($"{RegistryOverride}/{RepoPrefix}{RuntimeRepo}:{Tag}", false));
             }
-            
+
             dockerServiceMock.Verify(o => o.PushImage($"{RegistryOverride}/{RepoPrefix}{AspnetRepo}:{Tag}", false));
 
             dockerServiceMock.Verify(o => o.GetCreatedDate($"{RegistryOverride}/{RepoPrefix}{RuntimeDepsRepo}:{Tag}", false));
@@ -3337,7 +3337,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 dockerServiceMock.Verify(o => o.GetImageArch(mirrorBaseTag, false));
                 dockerServiceMock.Verify(o => o.GetImageArch($"{RegistryOverride}/{RepoPrefix}{RuntimeDepsRepo}:{Tag}", false));
             }
-            
+
             dockerServiceMock.Verify(o => o.GetImageArch($"{RegistryOverride}/{RepoPrefix}{RuntimeRepo}:{Tag}", false));
 
             dockerServiceMock.VerifyNoOtherCalls();
@@ -3621,7 +3621,6 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     o.ImportImageAsync(
                         command.Options.Subscription,
                         command.Options.ResourceGroup,
-                        It.IsAny<ServicePrincipalOptions>(),
                         destTagNames,
                         destRegistryName,
                         srcTagName,

--- a/src/Microsoft.DotNet.ImageBuilder/tests/CopyAcrImagesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/CopyAcrImagesCommandTests.cs
@@ -100,7 +100,6 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         o.ImportImageAsync(
                             subscriptionId,
                             command.Options.ResourceGroup,
-                            It.IsAny<ServicePrincipalOptions>(),
                             new string[] { expectedTag },
                             manifest.Registry,
                             expectedTag,
@@ -206,7 +205,6 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         o.ImportImageAsync(
                             subscriptionId,
                             command.Options.ResourceGroup,
-                            It.IsAny<ServicePrincipalOptions>(),
                             new string[] { expectedTag },
                             manifest.Registry,
                             expectedTag,
@@ -324,7 +322,6 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         o.ImportImageAsync(
                             subscriptionId,
                             command.Options.ResourceGroup,
-                            It.IsAny<ServicePrincipalOptions>(),
                             new string[] { expectedTag },
                             manifest.Registry,
                             expectedTag,
@@ -442,7 +439,6 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         o.ImportImageAsync(
                             subscriptionId,
                             command.Options.ResourceGroup,
-                            It.IsAny<ServicePrincipalOptions>(),
                             new string[] { expectedTag },
                             manifest.Registry,
                             It.IsAny<string>(),

--- a/src/Microsoft.DotNet.ImageBuilder/tests/CopyBaseImagesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/CopyBaseImagesCommandTests.cs
@@ -88,7 +88,6 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         o.ImportImageAsync(
                             subscriptionId,
                             command.Options.ResourceGroup,
-                            It.IsAny<ServicePrincipalOptions>(),
                             new string[] { expectedTagInfo.TargetTag },
                             manifest.Registry,
                             expectedTagInfo.SourceImage,
@@ -169,7 +168,6 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         o.ImportImageAsync(
                             subscriptionId,
                             command.Options.ResourceGroup,
-                            It.IsAny<ServicePrincipalOptions>(),
                             new string[] { expectedTagInfo.TargetTag },
                             manifest.Registry,
                             expectedTagInfo.SourceImage,


### PR DESCRIPTION
I have the necessary pipeline changes ready to go when this version of ImageBuilder is built and the automated update PR is created.