### PR TITLE
EOL Annotation pipeline updates

### DIFF
--- a/eng/common/templates/steps/annotate-eol-digests.yml
+++ b/eng/common/templates/steps/annotate-eol-digests.yml
@@ -1,23 +1,32 @@
 parameters:
-  internalProjectName: null
-  force: false
   dataFile: null
 steps:
-  - script: |
-      optionalArgs=""
-      if [ "${{ lower(parameters.force) }}" == "true" ]; then
-        optionalArgs="$optionalArgs --force"
-      fi
-      echo "##vso[task.setvariable variable=optionalArgs]$optionalArgs"
-    displayName: Set Optional Args
+  - script: mkdir -p $(Build.ArtifactStagingDirectory)/annotation-digests
+    displayName: Create Annotation Digests Directory
   - template: /eng/common/templates/steps/run-imagebuilder.yml@self
     parameters:
       name: AnnotateEOLImages
       displayName: Annotate EOL Images
       serviceConnection: $(publish.serviceConnectionName)
-      internalProjectName: ${{ parameters.internalProjectName }}
+      internalProjectName: internal
       args: >
         annotateEolDigests
         /repo/${{ parameters.dataFile }}
         $(acr.server)
-        $(optionalArgs)
+        $(publishRepoPrefix)
+        $(artifactsPath)/annotation-digests/annotation-digests.txt
+  - template: /eng/common/templates/steps/publish-artifact.yml@self
+    parameters:
+      path: $(Build.ArtifactStagingDirectory)/annotation-digests
+      artifactName: annotation-digests-$(System.JobAttempt)
+      displayName: Publish Annotation Digests List
+      internalProjectName: internal
+      publicProjectName: public
+  - template: /eng/common/templates/steps/run-imagebuilder.yml@self
+    parameters:
+      displayName: Wait for Annotation Ingestion
+      serviceConnection: $(marStatus.serviceConnectionName)
+      internalProjectName: internal
+      args: >
+        waitForMarAnnotationIngestion
+        $(artifactsPath)/annotation-digests/annotation-digests.txt

--- a/eng/pipelines/annotate-eol-digests.yml
+++ b/eng/pipelines/annotate-eol-digests.yml
@@ -5,10 +5,6 @@ parameters:
 - name: dataFile
   displayName: Relative path to EOL annotations data file (e.g. eol-3.1.json for file in root of the branch)
   type: string
-- name: force
-  displayName: Annotate always, without checking if digests are already annotated for EOL
-  type: boolean
-  default: false
 
 variables:
 - template: templates/variables/image-builder.yml
@@ -26,6 +22,4 @@ extends:
         - template: /eng/common/templates/steps/init-docker-linux.yml@self
         - template: /eng/common/templates/steps/annotate-eol-digests.yml@self
           parameters:
-            internalProjectName: ${{ variables.internalProjectName }}
             dataFile: ${{ parameters.dataFile }}
-            force: ${{ parameters.force }}


### PR DESCRIPTION
* Updates the annotation publishing to account for the updates in https://github.com/dotnet/docker-tools/pull/1364.
* Consumes the new command from https://github.com/dotnet/docker-tools/pull/1373 to wait until annotations have been ingested.
* Publish a pipeline artifact text file of the annotation digests that were pushed.