### PR TITLE
Prepopulate credential cache for ACR

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
@@ -147,7 +147,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     processServiceMock.Object,
                     Mock.Of<ICopyImageService>(),
                     manifestServiceFactoryMock.Object,
-                    Mock.Of<IRegistryCredentialsProvider>());
+                    Mock.Of<IRegistryCredentialsProvider>(),
+                    Mock.Of<IAzureTokenCredentialProvider>());
                 command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
                 command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "image-info.json");
                 command.Options.IsPushEnabled = true;
@@ -349,7 +350,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     Mock.Of<IProcessService>(),
                     Mock.Of<ICopyImageService>(),
                     manifestServiceFactoryMock.Object,
-                    Mock.Of<IRegistryCredentialsProvider>());
+                    Mock.Of<IRegistryCredentialsProvider>(),
+                    Mock.Of<IAzureTokenCredentialProvider>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "image-info.json");
             command.Options.IsPushEnabled = true;
@@ -477,7 +479,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Mock.Of<IProcessService>(),
                 copyImageServiceMock.Object,
                 CreateManifestServiceFactoryMock().Object,
-                Mock.Of<IRegistryCredentialsProvider>());
+                Mock.Of<IRegistryCredentialsProvider>(),
+                Mock.Of<IAzureTokenCredentialProvider>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.IsPushEnabled = true;
 
@@ -554,7 +557,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Mock.Of<IProcessService>(),
                 Mock.Of<ICopyImageService>(),
                 CreateManifestServiceFactoryMock().Object,
-                Mock.Of<IRegistryCredentialsProvider>());
+                Mock.Of<IRegistryCredentialsProvider>(),
+                Mock.Of<IAzureTokenCredentialProvider>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
 
             const string runtimeRelativeDir = "1.0/runtime/os";
@@ -605,7 +609,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Mock.Of<IProcessService>(),
                 Mock.Of<ICopyImageService>(),
                 CreateManifestServiceFactoryMock().Object,
-                Mock.Of<IRegistryCredentialsProvider>());
+                Mock.Of<IRegistryCredentialsProvider>(),
+                Mock.Of<IAzureTokenCredentialProvider>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.BuildArgs.Add("arg1", "val1");
             command.Options.BuildArgs.Add("arg2", "val2a");
@@ -663,7 +668,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Mock.Of<IProcessService>(),
                 Mock.Of<ICopyImageService>(),
                 Mock.Of<IManifestServiceFactory>(),
-                Mock.Of<IRegistryCredentialsProvider>());
+                Mock.Of<IRegistryCredentialsProvider>(),
+                Mock.Of<IAzureTokenCredentialProvider>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.IsPushEnabled = true;
 
@@ -763,7 +769,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Mock.Of<IProcessService>(),
                 copyImageServiceMock.Object,
                 manifestServiceFactoryMock.Object,
-                Mock.Of<IRegistryCredentialsProvider>());
+                Mock.Of<IRegistryCredentialsProvider>(),
+                Mock.Of<IAzureTokenCredentialProvider>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "dest-image-info.json");
             command.Options.ImageInfoSourcePath = Path.Combine(tempFolderContext.Path, "src-image-info.json");
@@ -948,7 +955,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     Mock.Of<IProcessService>(),
                     Mock.Of<ICopyImageService>(),
                     manifestServiceFactoryMock.Object,
-                    Mock.Of<IRegistryCredentialsProvider>());
+                    Mock.Of<IRegistryCredentialsProvider>(),
+                    Mock.Of<IAzureTokenCredentialProvider>());
                 command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
                 command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "image-info.json");
                 command.Options.SourceRepoUrl = "https://source";
@@ -997,7 +1005,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Mock.Of<IProcessService>(),
                 Mock.Of<ICopyImageService>(),
                 CreateManifestServiceFactoryMock().Object,
-                Mock.Of<IRegistryCredentialsProvider>());
+                Mock.Of<IRegistryCredentialsProvider>(),
+                Mock.Of<IAzureTokenCredentialProvider>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.IsSkipPullingEnabled = isSkipPullingEnabled;
 
@@ -1158,7 +1167,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Mock.Of<IProcessService>(),
                 copyImageServiceMock.Object,
                 manifestServiceFactoryMock.Object,
-                Mock.Of<IRegistryCredentialsProvider>());
+                Mock.Of<IRegistryCredentialsProvider>(),
+                Mock.Of<IAzureTokenCredentialProvider>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "dest-image-info.json");
             command.Options.ImageInfoSourcePath = Path.Combine(tempFolderContext.Path, "src-image-info.json");
@@ -1469,7 +1479,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Mock.Of<IProcessService>(),
                 copyImageServiceMock.Object,
                 manifestServiceFactoryMock.Object,
-                Mock.Of<IRegistryCredentialsProvider>());
+                Mock.Of<IRegistryCredentialsProvider>(),
+                Mock.Of<IAzureTokenCredentialProvider>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "dest-image-info.json");
             command.Options.ImageInfoSourcePath = Path.Combine(tempFolderContext.Path, "src-image-info.json");
@@ -1782,7 +1793,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Mock.Of<IProcessService>(),
                 copyImageServiceMock.Object,
                 manifestServiceFactoryMock.Object,
