### PR TITLE
Factor out image caching logic from BuildCommand

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -374,15 +374,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             if (srcPlatformData != null)
             {
                 isCachedImage = await CheckForCachedImageFromImageInfoAsync(repo, platform, srcPlatformData, allTags);
-                if (platformData != null)
+                if (platformData != null && isCachedImage)
                 {
-                    platformData.IsUnchanged = isCachedImage &&
-                        CachedPlatformHasAllTagsPublished(srcPlatformData);
-                    if (isCachedImage)
-                    {
-                        CopyPlatformDataFromCachedPlatform(platformData, srcPlatformData);
-                        _cachedPlatforms[cacheKey] = srcPlatformData;
-                    }
+                    platformData.IsUnchanged = CachedPlatformHasAllTagsPublished(srcPlatformData);
+                    CopyPlatformDataFromCachedPlatform(platformData, srcPlatformData);
+                    _cachedPlatforms[cacheKey] = srcPlatformData;
                 }
             }
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -28,13 +28,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private readonly Lazy<IManifestService> _manifestService;
         private readonly IRegistryCredentialsProvider _registryCredentialsProvider;
         private readonly IAzureTokenCredentialProvider _tokenCredentialProvider;
+        private readonly IImageCacheService _imageCacheService;
         private readonly ImageDigestCache _imageDigestCache;
         private readonly List<TagInfo> _processedTags = new List<TagInfo>();
         private readonly HashSet<PlatformData> _builtPlatforms = new();
         private readonly Lazy<ImageNameResolver> _imageNameResolver;
-
-        // Metadata about Dockerfiles whose images have been retrieved from the cache
-        private readonly Dictionary<string, PlatformData> _cachedPlatforms = new Dictionary<string, PlatformData>();
 
         /// <summary>
         /// Maps a source digest from the image info file to the corresponding digest in the copied location for image caching.
@@ -53,7 +51,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             ICopyImageService copyImageService,
             IManifestServiceFactory manifestServiceFactory,
             IRegistryCredentialsProvider registryCredentialsProvider,
-            IAzureTokenCredentialProvider tokenCredentialProvider)
+            IAzureTokenCredentialProvider tokenCredentialProvider,
+            IImageCacheService imageCacheService)
         {
             _dockerService = new DockerServiceCache(dockerService ?? throw new ArgumentNullException(nameof(dockerService)));
             _loggerService = loggerService ?? throw new ArgumentNullException(nameof(loggerService));
@@ -62,6 +61,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             _copyImageService = copyImageService ?? throw new ArgumentNullException(nameof(copyImageService));
             _registryCredentialsProvider = registryCredentialsProvider ?? throw new ArgumentNullException(nameof(registryCredentialsProvider));
             _tokenCredentialProvider = tokenCredentialProvider ?? throw new ArgumentNullException(nameof(tokenCredentialProvider));
+            _imageCacheService = imageCacheService ?? throw new ArgumentNullException(nameof(imageCacheService));
 
             // Lazily create the Manifest Service so it can have access to options (not available in this constructor)
             ArgumentNullException.ThrowIfNull(manifestServiceFactory);
@@ -103,7 +103,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 registryName: Manifest.Registry,
                 ownedAcr: Options.RegistryOverride);
 
