### PR TITLE
Revert changes to task names in postPublishNotification args

### DIFF
--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -154,9 +154,9 @@ jobs:
       --repo-prefix '$(publishRepoPrefix)'
       --task "Copy Images"
       --task "Publish Manifest"
-      --task "WaitForImageIngestion"
+      --task "Wait For Image Ingestion"
       --task "Publish Readmes"
-      --task "WaitForMcrDocIngestion"
+      --task "Wait For Mcr Doc Ingestion"
       --task "Publish Image Info"
       --task "Ingest Kusto Image Info"
       $(dryRunArg)

--- a/eng/common/templates/steps/wait-for-mcr-doc-ingestion.yml
+++ b/eng/common/templates/steps/wait-for-mcr-doc-ingestion.yml
@@ -6,7 +6,6 @@ parameters:
 steps:
 - template: /eng/common/templates/steps/run-imagebuilder.yml@self
   parameters:
-    name: WaitForMcrDocIngestion
     displayName: Wait for MCR Doc Ingestion
     condition: and(${{ parameters.condition }}, eq(variables['waitForIngestionEnabled'], 'true'))
     args: >

--- a/eng/common/templates/steps/wait-for-mcr-image-ingestion.yml
+++ b/eng/common/templates/steps/wait-for-mcr-image-ingestion.yml
@@ -7,7 +7,6 @@ parameters:
 steps:
 - template: /eng/common/templates/steps/run-imagebuilder.yml@self
   parameters:
-    name: WaitForImageIngestion
     displayName: Wait for Image Ingestion
     condition: and(${{ parameters.condition }}, eq(variables['waitForIngestionEnabled'], 'true'))
     args: >


### PR DESCRIPTION
This hopefully fixes #1278. I don't have a great way to test this. Running it in any other context than a published build (AKA as a dry run) will skip the BuildTaskResults API call that failed in #1278. But maybe we can merge this followed by another open PR and see what happens?