### PR TITLE
Use service connection for MAR ingestion and use .default scope

### DIFF
--- a/eng/common/templates/steps/wait-for-mcr-image-ingestion.yml
+++ b/eng/common/templates/steps/wait-for-mcr-image-ingestion.yml
@@ -16,6 +16,7 @@ steps:
       '${{ parameters.imageInfoPath }}'
       --manifest '$(manifest)'
       --repo-prefix '$(publishRepoPrefix)'
+      --min-queue-time '${{ parameters.minQueueTime }}'
       --timeout '$(mcrImageIngestionTimeout)'
       $(manifestVariables)
       ${{ parameters.dryRunArg }}

--- a/eng/common/templates/steps/wait-for-mcr-image-ingestion.yml
+++ b/eng/common/templates/steps/wait-for-mcr-image-ingestion.yml
@@ -9,12 +9,13 @@ steps:
   parameters:
     displayName: Wait for Image Ingestion
     condition: and(${{ parameters.condition }}, eq(variables['waitForIngestionEnabled'], 'true'))
+    serviceConnection: $(marStatus.serviceConnectionName)
+    internalProjectName: 'internal'
     args: >
       waitForMcrImageIngestion
       '${{ parameters.imageInfoPath }}'
       --manifest '$(manifest)'
       --repo-prefix '$(publishRepoPrefix)'
-      --min-queue-time '${{ parameters.minQueueTime }}'
       --timeout '$(mcrImageIngestionTimeout)'
       $(manifestVariables)
       ${{ parameters.dryRunArg }}

--- a/src/Microsoft.DotNet.ImageBuilder/src/McrStatusClient.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/McrStatusClient.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.ImageBuilder
     [Export(typeof(IMcrStatusClient))]
     public class McrStatusClient : IMcrStatusClient
     {
-        private const string McrStatusResource = "api://c00053c3-a979-4ee6-b94e-941881e62d8e";
+        private const string McrStatusResource = "api://c00053c3-a979-4ee6-b94e-941881e62d8e/.default";
         // https://msazure.visualstudio.com/MicrosoftContainerRegistry/_git/docs?path=/status/status_v2.yaml
         private const string BaseUri = "https://status.mscr.io/api/onboardingstatus/v2";
         private readonly HttpClient _httpClient;
@@ -27,15 +27,8 @@ namespace Microsoft.DotNet.ImageBuilder
         [ImportingConstructor]
         public McrStatusClient(IHttpClientProvider httpClientProvider, ILoggerService loggerService)
         {
-            if (loggerService is null)
-            {
-                throw new ArgumentNullException(nameof(loggerService));
-            }
-
-            if (httpClientProvider is null)
-            {
-                throw new ArgumentNullException(nameof(httpClientProvider));
-            }
+            ArgumentNullException.ThrowIfNull(loggerService);
+            ArgumentNullException.ThrowIfNull(httpClientProvider);
 
             _httpClient = httpClientProvider.GetClient();
             _httpPolicy = HttpPolicyBuilder.Create()


### PR DESCRIPTION
This should fix https://github.com/dotnet/docker-tools/issues/1286 once the new ImageBuilder is built and flows in.

Using the service connection by itself yielded a new error:

```
 ---> Azure.Identity.AuthenticationFailedException: ClientAssertionCredential authentication failed: AADSTS1002012: The provided value for scope <snip> is not valid. Client credential flows must have a scope value with /.default suffixed to the resource identifier (application ID URI).
```

So that's why the ImageBuilder change is necessary. I will file a follow-up issue to use a pipeline variable for the status API scope since hardcoding it isn't great.