### PR TITLE
Pass internalProjectName to copy-base-images from base image update pipeline

### DIFF
--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -71,7 +71,7 @@ stages:
       additionalOptions: "--manifest '$(manifest)' $(imageBuilder.pathArgs) $(manifestVariables)"
       publicProjectName: ${{ parameters.publicProjectName }}
       internalProjectName: ${{ parameters.internalProjectName }}
-      customInitSteps: ${{ parameters.customCopyBaseImagesInitSteps}}
+      customInitSteps: ${{ parameters.customCopyBaseImagesInitSteps }}
   - template: /eng/common/templates/jobs/generate-matrix.yml@self
     parameters:
       matrixType: ${{ parameters.buildMatrixType }}

--- a/eng/common/templates/steps/copy-base-images.yml
+++ b/eng/common/templates/steps/copy-base-images.yml
@@ -26,5 +26,5 @@ steps:
       --registry-override '$(acr.server)'
       --os-type 'linux'
       --architecture '*'
-      $DRYRUNARG
+      $env:DRYRUNARG
       ${{ parameters.additionalOptions }}

--- a/eng/pipelines/check-base-image-updates.yml
+++ b/eng/pipelines/check-base-image-updates.yml
@@ -23,8 +23,12 @@ extends:
         parameters:
           jobName: CheckBaseImages
           subscriptionsPath: eng/check-base-image-subscriptions.json
+          publicProjectName: ${{ variables.publicProjectName }}
+          internalProjectName: ${{ variables.internalProjectName }}
       - template: /eng/pipelines/templates/jobs/check-base-image-updates.yml@self
         parameters:
           jobName: CheckBaseImages_BuildTools
           subscriptionsPath: eng/check-base-image-subscriptions-buildtools.json
           customGetStaleImagesArgs: --base-override-regex '^((centos|debian|ubuntu):.+)' --base-override-sub '$(overrideRegistry)/$1'
+          publicProjectName: ${{ variables.publicProjectName }}
+          internalProjectName: ${{ variables.internalProjectName }}

--- a/eng/pipelines/templates/jobs/check-base-image-updates.yml
+++ b/eng/pipelines/templates/jobs/check-base-image-updates.yml
@@ -2,6 +2,8 @@ parameters:
   jobName: null
   subscriptionsPath: null
   customGetStaleImagesArgs: ""
+  publicProjectName: null
+  internalProjectName: null
 
 jobs:
 - job: ${{ parameters.jobName }}
@@ -14,7 +16,8 @@ jobs:
   - template: /eng/common/templates/steps/copy-base-images.yml@self
     parameters:
       additionalOptions: "--subscriptions-path '${{ parameters.subscriptionsPath }}'"
-      publicProjectName: ${{ variables.publicProjectName }}
+      publicProjectName: ${{ parameters.publicProjectName }}
+      internalProjectName: ${{ parameters.internalProjectName }}
   - script: >
       $(runImageBuilderCmd)
       getStaleImages


### PR DESCRIPTION
An issue with the base image update pipeline was introduced in https://github.com/dotnet/docker-tools/pull/1261. In order to run with authentication, the copy-base-images step needs to know if it's in the internal project or not, but the parameter was not passed in.