### PR TITLE
Catch Overflow exceptions to workaround OctoKit issue

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/NotificationService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/NotificationService.cs
@@ -43,10 +43,20 @@ namespace Microsoft.DotNet.ImageBuilder
                 {
                     foreach (string comment in comments)
                     {
-                        string _ = await issueManager.CreateNewIssueCommentAsync(repoUrl, issueId, comment);
+                        try
+                        {
+                            string _ = await issueManager.CreateNewIssueCommentAsync(repoUrl, issueId, comment);
+                        }
+                        catch (OverflowException ex)
+                        {
+                            _loggerService.WriteError($"""
+                                Comment post threw {ex.GetType().FullName}, most likely due to https://github.com/dotnet/docker-tools/issues/1322.
+                                This message should be removed once the issue is fixed.
+                                Message: {ex.Message}
+                                """);
+                        }
                     }
                 }
-
             }
 
             _loggerService.WriteSubheading("POSTED NOTIFICATION:");


### PR DESCRIPTION
#1322 has been affecting us for a few days, so I'm submitting this PR to hopefully work around the issue and get our builds green by catching OverflowExceptions when posting comments. We can remove it once the issue is fixed in OctoKit and then Microsoft.DotNet.Git.IssueManager.