### PR TITLE
Use MSI for Kusto authentication

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/IngestKustoImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/IngestKustoImageInfoCommand.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -131,7 +130,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             if (!Options.IsDryRun)
             {
-                await _kustoClient.IngestFromCsvAsync(info, Options.ServicePrincipal, Options.Cluster, Options.Database, table, Options.IsDryRun);
+                await _kustoClient.IngestFromCsvAsync(info, Options.Cluster, Options.Database, table, Options.IsDryRun);
             }
         }
     }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/IngestKustoImageInfoOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/IngestKustoImageInfoOptions.cs
@@ -15,7 +15,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         public string Cluster { get; set; } = string.Empty;
         public string Database { get; set; } = string.Empty;
-        public ServicePrincipalOptions ServicePrincipal { get; set; } = new();
         public string ImageTable { get; set; } = string.Empty;
         public string LayerTable { get; set; } = string.Empty;
     }
@@ -23,27 +22,22 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     public class IngestKustoImageInfoOptionsBuilder : ImageInfoOptionsBuilder
     {
         private readonly ManifestFilterOptionsBuilder _manifestFilterOptionsBuilder = new();
-        private readonly ServicePrincipalOptionsBuilder _servicePrincipalOptionsBuilder =
-            ServicePrincipalOptionsBuilder.BuildWithDefaults();
 
         public override IEnumerable<Option> GetCliOptions() =>
             base.GetCliOptions()
-                .Concat(_manifestFilterOptionsBuilder.GetCliOptions())
-                .Concat(_servicePrincipalOptionsBuilder.GetCliOptions());
+                .Concat(_manifestFilterOptionsBuilder.GetCliOptions());
 
         public override IEnumerable<Argument> GetCliArguments() =>
             base.GetCliArguments()
                 .Concat(_manifestFilterOptionsBuilder.GetCliArguments())
                 .Concat(
-                    new Argument[]
-                    {
+                    [
                         new Argument<string>(nameof(IngestKustoImageInfoOptions.Cluster), "The cluster to ingest the data to"),
                         new Argument<string>(nameof(IngestKustoImageInfoOptions.Database), "The database to ingest the data to"),
                         new Argument<string>(nameof(IngestKustoImageInfoOptions.ImageTable), "The image table to ingest the data to"),
-                        new Argument<string>(nameof(IngestKustoImageInfoOptions.LayerTable), "The layer table to ingest the data to"),
-                    }
-                )
-                .Concat(_servicePrincipalOptionsBuilder.GetCliArguments());
+                        new Argument<string>(nameof(IngestKustoImageInfoOptions.LayerTable), "The layer table to ingest the data to")
+                    ]
+                );
     }
 }
 #nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Services/IKustoClient.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Services/IKustoClient.cs
@@ -3,13 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading.Tasks;
-using Microsoft.DotNet.ImageBuilder.Commands;
 
 namespace Microsoft.DotNet.ImageBuilder.Services
 {
     public interface IKustoClient
     {
         Task IngestFromCsvAsync(
-            string csv, ServicePrincipalOptions servicePrincipal, string cluster, string database, string table, bool isDryRun);
+            string csv, string cluster, string database, string table, bool isDryRun);
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Services/KustoClientWrapper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Services/KustoClientWrapper.cs
@@ -6,10 +6,10 @@ using System;
 using System.ComponentModel.Composition;
 using System.IO;
 using System.Threading.Tasks;
+using Azure.Identity;
 using Kusto.Data;
 using Kusto.Data.Common;
 using Kusto.Ingest;
-using Microsoft.DotNet.ImageBuilder.Commands;
 using Polly;
 using Polly.Contrib.WaitAndRetry;
 using Polly.Retry;
@@ -29,14 +29,11 @@ namespace Microsoft.DotNet.ImageBuilder.Services
         }
 
         public async Task IngestFromCsvAsync(
-            string csv, ServicePrincipalOptions servicePrincipal, string cluster, string database, string table, bool isDryRun)
+            string csv, string cluster, string database, string table, bool isDryRun)
         {
             KustoConnectionStringBuilder connectionBuilder =
                 new KustoConnectionStringBuilder($"https://{cluster}.kusto.windows.net")
-                    .WithAadApplicationKeyAuthentication(
-                        servicePrincipal.ClientId,
-                        servicePrincipal.Secret,
-                        servicePrincipal.Tenant);
+                    .WithAadAzureTokenCredentialsAuthentication(new DefaultAzureCredential());
 
             using (IKustoIngestClient client = KustoIngestFactory.CreateDirectIngestClient(connectionBuilder))
             {

--- a/src/Microsoft.DotNet.ImageBuilder/tests/IngestKustoImageInfoCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/IngestKustoImageInfoCommandTests.cs
@@ -274,9 +274,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Mock<IKustoClient> kustoClientMock = new();
             kustoClientMock
                 .Setup(o => o.IngestFromCsvAsync(
-                    It.IsAny<string>(), It.IsAny<ServicePrincipalOptions>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
-                .Callback<string, ServicePrincipalOptions, string, string, string, bool>(
-                    (csv, servicePrincipal, cluster, database, table, isDryRun) =>
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
+                .Callback<string, string, string, string, bool>(
+                    (csv, cluster, database, table, isDryRun) =>
                     {
                         ingestedData.Add(table, csv);
                     });
@@ -296,7 +296,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             _outputHelper.WriteLine($"Actual Layer Data: {Environment.NewLine}{ingestedData[command.Options.LayerTable]}");
 
             kustoClientMock.Verify(o => o.IngestFromCsvAsync(
-                It.IsAny<string>(), It.IsAny<ServicePrincipalOptions>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()));
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()));
             Assert.Equal(expectedImageData, ingestedData[command.Options.ImageTable]);
             Assert.Equal(expectedLayerData, ingestedData[command.Options.LayerTable]);
         }


### PR DESCRIPTION
Removes the use of service principal configuration for authentication to the Kusto cluster and replaces it with `DefaultAzureCredential` which will enable the use of a Managed Identity in the pipeline.

Contributes to https://github.com/dotnet/docker-tools/issues/1264