### PR TITLE
Move ArmClient initialization out of dry run

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/CopyImageService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/CopyImageService.cs
@@ -57,9 +57,6 @@ public class CopyImageService : ICopyImageService
     {
         destAcrName = GetBaseAcrName(destAcrName);
 
-        ContainerRegistryResource registryResource = _armClient.Value.GetContainerRegistryResource(
-            ContainerRegistryResource.CreateResourceIdentifier(subscription, resourceGroup, destAcrName));
-
         ContainerRegistryImportSource importSrc = new(srcTagName)
         {
             ResourceId = srcResourceId,
@@ -79,6 +76,9 @@ public class CopyImageService : ICopyImageService
 
         if (!isDryRun)
         {
+            ContainerRegistryResource registryResource = _armClient.Value.GetContainerRegistryResource(
+                ContainerRegistryResource.CreateResourceIdentifier(subscription, resourceGroup, destAcrName));
+
             try
             {
                 await RetryHelper.GetWaitAndRetryPolicy<Exception>(_loggerService)


### PR DESCRIPTION
The changes from https://github.com/dotnet/docker-tools/pull/1321 cause an attempt to get a token in `CopyImageService` when executing in dry run mode. This causes the following exception:

```
Unhandled exception: Azure.Identity.CredentialUnavailableException: DefaultAzureCredential failed to retrieve a token from the included credentials. See the troubleshooting guide for more information. https://aka.ms/azsdk/net/identity/defaultazurecredential/troubleshoot
- EnvironmentCredential authentication unavailable. Environment variables are not fully configured. See the troubleshooting guide for more information. https://aka.ms/azsdk/net/identity/environmentcredential/troubleshoot
- WorkloadIdentityCredential authentication unavailable. The workload options are not fully configured. See the troubleshooting guide for more information. https://aka.ms/azsdk/net/identity/workloadidentitycredential/troubleshoot
- ManagedIdentityCredential authentication unavailable. The requested identity has not been assigned to this resource.
Status: 400 (Bad Request)
```

That would be the expected behavior since it's not running in an authenticated context for a dry run. Instead, there should be no attempt made to get a token.

To fix this, I just moved the code which initializes `ArmClient` (and gets the token) to a section of the code that is only run when dry run is disabled.