### PR TITLE
Prepopulate token cache for publishManifest cmd

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -80,7 +80,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 _imageArtifactDetails = new ImageArtifactDetails();
             }
 
-            // Prepopulate the credential cache with the container registry scope so that the token isn't expired by the time we
+            // Prepopulate the credential cache with the container registry scope so that the OIDC token isn't expired by the time we
             // need to query the registry at the end of the command.
             if (Options.IsPushEnabled)
             {

--- a/src/Microsoft.DotNet.ImageBuilder/tests/PublishManifestCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/PublishManifestCommandTests.cs
@@ -46,7 +46,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Mock.Of<IDockerService>(),
                 Mock.Of<ILoggerService>(),
                 dateTimeService,
-                Mock.Of<IRegistryCredentialsProvider>());
+                Mock.Of<IRegistryCredentialsProvider>(),
+                Mock.Of<IAzureTokenCredentialProvider>());
 
             using TempFolderContext tempFolderContext = new TempFolderContext();
 
@@ -300,7 +301,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 dockerServiceMock.Object,
                 Mock.Of<ILoggerService>(),
                 Mock.Of<IDateTimeService>(),
-                Mock.Of<IRegistryCredentialsProvider>());
+                Mock.Of<IRegistryCredentialsProvider>(),
+                Mock.Of<IAzureTokenCredentialProvider>());
 
             using TempFolderContext tempFolderContext = new TempFolderContext();
 
@@ -424,7 +426,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 dockerServiceMock.Object,
                 Mock.Of<ILoggerService>(),
                 dateTimeService,
-                Mock.Of<IRegistryCredentialsProvider>());
+                Mock.Of<IRegistryCredentialsProvider>(),
+                Mock.Of<IAzureTokenCredentialProvider>());
 
             using TempFolderContext tempFolderContext = new TempFolderContext();
 


### PR DESCRIPTION
The `publishManifest` command ran into the [same issue as the `build` command](https://github.com/dotnet/docker-tools/issues/1350). See [example build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2482890&view=logs&j=739bb7ec-7296-5b40-7dff-ee3297bfdaa4&t=6123d7e1-dcba-5ae2-930b-8eeaf17e8400&s=380ab8c6-4139-55ff-15c4-fb48260f4dca) (internal link). In this case, there were numerous errors while pushing the manifests which resulted in a lot of retries. Those retries eventually succeeded but the overall effect was that the command took a long time to run. At the end of the command, it attempts to query the registry to get the digests and the token had expired due to the length of time.

The fix is to follow the same pattern that was done to fix the `build` command with https://github.com/dotnet/docker-tools/pull/1352.

