### PR TITLE
CleanAcrImages: don't use dry run for login

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesCommand.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             List<string> deletedImages = new List<string>();
 
             await _registryCredentialsProvider.ExecuteWithCredentialsAsync(
-                Options.IsDryRun,
+                isDryRun: false,
                 async () =>
                 {
                     IEnumerable<Task> cleanupTasks = await repositoryNames


### PR DESCRIPTION
The changes in https://github.com/dotnet/docker-tools/pull/1385 added a `docker login` call to ensure credentials were configured for calling `oras`. But this doesn't work when executing the image-clean pipeline in dry run mode. When dry run is set to true for the login call, it doesn't actually invoke the command. So no login occurs and the subsequent `oras` calls all fail.

This change explicitly sets dry run to `false` for the login command.