-            if (_processedTags.Any() || _cachedPlatforms.Any())
+            if (_processedTags.Any() || _imageCacheService.HasAnyCachedPlatforms)
             {
                 // Log in again to refresh token as it may have expired from a long build
                 await _registryCredentialsProvider.ExecuteWithCredentialsAsync(
@@ -300,13 +300,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             foreach (RepoInfo repoInfo in Manifest.FilteredRepos)
             {
-                RepoData? repoData = CreateRepoData(repoInfo);
+                RepoData repoData = CreateRepoData(repoInfo);
                 RepoData? srcRepoData = srcImageArtifactDetails?.Repos.FirstOrDefault(srcRepo => srcRepo.Repo == repoInfo.Name);
 
                 foreach (ImageInfo image in repoInfo.FilteredImages)
                 {
-                    ImageData? imageData = CreateImageData(image);
-                    repoData?.Images.Add(imageData);
+                    ImageData imageData = CreateImageData(image);
+                    repoData.Images.Add(imageData);
 
                     ImageData? srcImageData = srcRepoData?.Images.FirstOrDefault(srcImage => srcImage.ManifestImage == image);
 
@@ -323,11 +323,26 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                             .Select(tag => tag.FullyQualifiedName)
                             .ToList();
 
-                        PlatformData? platformData = CreatePlatformData(image, platform);
-                        imageData?.Platforms.Add(platformData);
+                        PlatformData platformData = CreatePlatformData(image, platform);
+                        imageData.Platforms.Add(platformData);
 
-                        bool isCachedImage = !Options.NoCache &&
-                            await CheckForCachedImageAsync(srcImageData, repoInfo, platform, allTagInfos, platformData);
+                        bool isCachedImage = false;
+                        if (!Options.NoCache)
+                        {
+                            ImageCacheResult cacheResult = await _imageCacheService.CheckForCachedImageAsync(
+                                srcImageData, platformData, _imageDigestCache, _imageNameResolver.Value, Options.SourceRepoUrl, Options.IsDryRun);
+                            if (cacheResult.State == ImageCacheState.Cached || cacheResult.State == ImageCacheState.CachedWithMissingTags)
+                            {
+                                isCachedImage = true;
+                                if (platformData is not null)
+                                {
+                                    CopyPlatformDataFromCachedPlatform(platformData, cacheResult.Platform!);
+                                    platformData.IsUnchanged = cacheResult.State == ImageCacheState.Cached;
+                                }
+
+                                await OnCacheHitAsync(repoInfo, allTagInfos, pullImage: cacheResult.IsNewCacheHit, cacheResult.Platform!.Digest);
+                            }
+                        }
 
                         if (!isCachedImage)
                         {
@@ -357,38 +372,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             }
         }
 
-        private async Task<bool> CheckForCachedImageAsync(
-            ImageData? srcImageData, RepoInfo repo, PlatformInfo platform, IEnumerable<TagInfo> allTags, PlatformData? platformData)
-        {
-            PlatformData? srcPlatformData = srcImageData?.Platforms.FirstOrDefault(srcPlatform => srcPlatform.PlatformInfo == platform);
-
-            string cacheKey = GetBuildCacheKey(platform);
-            if (platformData != null && _cachedPlatforms.TryGetValue(cacheKey, out PlatformData? cachedPlatform))
-            {
-                await OnCacheHitAsync(repo, allTags, pullImage: false, cachedPlatform.Digest);
-                CopyPlatformDataFromCachedPlatform(platformData, cachedPlatform);
-                platformData.IsUnchanged = srcPlatformData != null &&
-                    CachedPlatformHasAllTagsPublished(srcPlatformData);
-                return true;
-            }
-
-            bool isCachedImage = false;
-
-            // If this Dockerfile has been built and published before
-            if (srcPlatformData != null)
-            {
-                isCachedImage = await CheckForCachedImageFromImageInfoAsync(repo, platform, srcPlatformData, allTags);
-                if (platformData != null && isCachedImage)
-                {
-                    platformData.IsUnchanged = CachedPlatformHasAllTagsPublished(srcPlatformData);
-                    CopyPlatformDataFromCachedPlatform(platformData, srcPlatformData);
-                    _cachedPlatforms[cacheKey] = srcPlatformData;
-                }
-            }
-
-            return isCachedImage;
-        }
-
         private void CopyPlatformDataFromCachedPlatform(PlatformData dstPlatform, PlatformData srcPlatform)
         {
             // When a cache hit occurs for a Dockerfile, we want to transfer some of the metadata about the previously
@@ -397,27 +380,15 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             dstPlatform.Layers = new List<string>(srcPlatform.Layers);
         }
 
-        private bool CachedPlatformHasAllTagsPublished(PlatformData srcPlatformData) =>
-            (srcPlatformData.PlatformInfo?.Tags ?? Enumerable.Empty<TagInfo>())
-                .Where(tag => !tag.Model.IsLocal)
-                .Select(tag => tag.Name)
-                .AreEquivalent(srcPlatformData.SimpleTags);
-
-        private RepoData? CreateRepoData(RepoInfo repoInfo) =>
-            Options.ImageInfoOutputPath is null ? null :
-                new RepoData
-                {
-                    Repo = repoInfo.Name
-                };
-
-        private PlatformData? CreatePlatformData(ImageInfo image, PlatformInfo platform)
-        {
-            if (Options.ImageInfoOutputPath is null)
+        private RepoData CreateRepoData(RepoInfo repoInfo) =>
+            new RepoData
             {
-                return null;
-            }
+                Repo = repoInfo.Name
+            };
 
-            PlatformData? platformData = PlatformData.FromPlatformInfo(platform, image);
+        private PlatformData CreatePlatformData(ImageInfo image, PlatformInfo platform)
+        {
+            PlatformData platformData = PlatformData.FromPlatformInfo(platform, image);
             platformData.SimpleTags = GetPushTags(platform.Tags)
                 .Select(tag => tag.Name)
                 .OrderBy(name => name)
@@ -426,15 +397,15 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             return platformData;
         }
 
-        private ImageData? CreateImageData(ImageInfo image)
+        private ImageData CreateImageData(ImageInfo image)
         {
-            ImageData? imageData = Options.ImageInfoOutputPath is null ? null :
+            ImageData imageData =
                 new ImageData
                 {
                     ProductVersion = image.ProductVersion
                 };
 
-            if (image.SharedTags.Any() && imageData != null)
+            if (image.SharedTags.Any())
             {
                 imageData.Manifest = new ManifestData
                 {
@@ -533,25 +504,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             return buildArgs;
         }
 
-        private async Task<bool> CheckForCachedImageFromImageInfoAsync(
-            RepoInfo repo, PlatformInfo platform, PlatformData srcPlatformData, IEnumerable<TagInfo> allTags)
-        {
-            _loggerService.WriteMessage($"Checking for cached image for '{platform.DockerfilePathRelativeToManifest}'");
-
-            // If the previously published image was based on an image that is still the latest version AND
-            // the Dockerfile hasn't changed since it was last published
-            if (await IsBaseImageDigestUpToDateAsync(platform, srcPlatformData) && IsDockerfileUpToDate(platform, srcPlatformData))
-            {
-                await OnCacheHitAsync(repo, allTags, pullImage: true, sourceDigest: srcPlatformData.Digest);
-                return true;
-            }
-
-            _loggerService.WriteMessage("CACHE MISS");
-            _loggerService.WriteMessage();
-
-            return false;
-        }
-
         private async Task OnCacheHitAsync(RepoInfo repo, IEnumerable<TagInfo> allTags, bool pullImage, string sourceDigest)
         {
             _loggerService.WriteMessage();
@@ -633,46 +585,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             string destRepo = DockerHelper.GetRepo(DockerHelper.GetRepo(destTags.First()));
             sourceDigest = DockerHelper.GetImageName(Manifest.Registry, destRepo, digest: DockerHelper.GetDigestSha(sourceDigest));
             return sourceDigest;
-        }
-
-        private bool IsDockerfileUpToDate(PlatformInfo platform, PlatformData srcPlatformData)
-        {
-            string currentCommitUrl = _gitService.GetDockerfileCommitUrl(platform, Options.SourceRepoUrl);
-            bool commitShaMatches = false;
-            if (srcPlatformData.CommitUrl is not null)
-            {
-                commitShaMatches = srcPlatformData.CommitUrl.Equals(currentCommitUrl, StringComparison.OrdinalIgnoreCase);
-            }
-
-            _loggerService.WriteMessage();
-            _loggerService.WriteMessage($"Image info's Dockerfile commit: {srcPlatformData.CommitUrl}");
-            _loggerService.WriteMessage($"Latest Dockerfile commit: {currentCommitUrl}");
-            _loggerService.WriteMessage($"Dockerfile commits match: {commitShaMatches}");
-            return commitShaMatches;
-        }
-
-        private async Task<bool> IsBaseImageDigestUpToDateAsync(PlatformInfo platform, PlatformData srcPlatformData)
-        {
-            _loggerService.WriteMessage();
-
-            if (platform.FinalStageFromImage is null)
-            {
-                _loggerService.WriteMessage($"Image does not have a base image. By default, it is considered up-to-date.");
-                return true;
-            }
-
-            string? currentBaseImageDigest = await _imageDigestCache.GetImageDigestAsync(
-                _imageNameResolver.Value.GetFromImageLocalTag(platform.FinalStageFromImage),
-                Options.IsDryRun);
-
-            string? baseSha = srcPlatformData.BaseImageDigest is not null ? DockerHelper.GetDigestSha(srcPlatformData.BaseImageDigest) : null;
-            string? currentSha = currentBaseImageDigest is not null ? DockerHelper.GetDigestSha(currentBaseImageDigest) : null;
-            bool baseImageDigestMatches = baseSha?.Equals(currentSha, StringComparison.OrdinalIgnoreCase) == true;
-
-            _loggerService.WriteMessage($"Image info's base image digest: {srcPlatformData.BaseImageDigest}");
-            _loggerService.WriteMessage($"Latest base image digest: {currentBaseImageDigest}");
-            _loggerService.WriteMessage($"Base image digests match: {baseImageDigestMatches}");
-            return baseImageDigestMatches;
         }
 
         private void InvokeBuildHook(string hookName, string buildContextPath)
@@ -847,22 +759,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             }
 
             _loggerService.WriteMessage();
-        }
-
-        private static string GetBuildCacheKey(PlatformInfo platform) =>
-            $"{platform.DockerfilePathRelativeToManifest}-" +
-            string.Join('-', platform.BuildArgs.Select(kvp => $"{kvp.Key}={kvp.Value}").ToArray());
-
-        private class BuildCacheInfo
-        {
-            public BuildCacheInfo(string digest, string? baseImageDigest)
-            {
-                Digest = digest;
-                BaseImageDigest = baseImageDigest;
-            }
-
-            public string Digest { get; }
-            public string? BaseImageDigest { get; }
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ImageCacheService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ImageCacheService.cs
@@ -53,7 +53,8 @@ public class ImageCacheService : IImageCacheService
     {
         ImageCacheState cacheState = ImageCacheState.NotCached;
         bool isNewCacheHit = false;
-        PlatformData? srcPlatformData = srcImageData?.Platforms.FirstOrDefault(srcPlatform => srcPlatform.PlatformInfo == platformData.PlatformInfo);
+        PlatformData? srcPlatformData = srcImageData?.Platforms
+            .FirstOrDefault(srcPlatform => srcPlatform.PlatformInfo == platformData.PlatformInfo);
 
         if (platformData.PlatformInfo is null)
         {
@@ -76,7 +77,12 @@ public class ImageCacheService : IImageCacheService
         if (srcPlatformData != null)
         {
             bool isCachedImage = await CheckForCachedImageFromImageInfoAsync(
-                platformData.PlatformInfo, srcPlatformData, imageDigestCache, imageNameResolver, sourceRepoUrl, isDryRun);
+                platformData.PlatformInfo,
+                srcPlatformData,
+                imageDigestCache,
+                imageNameResolver,
+                sourceRepoUrl,
+                isDryRun);
 
             if (isCachedImage)
             {
@@ -111,7 +117,8 @@ public class ImageCacheService : IImageCacheService
 
         // If the previously published image was based on an image that is still the latest version AND
         // the Dockerfile hasn't changed since it was last published
-        if (await IsBaseImageDigestUpToDateAsync(platform, srcPlatformData, imageDigestCache, imageNameResolver, isDryRun) &&
+        if (await IsBaseImageDigestUpToDateAsync(
+                platform, srcPlatformData, imageDigestCache, imageNameResolver, isDryRun) &&
             IsDockerfileUpToDate(platform, srcPlatformData, sourceRepoUrl))
         {
             return true;
@@ -124,7 +131,11 @@ public class ImageCacheService : IImageCacheService
     }
 
     private async Task<bool> IsBaseImageDigestUpToDateAsync(
-        PlatformInfo platform, PlatformData srcPlatformData, ImageDigestCache imageDigestCache, ImageNameResolver imageNameResolver, bool isDryRun)
+        PlatformInfo platform,
+        PlatformData srcPlatformData,
+        ImageDigestCache imageDigestCache,
+        ImageNameResolver imageNameResolver,
+        bool isDryRun)
     {
         _loggerService.WriteMessage();
 
@@ -138,8 +149,12 @@ public class ImageCacheService : IImageCacheService
             imageNameResolver.GetFromImageLocalTag(platform.FinalStageFromImage),
             isDryRun);
 
-        string? baseSha = srcPlatformData.BaseImageDigest is not null ? DockerHelper.GetDigestSha(srcPlatformData.BaseImageDigest) : null;
-        string? currentSha = currentBaseImageDigest is not null ? DockerHelper.GetDigestSha(currentBaseImageDigest) : null;
+        string? baseSha = srcPlatformData.BaseImageDigest is not null ?
+            DockerHelper.GetDigestSha(srcPlatformData.BaseImageDigest) :
+            null;
+        string? currentSha = currentBaseImageDigest is not null ?
+            DockerHelper.GetDigestSha(currentBaseImageDigest) :
+            null;
         bool baseImageDigestMatches = baseSha?.Equals(currentSha, StringComparison.OrdinalIgnoreCase) == true;
 
         _loggerService.WriteMessage($"Image info's base image digest: {srcPlatformData.BaseImageDigest}");

--- a/src/Microsoft.DotNet.ImageBuilder/src/ImageCacheService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ImageCacheService.cs
@@ -1,0 +1,190 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.DotNet.ImageBuilder.Models.Image;
+using Microsoft.DotNet.ImageBuilder.ViewModel;
+
+namespace Microsoft.DotNet.ImageBuilder;
+
+#nullable enable
+public interface IImageCacheService
+{
+    bool HasAnyCachedPlatforms { get; }
+
+    Task<ImageCacheResult> CheckForCachedImageAsync(
+        ImageData? srcImageData,
+        PlatformData platformData,
+        ImageDigestCache imageDigestCache,
+        ImageNameResolver imageNameResolver,
+        string? sourceRepoUrl,
+        bool isDryRun);
+}
+
+[Export(typeof(IImageCacheService))]
+public class ImageCacheService : IImageCacheService
+{
+    private readonly ILoggerService _loggerService;
+    private readonly IGitService _gitService;
+
+    // Metadata about Dockerfiles whose images have been retrieved from the cache
+    private readonly Dictionary<string, PlatformData> _cachedPlatforms = [];
+
+    [ImportingConstructor]
+    public ImageCacheService(ILoggerService loggerService, IGitService gitService)
+    {
+        _loggerService = loggerService ?? throw new ArgumentNullException(nameof(loggerService));
+        _gitService = gitService ?? throw new ArgumentNullException(nameof(gitService));
+    }
+
+    public bool HasAnyCachedPlatforms => _cachedPlatforms.Any();
+
+    public async Task<ImageCacheResult> CheckForCachedImageAsync(
+        ImageData? srcImageData,
+        PlatformData platformData,
+        ImageDigestCache imageDigestCache,
+        ImageNameResolver imageNameResolver,
+        string? sourceRepoUrl,
+        bool isDryRun)
+    {
+        ImageCacheState cacheState = ImageCacheState.NotCached;
+        bool isNewCacheHit = false;
+        PlatformData? srcPlatformData = srcImageData?.Platforms.FirstOrDefault(srcPlatform => srcPlatform.PlatformInfo == platformData.PlatformInfo);
+
+        if (platformData.PlatformInfo is null)
+        {
+            throw new Exception("Expected platform info to be set");
+        }
+
+        string cacheKey = GetBuildCacheKey(platformData.PlatformInfo);
+        if (_cachedPlatforms.TryGetValue(cacheKey, out PlatformData? cachedPlatform))
+        {
+            cacheState = ImageCacheState.Cached;
+            if (srcPlatformData is null ||
+                !CachedPlatformHasAllTagsPublished(srcPlatformData))
+            {
+                cacheState = ImageCacheState.CachedWithMissingTags;
+            }
+            return new ImageCacheResult(cacheState, isNewCacheHit, cachedPlatform);
+        }
+
+        // If this Dockerfile has been built and published before
+        if (srcPlatformData != null)
+        {
+            bool isCachedImage = await CheckForCachedImageFromImageInfoAsync(
+                platformData.PlatformInfo, srcPlatformData, imageDigestCache, imageNameResolver, sourceRepoUrl, isDryRun);
+
+            if (isCachedImage)
+            {
+                isNewCacheHit = true;
+                cacheState = ImageCacheState.Cached;
+                if (!CachedPlatformHasAllTagsPublished(srcPlatformData))
+                {
+                    cacheState = ImageCacheState.CachedWithMissingTags;
+                }
+                _cachedPlatforms[cacheKey] = srcPlatformData;
+            }
+        }
+
+        return new ImageCacheResult(cacheState, isNewCacheHit, srcPlatformData);
+    }
+
+    private static bool CachedPlatformHasAllTagsPublished(PlatformData srcPlatformData) =>
+        (srcPlatformData.PlatformInfo?.Tags ?? [])
+            .Where(tag => !tag.Model.IsLocal)
+            .Select(tag => tag.Name)
+            .AreEquivalent(srcPlatformData.SimpleTags);
+
+    private async Task<bool> CheckForCachedImageFromImageInfoAsync(
+        PlatformInfo platform,
+        PlatformData srcPlatformData,
+        ImageDigestCache imageDigestCache,
+        ImageNameResolver imageNameResolver,
+        string? sourceRepoUrl,
+        bool isDryRun)
+    {
+        _loggerService.WriteMessage($"Checking for cached image for '{platform.DockerfilePathRelativeToManifest}'");
+
+        // If the previously published image was based on an image that is still the latest version AND
+        // the Dockerfile hasn't changed since it was last published
+        if (await IsBaseImageDigestUpToDateAsync(platform, srcPlatformData, imageDigestCache, imageNameResolver, isDryRun) &&
+            IsDockerfileUpToDate(platform, srcPlatformData, sourceRepoUrl))
+        {
+            return true;
+        }
+
+        _loggerService.WriteMessage("CACHE MISS");
+        _loggerService.WriteMessage();
+
+        return false;
+    }
+
+    private async Task<bool> IsBaseImageDigestUpToDateAsync(
+        PlatformInfo platform, PlatformData srcPlatformData, ImageDigestCache imageDigestCache, ImageNameResolver imageNameResolver, bool isDryRun)
+    {
+        _loggerService.WriteMessage();
+
+        if (platform.FinalStageFromImage is null)
+        {
+            _loggerService.WriteMessage($"Image does not have a base image. By default, it is considered up-to-date.");
+            return true;
+        }
+
+        string? currentBaseImageDigest = await imageDigestCache.GetImageDigestAsync(
+            imageNameResolver.GetFromImageLocalTag(platform.FinalStageFromImage),
+            isDryRun);
+
+        string? baseSha = srcPlatformData.BaseImageDigest is not null ? DockerHelper.GetDigestSha(srcPlatformData.BaseImageDigest) : null;
+        string? currentSha = currentBaseImageDigest is not null ? DockerHelper.GetDigestSha(currentBaseImageDigest) : null;
+        bool baseImageDigestMatches = baseSha?.Equals(currentSha, StringComparison.OrdinalIgnoreCase) == true;
+
+        _loggerService.WriteMessage($"Image info's base image digest: {srcPlatformData.BaseImageDigest}");
+        _loggerService.WriteMessage($"Latest base image digest: {currentBaseImageDigest}");
+        _loggerService.WriteMessage($"Base image digests match: {baseImageDigestMatches}");
+        return baseImageDigestMatches;
+    }
+
+    private bool IsDockerfileUpToDate(PlatformInfo platform, PlatformData srcPlatformData, string? sourceRepoUrl)
+    {
+        string currentCommitUrl = _gitService.GetDockerfileCommitUrl(platform, sourceRepoUrl);
+        bool commitShaMatches = false;
+        if (srcPlatformData.CommitUrl is not null)
+        {
+            commitShaMatches = srcPlatformData.CommitUrl.Equals(currentCommitUrl, StringComparison.OrdinalIgnoreCase);
+        }
+
+        _loggerService.WriteMessage();
+        _loggerService.WriteMessage($"Image info's Dockerfile commit: {srcPlatformData.CommitUrl}");
+        _loggerService.WriteMessage($"Latest Dockerfile commit: {currentCommitUrl}");
+        _loggerService.WriteMessage($"Dockerfile commits match: {commitShaMatches}");
+        return commitShaMatches;
+    }
+
+    private static string GetBuildCacheKey(PlatformInfo platform) =>
+        $"{platform.DockerfilePathRelativeToManifest}-" +
+        string.Join('-', platform.BuildArgs.Select(kvp => $"{kvp.Key}={kvp.Value}").ToArray());
+}
+
+public enum ImageCacheState
+{
+    /// <summary>
+    /// Indicates a previously built image was not found in the registry.
+    /// </summary>
+    NotCached,
+
+    /// <summary>
+    /// Indicates a previously built image was found in the registry.
+    /// </summary>
+    Cached,
+
+    /// <summary>
+    /// Indicates a previously built image was found in the registry but is missing new tags.
+    /// </summary>
+    CachedWithMissingTags
+}
+
+public record ImageCacheResult(ImageCacheState State, bool IsNewCacheHit, PlatformData? Platform);

--- a/src/Microsoft.DotNet.ImageBuilder/src/ImageNameResolver.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ImageNameResolver.cs
@@ -1,0 +1,98 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.ImageBuilder.Commands;
+using Microsoft.DotNet.ImageBuilder.ViewModel;
+
+namespace Microsoft.DotNet.ImageBuilder;
+
+#nullable enable
+internal class ImageNameResolver
+{
+    private readonly BaseImageOverrideOptions _baseImageOverrideOptions;
+    private readonly ManifestInfo _manifest;
+    private readonly string? _repoPrefix;
+    private readonly string? _sourceRepoPrefix;
+
+    public ImageNameResolver(BaseImageOverrideOptions baseImageOverrideOptions, ManifestInfo manifest, string? repoPrefix, string? sourceRepoPrefix)
+    {
+        _baseImageOverrideOptions = baseImageOverrideOptions;
+        _manifest = manifest;
+        _repoPrefix = repoPrefix;
+        _sourceRepoPrefix = sourceRepoPrefix;
+    }
+
+    /// <summary>
+    /// Returns the tag to use for interacting with the image of a FROM instruction that has been pulled or built locally.
+    /// </summary>
+    /// <param name="fromImage">Tag of the FROM image.</param>
+    public string GetFromImageLocalTag(string fromImage) =>
+        // Provides the overridable value of the registry (e.g. dotnetdocker.azurecr.io) because that is the registry that
+        // would be used for tags that exist locally.
+        GetFromImageTag(fromImage, _manifest.Registry);
+
+    /// <summary>
+    /// Returns the tag to use for pulling the image of a FROM instruction.
+    /// </summary>
+    /// <param name="fromImage">Tag of the FROM image.</param>
+    public string GetFromImagePullTag(string fromImage) =>
+        // Provides the raw registry value from the manifest (e.g. mcr.microsoft.com). This accounts for images that
+        // are classified as external within the model but they are owned internally and not mirrored. An example of
+        // this is sample images. By comparing their base image tag to that raw registry value from the manifest, we
+        // can know that these are owned internally and not to attempt to pull them from the mirror location.
+        GetFromImageTag(fromImage, _manifest.Model.Registry);
+
+    /// <summary>
+    /// Returns the tag that represents the publicly available tag of a FROM instruction.
+    /// </summary>
+    /// <param name="fromImage">Tag of the FROM image.</param>
+    /// <remarks>
+    /// This compares the registry of the image tag to determine if it's internally owned. If so, it returns
+    /// the tag using the raw (non-overriden) registry from the manifest (e.g. mcr.microsoft.com). Otherwise,
+    /// it returns the image tag unchanged.
+    /// </remarks>
+    public string GetFromImagePublicTag(string fromImage)
+    {
+        string trimmed = TrimInternallyOwnedRegistryAndRepoPrefix(fromImage);
+        if (trimmed == fromImage)
+        {
+            return _baseImageOverrideOptions.ApplyBaseImageOverride(trimmed);
+        }
+        else
+        {
+            return $"{_manifest.Model.Registry}/{trimmed}";
+        }
+    }
+
+    /// <summary>
+    /// Gets the tag to use for the image of a FROM instruction.
+    /// </summary>
+    /// <param name="fromImage">Tag of the FROM image.</param>
+    /// <param name="registry">Registry to use for comparing against the tag to determine if it's owned internally or external.</param>
+    /// <remarks>
+    /// This is meant to provide support for external images that need to be pulled from the mirror location.
+    /// </remarks>
+    private string GetFromImageTag(string fromImage, string? registry)
+    {
+        fromImage = _baseImageOverrideOptions.ApplyBaseImageOverride(fromImage);
+
+        if ((registry is not null && DockerHelper.IsInRegistry(fromImage, registry)) ||
+            DockerHelper.IsInRegistry(fromImage, _manifest.Model.Registry)
+            || _sourceRepoPrefix is null)
+        {
+            return fromImage;
+        }
+
+        string srcImage = TrimInternallyOwnedRegistryAndRepoPrefix(DockerHelper.NormalizeRepo(fromImage));
+        return $"{_manifest.Registry}/{_sourceRepoPrefix}{srcImage}";
+    }
+
+    private string TrimInternallyOwnedRegistryAndRepoPrefix(string imageTag) =>
+        IsInInternallyOwnedRegistry(imageTag) ?
+            DockerHelper.TrimRegistry(imageTag).TrimStart(_repoPrefix) :
+            imageTag;
+
+    private bool IsInInternallyOwnedRegistry(string imageTag) =>
+        DockerHelper.IsInRegistry(imageTag, _manifest.Registry) ||
+        DockerHelper.IsInRegistry(imageTag, _manifest.Model.Registry);
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/ImageNameResolver.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ImageNameResolver.cs
@@ -7,7 +7,7 @@ using Microsoft.DotNet.ImageBuilder.ViewModel;
 namespace Microsoft.DotNet.ImageBuilder;
 
 #nullable enable
-internal class ImageNameResolver
+public class ImageNameResolver
 {
     private readonly BaseImageOverrideOptions _baseImageOverrideOptions;
     private readonly ManifestInfo _manifest;

--- a/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
@@ -148,7 +148,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     Mock.Of<ICopyImageService>(),
                     manifestServiceFactoryMock.Object,
                     Mock.Of<IRegistryCredentialsProvider>(),
-                    Mock.Of<IAzureTokenCredentialProvider>());
+                    Mock.Of<IAzureTokenCredentialProvider>(),
+                    new ImageCacheService(Mock.Of<ILoggerService>(), gitServiceMock.Object));
                 command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
                 command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "image-info.json");
                 command.Options.IsPushEnabled = true;
@@ -351,7 +352,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     Mock.Of<ICopyImageService>(),
                     manifestServiceFactoryMock.Object,
                     Mock.Of<IRegistryCredentialsProvider>(),
-                    Mock.Of<IAzureTokenCredentialProvider>());
+                    Mock.Of<IAzureTokenCredentialProvider>(),
+                    new ImageCacheService(Mock.Of<ILoggerService>(), gitServiceMock.Object));
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "image-info.json");
             command.Options.IsPushEnabled = true;
@@ -480,7 +482,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 copyImageServiceMock.Object,
                 CreateManifestServiceFactoryMock().Object,
                 Mock.Of<IRegistryCredentialsProvider>(),
-                Mock.Of<IAzureTokenCredentialProvider>());
+                Mock.Of<IAzureTokenCredentialProvider>(),
+                new ImageCacheService(Mock.Of<ILoggerService>(), Mock.Of<IGitService>()));
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.IsPushEnabled = true;
 
@@ -558,7 +561,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Mock.Of<ICopyImageService>(),
                 CreateManifestServiceFactoryMock().Object,
                 Mock.Of<IRegistryCredentialsProvider>(),
-                Mock.Of<IAzureTokenCredentialProvider>());
+                Mock.Of<IAzureTokenCredentialProvider>(),
+                new ImageCacheService(Mock.Of<ILoggerService>(), Mock.Of<IGitService>()));
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
 
             const string runtimeRelativeDir = "1.0/runtime/os";
