### PR TITLE
Use SBOM Manifest Generator Task from 1ES PT

### DIFF
--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -139,13 +139,8 @@ jobs:
       internalProjectName: ${{ parameters.internalProjectName }}
       publicProjectName: ${{ parameters.publicProjectName }}
   - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
-      # Define the task here to load it into the agent so that we can invoke the tool manually
-      # TODO: Revert the build-specific pinned version when https://github.com/dotnet/docker-tools/issues/1152 is fixed
-    - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0.197.56
-      inputs:
-        BuildDropPath: $(Build.ArtifactStagingDirectory)
-      displayName: Load Manifest Generator
-      condition: and(succeeded(), ne(variables['BuildImages.builtImages'], ''))
+    # The following task depends on the SBOM Manifest Generator task installed on the agent.
+    # This task is auto-injected by 1ES Pipeline Templates so we don't need to install it ourselves.
     - powershell: |
         $images = "$(BuildImages.builtImages)"
         if (-not $images) { return 0 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/docker-tools/issues/1152 and also fixes the following error in the Build stage when creating SBOM manifests:

```
Detected SPDX 2.2 sbom in the path. Submitting for signing...
##[warning]Error: The signing feature is not available for your organization yet.
##[warning]Error: An error occured while using the SBOM signing feature, service returned status code 401
##[warning]Error: An error occured while using the SBOM signing feature, service returned status code 401
##[warning]Error: The signing feature is not available for your organization yet.
##[warning]Error: The signing feature is not available for your organization yet.
##[error]An error occured while using the SBOM signing feature, service returned status code 401
```