### PR TITLE
Improve Azure token logic

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/AuthHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/AuthHelper.cs
@@ -5,24 +5,23 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using Azure.Core;
-using Azure.Identity;
 using Azure.ResourceManager;
 
 namespace Microsoft.DotNet.ImageBuilder
 {
     public static class AuthHelper
     {
-        private const string DefaultScope = "https://management.azure.com/.default";
+        public const string DefaultAzureManagementScope = "https://management.azure.com/.default";
+        public const string ContainerRegistryScope = "https://containerregistry.azure.net/.default";
+        public const string McrStatusScope = "api://c00053c3-a979-4ee6-b94e-941881e62d8e/.default";
 
-        public static async Task<(string token, Guid tenantId)> GetDefaultAccessTokenAsync(ILoggerService loggerService, string resource = DefaultScope)
-        {
-            DefaultAzureCredential credential  = new();
-            AccessToken token = await credential.GetTokenAsync(new TokenRequestContext([ resource ]));
-            Guid tenantId = GetTenantId(loggerService, credential);
-            return (token.Token, tenantId);
-        }
+        public static readonly string[] AllScopes =
+            [
+                DefaultAzureManagementScope,
+                ContainerRegistryScope,
+                McrStatusScope
+            ];
 
         public static Guid GetTenantId(ILoggerService loggerService, TokenCredential credential)
         {

--- a/src/Microsoft.DotNet.ImageBuilder/src/AuthHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/AuthHelper.cs
@@ -12,17 +12,6 @@ namespace Microsoft.DotNet.ImageBuilder
 {
     public static class AuthHelper
     {
-        public const string DefaultAzureManagementScope = "https://management.azure.com/.default";
-        public const string ContainerRegistryScope = "https://containerregistry.azure.net/.default";
-        public const string McrStatusScope = "api://c00053c3-a979-4ee6-b94e-941881e62d8e/.default";
-
-        public static readonly string[] AllScopes =
-            [
-                DefaultAzureManagementScope,
-                ContainerRegistryScope,
-                McrStatusScope
-            ];
-
         public static Guid GetTenantId(ILoggerService loggerService, TokenCredential credential)
         {
             ArmClient armClient = new(credential);

--- a/src/Microsoft.DotNet.ImageBuilder/src/AzureScopes.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/AzureScopes.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.ImageBuilder;
+
+#nullable enable
+internal static class AzureScopes
+{
+    public const string ScopeSuffix = "/.default";
+    public const string DefaultAzureManagementScope = "https://management.azure.com" + ScopeSuffix;
+    public const string ContainerRegistryScope = "https://containerregistry.azure.net" + ScopeSuffix;
+    public const string McrStatusScope = "api://c00053c3-a979-4ee6-b94e-941881e62d8e" + ScopeSuffix;
+    public static readonly string[] AllScopes =
+        [
+            DefaultAzureManagementScope,
+            ContainerRegistryScope,
+            McrStatusScope
+        ];
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/AzureScopes.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/AzureScopes.cs
@@ -10,10 +10,4 @@ internal static class AzureScopes
     public const string DefaultAzureManagementScope = "https://management.azure.com" + ScopeSuffix;
     public const string ContainerRegistryScope = "https://containerregistry.azure.net" + ScopeSuffix;
     public const string McrStatusScope = "api://c00053c3-a979-4ee6-b94e-941881e62d8e" + ScopeSuffix;
-    public static readonly string[] AllScopes =
-        [
-            DefaultAzureManagementScope,
-            ContainerRegistryScope,
-            McrStatusScope
-        ];
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/AzureTokenCredentialProvider.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/AzureTokenCredentialProvider.cs
@@ -1,10 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
@@ -16,55 +14,19 @@ namespace Microsoft.DotNet.ImageBuilder;
 [Export(typeof(IAzureTokenCredentialProvider))]
 internal class AzureTokenCredentialProvider : IAzureTokenCredentialProvider
 {
-    private readonly Dictionary<string, TokenCredential?> _credentialsByScope;
+    private readonly object _cacheLock = new();
+    private readonly Dictionary<string, TokenCredential?> _credentialsByScope = [];
 
-    [ImportingConstructor]
-    public AzureTokenCredentialProvider(ILoggerService loggerService)
-    {
-        loggerService.WriteSubheading("Initializing Azure credentials");
-
-        // Pre-cache the credentials for all the scopes we need. This is done at startup to ensure we have a valid OIDC token from the pipeline before it expires.
-        // Otherwise, long-running commands that don't attempt to request an Azure access token until much later run the risk of failing due to the expired OIDC token.
-        _credentialsByScope = AzureScopes.AllScopes
-            .ToDictionary<string, string, TokenCredential?>(scope => scope, scope =>
+    public TokenCredential GetCredential(string scope = AzureScopes.DefaultAzureManagementScope) =>
+        LockHelper.DoubleCheckedLockLookup(
+            _cacheLock,
+            _credentialsByScope,
+            scope,
+            () =>
             {
-                TokenCredential? credential = null;
-
-                // If debugging on a dev machine, use DefaultAzureCredential which will use whatever method available for authenticating with Azure (e.g. Azure CLI).
-                // This allows the developer's identity to be used to authenticate to the resource. Otherwise, assume this is being run in the context of an AzDO
-                // pipeline.
-#if DEBUG
-                loggerService.WriteMessage($"Getting default credentials for scope '{scope}'");
-                credential = new DefaultAzureCredential();
-#else
-                // When running in the context of an AzDO pipeline, the AZURE_FEDERATED_TOKEN_FILE env var will be set when the step is configured to use
-                // Azure authentication. If this var is not set, the step is not configured for authentication and no credential should be associated with the
-                // scope. This ensures that an exception will be thrown when retrieving the credential if an attempt is made to authenticate.
-                if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURE_FEDERATED_TOKEN_FILE")))
-                {
-                    loggerService.WriteMessage($"Getting token for scope '{scope}'");
-                    AccessToken token = new WorkloadIdentityCredential().GetToken(new TokenRequestContext([scope]), CancellationToken.None);
-                    credential = new StaticTokenCredential(token);
-                }
-                else
-                {
-                    loggerService.WriteMessage($"No credentials set for scope '{scope}'");
-                }
-#endif
-
-                return credential;
+                AccessToken token = new DefaultAzureCredential().GetToken(new TokenRequestContext([scope]), CancellationToken.None);
+                return new StaticTokenCredential(token);
             });
-    }
-
-    public TokenCredential GetCredential(string scope = AzureScopes.DefaultAzureManagementScope)
-    {
-        if (!_credentialsByScope.TryGetValue(scope, out TokenCredential? credential) || credential is null)
-        {
-            throw new Exception($"A credential for scope '{scope}' has not been set.");
-        }
-
-        return credential;
-    }
 
     private class StaticTokenCredential(AccessToken accessToken) : TokenCredential
     {

--- a/src/Microsoft.DotNet.ImageBuilder/src/AzureTokenCredentialProvider.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/AzureTokenCredentialProvider.cs
@@ -25,7 +25,7 @@ internal class AzureTokenCredentialProvider : IAzureTokenCredentialProvider
 
         // Pre-cache the credentials for all the scopes we need. This is done at startup to ensure we have a valid OIDC token from the pipeline before it expires.
         // Otherwise, long-running commands that don't attempt to request an Azure access token until much later run the risk of failing due to the expired OIDC token.
-        _credentialsByScope = AuthHelper.AllScopes
+        _credentialsByScope = AzureScopes.AllScopes
             .ToDictionary<string, string, TokenCredential?>(scope => scope, scope =>
             {
                 TokenCredential? credential = null;
@@ -56,7 +56,7 @@ internal class AzureTokenCredentialProvider : IAzureTokenCredentialProvider
             });
     }
 
-    public TokenCredential GetCredential(string scope = AuthHelper.DefaultAzureManagementScope)
+    public TokenCredential GetCredential(string scope = AzureScopes.DefaultAzureManagementScope)
     {
         if (!_credentialsByScope.TryGetValue(scope, out TokenCredential? credential) || credential is null)
         {

--- a/src/Microsoft.DotNet.ImageBuilder/src/AzureTokenCredentialProvider.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/AzureTokenCredentialProvider.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Identity;
+
+namespace Microsoft.DotNet.ImageBuilder;
+
+#nullable enable
+[Export(typeof(IAzureTokenCredentialProvider))]
+internal class AzureTokenCredentialProvider : IAzureTokenCredentialProvider
+{
+    private readonly Dictionary<string, TokenCredential?> _credentialsByScope;
+
+    [ImportingConstructor]
+    public AzureTokenCredentialProvider(ILoggerService loggerService)
+    {
+        loggerService.WriteSubheading("Initializing Azure credentials");
+
+        // Pre-cache the credentials for all the scopes we need. This is done at startup to ensure we have a valid OIDC token from the pipeline before it expires.
+        // Otherwise, long-running commands that don't attempt to request an Azure access token until much later run the risk of failing due to the expired OIDC token.
+        _credentialsByScope = AuthHelper.AllScopes
+            .ToDictionary<string, string, TokenCredential?>(scope => scope, scope =>
+            {
+                TokenCredential? credential = null;
+
+                // If debugging on a dev machine, use DefaultAzureCredential which will use whatever method available for authenticating with Azure (e.g. Azure CLI).
+                // This allows the developer's identity to be used to authenticate to the resource. Otherwise, assume this is being run in the context of an AzDO
+                // pipeline.
+#if DEBUG
+                loggerService.WriteMessage($"Getting default credentials for scope '{scope}'");
+                credential = new DefaultAzureCredential();
+#else
+                // When running in the context of an AzDO pipeline, the AZURE_FEDERATED_TOKEN_FILE env var will be set when the step is configured to use
+                // Azure authentication. If this var is not set, the step is not configured for authentication and no credential should be associated with the
+                // scope. This ensures that an exception will be thrown when retrieving the credential if an attempt is made to authenticate.
+                if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURE_FEDERATED_TOKEN_FILE")))
+                {
+                    loggerService.WriteMessage($"Getting token for scope '{scope}'");
+                    AccessToken token = new WorkloadIdentityCredential().GetToken(new TokenRequestContext([scope]), CancellationToken.None);
+                    credential = new StaticTokenCredential(token);
+                }
+                else
+                {
+                    loggerService.WriteMessage($"No credentials set for scope '{scope}'");
+                }
+#endif
+
+                return credential;
+            });
+    }
+
+    public TokenCredential GetCredential(string scope = AuthHelper.DefaultAzureManagementScope)
+    {
+        if (!_credentialsByScope.TryGetValue(scope, out TokenCredential? credential) || credential is null)
+        {
+            throw new Exception($"A credential for scope '{scope}' has not been set.");
+        }
+
+        return credential;
+    }
+
+    private class StaticTokenCredential(AccessToken accessToken) : TokenCredential
+    {
+        public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken) => accessToken;
+        public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken) => ValueTask.FromResult(accessToken);
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/AzureTokenCredentialProviderExtensions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/AzureTokenCredentialProviderExtensions.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+
+namespace Microsoft.DotNet.ImageBuilder;
+
+#nullable enable
+internal static class AzureTokenCredentialProviderExtensions
+{
+    public static ValueTask<AccessToken> GetTokenAsync(this IAzureTokenCredentialProvider provider, string scope = AuthHelper.DefaultAzureManagementScope) =>
+        provider.GetCredential(scope).GetTokenAsync(new TokenRequestContext([scope]), CancellationToken.None);
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/AzureTokenCredentialProviderExtensions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/AzureTokenCredentialProviderExtensions.cs
@@ -10,6 +10,6 @@ namespace Microsoft.DotNet.ImageBuilder;
 #nullable enable
 internal static class AzureTokenCredentialProviderExtensions
 {
-    public static ValueTask<AccessToken> GetTokenAsync(this IAzureTokenCredentialProvider provider, string scope = AuthHelper.DefaultAzureManagementScope) =>
+    public static ValueTask<AccessToken> GetTokenAsync(this IAzureTokenCredentialProvider provider, string scope = AzureScopes.DefaultAzureManagementScope) =>
         provider.GetCredential(scope).GetTokenAsync(new TokenRequestContext([scope]), CancellationToken.None);
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ContainerRegistryContentClientFactory.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ContainerRegistryContentClientFactory.cs
@@ -1,44 +1,21 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.ComponentModel.Composition;
-using System.Threading;
-using System.Threading.Tasks;
 using Azure.Containers.ContainerRegistry;
 using Azure.Core;
-using Azure.Identity;
 
 namespace Microsoft.DotNet.ImageBuilder;
 
 #nullable enable
 [Export(typeof(IContainerRegistryContentClientFactory))]
-internal class ContainerRegistryContentClientFactory : IContainerRegistryContentClientFactory
+[method: ImportingConstructor]
+internal class ContainerRegistryContentClientFactory(IAzureTokenCredentialProvider tokenCredentialProvider) : IContainerRegistryContentClientFactory
 {
-    private readonly CachedTokenCredential? _credential;
-
-    [ImportingConstructor]
-    public ContainerRegistryContentClientFactory(ILoggerService loggerService)
-    {
-        try
-        {
-            AccessToken token = new DefaultAzureCredential().GetToken(new TokenRequestContext(["https://containerregistry.azure.net/.default"]), CancellationToken.None);
-            _credential = new CachedTokenCredential(token);
-        }
-        catch (Exception ex)
-        {
-            loggerService.WriteError(ex.Message);
-        }
-    }
-
-    public IContainerRegistryContentClient Create(string acrName, string repositoryName, TokenCredential credential)
-    {
-        return new ContainerRegistryContentClientWrapper(new ContainerRegistryContentClient(DockerHelper.GetAcrUri(acrName), repositoryName, _credential));
-    }
-
-    private class CachedTokenCredential(AccessToken accessToken) : TokenCredential
-    {
-        public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken) => accessToken;
-        public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken) => ValueTask.FromResult(accessToken);
-    }
+    public IContainerRegistryContentClient Create(string acrName, string repositoryName, TokenCredential credential) =>
+        new ContainerRegistryContentClientWrapper(
+            new ContainerRegistryContentClient(
+                DockerHelper.GetAcrUri(acrName),
+                repositoryName,
+                tokenCredentialProvider.GetCredential(AuthHelper.ContainerRegistryScope)));
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ContainerRegistryContentClientFactory.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ContainerRegistryContentClientFactory.cs
@@ -17,5 +17,5 @@ internal class ContainerRegistryContentClientFactory(IAzureTokenCredentialProvid
             new ContainerRegistryContentClient(
                 DockerHelper.GetAcrUri(acrName),
                 repositoryName,
-                tokenCredentialProvider.GetCredential(AuthHelper.ContainerRegistryScope)));
+                tokenCredentialProvider.GetCredential(AzureScopes.ContainerRegistryScope)));
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/CopyImageService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/CopyImageService.cs
@@ -33,13 +33,13 @@ public interface ICopyImageService
 public class CopyImageService : ICopyImageService
 {
     private readonly ILoggerService _loggerService;
-    private readonly Lazy<ArmClient> _armClient;
+    private readonly ArmClient _armClient;
 
     [ImportingConstructor]
     public CopyImageService(ILoggerService loggerService, IAzureTokenCredentialProvider tokenCredentialProvider)
     {
         _loggerService = loggerService;
-        _armClient = new(() => new ArmClient(tokenCredentialProvider.GetCredential()));
+        _armClient = new ArmClient(tokenCredentialProvider.GetCredential());
     }
 
     public static string GetBaseAcrName(string registry) => registry.TrimEnd(DockerHelper.AcrDomain);
@@ -57,7 +57,7 @@ public class CopyImageService : ICopyImageService
     {
         destAcrName = GetBaseAcrName(destAcrName);
 
-        ContainerRegistryResource registryResource = _armClient.Value.GetContainerRegistryResource(
+        ContainerRegistryResource registryResource = _armClient.GetContainerRegistryResource(
             ContainerRegistryResource.CreateResourceIdentifier(subscription, resourceGroup, destAcrName));
 
         ContainerRegistryImportSource importSrc = new(srcTagName)

--- a/src/Microsoft.DotNet.ImageBuilder/src/CopyImageService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/CopyImageService.cs
@@ -33,13 +33,13 @@ public interface ICopyImageService
 public class CopyImageService : ICopyImageService
 {
     private readonly ILoggerService _loggerService;
-    private readonly ArmClient _armClient;
+    private readonly Lazy<ArmClient> _armClient;
 
     [ImportingConstructor]
     public CopyImageService(ILoggerService loggerService, IAzureTokenCredentialProvider tokenCredentialProvider)
     {
         _loggerService = loggerService;
-        _armClient = new ArmClient(tokenCredentialProvider.GetCredential());
+        _armClient = new(() => new ArmClient(tokenCredentialProvider.GetCredential()));
     }
 
     public static string GetBaseAcrName(string registry) => registry.TrimEnd(DockerHelper.AcrDomain);
@@ -57,7 +57,7 @@ public class CopyImageService : ICopyImageService
     {
         destAcrName = GetBaseAcrName(destAcrName);
 
-        ContainerRegistryResource registryResource = _armClient.GetContainerRegistryResource(
+        ContainerRegistryResource registryResource = _armClient.Value.GetContainerRegistryResource(
             ContainerRegistryResource.CreateResourceIdentifier(subscription, resourceGroup, destAcrName));
 
         ContainerRegistryImportSource importSrc = new(srcTagName)

--- a/src/Microsoft.DotNet.ImageBuilder/src/IAzureTokenCredentialProvider.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/IAzureTokenCredentialProvider.cs
@@ -8,5 +8,5 @@ namespace Microsoft.DotNet.ImageBuilder;
 #nullable enable
 public interface IAzureTokenCredentialProvider
 {
-    TokenCredential GetCredential(string scope = AuthHelper.DefaultAzureManagementScope);
+    TokenCredential GetCredential(string scope = AzureScopes.DefaultAzureManagementScope);
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/IAzureTokenCredentialProvider.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/IAzureTokenCredentialProvider.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Azure.Core;
+
+namespace Microsoft.DotNet.ImageBuilder;
+
+#nullable enable
+public interface IAzureTokenCredentialProvider
+{
+    TokenCredential GetCredential(string scope = AuthHelper.DefaultAzureManagementScope);
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/McrStatusClient.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/McrStatusClient.cs
@@ -72,10 +72,10 @@ namespace Microsoft.DotNet.ImageBuilder
 
         private Task<string> GetAccessTokenAsync() =>
             _accessToken.GetValueAsync(async () =>
-                (await _tokenCredentialProvider.GetTokenAsync(AuthHelper.McrStatusScope)).Token);
+                (await _tokenCredentialProvider.GetTokenAsync(AzureScopes.McrStatusScope)).Token);
 
         private Task RefreshAccessTokenAsync() =>
             _accessToken.ResetValueAsync(async () =>
-                (await _tokenCredentialProvider.GetTokenAsync(AuthHelper.McrStatusScope)).Token);
+                (await _tokenCredentialProvider.GetTokenAsync(AzureScopes.McrStatusScope)).Token);
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/McrStatusClient.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/McrStatusClient.cs
@@ -6,7 +6,6 @@ using System;
 using System.ComponentModel.Composition;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Azure.Identity;
 using Microsoft.DotNet.ImageBuilder.Models.McrStatus;
 using Newtonsoft.Json;
 using Polly;
@@ -17,16 +16,16 @@ namespace Microsoft.DotNet.ImageBuilder
     [Export(typeof(IMcrStatusClient))]
     public class McrStatusClient : IMcrStatusClient
     {
-        private const string McrStatusResource = "api://c00053c3-a979-4ee6-b94e-941881e62d8e/.default";
         // https://msazure.visualstudio.com/MicrosoftContainerRegistry/_git/docs?path=/status/status_v2.yaml
         private const string BaseUri = "https://status.mscr.io/api/onboardingstatus/v2";
         private readonly HttpClient _httpClient;
         private readonly AsyncLockedValue<string> _accessToken = new AsyncLockedValue<string>();
         private readonly AsyncPolicy<HttpResponseMessage> _httpPolicy;
         private readonly ILoggerService _loggerService;
+        private readonly IAzureTokenCredentialProvider _tokenCredentialProvider;
 
         [ImportingConstructor]
-        public McrStatusClient(IHttpClientProvider httpClientProvider, ILoggerService loggerService)
+        public McrStatusClient(IHttpClientProvider httpClientProvider, ILoggerService loggerService, IAzureTokenCredentialProvider tokenCredentialProvider)
         {
             ArgumentNullException.ThrowIfNull(loggerService);
             ArgumentNullException.ThrowIfNull(httpClientProvider);
@@ -38,6 +37,7 @@ namespace Microsoft.DotNet.ImageBuilder
                 .WithNotFoundRetryPolicy(TimeSpan.FromHours(1), TimeSpan.FromSeconds(10), loggerService)
                 .Build() ?? throw new InvalidOperationException("Policy should not be null");
             _loggerService = loggerService;
+            _tokenCredentialProvider = tokenCredentialProvider;
         }
 
         public Task<ImageResult> GetImageResultAsync(string imageDigest)
@@ -72,10 +72,10 @@ namespace Microsoft.DotNet.ImageBuilder
 
         private Task<string> GetAccessTokenAsync() =>
             _accessToken.GetValueAsync(async () =>
-                (await AuthHelper.GetDefaultAccessTokenAsync(_loggerService, McrStatusResource)).token);
+                (await _tokenCredentialProvider.GetTokenAsync(AuthHelper.McrStatusScope)).Token);
 
         private Task RefreshAccessTokenAsync() =>
             _accessToken.ResetValueAsync(async () =>
-                (await AuthHelper.GetDefaultAccessTokenAsync(_loggerService, McrStatusResource)).token);
+                (await _tokenCredentialProvider.GetTokenAsync(AuthHelper.McrStatusScope)).Token);
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/RegistryContentClientFactory.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/RegistryContentClientFactory.cs
@@ -37,7 +37,7 @@ public class RegistryContentClientFactory(
         if (apiRegistry == ownedAcr)
         {
             // If the target registry is the owned ACR, connect to it with the Azure library API. This handles all the Azure auth.
-            return _containerRegistryContentClientFactory.Create(ownedAcr, repo, _tokenCredentialProvider.GetCredential(AuthHelper.ContainerRegistryScope));
+            return _containerRegistryContentClientFactory.Create(ownedAcr, repo, _tokenCredentialProvider.GetCredential(AzureScopes.ContainerRegistryScope));
         }
 
         // Look up the credentials, if any, for the registry where the image is located

--- a/src/Microsoft.DotNet.ImageBuilder/src/RegistryCredentialsProvider.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/RegistryCredentialsProvider.cs
@@ -3,17 +3,20 @@
 
 using System;
 using System.ComponentModel.Composition;
+using System.Threading;
 using System.Threading.Tasks;
+using Azure.Core;
 
 namespace Microsoft.DotNet.ImageBuilder;
 
 #nullable enable
 [Export(typeof(IRegistryCredentialsProvider))]
 [method: ImportingConstructor]
-public class RegistryCredentialsProvider(ILoggerService loggerService, IHttpClientProvider httpClientProvider) : IRegistryCredentialsProvider
+public class RegistryCredentialsProvider(ILoggerService loggerService, IHttpClientProvider httpClientProvider, IAzureTokenCredentialProvider tokenCredentialProvider) : IRegistryCredentialsProvider
 {
     private readonly ILoggerService _loggerService = loggerService;
     private readonly IHttpClientProvider _httpClientProvider = httpClientProvider;
+    private readonly IAzureTokenCredentialProvider _tokenCredentialProvider = tokenCredentialProvider;
 
     /// <summary>
     /// Dynamically gets the RegistryCredentials for the specified registry in the following order of preference:
@@ -46,7 +49,9 @@ public class RegistryCredentialsProvider(ILoggerService loggerService, IHttpClie
 
     private async ValueTask<RegistryCredentials> GetAcrCredentialsWithOAuthAsync(ILoggerService logger, string apiRegistry)
     {
-        (string token, Guid tenantId) = await AuthHelper.GetDefaultAccessTokenAsync(logger);
+        TokenCredential tokenCredential = _tokenCredentialProvider.GetCredential();
+        Guid tenantId = AuthHelper.GetTenantId(logger, tokenCredential);
+        string token = (await tokenCredential.GetTokenAsync(new TokenRequestContext([AuthHelper.DefaultAzureManagementScope]), CancellationToken.None)).Token;
         string refreshToken = await OAuthHelper.GetRefreshTokenAsync(_httpClientProvider.GetClient(), apiRegistry, tenantId, token);
         return new RegistryCredentials(Guid.Empty.ToString(), refreshToken);
     }

--- a/src/Microsoft.DotNet.ImageBuilder/src/RegistryCredentialsProvider.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/RegistryCredentialsProvider.cs
@@ -51,7 +51,7 @@ public class RegistryCredentialsProvider(ILoggerService loggerService, IHttpClie
     {
         TokenCredential tokenCredential = _tokenCredentialProvider.GetCredential();
         Guid tenantId = AuthHelper.GetTenantId(logger, tokenCredential);
-        string token = (await tokenCredential.GetTokenAsync(new TokenRequestContext([AuthHelper.DefaultAzureManagementScope]), CancellationToken.None)).Token;
+        string token = (await tokenCredential.GetTokenAsync(new TokenRequestContext([AzureScopes.DefaultAzureManagementScope]), CancellationToken.None)).Token;
         string refreshToken = await OAuthHelper.GetRefreshTokenAsync(_httpClientProvider.GetClient(), apiRegistry, tenantId, token);
         return new RegistryCredentials(Guid.Empty.ToString(), refreshToken);
     }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Services/KustoClientWrapper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Services/KustoClientWrapper.cs
@@ -33,6 +33,9 @@ namespace Microsoft.DotNet.ImageBuilder.Services
         {
             KustoConnectionStringBuilder connectionBuilder =
                 new KustoConnectionStringBuilder($"https://{cluster}.kusto.windows.net")
+                    // We can't use AzureTokenCredentialProvider here to get the credential because that would require
+                    // knowing the scope at startup which is based on the cluster name. It's fine to not use a pre-cached
+                    // token anyway since kusto ingestion happens right away in the command invocation.
                     .WithAadAzureTokenCredentialsAuthentication(new DefaultAzureCredential());
 
             using (IKustoIngestClient client = KustoIngestFactory.CreateDirectIngestClient(connectionBuilder))

--- a/src/Microsoft.DotNet.ImageBuilder/tests/CleanAcrImagesCommandTest.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/CleanAcrImagesCommandTest.cs
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             IContainerRegistryClientFactory acrClientFactory = CreateContainerRegistryClientFactory(acrName, acrClientMock.Object);
 
             CleanAcrImagesCommand command = new(
-                acrClientFactory, Mock.Of<IContainerRegistryContentClientFactory>(), Mock.Of<ILoggerService>());
+                acrClientFactory, Mock.Of<IContainerRegistryContentClientFactory>(), Mock.Of<ILoggerService>(), Mock.Of<IAzureTokenCredentialProvider>());
             command.Options.Subscription = subscription;
             command.Options.ResourceGroup = resourceGroup;
             command.Options.RegistryName = acrName;
@@ -127,7 +127,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 acrName, [repo1ContentClient, repo2ContentClient, repo3ContentClient, repo4ContentClient]);
 
             CleanAcrImagesCommand command = new(
-                acrClientFactory, acrContentClientFactory, Mock.Of<ILoggerService>());
+                acrClientFactory, acrContentClientFactory, Mock.Of<ILoggerService>(), Mock.Of<IAzureTokenCredentialProvider>());
             command.Options.Subscription = subscription;
             command.Options.ResourceGroup = resourceGroup;
             command.Options.RegistryName = acrName;
@@ -178,7 +178,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             IContainerRegistryClientFactory acrClientFactory = CreateContainerRegistryClientFactory(acrName, acrClientMock.Object);
 
             CleanAcrImagesCommand command = new(
-                acrClientFactory, Mock.Of<IContainerRegistryContentClientFactory>(), Mock.Of<ILoggerService>());
+                acrClientFactory, Mock.Of<IContainerRegistryContentClientFactory>(), Mock.Of<ILoggerService>(), Mock.Of<IAzureTokenCredentialProvider>());
             command.Options.Subscription = subscription;
             command.Options.ResourceGroup = resourceGroup;
             command.Options.RegistryName = acrName;
@@ -223,7 +223,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             IContainerRegistryClientFactory acrClientFactory = CreateContainerRegistryClientFactory(acrName, acrClientMock.Object);
 
             CleanAcrImagesCommand command = new CleanAcrImagesCommand(
-                acrClientFactory, Mock.Of<IContainerRegistryContentClientFactory>(), Mock.Of<ILoggerService>());
+                acrClientFactory, Mock.Of<IContainerRegistryContentClientFactory>(), Mock.Of<ILoggerService>(), Mock.Of<IAzureTokenCredentialProvider>());
             command.Options.Subscription = subscription;
             command.Options.ResourceGroup = resourceGroup;
             command.Options.RegistryName = acrName;
@@ -278,7 +278,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             IContainerRegistryContentClientFactory acrContentClientFactory = CreateContainerRegistryContentClientFactory(acrName, [repo1ContentClientMock, repo2ContentClientMock]);
 
             CleanAcrImagesCommand command = new CleanAcrImagesCommand(
-                acrClientFactory, acrContentClientFactory, Mock.Of<ILoggerService>());
+                acrClientFactory, acrContentClientFactory, Mock.Of<ILoggerService>(), Mock.Of<IAzureTokenCredentialProvider>());
             command.Options.Subscription = subscription;
             command.Options.ResourceGroup = resourceGroup;
             command.Options.RegistryName = acrName;

--- a/src/Microsoft.DotNet.ImageBuilder/tests/RegistryContentClientFactoryTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/RegistryContentClientFactoryTests.cs
@@ -31,7 +31,7 @@ public class RegistryContentClientFactoryTests
             .Returns(contentClient);
 
 
-        RegistryContentClientFactory clientFactory = new(Mock.Of<IHttpClientProvider>(), acrContentClientFactoryMock.Object);
+        RegistryContentClientFactory clientFactory = new(Mock.Of<IHttpClientProvider>(), acrContentClientFactoryMock.Object, Mock.Of<IAzureTokenCredentialProvider>());
         IRegistryContentClient client = clientFactory.Create(AcrName, RepoName, ownedAcr, credsHost);
 
         Assert.Same(contentClient, client);
@@ -44,7 +44,7 @@ public class RegistryContentClientFactoryTests
     public void CreateOtherRegistryClient(string registry, string expectedBaseUri)
     {
         DockerRegistryOptions options = Mock.Of<DockerRegistryOptions>(options => options.RegistryOverride == "my-acr");
-        RegistryContentClientFactory clientFactory = new(Mock.Of<IHttpClientProvider>(), Mock.Of<IContainerRegistryContentClientFactory>());
+        RegistryContentClientFactory clientFactory = new(Mock.Of<IHttpClientProvider>(), Mock.Of<IContainerRegistryContentClientFactory>(), Mock.Of<IAzureTokenCredentialProvider>());
         IRegistryCredentialsHost credsHost = Mock.Of<IRegistryCredentialsHost>(host => host.Credentials == new Dictionary<string, RegistryCredentials>());
         IRegistryContentClient client = clientFactory.Create(registry, "repo-name");
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/docker-tools/issues/1316

The original changes from https://github.com/dotnet/docker-tools/pull/1310 and https://github.com/dotnet/docker-tools/pull/1314 were hacks in order to deal with token expiration that occurs with a long-running command. If execution of the command takes longer than an hour and then an attempt is made to retrieve an Azure access token, it will fail. This is resolved by retrieving the token at the beginning of the command instead.

This defines a provider component that returns an Azure credential that's configured with a pre-cached access token. The access tokens are retrieved during the startup of the command during component composition.

In order to get the tokens, we have to know the scope ahead of time. So these are explicitly defined and a token is retrieved for each one of them. When the caller needs the credential, it specifies which scope is needed and the appropriate credential for that scope is returned.