@@ -610,7 +614,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Mock.Of<ICopyImageService>(),
                 CreateManifestServiceFactoryMock().Object,
                 Mock.Of<IRegistryCredentialsProvider>(),
-                Mock.Of<IAzureTokenCredentialProvider>());
+                Mock.Of<IAzureTokenCredentialProvider>(),
+                new ImageCacheService(Mock.Of<ILoggerService>(), Mock.Of<IGitService>()));
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.BuildArgs.Add("arg1", "val1");
             command.Options.BuildArgs.Add("arg2", "val2a");
@@ -669,7 +674,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Mock.Of<ICopyImageService>(),
                 Mock.Of<IManifestServiceFactory>(),
                 Mock.Of<IRegistryCredentialsProvider>(),
-                Mock.Of<IAzureTokenCredentialProvider>());
+                Mock.Of<IAzureTokenCredentialProvider>(),
+                new ImageCacheService(Mock.Of<ILoggerService>(), Mock.Of<IGitService>()));
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.IsPushEnabled = true;
 
@@ -770,7 +776,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 copyImageServiceMock.Object,
                 manifestServiceFactoryMock.Object,
                 Mock.Of<IRegistryCredentialsProvider>(),
-                Mock.Of<IAzureTokenCredentialProvider>());
+                Mock.Of<IAzureTokenCredentialProvider>(),
+                new ImageCacheService(Mock.Of<ILoggerService>(), gitServiceMock.Object));
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "dest-image-info.json");
             command.Options.ImageInfoSourcePath = Path.Combine(tempFolderContext.Path, "src-image-info.json");
