### PR TITLE
Add pipeline for mirroring base images to cache ACR on a schedule

### DIFF
--- a/eng/common/templates/jobs/copy-base-images-staging.yml
+++ b/eng/common/templates/jobs/copy-base-images-staging.yml
@@ -1,0 +1,30 @@
+parameters:
+- name: name
+  type: string
+  default: null
+- name: pool
+  type: object
+  default: {}
+- name: customInitSteps
+  type: stepList
+  default: []
+- name: additionalOptions
+  type: string
+  default: ''
+- name: continueOnError
+  type: string
+  default: false
+
+jobs:
+- template: /eng/common/templates/jobs/copy-base-images.yml@self
+  parameters:
+    name: ${{ parameters.name }}
+    pool: ${{ parameters.pool }}
+    customInitSteps: ${{ parameters.customInitSteps }}
+    additionalOptions: ${{ parameters.additionalOptions }}
+    acr:
+      server: $(acr-staging.server)
+      serviceConnection: $(acr-staging.serviceConnectionName)
+      subscription: $(acr-staging.subscription)
+      resourceGroup: $(acr-staging.resourceGroup)
+    repoPrefix: $(mirrorRepoPrefix)

--- a/eng/common/templates/jobs/copy-base-images.yml
+++ b/eng/common/templates/jobs/copy-base-images.yml
@@ -1,10 +1,28 @@
 parameters:
-  name: null
-  pool: {}
-  additionalOptions: null
-  publicProjectName: null
-  internalProjectName: null
-  customInitSteps: []
+- name: name
+  type: string
+  default: null
+- name: pool
+  type: object
+  default: {}
+- name: acr
+  type: object
+  default: null
+- name: repoPrefix
+  type: string
+  default: null
+- name: customInitSteps
+  type: stepList
+  default: []
+- name: additionalOptions
+  type: string
+  default: ''
+- name: continueOnError
+  type: string
+  default: false
+- name: forceDryRun
+  type: boolean
+  default: false
 
 jobs:
 - job: ${{ parameters.name }}
@@ -14,7 +32,8 @@ jobs:
   - ${{ parameters.customInitSteps }}
   - template: /eng/common/templates/steps/copy-base-images.yml@self
     parameters:
+      acr: ${{ parameters.acr }} 
+      repoPrefix: ${{ parameters.repoPrefix }}
       additionalOptions: ${{ parameters.additionalOptions }}
-      publicProjectName: ${{ parameters.publicProjectName }}
-      internalProjectName: ${{ parameters.internalProjectName }}
-      continueOnError: true
+      continueOnError: ${{ parameters.continueOnError }}
+      forceDryRun: ${{ parameters.forceDryRun }}

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -64,13 +64,11 @@ stages:
             echo "##vso[task.setvariable variable=osVersions]"
             echo "##vso[task.setvariable variable=architecture]"
           displayName: Initialize Test Variables
-  - template: /eng/common/templates/jobs/copy-base-images.yml@self
+  - template: /eng/common/templates/jobs/copy-base-images-staging.yml@self
     parameters:
       name: CopyBaseImages
       pool: ${{ parameters.linuxAmd64Pool }}
       additionalOptions: "--manifest '$(manifest)' $(imageBuilder.pathArgs) $(manifestVariables)"
-      publicProjectName: ${{ parameters.publicProjectName }}
-      internalProjectName: ${{ parameters.internalProjectName }}
       customInitSteps: ${{ parameters.customCopyBaseImagesInitSteps }}
   - template: /eng/common/templates/jobs/generate-matrix.yml@self
     parameters:

--- a/eng/common/templates/steps/copy-base-images-staging.yml
+++ b/eng/common/templates/steps/copy-base-images-staging.yml
@@ -1,0 +1,19 @@
+parameters:
+- name: additionalOptions
+  type: string
+  default: null
+- name: continueOnError
+  type: string
+  default: false
+
+steps:
+- template: /eng/common/templates/steps/copy-base-images.yml@self
+  parameters:
+    additionalOptions: ${{ parameters.additionalOptions }}
+    continueOnError: ${{ parameters.continueOnError }}
+    repoPrefix: $(mirrorRepoPrefix)
+    acr:
+      resourceGroup: $(acr-staging.resourceGroup)
+      server: $(acr-staging.server)
+      serviceConnection: $(acr-staging.serviceConnectionName)
+      subscription: $(acr-staging.subscription)

--- a/eng/common/templates/steps/copy-base-images.yml
+++ b/eng/common/templates/steps/copy-base-images.yml
@@ -1,29 +1,44 @@
 parameters:
-  additionalOptions: null
-  publicProjectName: null
-  internalProjectName: null
-  continueOnError: false
+- name: acr
+  type: object
+  default:
+    server: ""
+    serviceConnection: ""
+    subscription: ""
+    resourceGroup: ""
+- name: repoPrefix
+  type: string
+  default: null
+- name: additionalOptions
+  type: string
+  default: ""
+- name: continueOnError
+  type: string
+  default: false
+- name: forceDryRun
+  type: boolean
+  default: false
 
 steps:
