### PR TITLE
Login to Docker for GenerateEolAnnotationDataCommand

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateEolAnnotationDataOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateEolAnnotationDataOptions.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.CommandLine;
-using System.Linq;
 using static Microsoft.DotNet.ImageBuilder.Commands.CliHelper;
 
 #nullable enable
@@ -12,6 +11,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands;
 
 public class GenerateEolAnnotationDataOptions : Options
 {
+    public RegistryCredentialsOptions CredentialsOptions { get; set; } = new();
+
     public string EolDigestsListPath { get; set; } = string.Empty;
     public string OldImageInfoPath { get; set; } = string.Empty;
     public string NewImageInfoPath { get; set; } = string.Empty;
@@ -22,29 +23,29 @@ public class GenerateEolAnnotationDataOptions : Options
 
 public class GenerateEolAnnotationDataOptionsBuilder : CliOptionsBuilder
 {
+    private readonly RegistryCredentialsOptionsBuilder _registryCredentialsOptionsBuilder = new();
+
     public override IEnumerable<Option> GetCliOptions() =>
-        base.GetCliOptions()
-            .Concat(
-                [
-                    CreateOption<bool>("annotate-eol-products", nameof(GenerateEolAnnotationDataOptions.AnnotateEolProducts),
-                        "Annotate images of EOL products"),
-                ]
-            );
+        [
+            ..base.GetCliOptions(),
+            .._registryCredentialsOptionsBuilder.GetCliOptions(),
+            CreateOption<bool>("annotate-eol-products", nameof(GenerateEolAnnotationDataOptions.AnnotateEolProducts),
+                "Annotate images of EOL products")
+        ];
 
     public override IEnumerable<Argument> GetCliArguments() =>
-        base.GetCliArguments()
-            .Concat(
-                [
-                    new Argument<string>(nameof(GenerateEolAnnotationDataOptions.EolDigestsListPath),
-                        "EOL annotations digests list output path"),
-                    new Argument<string>(nameof(GenerateEolAnnotationDataOptions.OldImageInfoPath),
-                        "Old image-info file"),
-                    new Argument<string>(nameof(GenerateEolAnnotationDataOptions.NewImageInfoPath),
-                        "New image-info file"),
-                    new Argument<string>(nameof(GenerateEolAnnotationDataOptions.RepoPrefix),
-                        "Prefix to add to the repo names specified in the manifest"),
-                    new Argument<string>(nameof(GenerateEolAnnotationDataOptions.RegistryName),
-                        "Name of the registry"),
-                ]
-            );
+        [
+            ..base.GetCliArguments(),
+            .._registryCredentialsOptionsBuilder.GetCliArguments(),
+            new Argument<string>(nameof(GenerateEolAnnotationDataOptions.EolDigestsListPath),
+                "EOL annotations digests list output path"),
+            new Argument<string>(nameof(GenerateEolAnnotationDataOptions.OldImageInfoPath),
+                "Old image-info file"),
+            new Argument<string>(nameof(GenerateEolAnnotationDataOptions.NewImageInfoPath),
+                "New image-info file"),
+            new Argument<string>(nameof(GenerateEolAnnotationDataOptions.RepoPrefix),
+                "Prefix to add to the repo names specified in the manifest"),
+            new Argument<string>(nameof(GenerateEolAnnotationDataOptions.RegistryName),
+                "Name of the registry"),
+        ];
 }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateEolAnnotationDataCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateEolAnnotationDataCommandTests.cs
@@ -1205,6 +1205,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 registryClientFactory,
                 registryContentClientFactory,
                 Mock.Of<IAzureTokenCredentialProvider>(),
+                Mock.Of<IRegistryCredentialsProvider>(),
                 orasService);
             command.Options.OldImageInfoPath = oldImageInfoPath;
             command.Options.NewImageInfoPath = newImageInfoPath;


### PR DESCRIPTION
The `GenerateEolAnnotationDataCommand` calls the `oras` tool to query for annotations. In order for the `oras` tool to communicate with the ACR, it needs to be authenticated. This isn't being done today, so it fails in the pipeline with unauthorized errors (it works locally when you're logged into docker CLI).
