### PR TITLE
Dry run fix for GenerateEolAnnotationDataCommand

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateEolAnnotationDataCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateEolAnnotationDataCommand.cs
@@ -145,6 +145,11 @@ public class GenerateEolAnnotationDataCommand : Command<GenerateEolAnnotationDat
 
     private async Task<IEnumerable<(string Digest, string? Tag)>> GetAllImageDigestsFromRegistry(IEnumerable<string> repoNames)
     {
+        if (Options.IsDryRun)
+        {
+            return [];
+        }
+
         IContainerRegistryClient acrClient =
             _acrClientFactory.Create(Options.RegistryOptions.Registry, _tokenCredentialProvider.GetCredential());
         IAsyncEnumerable<string> repositoryNames = acrClient.GetRepositoryNamesAsync();


### PR DESCRIPTION
When executing `GenerateEolAnnotationDataCommand` in dry run mode, it attempts to authenticate with Azure credentials in the `GetAllImageDigestsFromRegistry` method. This fails on the build agent because it has no default Azure credentials.

This is fixed by defaulting the method results to an empty set when in dry run mode.