### PR TITLE
Use repo prefix for EOL data logic

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateEolAnnotationDataCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateEolAnnotationDataCommand.cs
@@ -83,7 +83,8 @@ public class GenerateEolAnnotationDataCommand : Command<GenerateEolAnnotationDat
             // need the previous version of the image info file to know that the repo had previously existed and so that repo is included in the scope for
             // the query of the digests.
             IEnumerable<string> repoNames = newImageArtifactDetails.Repos.Select(repo => repo.Repo)
-                .Union(oldImageArtifactDetails.Repos.Select(repo => repo.Repo));
+                .Union(oldImageArtifactDetails.Repos.Select(repo => repo.Repo))
+                .Select(name => Options.RepoPrefix + name);
             IEnumerable<(string Digest, string? Tag)> registryDigests = await GetAllImageDigestsFromRegistry(repoNames);
 
             IEnumerable<string> supportedDigests = GetSupportedDigests(newImageArtifactDetails);
@@ -129,24 +130,28 @@ public class GenerateEolAnnotationDataCommand : Command<GenerateEolAnnotationDat
             .Where(registryDigest => !supportedDigests.Contains(registryDigest.Digest))
             .Select(registryDigest => new EolDigestData(registryDigest.Digest) { Tag = registryDigest.Tag });
 
-    private static IEnumerable<string> GetSupportedDigests(ImageArtifactDetails newImageArtifactDetails) =>
+    private IEnumerable<string> GetSupportedDigests(ImageArtifactDetails newImageArtifactDetails) =>
         newImageArtifactDetails.Repos
             .SelectMany(repo => repo.Images)
             .SelectMany(GetImageDigests)
             .Select(digest => digest.Digest);
     
-    private static IEnumerable<(string Digest, string? Tag)> GetImageDigests(ImageData image)
+    private IEnumerable<(string Digest, string? Tag)> GetImageDigests(ImageData image)
     {
         if (image.Manifest is not null)
         {
-            yield return (image.Manifest.Digest, GetLongestTag(image.Manifest.SharedTags));
+            yield return (ReplaceMcrWithAcr(image.Manifest.Digest), GetLongestTag(image.Manifest.SharedTags));
         }
 
         foreach (PlatformData platform in image.Platforms)
         {
-            yield return (platform.Digest, GetLongestTag(platform.SimpleTags));
+            yield return (ReplaceMcrWithAcr(platform.Digest), GetLongestTag(platform.SimpleTags));
         }
     }
+
+    // This is used for transforming the image names in the image info file to match the image names in the ACR
+    private string ReplaceMcrWithAcr(string imageName) =>
+        imageName.Replace("mcr.microsoft.com/", $"{Options.RegistryName}/{Options.RepoPrefix}");
 
     private static string? GetLongestTag(IEnumerable<string> tags) =>
         tags.OrderByDescending(tag => tag.Length).FirstOrDefault();
@@ -182,7 +187,7 @@ public class GenerateEolAnnotationDataCommand : Command<GenerateEolAnnotationDat
         return digests;
     }
 
-    private static IEnumerable<EolDigestData> GetProductEolDigests(ImageData image, Dictionary<string, DateOnly> productEolDates)
+    private IEnumerable<EolDigestData> GetProductEolDigests(ImageData image, Dictionary<string, DateOnly> productEolDates)
     {
         if (image.ProductVersion == null)
         {

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateEolAnnotationDataCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateEolAnnotationDataCommandTests.cs
@@ -22,7 +22,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 {
     public class GenerateEolAnnotationDataTests
     {
+        private const string DefaultRepoPrefix = "public/";
         private const string AcrName = "myacr.azurecr.io";
+        private const string McrName = "mcr.microsoft.com";
         private readonly DateOnly _globalDate = DateOnly.FromDateTime(DateTime.UtcNow);
 
         // Additional test scenarios:
@@ -55,7 +57,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         [
                                             "tag"
                                         ],
-                                        digest: DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest101"))
+                                        digest: DockerHelper.GetImageName(McrName, "repo1", digest: "platformdigest101"))
                                 },
                                 ProductVersion = "1.0",
                                 Manifest = new ManifestData
@@ -64,7 +66,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     [
                                         "1.0"
                                     ],
-                                    Digest = DockerHelper.GetImageName(AcrName, "repo1", digest: "imagedigest101")
+                                    Digest = DockerHelper.GetImageName(McrName, "repo1", digest: "imagedigest101")
                                 }
                             },
                             new ImageData
@@ -76,7 +78,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         [
                                             "tag"
                                         ],
