### PR TITLE
Workaround for token failure in non-authenticated configurations

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/tests/DependencyInjectionTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/DependencyInjectionTests.cs
@@ -9,8 +9,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests;
 
 public class DependencyInjectionTests
 {
-    // Temporarily disable due to implementation of ContainerRegistryContentClientFactory constructor which attempts to authenticate as part of DI. Doesn't work in test environment.
-    //[Fact]
+    [Fact]
     public void DependencyResolution()
     {
         ICommand[] commands = ImageBuilder.Commands;


### PR DESCRIPTION
The changes from https://github.com/dotnet/docker-tools/pull/1310 are causing a failure in the `GenerateBuildMatrix` pipeline step because the agent has no auth configuration in that step, causing the `GetToken` method to fail during component composition.

Workaround is to just catch the exception. It will work correctly in build steps that are configured with authentication enabled.