### PR TITLE
Handle unknown state for MAR ingestion

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/MarImageIngestionReporter.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/MarImageIngestionReporter.cs
@@ -129,6 +129,7 @@ public class MarImageIngestionReporter : IMarImageIngestionReporter
                             case StageStatus.Processing:
                             case StageStatus.NotStarted:
                             case StageStatus.Failed:
+                            case StageStatus.Unknown:
                                 break;
                             case StageStatus.Succeeded:
                                 // If we've found at least one successful overall status for the tag, we're done with that tag.


### PR DESCRIPTION
While running a build that executed the MAR ingestion reporting logic, I encountered a scenario where a status had a value of `Unknown` that was not handled. It caused a `NotSupportedException` to be thrown by the code. Upon examining the digest that was being reported on, it eventually did have a `Succeeded` state.

This updates the code to handle the `Unknown` state just like it would other "pending" states.