### PR TITLE
Remove Microsoft.IdentityModel.Clients.ActiveDirectory dependency

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/AuthHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/AuthHelper.cs
@@ -5,20 +5,11 @@
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Identity;
-using Microsoft.IdentityModel.Clients.ActiveDirectory;
 
 namespace Microsoft.DotNet.ImageBuilder
 {
     public static class AuthHelper
     {
-        public static async Task<string> GetAadAccessTokenAsync(string resource, string tenant, string username, string password)
-        {
-            AuthenticationContext authContext = new AuthenticationContext($"https://login.microsoftonline.com/{tenant}");
-            AuthenticationResult result = await authContext.AcquireTokenAsync(
-                resource, new ClientCredential(username, password));
-            return result.AccessToken;
-        }
-
         public static async Task<string> GetDefaultAccessTokenAsync(string resource)
         {
             DefaultAzureCredential credential  = new();

--- a/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
@@ -21,8 +21,6 @@
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.3" />
     <PackageReference Include="Microsoft.DotNet.Git.IssueManager" Version="9.0.0-beta.24123.3" />
     <PackageReference Include="Microsoft.DotNet.VersionTools" Version="9.0.0-beta.24151.5" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.3.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.60.3" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.205.1" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.15" />
     <PackageReference Include="Polly" Version="8.0.0" />


### PR DESCRIPTION
Microsoft.IdentityModel.Clients.ActiveDirectory is deprecated. This removes all dependencies on that package.

I also removed Microsoft.Identity.Client since a direct dependency is not needed. It's a transitive dependency from Azure.Identity.

Fixes https://github.com/dotnet/docker-tools/issues/1176