-                                        digest: DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest102"))
+                                        digest: DockerHelper.GetImageName(McrName, "repo1", digest: "platformdigest102"))
                                 },
                                 ProductVersion = "1.0",
                                 Manifest = new ManifestData
@@ -85,7 +87,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     [
                                         "1.0"
                                     ],
-                                    Digest = DockerHelper.GetImageName(AcrName, "repo1", digest: "imagedigest102")
+                                    Digest = DockerHelper.GetImageName(McrName, "repo1", digest: "imagedigest102")
                                 }
                             }
                         }
@@ -104,7 +106,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         [
                                             "newtag"
                                         ],
-                                        digest: DockerHelper.GetImageName(AcrName, "repo2", digest: "platformdigest201"))
+                                        digest: DockerHelper.GetImageName(McrName, "repo2", digest: "platformdigest201"))
                                 },
                                 ProductVersion = "2.0",
                                 Manifest = new ManifestData
@@ -113,7 +115,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     [
                                         "2.0"
                                     ],
-                                    Digest = DockerHelper.GetImageName(AcrName, "repo2", digest: "imagedigest201")
+                                    Digest = DockerHelper.GetImageName(McrName, "repo2", digest: "imagedigest201")
                                 }
                             }
                         }
@@ -134,14 +136,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             Mock<IContainerRegistryClient> registryClientMock = CreateContainerRegistryClientMock(
                 [
-                    CreateContainerRepository("repo1",
+                    CreateContainerRepository($"{DefaultRepoPrefix}repo1",
                         manifestProperties: [
                             CreateArtifactManifestProperties(digest: "platformdigest101", tags: ["tag"]),
                             CreateArtifactManifestProperties(digest: "platformdigest102", tags: ["tag"]),
                             CreateArtifactManifestProperties(digest: "imagedigest101", tags: ["1.0"]),
                             CreateArtifactManifestProperties(digest: "imagedigest102", tags: ["1.0"])
                         ]),
-                    CreateContainerRepository("repo2",
+                    CreateContainerRepository($"{DefaultRepoPrefix}repo2",
                         manifestProperties: [
                             CreateArtifactManifestProperties(digest: "platformdigest201", tags: ["newtag"]),
                             CreateArtifactManifestProperties(digest: "imagedigest201", tags: ["2.0"]),
@@ -152,7 +154,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             IContainerRegistryContentClientFactory registryContentClientFactory = CreateContainerRegistryContentClientFactory(AcrName,
                 [
-                    CreateContainerRegistryContentClientMock("repo1",
+                    CreateContainerRegistryContentClientMock($"{DefaultRepoPrefix}repo1",
                         imageNameToQueryResultsMapping: new Dictionary<string, ManifestQueryResult>
                         {
                             { "platformdigest101", new ManifestQueryResult(string.Empty, []) },
@@ -160,7 +162,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             { "imagedigest101", new ManifestQueryResult(string.Empty, []) },
                             { "imagedigest102", new ManifestQueryResult(string.Empty, []) }
                         }),
-                    CreateContainerRegistryContentClientMock("repo2",
+                    CreateContainerRegistryContentClientMock($"{DefaultRepoPrefix}repo2",
                         imageNameToQueryResultsMapping: new Dictionary<string, ManifestQueryResult>
                         {
                             { "platformdigest201", new ManifestQueryResult(string.Empty, []) },
@@ -182,10 +184,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 EolDate = _globalDate,
                 EolDigests =
                 [
-                    new(DockerHelper.GetImageName(AcrName, "repo1", digest: "imagedigest101")) { Tag = "1.0" },
-                    new(DockerHelper.GetImageName(AcrName, "repo1", digest: "imagedigest102")) { Tag = "1.0" },
-                    new(DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest101")) { Tag = "tag" },
-                    new(DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest102")) { Tag = "tag" },
+                    new(DockerHelper.GetImageName(AcrName, $"{DefaultRepoPrefix}repo1", digest: "imagedigest101")) { Tag = "1.0" },
+                    new(DockerHelper.GetImageName(AcrName, $"{DefaultRepoPrefix}repo1", digest: "imagedigest102")) { Tag = "1.0" },
+                    new(DockerHelper.GetImageName(AcrName, $"{DefaultRepoPrefix}repo1", digest: "platformdigest101")) { Tag = "tag" },
+                    new(DockerHelper.GetImageName(AcrName, $"{DefaultRepoPrefix}repo1", digest: "platformdigest102")) { Tag = "tag" },
                 ]
             };
 
@@ -221,7 +223,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         [
                                             "1.0"
                                         ],
-                                        digest: DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest101"))
+                                        digest: DockerHelper.GetImageName(McrName, "repo1", digest: "platformdigest101"))
                                 },
                                 ProductVersion = "1.0",
                                 Manifest = new ManifestData
@@ -230,7 +232,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     [
                                         "1.0"
                                     ],
-                                    Digest = DockerHelper.GetImageName(AcrName, "repo1", digest: "imagedigest101")
+                                    Digest = DockerHelper.GetImageName(McrName, "repo1", digest: "imagedigest101")
                                 }
                             },
                             new ImageData
@@ -242,13 +244,13 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         [
                                             "2.0"
                                         ],
-                                        digest: DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest102-amd64")),
+                                        digest: DockerHelper.GetImageName(McrName, "repo1", digest: "platformdigest102-amd64")),
                                     Helpers.ImageInfoHelper.CreatePlatform(repo1Image2arm64DockerfilePath,
                                         simpleTags:
                                         [
                                             "2.0"
                                         ],
-                                        digest: DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest102-arm64"))
+                                        digest: DockerHelper.GetImageName(McrName, "repo1", digest: "platformdigest102-arm64"))
                                 },
                                 ProductVersion = "2.0",
                                 Manifest = new ManifestData
@@ -257,7 +259,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     [
                                         "2.0"
                                     ],
-                                    Digest = DockerHelper.GetImageName(AcrName, "repo1", digest: "imagedigest102")
+                                    Digest = DockerHelper.GetImageName(McrName, "repo1", digest: "imagedigest102")
                                 }
                             }
                         }
@@ -278,7 +280,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             Mock<IContainerRegistryClient> registryClientMock = CreateContainerRegistryClientMock(
                 [
-                    CreateContainerRepository("repo1",
+                    CreateContainerRepository($"{DefaultRepoPrefix}repo1",
                         manifestProperties: [
                             CreateArtifactManifestProperties(digest: "platformdigest101", tags: ["1.0"]),
                             CreateArtifactManifestProperties(digest: "imagedigest101", tags: ["1.0"]),
@@ -292,7 +294,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             IContainerRegistryContentClientFactory registryContentClientFactory = CreateContainerRegistryContentClientFactory(AcrName,
                 [
-                    CreateContainerRegistryContentClientMock("repo1",
+                    CreateContainerRegistryContentClientMock($"{DefaultRepoPrefix}repo1",
                         imageNameToQueryResultsMapping: new Dictionary<string, ManifestQueryResult>
                         {
                             { "platformdigest101", new ManifestQueryResult(string.Empty, []) },
@@ -317,9 +319,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 EolDate = _globalDate,
                 EolDigests =
                 [
-                    new(DockerHelper.GetImageName(AcrName, "repo1", digest: "imagedigest102")) { Tag = "2.0" },
-                    new(DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest102-amd64")) { Tag = "2.0" },
-                    new(DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest102-arm64")) { Tag = "2.0" },
+                    new(DockerHelper.GetImageName(AcrName, $"{DefaultRepoPrefix}repo1", digest: "imagedigest102")) { Tag = "2.0" },
+                    new(DockerHelper.GetImageName(AcrName, $"{DefaultRepoPrefix}repo1", digest: "platformdigest102-amd64")) { Tag = "2.0" },
+                    new(DockerHelper.GetImageName(AcrName, $"{DefaultRepoPrefix}repo1", digest: "platformdigest102-arm64")) { Tag = "2.0" },
                 ]
             };
 
@@ -355,7 +357,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         [
                                             "1.0"
                                         ],
-                                        digest: DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest101"))
+                                        digest: DockerHelper.GetImageName(McrName, "repo1", digest: "platformdigest101"))
                                 },
                                 ProductVersion = "1.0",
                                 Manifest = new ManifestData
@@ -364,7 +366,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     [
                                         "1.0"
                                     ],
-                                    Digest = DockerHelper.GetImageName(AcrName, "repo1", digest: "imagedigest101")
+                                    Digest = DockerHelper.GetImageName(McrName, "repo1", digest: "imagedigest101")
                                 }
                             },
                             new ImageData
@@ -376,13 +378,13 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         [
                                             "2.0"
                                         ],
-                                        digest: DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest102-amd64")),
+                                        digest: DockerHelper.GetImageName(McrName, "repo1", digest: "platformdigest102-amd64")),
                                     Helpers.ImageInfoHelper.CreatePlatform(repo1Image2arm64DockerfilePath,
                                         simpleTags:
                                         [
                                             "2.0"
                                         ],
-                                        digest: DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest102-arm64"))
+                                        digest: DockerHelper.GetImageName(McrName, "repo1", digest: "platformdigest102-arm64"))
                                 },
                                 ProductVersion = "2.0",
                                 Manifest = new ManifestData
@@ -391,7 +393,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     [
                                         "2.0"
                                     ],
-                                    Digest = DockerHelper.GetImageName(AcrName, "repo1", digest: "imagedigest102")
+                                    Digest = DockerHelper.GetImageName(McrName, "repo1", digest: "imagedigest102")
                                 }
                             }
                         }
@@ -412,7 +414,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             Mock<IContainerRegistryClient> registryClientMock = CreateContainerRegistryClientMock(
                 [
-                    CreateContainerRepository("repo1",
+                    CreateContainerRepository($"{DefaultRepoPrefix}repo1",
                         manifestProperties: [
                             CreateArtifactManifestProperties(digest: "platformdigest101", tags: ["1.0"]),
                             CreateArtifactManifestProperties(digest: "imagedigest101", tags: ["1.0"]),
@@ -424,7 +426,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             IContainerRegistryClientFactory registryClientFactory = CreateContainerRegistryClientFactory(
                 AcrName, registryClientMock.Object);
 
-            string armDigest = DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest102-arm64");
+            string armDigest = DockerHelper.GetImageName(AcrName, $"{DefaultRepoPrefix}repo1", digest: "platformdigest102-arm64");
 
             // Set the Arm64 digest as already annotated. This should exclude it from the list of digests to annotate.
             OciManifest lifecycleArtifactManifest;
@@ -435,7 +437,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             IContainerRegistryContentClientFactory registryContentClientFactory = CreateContainerRegistryContentClientFactory(AcrName,
                 [
-                    CreateContainerRegistryContentClientMock("repo1",
+                    CreateContainerRegistryContentClientMock($"{DefaultRepoPrefix}repo1",
                         imageNameToQueryResultsMapping: new Dictionary<string, ManifestQueryResult>
                         {
                             { "platformdigest101", new ManifestQueryResult(string.Empty, []) },
@@ -461,8 +463,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 EolDate = _globalDate,
                 EolDigests =
                 [
-                    new(DockerHelper.GetImageName(AcrName, "repo1", digest: "imagedigest102")) { Tag = "2.0" },
-                    new(DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest102-amd64")) { Tag = "2.0" },
+                    new(DockerHelper.GetImageName(AcrName, $"{DefaultRepoPrefix}repo1", digest: "imagedigest102")) { Tag = "2.0" },
+                    new(DockerHelper.GetImageName(AcrName, $"{DefaultRepoPrefix}repo1", digest: "platformdigest102-amd64")) { Tag = "2.0" },
                 ]
             };
 
@@ -496,7 +498,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         [
                                             "1.0"
                                         ],
-                                        digest: DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest101"))
+                                        digest: DockerHelper.GetImageName(McrName, "repo1", digest: "platformdigest101"))
                                 },
                                 ProductVersion = "1.0",
                                 Manifest = new ManifestData
@@ -505,7 +507,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     [
                                         "1.0"
                                     ],
-                                    Digest = DockerHelper.GetImageName(AcrName, "repo1", digest: "imagedigest101")
+                                    Digest = DockerHelper.GetImageName(McrName, "repo1", digest: "imagedigest101")
                                 }
                             },
                             new ImageData
@@ -517,7 +519,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         [
                                             "2.0"
                                         ],
-                                        digest: DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest102"))
+                                        digest: DockerHelper.GetImageName(McrName, "repo1", digest: "platformdigest102"))
                                 },
                                 ProductVersion = "2.0",
                                 Manifest = new ManifestData
@@ -526,7 +528,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     [
                                         "2.0"
                                     ],
-                                    Digest = DockerHelper.GetImageName(AcrName, "repo1", digest: "imagedigest102")
+                                    Digest = DockerHelper.GetImageName(McrName, "repo1", digest: "imagedigest102")
                                 }
                             }
                         }
@@ -538,8 +540,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             File.WriteAllText(oldImageInfoPath, JsonHelper.SerializeObject(imageArtifactDetails));
 
             // Update image and platform digests in only one image that uses the shared Dockerfile
-            imageArtifactDetails.Repos[0].Images[1].Manifest.Digest = DockerHelper.GetImageName(AcrName, "repo1", digest: "imagedigest102-updated");
-            imageArtifactDetails.Repos[0].Images[1].Platforms[0].Digest = DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest102-updated");
+            imageArtifactDetails.Repos[0].Images[1].Manifest.Digest = DockerHelper.GetImageName(McrName, "repo1", digest: "imagedigest102-updated");
+            imageArtifactDetails.Repos[0].Images[1].Platforms[0].Digest = DockerHelper.GetImageName(McrName, "repo1", digest: "platformdigest102-updated");
 
             string newImageInfoPath = Path.Combine(tempFolderContext.Path, "new-image-info.json");
             File.WriteAllText(newImageInfoPath, JsonHelper.SerializeObject(imageArtifactDetails));
@@ -548,7 +550,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             Mock<IContainerRegistryClient> registryClientMock = CreateContainerRegistryClientMock(
                 [
-                    CreateContainerRepository("repo1",
+                    CreateContainerRepository($"{DefaultRepoPrefix}repo1",
                         manifestProperties: [
                             CreateArtifactManifestProperties(digest: "platformdigest101", tags: ["1.0"]),
                             CreateArtifactManifestProperties(digest: "imagedigest101", tags: ["1.0"]),
@@ -563,7 +565,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             IContainerRegistryContentClientFactory registryContentClientFactory = CreateContainerRegistryContentClientFactory(AcrName,
                 [
-                    CreateContainerRegistryContentClientMock("repo1",
+                    CreateContainerRegistryContentClientMock($"{DefaultRepoPrefix}repo1",
                         imageNameToQueryResultsMapping: new Dictionary<string, ManifestQueryResult>
                         {
                             { "platformdigest101", new ManifestQueryResult(string.Empty, []) },
@@ -589,8 +591,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 EolDate = _globalDate,
                 EolDigests =
                 [
-                    new(DockerHelper.GetImageName(AcrName, "repo1", digest: "imagedigest102")),
-                    new(DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest102")),
+                    new(DockerHelper.GetImageName(AcrName, $"{DefaultRepoPrefix}repo1", digest: "imagedigest102")),
+                    new(DockerHelper.GetImageName(AcrName, $"{DefaultRepoPrefix}repo1", digest: "platformdigest102")),
                 ]
             };
 
@@ -624,7 +626,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         [
                                             "1.0"
                                         ],
-                                        digest: DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest101"))
+                                        digest: DockerHelper.GetImageName(McrName, "repo1", digest: "platformdigest101"))
                                 },
                                 ProductVersion = "1.0",
                                 Manifest = new ManifestData
@@ -633,7 +635,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     [
                                         "1.0"
                                     ],
-                                    Digest = DockerHelper.GetImageName(AcrName, "repo1", digest: "imagedigest101")
+                                    Digest = DockerHelper.GetImageName(McrName, "repo1", digest: "imagedigest101")
                                 }
                             },
                             new ImageData
@@ -645,7 +647,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         [
                                             "2.0"
                                         ],
-                                        digest: DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest102"))
+                                        digest: DockerHelper.GetImageName(McrName, "repo1", digest: "platformdigest102"))
                                 },
                                 ProductVersion = "2.0",
                                 Manifest = new ManifestData
@@ -654,7 +656,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     [
                                         "2.0"
                                     ],
-                                    Digest = DockerHelper.GetImageName(AcrName, "repo1", digest: "imagedigest102")
+                                    Digest = DockerHelper.GetImageName(McrName, "repo1", digest: "imagedigest102")
                                 }
                             }
                         }
@@ -666,8 +668,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             File.WriteAllText(oldImageInfoPath, JsonHelper.SerializeObject(imageArtifactDetails));
 
             // Update image a platform digest for EOL product.
-            imageArtifactDetails.Repos[0].Images[0].Manifest.Digest = DockerHelper.GetImageName(AcrName, "repo1", digest: "imagedigest101-updated");
-            imageArtifactDetails.Repos[0].Images[0].Platforms[0].Digest = DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest101-updated");
+            imageArtifactDetails.Repos[0].Images[0].Manifest.Digest = DockerHelper.GetImageName(McrName, "repo1", digest: "imagedigest101-updated");
+            imageArtifactDetails.Repos[0].Images[0].Platforms[0].Digest = DockerHelper.GetImageName(McrName, "repo1", digest: "platformdigest101-updated");
 
 
             string newImageInfoPath = Path.Combine(tempFolderContext.Path, "new-image-info.json");
@@ -683,7 +685,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             Mock<IContainerRegistryClient> registryClientMock = CreateContainerRegistryClientMock(
                 [
-                    CreateContainerRepository("repo1",
+                    CreateContainerRepository($"{DefaultRepoPrefix}repo1",
                         manifestProperties: [
                             CreateArtifactManifestProperties(digest: "platformdigest101"),
                             CreateArtifactManifestProperties(digest: "platformdigest101-updated", tags: ["1.0"]),
@@ -698,7 +700,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             IContainerRegistryContentClientFactory registryContentClientFactory = CreateContainerRegistryContentClientFactory(AcrName,
                 [
-                    CreateContainerRegistryContentClientMock("repo1",
+                    CreateContainerRegistryContentClientMock($"{DefaultRepoPrefix}repo1",
                         imageNameToQueryResultsMapping: new Dictionary<string, ManifestQueryResult>
                         {
                             { "platformdigest101", new ManifestQueryResult(string.Empty, []) },
@@ -726,10 +728,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 EolDate = _globalDate,
                 EolDigests =
                 [
-                    new(DockerHelper.GetImageName(AcrName, "repo1", digest: "imagedigest101")),
-                    new(DockerHelper.GetImageName(AcrName, "repo1", digest: "imagedigest101-updated")) { EolDate = productEolDate, Tag = "1.0" },
-                    new(DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest101")),
-                    new(DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest101-updated")) { EolDate = productEolDate, Tag = "1.0" }
+                    new(DockerHelper.GetImageName(AcrName, $"{DefaultRepoPrefix}repo1", digest: "imagedigest101")),
+                    new(DockerHelper.GetImageName(AcrName, $"{DefaultRepoPrefix}repo1", digest: "imagedigest101-updated")) { EolDate = productEolDate, Tag = "1.0" },
+                    new(DockerHelper.GetImageName(AcrName, $"{DefaultRepoPrefix}repo1", digest: "platformdigest101")),
+                    new(DockerHelper.GetImageName(AcrName, $"{DefaultRepoPrefix}repo1", digest: "platformdigest101-updated")) { EolDate = productEolDate, Tag = "1.0" }
                 ]
             };
 
@@ -763,7 +765,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         [
                                             "1.0"
                                         ],
-                                        digest: DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest101"))
+                                        digest: DockerHelper.GetImageName(McrName, "repo1", digest: "platformdigest101"))
                                 },
                                 ProductVersion = "1.0",
                                 Manifest = new ManifestData
@@ -772,7 +774,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     [
                                         "1.0"
                                     ],
-                                    Digest = DockerHelper.GetImageName(AcrName, "repo1", digest: "imagedigest101")
+                                    Digest = DockerHelper.GetImageName(McrName, "repo1", digest: "imagedigest101")
                                 }
                             }
                         }
@@ -784,8 +786,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             File.WriteAllText(oldImageInfoPath, JsonHelper.SerializeObject(imageArtifactDetails));
 
             // Update and image and platform digests
-            imageArtifactDetails.Repos[0].Images[0].Manifest.Digest = DockerHelper.GetImageName(AcrName, "repo1", digest: "imagedigest101-updated");
-            imageArtifactDetails.Repos[0].Images[0].Platforms[0].Digest = DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest101-updated");
+            imageArtifactDetails.Repos[0].Images[0].Manifest.Digest = DockerHelper.GetImageName(McrName, "repo1", digest: "imagedigest101-updated");
+            imageArtifactDetails.Repos[0].Images[0].Platforms[0].Digest = DockerHelper.GetImageName(McrName, "repo1", digest: "platformdigest101-updated");
 
             string newImageInfoPath = Path.Combine(tempFolderContext.Path, "new-image-info.json");
             File.WriteAllText(newImageInfoPath, JsonHelper.SerializeObject(imageArtifactDetails));
@@ -794,7 +796,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             Mock<IContainerRegistryClient> registryClientMock = CreateContainerRegistryClientMock(
                 [
-                    CreateContainerRepository("repo1",
+                    CreateContainerRepository($"{DefaultRepoPrefix}repo1",
                         manifestProperties: [
                             CreateArtifactManifestProperties(digest: "platformdigest101"),
                             CreateArtifactManifestProperties(digest: "platformdigest101-updated", tags: ["1.0"]),
@@ -807,7 +809,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             IContainerRegistryContentClientFactory registryContentClientFactory = CreateContainerRegistryContentClientFactory(AcrName,
                 [
-                    CreateContainerRegistryContentClientMock("repo1",
+                    CreateContainerRegistryContentClientMock($"{DefaultRepoPrefix}repo1",
                         imageNameToQueryResultsMapping: new Dictionary<string, ManifestQueryResult>
                         {
                             { "platformdigest101", new ManifestQueryResult(string.Empty, []) },
@@ -831,8 +833,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 EolDate = _globalDate,
                 EolDigests =
                 [
-                    new(DockerHelper.GetImageName(AcrName, "repo1", digest: "imagedigest101")),
-                    new(DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest101")),
+                    new(DockerHelper.GetImageName(AcrName, $"{DefaultRepoPrefix}repo1", digest: "imagedigest101")),
+                    new(DockerHelper.GetImageName(AcrName, $"{DefaultRepoPrefix}repo1", digest: "platformdigest101")),
                 ]
             };
 
@@ -867,13 +869,13 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         [
                                             "tag"
                                         ],
-                                        digest: DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest101")),
+                                        digest: DockerHelper.GetImageName(McrName, "repo1", digest: "platformdigest101")),
                                     Helpers.ImageInfoHelper.CreatePlatform(repo1Image2DockerfilePath,
                                         simpleTags:
                                         [
                                             "tag2"
                                         ],
-                                        digest: DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest102"))
+                                        digest: DockerHelper.GetImageName(McrName, "repo1", digest: "platformdigest102"))
                                 },
                                 ProductVersion = "1.0",
                                 Manifest = new ManifestData
@@ -882,7 +884,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     [
                                         "1.0"
                                     ],
-                                    Digest = DockerHelper.GetImageName(AcrName, "repo1", digest: "imagedigest101")
+                                    Digest = DockerHelper.GetImageName(McrName, "repo1", digest: "imagedigest101")
                                 }
                             }
                         }
@@ -894,7 +896,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             File.WriteAllText(oldImageInfoPath, JsonHelper.SerializeObject(imageArtifactDetails));
 
             // Update just one platform digest
-            imageArtifactDetails.Repos[0].Images[0].Platforms[1].Digest = DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest102-updated");
+            imageArtifactDetails.Repos[0].Images[0].Platforms[1].Digest = DockerHelper.GetImageName(McrName, "repo1", digest: "platformdigest102-updated");
 
             string newImageInfoPath = Path.Combine(tempFolderContext.Path, "new-image-info.json");
             File.WriteAllText(newImageInfoPath, JsonHelper.SerializeObject(imageArtifactDetails));
@@ -903,7 +905,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             Mock<IContainerRegistryClient> registryClientMock = CreateContainerRegistryClientMock(
                 [
-                    CreateContainerRepository("repo1",
+                    CreateContainerRepository($"{DefaultRepoPrefix}repo1",
                         manifestProperties: [
                             CreateArtifactManifestProperties(digest: "platformdigest101", tags: ["tag"]),
                             CreateArtifactManifestProperties(digest: "platformdigest102"),
@@ -916,7 +918,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             IContainerRegistryContentClientFactory registryContentClientFactory = CreateContainerRegistryContentClientFactory(AcrName,
                 [
-                    CreateContainerRegistryContentClientMock("repo1",
+                    CreateContainerRegistryContentClientMock($"{DefaultRepoPrefix}repo1",
                         imageNameToQueryResultsMapping: new Dictionary<string, ManifestQueryResult>
                         {
                             { "platformdigest101", new ManifestQueryResult(string.Empty, []) },
@@ -940,7 +942,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 EolDate = _globalDate,
                 EolDigests =
                 [
-                    new(DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest102"))
+                    new(DockerHelper.GetImageName(AcrName, $"{DefaultRepoPrefix}repo1", digest: "platformdigest102"))
                 ]
             };
 
@@ -975,13 +977,13 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         [
                                             "tag"
                                         ],
-                                        digest: DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest101")),
+                                        digest: DockerHelper.GetImageName(McrName, "repo1", digest: "platformdigest101")),
                                     Helpers.ImageInfoHelper.CreatePlatform(repo1Image2DockerfilePath,
                                         simpleTags:
                                         [
                                             "tag2"
                                         ],
-                                        digest: DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest102"))
+                                        digest: DockerHelper.GetImageName(McrName, "repo1", digest: "platformdigest102"))
                                 },
                                 ProductVersion = "1.0",
                                 Manifest = new ManifestData
@@ -990,7 +992,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     [
                                         "1.0"
                                     ],
-                                    Digest = DockerHelper.GetImageName(AcrName, "repo1", digest: "imagedigest101")
+                                    Digest = DockerHelper.GetImageName(McrName, "repo1", digest: "imagedigest101")
                                 }
                             }
                         }
@@ -1002,7 +1004,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             File.WriteAllText(oldImageInfoPath, JsonHelper.SerializeObject(imageArtifactDetails));
 
             // Update just one platform digest
-            imageArtifactDetails.Repos[0].Images[0].Platforms[1].Digest = DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest102-updated");
+            imageArtifactDetails.Repos[0].Images[0].Platforms[1].Digest = DockerHelper.GetImageName(McrName, "repo1", digest: "platformdigest102-updated");
 
             string newImageInfoPath = Path.Combine(tempFolderContext.Path, "new-image-info.json");
             File.WriteAllText(newImageInfoPath, JsonHelper.SerializeObject(imageArtifactDetails));
@@ -1011,7 +1013,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             Mock<IContainerRegistryClient> registryClientMock = CreateContainerRegistryClientMock(
                 [
-                    CreateContainerRepository("repo1",
+                    CreateContainerRepository($"{DefaultRepoPrefix}repo1",
                         manifestProperties: [
                             CreateArtifactManifestProperties(digest: "platformdigest101", tags: ["tag"]),
                             CreateArtifactManifestProperties(digest: "platformdigest102"),
@@ -1025,7 +1027,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             IContainerRegistryContentClientFactory registryContentClientFactory = CreateContainerRegistryContentClientFactory(AcrName,
                 [
-                    CreateContainerRegistryContentClientMock("repo1",
+                    CreateContainerRegistryContentClientMock($"{DefaultRepoPrefix}repo1",
                         imageNameToQueryResultsMapping: new Dictionary<string, ManifestQueryResult>
                         {
                             { "platformdigest101", new ManifestQueryResult(string.Empty, []) },
@@ -1051,7 +1053,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 EolDate = _globalDate,
                 EolDigests =
                 [
-                    new(DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest102"))
+                    new(DockerHelper.GetImageName(AcrName, $"{DefaultRepoPrefix}repo1", digest: "platformdigest102"))
                 ]
             };
 
@@ -1086,13 +1088,13 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                         [
                                             "2.0"
                                         ],
-                                        digest: DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest102-amd64")),
+                                        digest: DockerHelper.GetImageName(McrName, "repo1", digest: "platformdigest102-amd64")),
                                     Helpers.ImageInfoHelper.CreatePlatform(repo1Image2arm64DockerfilePath,
                                         simpleTags:
                                         [
                                             "2.0"
                                         ],
-                                        digest: DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest102-arm64"))
+                                        digest: DockerHelper.GetImageName(McrName, "repo1", digest: "platformdigest102-arm64"))
                                 },
                                 ProductVersion = "2.0",
                                 Manifest = new ManifestData
@@ -1101,7 +1103,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                     [
                                         "2.0"
                                     ],
-                                    Digest = DockerHelper.GetImageName(AcrName, "repo1", digest: "imagedigest102")
+                                    Digest = DockerHelper.GetImageName(McrName, "repo1", digest: "imagedigest102")
                                 }
                             }
                         }
@@ -1122,7 +1124,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             Mock<IContainerRegistryClient> registryClientMock = CreateContainerRegistryClientMock(
                 [
-                    CreateContainerRepository("repo1",
+                    CreateContainerRepository($"{DefaultRepoPrefix}repo1",
                         manifestProperties: [
                             CreateArtifactManifestProperties(digest: "platformdigest102-amd64", tags: ["2.0"]),
                             CreateArtifactManifestProperties(digest: "platformdigest102-arm64", tags: ["2.0"]),
@@ -1134,7 +1136,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             IContainerRegistryContentClientFactory registryContentClientFactory = CreateContainerRegistryContentClientFactory(AcrName,
                 [
-                    CreateContainerRegistryContentClientMock("repo1",
+                    CreateContainerRegistryContentClientMock($"{DefaultRepoPrefix}repo1",
                         imageNameToQueryResultsMapping: new Dictionary<string, ManifestQueryResult>
                         {
                             { "platformdigest102-amd64", new ManifestQueryResult(string.Empty, []) },
@@ -1157,7 +1159,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 EolDate = _globalDate,
                 EolDigests =
                 [
-                    new(DockerHelper.GetImageName(AcrName, "repo1", digest: "platformdigest102-arm64")) { Tag = "2.0" },
+                    new(DockerHelper.GetImageName(AcrName, $"{DefaultRepoPrefix}repo1", digest: "platformdigest102-arm64")) { Tag = "2.0" },
                 ]
             };
 
@@ -1173,7 +1175,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             string newEolDigestsListPath,
             IContainerRegistryClientFactory registryClientFactory,
             IContainerRegistryContentClientFactory registryContentClientFactory,
-            string repoPrefix = "public/",
+            string repoPrefix = DefaultRepoPrefix,
             IOrasService orasService = null,
             IDotNetReleasesService dotNetReleasesService = null)
         {


### PR DESCRIPTION
There are a couple issues with the logic in `GenerateEolAnnotationDataCommand` related to image names that prevent it from working properly in the production environment:
* When computing the repo names to process, it doesn't prepend the repo prefix specified in the command options. This prevents it from querying the correct repos to find images that need to be annotated.
* The image digest names in the image info file are based on their public name (e.g. mcr.microsoft.com). These values need to be transformed to the ACR name (with repo prefix) in order to properly match against the names in the ACR.