@@ -956,7 +963,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     Mock.Of<ICopyImageService>(),
                     manifestServiceFactoryMock.Object,
                     Mock.Of<IRegistryCredentialsProvider>(),
-                    Mock.Of<IAzureTokenCredentialProvider>());
+                    Mock.Of<IAzureTokenCredentialProvider>(),
+                    new ImageCacheService(Mock.Of<ILoggerService>(), gitServiceMock.Object));
                 command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
                 command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "image-info.json");
                 command.Options.SourceRepoUrl = "https://source";
@@ -1006,7 +1014,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Mock.Of<ICopyImageService>(),
                 CreateManifestServiceFactoryMock().Object,
                 Mock.Of<IRegistryCredentialsProvider>(),
-                Mock.Of<IAzureTokenCredentialProvider>());
+                Mock.Of<IAzureTokenCredentialProvider>(),
+                new ImageCacheService(Mock.Of<ILoggerService>(), Mock.Of<IGitService>()));
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.IsSkipPullingEnabled = isSkipPullingEnabled;
 
@@ -1168,7 +1177,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 copyImageServiceMock.Object,
                 manifestServiceFactoryMock.Object,
                 Mock.Of<IRegistryCredentialsProvider>(),
-                Mock.Of<IAzureTokenCredentialProvider>());
+                Mock.Of<IAzureTokenCredentialProvider>(),
+                new ImageCacheService(Mock.Of<ILoggerService>(), gitServiceMock.Object));
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "dest-image-info.json");
             command.Options.ImageInfoSourcePath = Path.Combine(tempFolderContext.Path, "src-image-info.json");
