### PR TITLE
Avoid getting creds on dry run

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/RegistryCredentialsProviderExtensions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/RegistryCredentialsProviderExtensions.cs
@@ -20,8 +20,11 @@ internal static class RegistryCredentialsProviderExtensions
     {
         bool loggedIn = false;
 
-        RegistryCredentials? credentials = await credsProvider.GetCredentialsAsync(
-                registryName, ownedAcr, credentialsOptions);
+        RegistryCredentials? credentials = null;
+        if (!isDryRun)
+        {
+            credentials = await credsProvider.GetCredentialsAsync(registryName, ownedAcr, credentialsOptions);
+        }
 
         if (!string.IsNullOrEmpty(registryName) && credentials is not null)
         {


### PR DESCRIPTION
I ran into an issue in https://github.com/dotnet/dotnet-docker/pull/5837 where `PublishManifestCommand` was failing after defaulting the value of the `acr.server` to an empty value for public builds. Previously, this variable was undefined and so the pipeline was interpreting `$(acr.server)` as the literal value. But I needed to set it to an empty value to fix a different issue, which is the correct thing to do in this case. But when setting it to an empty value, it was causing `PublishManifestCommand` to attempt to get default Azure credentials and failing. This is because the public builds are not configured to have auth. The reason that setting `acr.server` to an empty value causes this is because of the combination of these calls:

https://github.com/dotnet/docker-tools/blob/495e22ba8874c3f90f4cccbeafefdb9b9e9ff524/src/Microsoft.DotNet.ImageBuilder/src/RegistryCredentialsProvider.cs#L37-L45

Without defaulting the value of the `acr.server` variable, the `$(acr.server)` literal value would get formatted as `$(acr.server).azurecr.io` which would then differ from the API registry value of `$(acr.server)`. Since they were different, it would skip the call to `GetAcrCredentialsWithOAuthAsync`. But when defaulting it to an empty value, the comparison succeeds and the call to `GetAcrCredentialsWithOAuthAsync` is made which results in the auth errors.

The fix is to avoid getting credentials at all when running in dry mode.