### PR TITLE
Use case insensitive comparison for publish notify tasks

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PostPublishNotificationCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PostPublishNotificationCommand.cs
@@ -150,7 +150,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             Timeline timeline = await buildClient.GetBuildTimelineAsync(project.Id, Options.BuildId);
             foreach (string task in Options.TaskNames)
             {
-                TimelineRecord? record = timeline.Records.FirstOrDefault(rec => rec.Name == task);
+                TimelineRecord? record = timeline.Records.FirstOrDefault(rec => rec.Name.Equals(task, StringComparison.OrdinalIgnoreCase));
                 if (record is null)
                 {
                     throw new InvalidOperationException(


### PR DESCRIPTION
Related to https://github.com/dotnet/docker-tools/pull/1280

This uses case-insensitivity when finding matching task names so the logic isn't so strict. 