### PR TITLE
Opt-in to SBOM for unofficial pipelines

### DIFF
--- a/eng/common/templates/1es-unofficial.yml
+++ b/eng/common/templates/1es-unofficial.yml
@@ -44,6 +44,8 @@ extends:
         ignoreDirectories: $(Build.SourcesDirectory)/versions
         whatIf: true
         showAlertLink: true
+      sbom:
+        enabled: ture
       sourceRepositoriesToScan:
         exclude:
         - repository: InternalVersionsRepo

--- a/eng/common/templates/1es-unofficial.yml
+++ b/eng/common/templates/1es-unofficial.yml
@@ -45,7 +45,7 @@ extends:
         whatIf: true
         showAlertLink: true
       sbom:
-        enabled: ture
+        enabled: true
       sourceRepositoriesToScan:
         exclude:
         - repository: InternalVersionsRepo


### PR DESCRIPTION
This should fix #1285, pending a test that's running internally. This also brings our eng-validation pipeline closer in line with the official pipeline which is a design goal for the eng-validation pipeline.