### PR TITLE
Use concurrency limiter when deleting repo manifests

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesCommand.cs
@@ -11,10 +11,10 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Azure.Containers.ContainerRegistry;
-using Microsoft.DotNet.ImageBuilder.Models.Annotations;
 using Microsoft.DotNet.ImageBuilder.Models.Oras;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
 
+#nullable enable
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     [Export(typeof(ICommand))]
@@ -26,7 +26,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private readonly IAzureTokenCredentialProvider _tokenCredentialProvider;
         private readonly IOrasService _orasService;
         private readonly IRegistryCredentialsProvider _registryCredentialsProvider;
-        private Regex _repoNameFilterRegex;
 
         [ImportingConstructor]
         public CleanAcrImagesCommand(
@@ -49,7 +48,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         public override async Task ExecuteAsync()
         {
-            _repoNameFilterRegex = new Regex(ManifestFilter.GetFilterRegexPattern(Options.RepoName));
+            Regex repoNameFilterRegex = new(ManifestFilter.GetFilterRegexPattern(Options.RepoName));
 
             _loggerService.WriteHeading("FINDING IMAGES TO CLEAN");
 
@@ -69,7 +68,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 async () =>
                 {
                     IEnumerable<Task> cleanupTasks = await repositoryNames
-                        .Where(repoName => _repoNameFilterRegex.IsMatch(repoName))
+                        .Where(repoName => repoNameFilterRegex.IsMatch(repoName))
                         .Select(repoName => acrClient.GetRepository(repoName))
                         .Select(repo =>
                         {

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesCommand.cs
@@ -196,14 +196,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 .AddConcurrencyLimiter(permitLimit: MaxConcurrentDeleteRequestsPerRepo, queueLimit: int.MaxValue)
                 .Build();
 
-            List<Task> tasks = [];
-            foreach (ArtifactManifestProperties manifest in manifests)
-            {
-                tasks.Add(pipeline.ExecuteAsync(async cancellationToken =>
-                {
-                    await DeleteManifestAsync(acrContentClient, deletedImages, repository, manifest);
-                }).AsTask());
-            }
+            IEnumerable<Task> tasks =
+                manifests.Select(manifest =>
+                    pipeline.ExecuteAsync(async cancellationToken =>
+                        await DeleteManifestAsync(acrContentClient, deletedImages, repository, manifest))
+                    .AsTask());
 
             await Task.WhenAll(tasks);
         }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Octokit" Version="13.0.1" />
     <PackageReference Include="Polly" Version="8.4.1" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
+    <PackageReference Include="Polly.RateLimiting" Version="8.4.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
     <PackageReference Include="System.ComponentModel.Composition" Version="8.0.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />


### PR DESCRIPTION
This change adjusts how many delete requests that are sent to the ACR when cleaning up manifests. This avoids potential issues that have been seen when sending several thousand delete requests at once. It makes use of the concurrency limiter from Polly. That lets us queue up all our delete tasks at once and then it will only allow a specific number of them to execute concurrently.