### PR TITLE
Fix casing for tasks of publish notification

### DIFF
--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -154,9 +154,9 @@ jobs:
       --repo-prefix '$(publishRepoPrefix)'
       --task "Copy Images"
       --task "Publish Manifest"
-      --task "Wait For Image Ingestion"
+      --task "Wait for Image Ingestion"
       --task "Publish Readmes"
-      --task "Wait For Mcr Doc Ingestion"
+      --task "Wait for Mcr Doc Ingestion"
       --task "Publish Image Info"
       --task "Ingest Kusto Image Info"
       $(dryRunArg)


### PR DESCRIPTION
The `Post Publish Notification` task fails with this error:

```
Unhandled exception: System.InvalidOperationException: Build task with name 'Wait For Image Ingestion' could not be found in the build timeline.
```

Fixed by using the correct casing that matches the actual task.