### PR TITLE
Pass through linuxArmBuildJobTimeout

### DIFF
--- a/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
@@ -14,6 +14,7 @@ parameters:
   windowsAmdBuildJobTimeout: 60
   windowsAmdTestJobTimeout: 60
   linuxAmdBuildJobTimeout: 60
+  linuxArmBuildJobTimeout: 60
   linuxAmd64Pool: ""
   buildMatrixType: platformDependencyGraph
   testMatrixType: platformVersionedOs
@@ -51,6 +52,7 @@ stages:
     windowsAmdBuildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
     windowsAmdTestJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
     linuxAmdBuildJobTimeout: ${{ parameters.linuxAmdBuildJobTimeout }}
+    linuxArmBuildJobTimeout: ${{ parameters.linuxArmBuildJobTimeout }}
     buildMatrixType: ${{ parameters.buildMatrixType }}
     testMatrixType: ${{ parameters.testMatrixType }}
 


### PR DESCRIPTION
Needed to set arm timeout in jobs that (indirectly) use this template. Context: https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1083/files#r1633704323

@mthalman PTAL