### PR TITLE
Allow readmes to have tags header w/o tags table

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/ReadmeHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ReadmeHelper.cs
@@ -32,12 +32,11 @@ namespace Microsoft.DotNet.ImageBuilder
             if (fullTagListingHeaderIndex >= 0)
             {
                 int endOfFullTagListingHeaderIndex = fullTagListingHeaderIndex + TagsSectionHeader.Length;
-                int endOfGeneratedTagsIndex = readme.IndexOf(EndOfGeneratedTagsMarker) + EndOfGeneratedTagsMarker.Length;
+                int endOfGeneratedTagsIndex = readme.IndexOf(EndOfGeneratedTagsMarker);
 
                 if (endOfGeneratedTagsIndex < 0)
                 {
-                    throw new InvalidOperationException(
-                        $"Unable to find marker '{EndOfGeneratedTagsMarker}' in the readme content:{Environment.NewLine}{readme}");
+                    return readme;
                 }
 
                 readme =
@@ -47,7 +46,7 @@ namespace Microsoft.DotNet.ImageBuilder
                     tagsListing +
                     EndOfGeneratedTagsMarker +
                     targetLineEnding +
-                    readme.Substring(endOfGeneratedTagsIndex);
+                    readme.Substring(endOfGeneratedTagsIndex + EndOfGeneratedTagsMarker.Length);
             }
 
             return readme;


### PR DESCRIPTION
Readme generation doesn't allow a readme to contain the `Full Tag Listing` header w/o also injecting the tags table. This blocks the implementation of https://github.com/dotnet/dotnet-docker/pull/5585. See https://github.com/dotnet/dotnet-docker/pull/5585#discussion_r1647680272.

In such a scenario where a readme has the header but not the end of tags marker, it essentially duplicates much of the readme and prepends it, along with the tags table. I've updated the logic to check if the end of tags marker is not present and not inject the tags table in that case. (The original intent was to throw if this marker was missing but there was a bug there preventing that from happening.)