### PR TITLE
Add simple test for MEF Dependency Injection

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/tests/DependencyInjectionTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/DependencyInjectionTests.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.ImageBuilder.Commands;
+using Xunit;
+
+namespace Microsoft.DotNet.ImageBuilder.Tests;
+
+public class DependencyInjectionTests
+{
+    [Fact]
+    public void DependencyResolution()
+    {
+        ICommand[] commands = ImageBuilder.Commands;
+        Assert.NotNull(commands);
+        Assert.NotEmpty(commands);
+    }
+}


### PR DESCRIPTION
Fixes #1273 by adding a test that will fail when there are any composition errors. Also by adding the config option for disabling silent rejection on the container, ImageBuilder will no longer start when there are composition errors.