### PR TITLE
Pipeline Changes for Pushing Mirror and Build-Staging Repositories to Separate ACR

### DIFF
--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -97,7 +97,7 @@ jobs:
       New-Item -Path $(imageInfoHostDir) -ItemType Directory -Force
       $imageBuilderBuildArgs = "$env:IMAGEBUILDERBUILDARGS $(imageBuilder.queueArgs) --image-info-output-path $(imageInfoContainerDir)/$(legName)-image-info.json"
       if ($env:SYSTEM_TEAMPROJECT -eq "${{ parameters.internalProjectName }}" -and $env:BUILD_REASON -ne "PullRequest") {
-        $imageBuilderBuildArgs = "$imageBuilderBuildArgs --registry-override $(acr.server) --repo-prefix $(stagingRepoPrefix) --source-repo-prefix $(mirrorRepoPrefix) --push"
+        $imageBuilderBuildArgs = "$imageBuilderBuildArgs --registry-override $(acr-staging.server) --repo-prefix $(stagingRepoPrefix) --source-repo-prefix $(mirrorRepoPrefix) --push"
       }
 
       # If the pipeline isn't configured to disable the cache and a build variable hasn't been set to disable the cache
@@ -172,7 +172,7 @@ jobs:
         # Manifest tool docs: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/secure-supply-chain/custom-sbom-generation-workflows
         $images -Split ',' | ForEach-Object {
           echo "Generating SBOM for $_";
-          $formattedImageName = $_.Replace('$(acr.server)/$(stagingRepoPrefix)', "").Replace('/', '_').Replace(':', '_');
+          $formattedImageName = $_.Replace('$(acr-staging.server)/$(stagingRepoPrefix)', "").Replace('/', '_').Replace(':', '_');
           $sbomChildDir = "$(sbomDirectory)/$formattedImageName";
           New-Item -Type Directory -Path $sbomChildDir > $null;
           & $dotnetPath "$manifestToolDllPath" `

--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -109,6 +109,7 @@ jobs:
     displayName: Set Image Builder Build Args
   - template: /eng/common/templates/steps/run-imagebuilder.yml@self
     parameters:
+      TODO: 'Does this need to be updated if the ACRs have different subs and RGs?'
       name: BuildImages
       displayName: Build Images
       serviceConnection: $(acr.serviceConnectionName)

--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -109,10 +109,9 @@ jobs:
     displayName: Set Image Builder Build Args
   - template: /eng/common/templates/steps/run-imagebuilder.yml@self
     parameters:
-      TODO: 'Does this need to be updated if the ACRs have different subs and RGs?'
       name: BuildImages
       displayName: Build Images
-      serviceConnection: $(acr.serviceConnectionName)
+      serviceConnection: $(acr-staging.serviceConnectionName)
       internalProjectName: ${{ parameters.internalProjectName }}
       dockerClientOS: ${{ parameters.dockerClientOS }}
       args: >
@@ -125,8 +124,8 @@ jobs:
         --retry
         --source-repo $(publicGitRepoUri)
         --digests-out-var 'builtImages'
-        --acr-subscription '$(acr.subscription)'
-        --acr-resource-group '$(acr.resourceGroup)'
+        --acr-subscription '$(acr-staging.subscription)'
+        --acr-resource-group '$(acr-staging.resourceGroup)'
         $(manifestVariables)
         $(imageBuilderBuildArgs)
   - template: /eng/common/templates/steps/publish-artifact.yml@self

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -66,6 +66,7 @@ jobs:
     displayName: Trim Unchanged Images
   - template: /eng/common/templates/steps/run-imagebuilder.yml@self
     parameters:
+      TODO: 'Does this need to be updated if the ACRs have different subs and RGs?'
       displayName: Copy Images
       serviceConnection: $(acr.serviceConnectionName)
       internalProjectName: ${{ parameters.internalProjectName }}

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -66,7 +66,6 @@ jobs:
     displayName: Trim Unchanged Images
   - template: /eng/common/templates/steps/run-imagebuilder.yml@self
     parameters:
-      TODO: 'Does this need to be updated if the ACRs have different subs and RGs?'
       displayName: Copy Images
       serviceConnection: $(acr.serviceConnectionName)
       internalProjectName: ${{ parameters.internalProjectName }}

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -74,6 +74,7 @@ jobs:
         '$(acr.subscription)'
         '$(acr.resourceGroup)'
         '$(stagingRepoPrefix)'
+        '$(acr-staging.server)'
         --os-type '*'
         --architecture '*'
         --repo-prefix '$(publishRepoPrefix)'

--- a/eng/common/templates/steps/clean-acr-images.yml
+++ b/eng/common/templates/steps/clean-acr-images.yml
@@ -1,5 +1,7 @@
 parameters:
   repo: null
+  subscription: null
+  resourceGroup: null
   acr: null
   action: null
   age: null
@@ -15,8 +17,8 @@ steps:
       args: >
         cleanAcrImages
         ${{ parameters.repo }}
-        $(acr.subscription)
-        $(acr.resourceGroup)
+        ${{ parameters.subscription }}
+        ${{ parameters.resourceGroup }}
         ${{ parameters.acr }}
         --action ${{ parameters.action }}
         --age ${{ parameters.age }}

--- a/eng/common/templates/steps/clean-acr-images.yml
+++ b/eng/common/templates/steps/clean-acr-images.yml
@@ -1,21 +1,23 @@
 parameters:
   repo: null
+  acr: null
   action: null
   age: null
   customArgs: ""
+  serviceConnection: null
   internalProjectName: null
 steps:
   - template: /eng/common/templates/steps/run-imagebuilder.yml@self
     parameters:
       displayName: Clean ACR Images - ${{ parameters.repo }}
-      serviceConnection: $(acr.serviceConnectionName)
+      serviceConnection: ${{ parameters.serviceConnection }}
       internalProjectName: ${{ parameters.internalProjectName }}
       args: >
         cleanAcrImages
         ${{ parameters.repo }}
         $(acr.subscription)
         $(acr.resourceGroup)
-        $(acr.server)
+        ${{ parameters.acr }}
         --action ${{ parameters.action }}
         --age ${{ parameters.age }}
         ${{ parameters.customArgs }}

--- a/eng/common/templates/steps/copy-base-images.yml
+++ b/eng/common/templates/steps/copy-base-images.yml
@@ -10,7 +10,7 @@ steps:
 - template: /eng/common/templates/steps/run-imagebuilder.yml@self
   parameters:
     displayName: Copy Base Images
-    serviceConnection: $(acr.serviceConnectionName)
+    serviceConnection: $(acr-staging.serviceConnectionName)
     continueOnError: ${{ parameters.continueOnError }}
     internalProjectName: ${{ parameters.internalProjectName }}
     # Use environment variable to reference $(dryRunArg). Since $(dryRunArg) might be undefined,
@@ -23,7 +23,7 @@ steps:
       $(dockerHubRegistryCreds)
       $(customCopyBaseImagesArgs)
       --repo-prefix $(mirrorRepoPrefix)
-      --registry-override '$(acr.server)'
+      --registry-override '$(acr-staging.server)'
       --os-type 'linux'
       --architecture '*'
       $env:DRYRUNARG

--- a/eng/common/templates/steps/copy-base-images.yml
+++ b/eng/common/templates/steps/copy-base-images.yml
@@ -9,6 +9,7 @@ steps:
   - template: /eng/common/templates/steps/set-dry-run.yml@self
 - template: /eng/common/templates/steps/run-imagebuilder.yml@self
   parameters:
+    TODO: 'Does this need to be updated if the ACRs have different subs and RGs?'
     displayName: Copy Base Images
     serviceConnection: $(acr-staging.serviceConnectionName)
     continueOnError: ${{ parameters.continueOnError }}

--- a/eng/common/templates/steps/copy-base-images.yml
+++ b/eng/common/templates/steps/copy-base-images.yml
@@ -9,7 +9,6 @@ steps:
   - template: /eng/common/templates/steps/set-dry-run.yml@self
 - template: /eng/common/templates/steps/run-imagebuilder.yml@self
   parameters:
-    TODO: 'Does this need to be updated if the ACRs have different subs and RGs?'
     displayName: Copy Base Images
     serviceConnection: $(acr-staging.serviceConnectionName)
     continueOnError: ${{ parameters.continueOnError }}
@@ -19,8 +18,8 @@ steps:
     # error
     args: >
       copyBaseImages
-      '$(acr.subscription)'
-      '$(acr.resourceGroup)'
+      '$(acr-staging.subscription)'
+      '$(acr-staging.resourceGroup)'
       $(dockerHubRegistryCreds)
       $(customCopyBaseImagesArgs)
       --repo-prefix $(mirrorRepoPrefix)

--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -22,7 +22,7 @@ steps:
       optionalTestArgs="$optionalTestArgs -TestCategories pre-build"
     else
       if [ "${{ variables['System.TeamProject'] }}" == "${{ parameters.internalProjectName }}" ] && [ "${{ variables['Build.Reason'] }}" != "PullRequest" ]; then
-        optionalTestArgs="$optionalTestArgs -PullImages -Registry $(acr.server) -RepoPrefix $(stagingRepoPrefix) -ImageInfoPath $(artifactsPath)/image-info.json"
+        optionalTestArgs="$optionalTestArgs -PullImages -Registry $(acr-staging.server) -RepoPrefix $(stagingRepoPrefix) -ImageInfoPath $(artifactsPath)/image-info.json"
       fi
       if [ "$REPOTESTARGS" != "" ]; then
         optionalTestArgs="$optionalTestArgs $REPOTESTARGS"
@@ -45,13 +45,13 @@ steps:
   - template: /eng/common/templates/steps/run-pwsh-with-auth.yml@self
     parameters:
       displayName: Docker login
-      serviceConnection: $(acr.serviceConnectionName)
+      serviceConnection: $(acr-staging.serviceConnectionName)
       condition: and(succeeded(), ${{ parameters.condition }})
       command: >
         $azLoginArgs = '--service-principal --tenant $env:AZURE_TENANT_ID -u $env:AZURE_CLIENT_ID --federated-token $env:AZURE_FEDERATED_TOKEN';
         docker exec -e AZURE_TENANT_ID=$env:tenantId -e AZURE_CLIENT_ID=$env:servicePrincipalId -e AZURE_FEDERATED_TOKEN=$env:idToken $(testRunner.container) pwsh
         -File $(engCommonRelativePath)/Invoke-WithRetry.ps1
-        "az login $azLoginArgs; az acr login -n $(acr.server)"
+        "az login $azLoginArgs; az acr login -n $(acr-staging.server)"
   - ${{ if eq(parameters.preBuildValidation, 'false') }}:
     - template: /eng/common/templates/steps/download-build-artifact.yml@self
       parameters:
@@ -73,7 +73,7 @@ steps:
   displayName: Test Images
   condition: and(succeeded(), ${{ parameters.condition }})
 - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
-  - script: docker exec $(testRunner.container) docker logout $(acr.server)
+  - script: docker exec $(testRunner.container) docker logout $(acr-staging.server)
     displayName: Docker logout
     condition: and(always(), ${{ parameters.condition }})
     continueOnError: true

--- a/eng/common/templates/steps/test-images-windows-client.yml
+++ b/eng/common/templates/steps/test-images-windows-client.yml
@@ -13,17 +13,17 @@ steps:
   - template: /eng/common/templates/steps/run-pwsh-with-auth.yml@self
     parameters:
       displayName: Docker login
-      serviceConnection: $(acr.serviceConnectionName)
+      serviceConnection: $(acr-staging.serviceConnectionName)
       dockerClientOS: windows
       condition: and(succeeded(), ${{ parameters.condition }})
       command: >
         az login --service-principal --tenant $env:tenantId -u $env:servicePrincipalId --federated-token $env:idToken;
-        $accessToken = $(az acr login -n $(acr.server) --expose-token --query accessToken --output tsv);
-        docker login $(acr.server) -u 00000000-0000-0000-0000-000000000000 -p $accessToken
+        $accessToken = $(az acr login -n $(acr-staging.server) --expose-token --query accessToken --output tsv);
+        docker login $(acr-staging.server) -u 00000000-0000-0000-0000-000000000000 -p $accessToken
 - ${{ parameters.customInitSteps }}
 - powershell: |
     if ("${{ variables['System.TeamProject'] }}" -eq "${{ parameters.internalProjectName }}" -and "${{ variables['Build.Reason'] }}" -ne "PullRequest") {
-      $optionalTestArgs="$optionalTestArgs -PullImages -Registry $env:ACR_SERVER -RepoPrefix $env:STAGINGREPOPREFIX -ImageInfoPath $(artifactsPath)/image-info.json"
+      $optionalTestArgs="$optionalTestArgs -PullImages -Registry $env:ACR_STAGING_SERVER -RepoPrefix $env:STAGINGREPOPREFIX -ImageInfoPath $(artifactsPath)/image-info.json"
     }
     if ($env:REPOTESTARGS) {
       $optionalTestArgs += " $env:REPOTESTARGS"
@@ -50,7 +50,7 @@ steps:
   displayName: Test Images
   condition: and(succeeded(), ${{ parameters.condition }})
 - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
-  - script: docker logout $(acr.server)
+  - script: docker logout $(acr-staging.server)
     displayName: Docker logout
     condition: and(always(), ${{ parameters.condition }})
     continueOnError: true

--- a/eng/common/templates/steps/test-images-windows-client.yml
+++ b/eng/common/templates/steps/test-images-windows-client.yml
@@ -23,7 +23,7 @@ steps:
 - ${{ parameters.customInitSteps }}
 - powershell: |
     if ("${{ variables['System.TeamProject'] }}" -eq "${{ parameters.internalProjectName }}" -and "${{ variables['Build.Reason'] }}" -ne "PullRequest") {
-      $optionalTestArgs="$optionalTestArgs -PullImages -Registry $env:ACR_STAGING_SERVER -RepoPrefix $env:STAGINGREPOPREFIX -ImageInfoPath $(artifactsPath)/image-info.json"
+      $optionalTestArgs="$optionalTestArgs -PullImages -Registry $env:ACR-STAGING_SERVER -RepoPrefix $env:STAGINGREPOPREFIX -ImageInfoPath $(artifactsPath)/image-info.json"
     }
     if ($env:REPOTESTARGS) {
       $optionalTestArgs += " $env:REPOTESTARGS"

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -65,3 +65,5 @@ variables:
   value: 00000000-0000-0000-0000-000000000000
 - name: acr.subscription
   value: 00000000-0000-0000-0000-000000000000
+- name: acr-staging.subscription
+  value: 00000000-0000-0000-0000-000000000000

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2465839
+  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2472089
   imageNames.imageBuilder: $(imageNames.imageBuilderName)
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner2.0-docker-testrunner

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2461919
+  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2465596
   imageNames.imageBuilder: $(imageNames.imageBuilderName)
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner2.0-docker-testrunner

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2465596
+  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2465839
   imageNames.imageBuilder: $(imageNames.imageBuilderName)
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner2.0-docker-testrunner

--- a/eng/pipelines/cleanup-acr-images-custom.yml
+++ b/eng/pipelines/cleanup-acr-images-custom.yml
@@ -15,6 +15,8 @@ jobs:
       internalProjectName: ${{ variables.internalProjectName }}
       serviceConnection: $(acr.serviceConnectionName)
       repo: $(repo)
+      subscription: $(acr.subscription)
+      resourceGroup: $(acr.resourceGroup)
       acr: $(acr.server)
       action: $(action)
       age: $(age)

--- a/eng/pipelines/cleanup-acr-images-custom.yml
+++ b/eng/pipelines/cleanup-acr-images-custom.yml
@@ -13,7 +13,9 @@ jobs:
   - template: ../common/templates/steps/clean-acr-images.yml
     parameters:
       internalProjectName: ${{ variables.internalProjectName }}
+      serviceConnection: $(acr.serviceConnectionName)
       repo: $(repo)
+      acr: $(acr.server)
       action: $(action)
       age: $(age)
       customArgs: $(customArgs)

--- a/eng/pipelines/cleanup-acr-images.yml
+++ b/eng/pipelines/cleanup-acr-images.yml
@@ -20,31 +20,41 @@ jobs:
   - template: ../common/templates/steps/init-docker-linux.yml
   - template: ../common/templates/steps/clean-acr-images.yml
     parameters:
+      serviceConnection: $(acr-staging.serviceConnectionName)
       internalProjectName: ${{ variables.internalProjectName }}
       repo: "build-staging/*"
+      acr: $(acr-staging.server)
       action: delete
       age: 15
   - template: ../common/templates/steps/clean-acr-images.yml
     parameters:
+      serviceConnection: $(acr.serviceConnectionName)
       internalProjectName: ${{ variables.internalProjectName }}
       repo: "public/dotnet/*nightly/*"
+      acr: $(acr.server)
       action: pruneDangling
       age: 30
   - template: ../common/templates/steps/clean-acr-images.yml
     parameters:
+      serviceConnection: $(acr.serviceConnectionName)
       internalProjectName: ${{ variables.internalProjectName }}
       repo: "test/*"
+      acr: $(acr.server)
       action: pruneAll
       age: 7
   - template: ../common/templates/steps/clean-acr-images.yml
     parameters:
+      serviceConnection: $(acr.serviceConnectionName)
       internalProjectName: ${{ variables.internalProjectName }}
       repo: "public/dotnet*/samples*"
+      acr: $(acr.server)
       action: pruneDangling
       age: 0
   # Disabled due to https://github.com/dotnet/docker-tools/issues/797
   # - template: ../common/templates/steps/clean-acr-images.yml
   #   parameters:
+  #     serviceConnection: $(acr-staging.serviceConnectionName)
   #     repo: "mirror/*"
+  #     arc: $(acr-staging.server)
   #     action: pruneDangling
   #     age: 0

--- a/eng/pipelines/cleanup-acr-images.yml
+++ b/eng/pipelines/cleanup-acr-images.yml
@@ -23,6 +23,8 @@ jobs:
       serviceConnection: $(acr-staging.serviceConnectionName)
       internalProjectName: ${{ variables.internalProjectName }}
       repo: "build-staging/*"
+      subscription: $(acr-staging.subscription)
+      resourceGroup: $(acr-staging.resourceGroup)
       acr: $(acr-staging.server)
       action: delete
       age: 15
@@ -31,6 +33,8 @@ jobs:
       serviceConnection: $(acr.serviceConnectionName)
       internalProjectName: ${{ variables.internalProjectName }}
       repo: "public/dotnet/*nightly/*"
+      subscription: $(acr.subscription)
+      resourceGroup: $(acr.resourceGroup)
       acr: $(acr.server)
       action: pruneDangling
       age: 30
@@ -39,6 +43,8 @@ jobs:
       serviceConnection: $(acr.serviceConnectionName)
       internalProjectName: ${{ variables.internalProjectName }}
       repo: "test/*"
+      subscription: $(acr.subscription)
+      resourceGroup: $(acr.resourceGroup)
       acr: $(acr.server)
       action: pruneAll
       age: 7
@@ -47,6 +53,8 @@ jobs:
       serviceConnection: $(acr.serviceConnectionName)
       internalProjectName: ${{ variables.internalProjectName }}
       repo: "public/dotnet*/samples*"
+      subscription: $(acr.subscription)
+      resourceGroup: $(acr.resourceGroup)
       acr: $(acr.server)
       action: pruneDangling
       age: 0
@@ -55,6 +63,8 @@ jobs:
   #   parameters:
   #     serviceConnection: $(acr-staging.serviceConnectionName)
   #     repo: "mirror/*"
+  #     subscription: $(acr-staging.subscription)
+  #     resourceGroup: $(acr-staging.resourceGroup)
   #     arc: $(acr-staging.server)
   #     action: pruneDangling
   #     age: 0


### PR DESCRIPTION
Related to https://github.com/dotnet/dotnet-docker-internal/issues/5024 and https://github.com/dotnet/dotnet-docker-internal/issues/5026

This PR updates the ymls to use the appropriate ACR server and serviceConnectionName for the given repo. The changes were made to the following ymls:

- common/templates/jobs/build-images.yml
- common/templates/jobs/publish.yml
- common/templates/steps/clean-acr-images.yml
- common/templates/steps/copy-base-images.yml
- common/templates/steps/test-images-linux-client.yml
- common/templates/steps/test-images-windows-client.yml
- pipelines/cleanup-acr-images-custom.yml
- pipelines/cleanup-acr-images.yml

[ImageBuilder pipeline run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2459246&view=results)
[Windows tests pipeline run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2462833&view=logs&j=ac422da1-c6cf-5423-8ede-22ab7060639a)
[Nightly pipeline run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2465765&view=results)
[Cleanup pipeline run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2465775&view=results)
