### PR TITLE
Explicitly reference Octokit package in ImageBuilder and revert #1325

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Microsoft.DotNet.VersionTools" Version="9.0.0-beta.24151.5" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="19.225.1" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.15" />
+    <PackageReference Include="Octokit" Version="12.0.0" />
     <PackageReference Include="Polly" Version="8.4.0" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />

--- a/src/Microsoft.DotNet.ImageBuilder/src/NotificationService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/NotificationService.cs
@@ -46,7 +46,6 @@ namespace Microsoft.DotNet.ImageBuilder
                         string _ = await issueManager.CreateNewIssueCommentAsync(repoUrl, issueId, comment);
                     }
                 }
-
             }
 
             _loggerService.WriteSubheading("POSTED NOTIFICATION:");

--- a/src/Microsoft.DotNet.ImageBuilder/src/NotificationService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/NotificationService.cs
@@ -43,20 +43,10 @@ namespace Microsoft.DotNet.ImageBuilder
                 {
                     foreach (string comment in comments)
                     {
-                        try
-                        {
-                            string _ = await issueManager.CreateNewIssueCommentAsync(repoUrl, issueId, comment);
-                        }
-                        catch (OverflowException ex)
-                        {
-                            _loggerService.WriteError($"""
-                                Comment post threw {ex.GetType().FullName}, most likely due to https://github.com/dotnet/docker-tools/issues/1322.
-                                This message should be removed once the issue is fixed.
-                                Message: {ex.Message}
-                                """);
-                        }
+                        string _ = await issueManager.CreateNewIssueCommentAsync(repoUrl, issueId, comment);
                     }
                 }
+
             }
 
             _loggerService.WriteSubheading("POSTED NOTIFICATION:");


### PR DESCRIPTION
Fixes #1322 

Also references Octokit explicitly in ImageBuilder's project file since we do use it explicitly:

https://github.com/dotnet/docker-tools/blob/c3f7994c4e427812c1b9c07b3b050104d4c4eb6e/src/Microsoft.DotNet.ImageBuilder/src/BlobsClientExtensions.cs#L7