### PR TITLE
Only prepopulate creds cache when push enabled

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -82,7 +82,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             // Prepopulate the credential cache with the container registry scope so that the token isn't expired by the time we
             // need to query the registry at the end of the command.
-            _tokenCredentialProvider.GetCredential(AzureScopes.ContainerRegistryScope);
+            if (Options.IsPushEnabled)
+            {
+                _tokenCredentialProvider.GetCredential(AzureScopes.ContainerRegistryScope);
+            }
 
             await _registryCredentialsProvider.ExecuteWithCredentialsAsync(
                 Options.IsDryRun,


### PR DESCRIPTION
The change from https://github.com/dotnet/docker-tools/pull/1352 was causing the `build` command to fail on public builds because the environment isn't configured to have creds.

Updated it to only execute when push is enabled, which is the case for internal builds where the creds will exist.