### PR TITLE
Add ORAS tool to Linux ImageBuilder images

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/Dockerfile.linux
+++ b/src/Microsoft.DotNet.ImageBuilder/Dockerfile.linux
@@ -38,7 +38,6 @@ WORKDIR /image-builder
 COPY --from=build-env /image-builder/out ./
 
 # install oras tool
-WORKDIR /usr/local/bin
-COPY --from=build-env /oras-install/oras ./
+COPY --from=build-env ["/oras-install/oras", "/usr/local/bin"]
 
 ENTRYPOINT ["/image-builder/Microsoft.DotNet.ImageBuilder"]

--- a/src/Microsoft.DotNet.ImageBuilder/Dockerfile.linux
+++ b/src/Microsoft.DotNet.ImageBuilder/Dockerfile.linux
@@ -16,6 +16,11 @@ RUN dotnet restore -r linux-musl-$TARGETARCH ./src/Microsoft.DotNet.ImageBuilder
 COPY . ./
 RUN dotnet publish -r linux-musl-$TARGETARCH ./src/Microsoft.DotNet.ImageBuilder.csproj --self-contained=true --no-restore -o out
 
+# download oras package tarball
+WORKDIR /
+RUN oras_version=1.1.0 \
+    && wget https://github.com/oras-project/oras/releases/download/v${oras_version}/oras_${oras_version}_linux_${TARGETARCH}.tar.gz -O oras_linux.tar.gz
+
 
 # build runtime image
 FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-alpine
@@ -28,5 +33,12 @@ RUN apk add --no-cache \
 # install image-builder
 WORKDIR /image-builder
 COPY --from=build-env /image-builder/out ./
+
+# install oras tool
+COPY --from=build-env /oras_linux.tar.gz ./
+RUN mkdir -p oras-install/ \
+    && tar -zxf oras_linux.tar.gz -C oras-install/ \
+    && mv oras-install/oras /usr/local/bin/ \
+    && rm -rf oras_linux.tar.gz oras-install/
 
 ENTRYPOINT ["/image-builder/Microsoft.DotNet.ImageBuilder"]

--- a/src/Microsoft.DotNet.ImageBuilder/Dockerfile.linux
+++ b/src/Microsoft.DotNet.ImageBuilder/Dockerfile.linux
@@ -19,7 +19,10 @@ RUN dotnet publish -r linux-musl-$TARGETARCH ./src/Microsoft.DotNet.ImageBuilder
 # download oras package tarball
 WORKDIR /
 RUN oras_version=1.1.0 \
-    && wget https://github.com/oras-project/oras/releases/download/v${oras_version}/oras_${oras_version}_linux_${TARGETARCH}.tar.gz -O oras_linux.tar.gz
+    && wget https://github.com/oras-project/oras/releases/download/v${oras_version}/oras_${oras_version}_linux_${TARGETARCH}.tar.gz -O oras_linux.tar.gz \
+    && mkdir -p oras-install/ \
+    && tar -zxf oras_linux.tar.gz -C oras-install/ \
+    && rm -rf oras_linux.tar.gz
 
 
 # build runtime image
@@ -35,10 +38,7 @@ WORKDIR /image-builder
 COPY --from=build-env /image-builder/out ./
 
 # install oras tool
-COPY --from=build-env /oras_linux.tar.gz ./
-RUN mkdir -p oras-install/ \
-    && tar -zxf oras_linux.tar.gz -C oras-install/ \
-    && mv oras-install/oras /usr/local/bin/ \
-    && rm -rf oras_linux.tar.gz oras-install/
+WORKDIR /usr/local/bin
+COPY --from=build-env /oras-install/oras ./
 
 ENTRYPOINT ["/image-builder/Microsoft.DotNet.ImageBuilder"]


### PR DESCRIPTION
Add ORAS tooling to Linux Image Builder image.

Used instructions from https://oras.land/docs/installation/ with necessary modification for Alpine, to use `wget` instead of `curl`.