### PR TITLE
Onboard .NET Docker Bot to secret manager

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "microsoft.dnceng.secretmanager": {
+      "version": "1.1.0-beta.24413.3",
+      "commands": [
+        "secret-manager"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/.vault-config/secrets.yaml
+++ b/.vault-config/secrets.yaml
@@ -1,0 +1,19 @@
+# Partially copied from https://github.com/dotnet/arcade/blob/dfc6882da43decb37f12e0d9011ce82b25225578/.vault-config/product-builds-dnceng-pipeline-secrets.yaml
+
+storageLocation:
+  type: azure-key-vault
+  parameters:
+    name: DotnetDockerKeyVault
+    subscription: 941d4baa-5ef2-462e-b4b1-505791294610
+
+secrets:
+  BotAccount-dotnet-docker-bot:
+    type: github-account
+    parameters:
+      Name: dotnet-docker-bot
+
+  BotAccount-dotnet-docker-bot-PAT:
+    type: github-access-token
+    parameters:
+      gitHubBotAccountSecret: BotAccount-dotnet-docker-bot
+      gitHubBotAccountName: dotnet-docker-bot

--- a/eng/pipelines/secret-management-weekly.yml
+++ b/eng/pipelines/secret-management-weekly.yml
@@ -1,0 +1,47 @@
+trigger: none
+
+schedules:
+- cron: 0 12 * * 0
+  displayName: Weekly Sunday build
+  branches:
+    include:
+    - main
+  always: true
+
+stages:
+- stage: SynchronizeSecrets
+  jobs:
+  - job: Synchronize
+    displayName: Synchronize secrets
+    pool:
+      name: NetCore1ESPool-Internal
+      demands: ImageOverride -equals 1es-windows-2019
+
+    steps:
+    - task: UseDotNet@2
+      displayName: Install .NET 8.0 SDK
+      inputs:
+        packageType: sdk
+        version: 8.0.x
+        installationPath: '$(Build.Repository.LocalPath)/.dotnet'
+
+    - task: UseDotNet@2
+      displayName: Install .NET 6.0 runtime
+      inputs:
+        packageType: runtime
+        version: 6.0.x
+        installationPath: '$(Build.Repository.LocalPath)/.dotnet'
+
+    - powershell: .dotnet/dotnet tool restore --tool-manifest .config/dotnet-tools.json
+      workingDirectory: $(Build.Repository.LocalPath)
+      displayName: Restore secret-manager
+
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: DotNet Eng Services Secret Manager
+        scriptType: pscore
+        scriptLocation: inlineScript
+        inlineScript: |
+          Get-ChildItem .vault-config/*.yaml |% { .dotnet/dotnet secret-manager synchronize $_}
+        workingDirectory: $(Build.Repository.LocalPath)
+      displayName: Run secret-manager synchronize


### PR DESCRIPTION
Copy from https://github.com/dotnet/dotnet-docker/pull/5797 in dotnet-docker.

Closes https://github.com/dotnet/dotnet-docker/issues/4517

This PR onboards .NET Docker Bot to secret manager and introduces a new pipeline for rotating secrets on a weekly basis.

[Example pipeline run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2519194&view=logs&j=adcf571c-cc13-5e72-b2ad-561cfc37a926)