-                Mock.Of<IRegistryCredentialsProvider>());
+                Mock.Of<IRegistryCredentialsProvider>(),
+                Mock.Of<IAzureTokenCredentialProvider>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "dest-image-info.json");
             command.Options.ImageInfoSourcePath = Path.Combine(tempFolderContext.Path, "src-image-info.json");
@@ -2075,7 +2087,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Mock.Of<IProcessService>(),
                 copyImageServiceMock.Object,
                 CreateManifestServiceFactoryMock(manifestServiceMock).Object,
-                Mock.Of<IRegistryCredentialsProvider>());
+                Mock.Of<IRegistryCredentialsProvider>(),
+                Mock.Of<IAzureTokenCredentialProvider>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "dest-image-info.json");
             command.Options.ImageInfoSourcePath = Path.Combine(tempFolderContext.Path, "src-image-info.json");
@@ -2279,7 +2292,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Mock.Of<IProcessService>(),
                 Mock.Of<ICopyImageService>(),
                 CreateManifestServiceFactoryMock(manifestServiceMock).Object,
-                Mock.Of<IRegistryCredentialsProvider>());
+                Mock.Of<IRegistryCredentialsProvider>(),
+                Mock.Of<IAzureTokenCredentialProvider>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "dest-image-info.json");
             command.Options.ImageInfoSourcePath = Path.Combine(tempFolderContext.Path, "src-image-info.json");
@@ -2519,7 +2533,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Mock.Of<IProcessService>(),
                 copyImageServiceMock.Object,
                 CreateManifestServiceFactoryMock(manifestServiceMock).Object,
-                Mock.Of<IRegistryCredentialsProvider>());
+                Mock.Of<IRegistryCredentialsProvider>(),
+                Mock.Of<IAzureTokenCredentialProvider>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "dest-image-info.json");
             command.Options.ImageInfoSourcePath = Path.Combine(tempFolderContext.Path, "src-image-info.json");
@@ -2738,8 +2753,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 gitServiceMock.Object,
                 Mock.Of<IProcessService>(),
                 copyImageServiceMock.Object,
-CreateManifestServiceFactoryMock(manifestServiceMock).Object,
-                Mock.Of<IRegistryCredentialsProvider>());
+                CreateManifestServiceFactoryMock(manifestServiceMock).Object,
+                Mock.Of<IRegistryCredentialsProvider>(),
+                Mock.Of<IAzureTokenCredentialProvider>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "dest-image-info.json");
             command.Options.ImageInfoSourcePath = Path.Combine(tempFolderContext.Path, "src-image-info.json");
@@ -3040,8 +3056,9 @@ CreateManifestServiceFactoryMock(manifestServiceMock).Object,
                 gitServiceMock.Object,
                 Mock.Of<IProcessService>(),
                 copyImageServiceMock.Object,
-CreateManifestServiceFactoryMock(manifestServiceMock).Object,
-                Mock.Of<IRegistryCredentialsProvider>());
+                CreateManifestServiceFactoryMock(manifestServiceMock).Object,
+                Mock.Of<IRegistryCredentialsProvider>(),
+                Mock.Of<IAzureTokenCredentialProvider>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "image-info.json");
             command.Options.ImageInfoSourcePath = Path.Combine(tempFolderContext.Path, "src-image-info.json");
@@ -3382,8 +3399,9 @@ CreateManifestServiceFactoryMock(manifestServiceMock).Object,
                 gitServiceMock.Object,
                 Mock.Of<IProcessService>(),
                 Mock.Of<ICopyImageService>(),
-CreateManifestServiceFactoryMock(manifestServiceMock).Object,
-                Mock.Of<IRegistryCredentialsProvider>());
+                CreateManifestServiceFactoryMock(manifestServiceMock).Object,
+                Mock.Of<IRegistryCredentialsProvider>(),
+                Mock.Of<IAzureTokenCredentialProvider>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "image-info.json");
             command.Options.IsPushEnabled = true;
@@ -3478,8 +3496,9 @@ CreateManifestServiceFactoryMock(manifestServiceMock).Object,
                 gitServiceMock.Object,
                 Mock.Of<IProcessService>(),
                 Mock.Of<ICopyImageService>(),
-CreateManifestServiceFactoryMock(manifestServiceMock).Object,
-                Mock.Of<IRegistryCredentialsProvider>());
+                CreateManifestServiceFactoryMock(manifestServiceMock).Object,
+                Mock.Of<IRegistryCredentialsProvider>(),
+                Mock.Of<IAzureTokenCredentialProvider>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "image-info.json");
             command.Options.IsPushEnabled = true;


### PR DESCRIPTION
Fixes #1350 

The changes from https://github.com/dotnet/docker-tools/pull/1321 don't work for long-running jobs. The presumption was that the necessary tokens would be retrieved up front when Image Builder runs a command. (It's necessary for the token to be retrieved right away while we still have a valid OIDC token from the pipeline. If you wait too long the OIDC token will expire, preventing you from retrieving any access tokens with it.) But this isn't true for the `build` command. It retrieves a token for the `AzureScopes.ContainerRegistryScope` scope at the end of the build when querying for digests of the pushed images. This is the first time an attempt is made to get a token for that scope. So no cached token exists for that scope. But by this point the OIDC token from the pipeline is expired, causing the error.

The solution is to simply prepopulate the cache by making a request to get the token for that scope at the beginning of the `build` command. 