### PR TITLE
Add custom steps to run after build

### DIFF
--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -5,6 +5,7 @@ parameters:
   dockerClientOS: null
   buildJobTimeout: 60
   customInitSteps: []
+  customPostSteps: []
   noCache: false
   internalProjectName: null
   publicProjectName: null
@@ -134,6 +135,7 @@ jobs:
         --acr-resource-group '$(acr-staging.resourceGroup)'
         $(manifestVariables)
         $(imageBuilderBuildArgs)
+  - ${{ parameters.customPostSteps }}
   - template: /eng/common/templates/steps/publish-artifact.yml@self
     parameters:
       path: $(imageInfoHostDir)

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -5,6 +5,7 @@ parameters:
   testMatrixCustomBuildLegGroupArgs: ""
   customCopyBaseImagesInitSteps: []
   customBuildInitSteps: []
+  customBuildPostSteps: []
   customTestInitSteps: []
   customPublishInitSteps: []
   customPublishVariables: []
@@ -87,6 +88,7 @@ stages:
       dockerClientOS: linux
       buildJobTimeout: ${{ parameters.linuxAmdBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
+      customPostSteps: ${{ parameters.customBuildPostSteps }}
       noCache: ${{ parameters.noCache }}
       internalProjectName: ${{ parameters.internalProjectName }}
       publicProjectName: ${{ parameters.publicProjectName }}
@@ -100,6 +102,7 @@ stages:
       dockerClientOS: linux
       buildJobTimeout: ${{ parameters.linuxArmBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
+      customPostSteps: ${{ parameters.customBuildPostSteps }}
       noCache: ${{ parameters.noCache }}
       internalProjectName: ${{ parameters.internalProjectName }}
       publicProjectName: ${{ parameters.publicProjectName }}
@@ -113,6 +116,7 @@ stages:
       dockerClientOS: linux
       buildJobTimeout: ${{ parameters.linuxArmBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
+      customPostSteps: ${{ parameters.customBuildPostSteps }}
       noCache: ${{ parameters.noCache }}
       internalProjectName: ${{ parameters.internalProjectName }}
       publicProjectName: ${{ parameters.publicProjectName }}
@@ -126,6 +130,7 @@ stages:
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
+      customPostSteps: ${{ parameters.customBuildPostSteps }}
       noCache: ${{ parameters.noCache }}
       internalProjectName: ${{ parameters.internalProjectName }}
       publicProjectName: ${{ parameters.publicProjectName }}
@@ -139,6 +144,7 @@ stages:
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
+      customPostSteps: ${{ parameters.customBuildPostSteps }}
       noCache: ${{ parameters.noCache }}
       internalProjectName: ${{ parameters.internalProjectName }}
       publicProjectName: ${{ parameters.publicProjectName }}
@@ -152,6 +158,7 @@ stages:
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
+      customPostSteps: ${{ parameters.customBuildPostSteps }}
       noCache: ${{ parameters.noCache }}
       internalProjectName: ${{ parameters.internalProjectName }}
       publicProjectName: ${{ parameters.publicProjectName }}


### PR DESCRIPTION
Needed for changes in https://github.com/dotnet/dotnet-docker/pull/5797 which runs `verify-secret-usage.yml` after building in CI and PRs.

For background, according to https://github.com/dotnet/dnceng/tree/main/src/SecretManager/Microsoft.DncEng.SecretManager#onboarding-a-new-repo, there are a series of steps which need to run after building in CI and PRs. In order to run these steps, the pipeline templates that we use need to be updated to accommodate for running custom steps in the build Stage after the build step.

Steps to do before publishing this PR:
- Test these changes via a pipeline run(s)