@@ -1480,7 +1490,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 copyImageServiceMock.Object,
                 manifestServiceFactoryMock.Object,
                 Mock.Of<IRegistryCredentialsProvider>(),
-                Mock.Of<IAzureTokenCredentialProvider>());
+                Mock.Of<IAzureTokenCredentialProvider>(),
+                new ImageCacheService(Mock.Of<ILoggerService>(), gitServiceMock.Object));
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "dest-image-info.json");
             command.Options.ImageInfoSourcePath = Path.Combine(tempFolderContext.Path, "src-image-info.json");
@@ -1794,7 +1805,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 copyImageServiceMock.Object,
                 manifestServiceFactoryMock.Object,
                 Mock.Of<IRegistryCredentialsProvider>(),
-                Mock.Of<IAzureTokenCredentialProvider>());
+                Mock.Of<IAzureTokenCredentialProvider>(),
+                new ImageCacheService(Mock.Of<ILoggerService>(), gitServiceMock.Object));
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "dest-image-info.json");
             command.Options.ImageInfoSourcePath = Path.Combine(tempFolderContext.Path, "src-image-info.json");
@@ -2088,7 +2100,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 copyImageServiceMock.Object,
                 CreateManifestServiceFactoryMock(manifestServiceMock).Object,
                 Mock.Of<IRegistryCredentialsProvider>(),
