### PR TITLE
Use ACR service connection to login to ACR for test job

### DIFF
--- a/eng/common/templates/steps/run-imagebuilder.yml
+++ b/eng/common/templates/steps/run-imagebuilder.yml
@@ -26,21 +26,16 @@ parameters:
 
 steps:
 - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest'), ne(parameters.serviceConnection, '')) }}:
-  - task: AzureCLI@2
-    ${{ if ne(parameters.name, '') }}:
-      name: ${{ parameters.name }}
-    displayName: ${{ parameters.displayName }}
-    continueOnError: ${{ parameters.continueOnError }}
-    condition: ${{ parameters.condition }}
-    inputs:
-      azureSubscription: ${{ parameters.serviceConnection }}
-      addSpnToEnvironment: true
-      ${{ if eq(parameters.dockerClientOS, 'windows') }}:
-        scriptType: 'ps'
-      ${{ else }}:
-        scriptType: 'pscore'
-      scriptLocation: 'inlineScript'
-      inlineScript: >
+  - template: /eng/common/templates/steps/run-pwsh-with-auth.yml@self
+    parameters:
+      ${{ if ne(parameters.name, '') }}:
+        name: ${{ parameters.name }}
+      displayName: ${{ parameters.displayName }}
+      serviceConnection: ${{ parameters.serviceConnection }}
+      continueOnError: ${{ parameters.continueOnError }}
+      dockerClientOS: ${{ parameters.dockerClientOS }}
+      condition: ${{ parameters.condition }}
+      command: >
         $env:idToken | Out-File -FilePath $(tokenHostFilePath);
         $(runAuthedImageBuilderCmd) ${{ parameters.args }};
         Remove-Item -Path $(tokenHostFilePath) -Force

--- a/eng/common/templates/steps/run-pwsh-with-auth.yml
+++ b/eng/common/templates/steps/run-pwsh-with-auth.yml
@@ -4,7 +4,7 @@ parameters:
   default: "RunPwshWithAuth"
 - name: displayName
   type: string
-  default: "Run PowerShell with Auth"
+  default: "Run PowerShell"
 - name: serviceConnection
   type: string
   default: ""
@@ -24,7 +24,7 @@ parameters:
 steps:
 - task: AzureCLI@2
   name: ${{ parameters.name }}
-  displayName: ${{ parameters.displayName }}
+  displayName: ${{ parameters.displayName }} (Authenticated)
   continueOnError: ${{ parameters.continueOnError }}
   condition: and(succeeded(), ${{ parameters.condition }})
   inputs:

--- a/eng/common/templates/steps/run-pwsh-with-auth.yml
+++ b/eng/common/templates/steps/run-pwsh-with-auth.yml
@@ -1,0 +1,38 @@
+parameters:
+- name: name
+  type: string
+  default: "RunPwshWithAuth"
+- name: displayName
+  type: string
+  default: "Run PowerShell with Auth"
+- name: serviceConnection
+  type: string
+  default: ""
+- name: command
+  type: string
+  default: null
+- name: continueOnError
+  type: boolean
+  default: false
+- name: dockerClientOS
+  type: string
+  default: "linux"
+- name: condition
+  type: string
+  default: true
+
+steps:
+- task: AzureCLI@2
+  name: ${{ parameters.name }}
+  displayName: ${{ parameters.displayName }}
+  continueOnError: ${{ parameters.continueOnError }}
+  condition: and(succeeded(), ${{ parameters.condition }})
+  inputs:
+    azureSubscription: ${{ parameters.serviceConnection }}
+    addSpnToEnvironment: true
+    ${{ if eq(parameters.dockerClientOS, 'windows') }}:
+      scriptType: 'ps'
+    ${{ else }}:
+      scriptType: 'pscore'
+    scriptLocation: 'inlineScript'
+    inlineScript: ${{ parameters.command }};

--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -42,12 +42,16 @@ steps:
   displayName: Start Test Runner Container
   condition: and(succeeded(), ${{ parameters.condition }})
 - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
-  - script: >
-      docker exec $(testRunner.container) pwsh
-      -File $(engCommonRelativePath)/Invoke-WithRetry.ps1
-      "docker login -u $(acr.userName) -p $(acr.password) $(acr.server)"
-    displayName: Docker login
-    condition: and(succeeded(), ${{ parameters.condition }})
+  - template: /eng/common/templates/steps/run-pwsh-with-auth.yml@self
+    parameters:
+      displayName: Docker login
+      serviceConnection: $(acr.serviceConnectionName)
+      condition: and(succeeded(), ${{ parameters.condition }})
+      command: >
+        $azLoginArgs = '--service-principal --tenant $env:AZURE_TENANT_ID -u $env:AZURE_CLIENT_ID --federated-token $env:AZURE_FEDERATED_TOKEN';
+        docker exec -e AZURE_TENANT_ID=$env:tenantId -e AZURE_CLIENT_ID=$env:servicePrincipalId -e AZURE_FEDERATED_TOKEN=$env:idToken $(testRunner.container) pwsh
+        -File $(engCommonRelativePath)/Invoke-WithRetry.ps1
+        "az login $azLoginArgs; az acr login -n $(acr.server)"
   - ${{ if eq(parameters.preBuildValidation, 'false') }}:
     - template: /eng/common/templates/steps/download-build-artifact.yml@self
       parameters:

--- a/eng/common/templates/steps/test-images-windows-client.yml
+++ b/eng/common/templates/steps/test-images-windows-client.yml
@@ -10,11 +10,16 @@ steps:
       cleanupDocker: true
       setupImageBuilder: false
       condition: ${{ parameters.condition }}
-  - powershell: >
-      $(engCommonPath)/Invoke-WithRetry.ps1
-      "cmd /c 'docker login -u $(acr.userName) --password $(acr.password) $(acr.server) 2>&1'"
-    displayName: Docker login
-    condition: and(succeeded(), ${{ parameters.condition }})
+  - template: /eng/common/templates/steps/run-pwsh-with-auth.yml@self
+    parameters:
+      displayName: Docker login
+      serviceConnection: $(acr.serviceConnectionName)
+      dockerClientOS: windows
+      condition: and(succeeded(), ${{ parameters.condition }})
+      command: >
+        az login --service-principal --tenant $env:tenantId -u $env:servicePrincipalId --federated-token $env:idToken;
+        $accessToken = $(az acr login -n $(acr.server) --expose-token --query accessToken --output tsv);
+        docker login $(acr.server) -u 00000000-0000-0000-0000-000000000000 -p $accessToken
 - ${{ parameters.customInitSteps }}
 - powershell: |
     if ("${{ variables['System.TeamProject'] }}" -eq "${{ parameters.internalProjectName }}" -and "${{ variables['Build.Reason'] }}" -ne "PullRequest") {


### PR DESCRIPTION
This removes the use of credentials for logging into the ACR in test jobs and replaces it with the use of a service connection.

This requires the changes in https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1057.

Contributes to https://github.com/dotnet/docker-tools/issues/1264