### PR TITLE
Remove registry creds for GetStaleImages

### DIFF
--- a/eng/pipelines/templates/jobs/check-base-image-updates.yml
+++ b/eng/pipelines/templates/jobs/check-base-image-updates.yml
@@ -29,7 +29,6 @@ jobs:
       --subscriptions-path ${{ parameters.subscriptionsPath }}
       --os-type '*'
       --architecture '*'
-      $(dockerHubRegistryCreds)
     displayName: Get Stale Images
     name: GetStaleImages
   - script: >


### PR DESCRIPTION
The `GetStaleImages` command doesn't take `--registry-creds` options anymore after the changes in https://github.com/dotnet/docker-tools/pull/1293.