-                Mock.Of<IAzureTokenCredentialProvider>());
+                Mock.Of<IAzureTokenCredentialProvider>(),
+                new ImageCacheService(Mock.Of<ILoggerService>(), gitServiceMock.Object));
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "dest-image-info.json");
             command.Options.ImageInfoSourcePath = Path.Combine(tempFolderContext.Path, "src-image-info.json");
@@ -2293,7 +2306,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Mock.Of<ICopyImageService>(),
                 CreateManifestServiceFactoryMock(manifestServiceMock).Object,
                 Mock.Of<IRegistryCredentialsProvider>(),
-                Mock.Of<IAzureTokenCredentialProvider>());
+                Mock.Of<IAzureTokenCredentialProvider>(),
+                new ImageCacheService(Mock.Of<ILoggerService>(), gitServiceMock.Object));
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "dest-image-info.json");
             command.Options.ImageInfoSourcePath = Path.Combine(tempFolderContext.Path, "src-image-info.json");
@@ -2534,7 +2548,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 copyImageServiceMock.Object,
                 CreateManifestServiceFactoryMock(manifestServiceMock).Object,
                 Mock.Of<IRegistryCredentialsProvider>(),
-                Mock.Of<IAzureTokenCredentialProvider>());
+                Mock.Of<IAzureTokenCredentialProvider>(),
+                new ImageCacheService(Mock.Of<ILoggerService>(), gitServiceMock.Object));
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "dest-image-info.json");
             command.Options.ImageInfoSourcePath = Path.Combine(tempFolderContext.Path, "src-image-info.json");
