### PR TITLE
Fix branch validation

### DIFF
--- a/eng/common/templates/steps/validate-branch.yml
+++ b/eng/common/templates/steps/validate-branch.yml
@@ -4,11 +4,19 @@ parameters:
 steps:
 - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
   - powershell: |
-      if (-not "$(officialBranches)".Split(',').Contains("$(sourceBranch)") `
-          -and "$(officialBranches)".Split(',').Contains("$(publishRepoPrefix)") `
-          -and "$(overrideOfficialBranchValidation)" -ne "true")
+      if ("$(officialBranches)".Split(',').Contains("$(sourceBranch)") `
+          -and "$(officialRepoPrefixes)".Split(',').Contains("$(publishRepoPrefix)"))
       {
-        echo "##vso[task.logissue type=error]Official builds must be done from an official branch: $(officialBranches)"
-        exit 1
+        echo "Conditions met for official build, continuing..."
+        exit 0
       }
+
+      if ("$(overrideOfficialBranchValidation)" -eq "true")
+      {
+        echo "Variable overrideOfficialBranchValidation is set to true, continuing..."
+        exit 0
+      }
+
+      echo "##vso[task.logissue type=error]Official builds must be done from an official branch: $(officialBranches)"
+      exit 1
     displayName: Validate Branch

--- a/eng/common/templates/steps/validate-branch.yml
+++ b/eng/common/templates/steps/validate-branch.yml
@@ -23,6 +23,6 @@ steps:
         exit 0
       }
 
-      echo "##vso[task.logissue type=error]Official builds must be done from an official branch: $(officialBranches)"
+      echo "##vso[task.logissue type=error]Official builds must be done from an official branch ($(officialBranches)) and repo prefix ($(officialRepoPrefixes))."
       exit 1
     displayName: Validate Branch

--- a/eng/common/templates/steps/validate-branch.yml
+++ b/eng/common/templates/steps/validate-branch.yml
@@ -11,6 +11,12 @@ steps:
         exit 0
       }
 
+      if (-not "$(officialRepoPrefixes)".Split(',').Contains("$(publishRepoPrefix)"))
+      {
+        echo "This build is a test build, continuing..."
+        exit 0
+      }
+
       if ("$(overrideOfficialBranchValidation)" -eq "true")
       {
         echo "Variable overrideOfficialBranchValidation is set to true, continuing..."

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -32,6 +32,8 @@ variables:
 - name: officialBranches
   # comma-delimited list of branch names
   value: main
+- name: overrideOfficialBranchValidation
+  value: false
 - name: mirrorRepoPrefix
   value: 'mirror/'
 - name: cgBuildGrepArgs


### PR DESCRIPTION
Fixes #1247 and applies the suggestion that we should fail by default and only pass if specific conditions are met (inverted the existing conditions).

- ~~Still needs to have an additional passing condition for publish prefixes that aren't in the `officialRepoPrefixes`~~