### PR TITLE
EOL annotation generation update to handle pre-release versions

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateEolAnnotationDataCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateEolAnnotationDataCommand.cs
@@ -190,8 +190,7 @@ public class GenerateEolAnnotationDataCommand : Command<GenerateEolAnnotationDat
         }
 
         // Check if the version has a pre-release label. If so, it's not EOL by definition.
-        int separatorIndex = image.ProductVersion.IndexOf("-");
-        if (separatorIndex != -1)
+        if (image.ProductVersion.Contains("-"))
         {
             return [];
         }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateEolAnnotationDataCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateEolAnnotationDataCommand.cs
@@ -189,6 +189,13 @@ public class GenerateEolAnnotationDataCommand : Command<GenerateEolAnnotationDat
             return [];
         }
 
+        // Check if the version has a pre-release label. If so, it's not EOL by definition.
+        int separatorIndex = image.ProductVersion.IndexOf("-");
+        if (separatorIndex != -1)
+        {
+            return [];
+        }
+
         string dotnetVersion = Version.Parse(image.ProductVersion).ToString(2);
         if (!productEolDates.TryGetValue(dotnetVersion, out DateOnly date))
         {

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateEolAnnotationDataCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateEolAnnotationDataCommandTests.cs
@@ -656,6 +656,27 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     ],
                                     Digest = DockerHelper.GetImageName(AcrName, "repo1", digest: "imagedigest102")
                                 }
+                            },
+                            new ImageData
+                            {
+                                Platforms =
+                                {
+                                    Helpers.ImageInfoHelper.CreatePlatform(repo1Image1DockerfilePath,
+                                        simpleTags:
+                                        [
+                                            "3.0-preview"
+                                        ],
+                                        digest: DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest103"))
+                                },
+                                ProductVersion = "3.0-preview",
+                                Manifest = new ManifestData
+                                {
+                                    SharedTags =
+                                    [
+                                        "3.0-preview"
+                                    ],
+                                    Digest = DockerHelper.GetImageName(AcrName, "repo1", digest: "imagedigest103")
+                                }
                             }
                         }
                     }
@@ -689,8 +710,6 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             CreateArtifactManifestProperties(digest: "platformdigest101-updated", tags: ["1.0"]),
                             CreateArtifactManifestProperties(digest: "imagedigest101"),
                             CreateArtifactManifestProperties(digest: "imagedigest101-updated", tags: ["1.0"]),
-                            CreateArtifactManifestProperties(digest: "platformdigest102", tags: ["2.0"]),
-                            CreateArtifactManifestProperties(digest: "imagedigest102", tags: ["2.0"]),
                         ])
                 ]);
             IContainerRegistryClientFactory registryClientFactory = CreateContainerRegistryClientFactory(
@@ -705,8 +724,6 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             { "platformdigest101-updated", new ManifestQueryResult(string.Empty, []) },
                             { "imagedigest101", new ManifestQueryResult(string.Empty, []) },
                             { "imagedigest101-updated", new ManifestQueryResult(string.Empty, []) },
-                            { "platformdigest102", new ManifestQueryResult(string.Empty, []) },
-                            { "imagedigest102", new ManifestQueryResult(string.Empty, []) }
                         })
                 ]);
 


### PR DESCRIPTION
When running `GenerateEolAnnotationDataCommand` on the dotnet-docker repo, it was getting an error due to the existence of `9.0-preview` product versions in the image info file:

```
Error occurred while generating EOL annotation data: System.FormatException: The input string '0-preview' was not in a correct format.
   at System.Number.ThrowFormatException[TChar](ReadOnlySpan`1 value)
   at System.Version.ParseVersion(ReadOnlySpan`1 input, Boolean throwOnFailure)
   at System.Version.Parse(String input)
   at Microsoft.DotNet.ImageBuilder.Commands.GenerateEolAnnotationDataCommand.GetProductEolDigests(ImageData image, Dictionary`2 productEolDates) in /image-builder/src/Commands/GenerateEolAnnotationDataCommand.cs:line 192
   at Microsoft.DotNet.ImageBuilder.Commands.GenerateEolAnnotationDataCommand.GetDigestsToAnnotate() in /image-builder/src/Commands/GenerateEolAnnotationDataCommand.cs:line 109
Unhandled exception: System.FormatException: The input string '0-preview' was not in a correct format.
   at System.Number.ThrowFormatException[TChar](ReadOnlySpan`1 value)
   at System.Version.ParseVersion(ReadOnlySpan`1 input, Boolean throwOnFailure)
   at System.Version.Parse(String input)
   at Microsoft.DotNet.ImageBuilder.Commands.GenerateEolAnnotationDataCommand.GetProductEolDigests(ImageData image, Dictionary`2 productEolDates) in /image-builder/src/Commands/GenerateEolAnnotationDataCommand.cs:line 192
```

The `Version` parse logic doesn't handle pre-release labels. Added a simple check in the logic to account for those labels and return empty EOL data since, by definition, a pre-release won't be EOL.