@@ -2755,7 +2770,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 copyImageServiceMock.Object,
                 CreateManifestServiceFactoryMock(manifestServiceMock).Object,
                 Mock.Of<IRegistryCredentialsProvider>(),
-                Mock.Of<IAzureTokenCredentialProvider>());
+                Mock.Of<IAzureTokenCredentialProvider>(),
+                new ImageCacheService(Mock.Of<ILoggerService>(), gitServiceMock.Object));
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "dest-image-info.json");
             command.Options.ImageInfoSourcePath = Path.Combine(tempFolderContext.Path, "src-image-info.json");
@@ -3058,7 +3074,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 copyImageServiceMock.Object,
                 CreateManifestServiceFactoryMock(manifestServiceMock).Object,
                 Mock.Of<IRegistryCredentialsProvider>(),
-                Mock.Of<IAzureTokenCredentialProvider>());
+                Mock.Of<IAzureTokenCredentialProvider>(),
+                new ImageCacheService(Mock.Of<ILoggerService>(), gitServiceMock.Object));
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "image-info.json");
             command.Options.ImageInfoSourcePath = Path.Combine(tempFolderContext.Path, "src-image-info.json");
@@ -3401,7 +3418,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Mock.Of<ICopyImageService>(),
                 CreateManifestServiceFactoryMock(manifestServiceMock).Object,
                 Mock.Of<IRegistryCredentialsProvider>(),
-                Mock.Of<IAzureTokenCredentialProvider>());
+                Mock.Of<IAzureTokenCredentialProvider>(),
+                new ImageCacheService(Mock.Of<ILoggerService>(), gitServiceMock.Object));
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "image-info.json");
             command.Options.IsPushEnabled = true;
@@ -3498,7 +3516,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Mock.Of<ICopyImageService>(),
                 CreateManifestServiceFactoryMock(manifestServiceMock).Object,
                 Mock.Of<IRegistryCredentialsProvider>(),
-                Mock.Of<IAzureTokenCredentialProvider>());
+                Mock.Of<IAzureTokenCredentialProvider>(),
+                new ImageCacheService(Mock.Of<ILoggerService>(), gitServiceMock.Object));
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "image-info.json");
             command.Options.IsPushEnabled = true;


### PR DESCRIPTION
Contributes to #1417 

In order to implement the approach described in https://github.com/dotnet/docker-tools/issues/1417#issuecomment-2315921521, we need to have common logic for determining whether an image is cached or not. This is currently defined in `BuildCommand`. In order to reuse that logic for the matrix generation, it's being factored out into a separate reusable service.