### PR TITLE
Upgrade System.Formats.Asn1 version

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
@@ -30,6 +30,8 @@
     <PackageReference Include="System.ComponentModel.Composition" Version="8.0.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <!-- Explicitly upgrade System.Formats.Asn1 from Microsoft.DotNet.VersionTools due to CVE-2024-38095 -->
+    <PackageReference Include="System.Formats.Asn1" Version="6.0.1" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="YamlDotNet" Version="15.1.2" />
   </ItemGroup>


### PR DESCRIPTION
Addresses a CG issue with Image Builder for CVE-2024-38095 by explicitly upgrading System.Formats.Asn1 that's a dependency of Microsoft.DotNet.VersionTools.