### PR TITLE
Add missing export for IContainerRegistryContentClientFactory

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/ContainerRegistryContentClientFactory.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ContainerRegistryContentClientFactory.cs
@@ -1,12 +1,14 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.ComponentModel.Composition;
 using Azure.Containers.ContainerRegistry;
 using Azure.Core;
 
 namespace Microsoft.DotNet.ImageBuilder;
 
 #nullable enable
+[Export(typeof(IContainerRegistryContentClientFactory))]
 internal class ContainerRegistryContentClientFactory : IContainerRegistryContentClientFactory
 {
     public IContainerRegistryContentClient Create(string acrName, string repositoryName, TokenCredential credential) =>


### PR DESCRIPTION
Related to https://github.com/dotnet/docker-tools/issues/1273. The issue of the `build` command not being available was because there was no export for `IContainerRegistryContentClientFactory`.