### PR TITLE
Fix staging server variable reference for PowerShell

### DIFF
--- a/eng/common/templates/steps/test-images-windows-client.yml
+++ b/eng/common/templates/steps/test-images-windows-client.yml
@@ -23,7 +23,7 @@ steps:
 - ${{ parameters.customInitSteps }}
 - powershell: |
     if ("${{ variables['System.TeamProject'] }}" -eq "${{ parameters.internalProjectName }}" -and "${{ variables['Build.Reason'] }}" -ne "PullRequest") {
-      $optionalTestArgs="$optionalTestArgs -PullImages -Registry $env:ACR-STAGING_SERVER -RepoPrefix $env:STAGINGREPOPREFIX -ImageInfoPath $(artifactsPath)/image-info.json"
+      $optionalTestArgs="$optionalTestArgs -PullImages -Registry ${env:ACR-STAGING_SERVER} -RepoPrefix $env:STAGINGREPOPREFIX -ImageInfoPath $(artifactsPath)/image-info.json"
     }
     if ($env:REPOTESTARGS) {
       $optionalTestArgs += " $env:REPOTESTARGS"


### PR DESCRIPTION
The use of `$env:ACR-STAGING_SERVER` is incorrect syntax. It results in PowerShell looking for an environment variable named `ACR` and then just appends the string `-STAGING_SERVER` to the result because `-` is a variable delimiter. Since there is no `ACR` variable, the result of this is `-STAGING_SERVER` which obviously isn't what we want.

Fixed to use `{..}` syntax to include the entire variable name.