-- ${{ if or(eq(variables['System.TeamProject'], parameters.publicProjectName), eq(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: /eng/common/templates/steps/set-dry-run.yml@self
+- ${{ if or(eq(parameters.forceDryRun, true), eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
+  - script: echo "##vso[task.setvariable variable=dryRunArg]--dry-run"
 - template: /eng/common/templates/steps/run-imagebuilder.yml@self
   parameters:
     displayName: Copy Base Images
-    serviceConnection: $(acr-staging.serviceConnectionName)
+    serviceConnection: '${{ parameters.acr.serviceConnection }}'
     continueOnError: ${{ parameters.continueOnError }}
-    internalProjectName: ${{ parameters.internalProjectName }}
+    internalProjectName: 'internal'
     # Use environment variable to reference $(dryRunArg). Since $(dryRunArg) might be undefined,
     # PowerShell will treat the Azure Pipelines variable macro syntax as a command and throw an
     # error
     args: >
       copyBaseImages
-      '$(acr-staging.subscription)'
-      '$(acr-staging.resourceGroup)'
+      '${{ parameters.acr.subscription }}'
+      '${{ parameters.acr.resourceGroup }}'
       $(dockerHubRegistryCreds)
       $(customCopyBaseImagesArgs)
-      --repo-prefix $(mirrorRepoPrefix)
-      --registry-override '$(acr-staging.server)'
+      --repo-prefix '${{ parameters.repoPrefix }}'
+      --registry-override '${{ parameters.acr.server }}'
       --os-type 'linux'
       --architecture '*'
       $env:DRYRUNARG

--- a/eng/pipelines/mirror-base-images.yml
+++ b/eng/pipelines/mirror-base-images.yml
@@ -1,0 +1,39 @@
+trigger: none
+pr: none
+
+schedules:
+- cron: "0 0,6,12,18 * * *"
+  displayName: Daily build
+  branches:
+    include:
+    - main
+  always: true
+
+parameters:
+- name: dryRun
+  displayName: Dry Run
+  type: boolean
+  default: false
+
+variables:
+- template: /eng/common/templates/variables/dotnet/common.yml@self
+- name: mirrorRepoPrefix
+  value: ""
+
+extends:
+  template: /eng/common/templates/1es-unofficial.yml@self
+  parameters:
+    stages:
+    - stage: MirrorBaseImages
+      displayName: Mirror Base Images
+      jobs:
+      - template: /eng/pipelines/templates/jobs/copy-base-images-public-mirror.yml@self
+        parameters:
+          name: "Public"
+          subscriptionsPath: eng/check-base-image-subscriptions.json
+          dryRun: ${{ parameters.dryRun }}
+      - template: /eng/pipelines/templates/jobs/copy-base-images-public-mirror.yml@self
+        parameters:
+          name: "Public_Buildtools"
+          subscriptionsPath: eng/check-base-image-subscriptions-buildtools.json
+          dryRun: ${{ parameters.dryRun }}

--- a/eng/pipelines/templates/jobs/check-base-image-updates.yml
+++ b/eng/pipelines/templates/jobs/check-base-image-updates.yml
@@ -15,6 +15,12 @@ jobs:
   - template: /eng/common/templates/steps/init-docker-linux.yml@self
   - template: /eng/common/templates/steps/copy-base-images.yml@self
     parameters:
+      acr:
+        server: $(acr-staging.server)
+        serviceConnection: $(acr-staging.serviceConnectionName)
+        subscription: $(acr-staging.subscription)
+        resourceGroup: $(acr-staging.resourceGroup)
+      repoPrefix: $(mirrorRepoPrefix)
       additionalOptions: "--subscriptions-path '${{ parameters.subscriptionsPath }}'"
   - script: >
       $(runImageBuilderCmd)

--- a/eng/pipelines/templates/jobs/check-base-image-updates.yml
+++ b/eng/pipelines/templates/jobs/check-base-image-updates.yml
@@ -16,8 +16,6 @@ jobs:
   - template: /eng/common/templates/steps/copy-base-images.yml@self
     parameters:
       additionalOptions: "--subscriptions-path '${{ parameters.subscriptionsPath }}'"
-      publicProjectName: ${{ parameters.publicProjectName }}
-      internalProjectName: ${{ parameters.internalProjectName }}
   - script: >
       $(runImageBuilderCmd)
       getStaleImages

--- a/eng/pipelines/templates/jobs/copy-base-images-public-mirror.yml
+++ b/eng/pipelines/templates/jobs/copy-base-images-public-mirror.yml
@@ -1,0 +1,31 @@
+parameters:
+- name: name
+  type: string
+  default: null
+- name: subscriptionsPath
+  type: string
+  default: null
+- name: customInitSteps
+  type: stepList
+  default: []
+- name: dryRun
+  type: boolean
+  default: false
+
+jobs:
+- template: /eng/common/templates/jobs/copy-base-images.yml@self
+  parameters:
+    name: MirrorBaseImages_${{ parameters.name }}
+    pool:
+      name: NetCore1ESPool-Internal
+      image: 1es-ubuntu-2204
+      os: linux
+    acr:
+      server: $(public-mirror.server)
+      serviceConnection: $(public-mirror.serviceConnectionName)
+      subscription: $(public-mirror.subscription)
+      resourceGroup: $(public-mirror.resourceGroup)
+    repoPrefix: $(mirrorRepoPrefix)
+    customInitSteps: ${{ parameters.customInitSteps }}
+    additionalOptions: '--subscriptions-path ${{ parameters.subscriptionsPath }}'
+    forceDryRun: ${{ parameters.dryRun }}


### PR DESCRIPTION
1/2 of https://github.com/dotnet/dotnet-docker-internal/issues/5504

Implements a new subscription type (manifest-only subscription) and pipeline that consumes that subscription. The pipeline runs an import of all the base images into our cache ACR. Some minor refactoring of the CopyBaseImages pipeline templates was required.