### PR TITLE
Minor updates for EOL annotation publishing

### DIFF
--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -161,7 +161,7 @@ jobs:
   - template: /eng/common/templates/steps/publish-artifact.yml@self
     parameters:
       path: $(Build.ArtifactStagingDirectory)/eol-annotation-data
-      artifactName: eol-annotation-data
+      artifactName: eol-annotation-data-$(System.JobAttempt)
       displayName: Publish EOL Annotation Data Artifact
       internalProjectName: internal
       publicProjectName: public

--- a/eng/common/templates/steps/annotate-eol-digests.yml
+++ b/eng/common/templates/steps/annotate-eol-digests.yml
@@ -16,6 +16,7 @@ steps:
         $(acr.server)
         $(publishRepoPrefix)
         $(artifactsPath)/annotation-digests/annotation-digests.txt
+        $(dryRunArg)
   - template: /eng/common/templates/steps/publish-artifact.yml@self
     parameters:
       path: $(Build.ArtifactStagingDirectory)/annotation-digests

--- a/eng/pipelines/annotate-eol-digests.yml
+++ b/eng/pipelines/annotate-eol-digests.yml
@@ -10,6 +10,8 @@ variables:
 - template: templates/variables/image-builder.yml
 - name: publishEolAnnotations
   value: true
+- name: dryRunArg
+  value: ""
 
 extends:
   template: /eng/common/templates/1es-official.yml@self


### PR DESCRIPTION
* Avoids pipeline artifact name collision when publishing EOL data artifact
* Supports PR builds by setting the dry run option for the `annotateEolDigests` command.