### PR TITLE
Conditionally set task name

### DIFF
--- a/eng/common/templates/steps/run-pwsh-with-auth.yml
+++ b/eng/common/templates/steps/run-pwsh-with-auth.yml
@@ -1,7 +1,7 @@
 parameters:
 - name: name
   type: string
-  default: "RunPwshWithAuth"
+  default: ""
 - name: displayName
   type: string
   default: "Run PowerShell"
@@ -23,7 +23,8 @@ parameters:
 
 steps:
 - task: AzureCLI@2
-  name: ${{ parameters.name }}
+  ${{ if ne(parameters.name, '') }}:
+    name: ${{ parameters.name }}
   displayName: ${{ parameters.displayName }} (Authenticated)
   continueOnError: ${{ parameters.continueOnError }}
   condition: and(succeeded(), ${{ parameters.condition }})


### PR DESCRIPTION
The changes in https://github.com/dotnet/docker-tools/pull/1290 are causing a failure in the image builder pipeline:

```
Job Publish: The step name RunPwshWithAuth appears more than once. Step names must be unique within a job.
```

The template needs to not default a name for the step because it can cause duplicates. Instead, it should be defaulted to nothing.