### PR TITLE
Defer Docker login until just before pulling cached images during build command

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/RegistryCredentialsProviderExtensions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/RegistryCredentialsProviderExtensions.cs
@@ -46,24 +46,16 @@ internal static class RegistryCredentialsProviderExtensions
         string registryName,
         string? ownedAcr)
     {
-        bool loggedIn = await LogInToRegistry(
-            credsProvider,
+        await credsProvider.ExecuteWithCredentialsAsync(
             isDryRun,
+            () => {
+                action();
+                return Task.CompletedTask;
+            },
             credentialsOptions,
             registryName,
-            ownedAcr);
-
-        try
-        {
-            action();
-        }
-        finally
-        {
-            if (loggedIn && !string.IsNullOrEmpty(registryName))
-            {
-                DockerHelper.Logout(registryName, isDryRun);
-            }
-        }
+            ownedAcr
+        );
     }
 
     private static async Task<bool> LogInToRegistry(

--- a/src/Microsoft.DotNet.ImageBuilder/src/RegistryCredentialsProviderExtensions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/RegistryCredentialsProviderExtensions.cs
@@ -18,6 +18,61 @@ internal static class RegistryCredentialsProviderExtensions
         string registryName,
         string? ownedAcr)
     {
+        bool loggedIn = await LogInToRegistry(
+            credsProvider,
+            isDryRun,
+            credentialsOptions,
+            registryName,
+            ownedAcr);
+
+        try
+        {
+            await action();
+        }
+        finally
+        {
+            if (loggedIn && !string.IsNullOrEmpty(registryName))
+            {
+                DockerHelper.Logout(registryName, isDryRun);
+            }
+        }
+    }
+
+    public static async Task ExecuteWithCredentialsAsync(
+        this IRegistryCredentialsProvider credsProvider,
+        bool isDryRun,
+        Action action,
+        RegistryCredentialsOptions credentialsOptions,
+        string registryName,
+        string? ownedAcr)
+    {
+        bool loggedIn = await LogInToRegistry(
+            credsProvider,
+            isDryRun,
+            credentialsOptions,
+            registryName,
+            ownedAcr);
+
+        try
+        {
+            action();
+        }
+        finally
+        {
+            if (loggedIn && !string.IsNullOrEmpty(registryName))
+            {
+                DockerHelper.Logout(registryName, isDryRun);
+            }
+        }
+    }
+
+    private static async Task<bool> LogInToRegistry(
+        this IRegistryCredentialsProvider credsProvider,
+        bool isDryRun,
+        RegistryCredentialsOptions credentialsOptions,
+        string registryName,
+        string? ownedAcr)
+    {
         bool loggedIn = false;
 
         RegistryCredentials? credentials = null;
@@ -32,16 +87,6 @@ internal static class RegistryCredentialsProviderExtensions
             loggedIn = true;
         }
 
-        try
-        {
-            await action();
-        }
-        finally
-        {
-            if (loggedIn && !string.IsNullOrEmpty(registryName))
-            {
-                DockerHelper.Logout(registryName, isDryRun);
-            }
-        }
+        return loggedIn;
     }
 }


### PR DESCRIPTION
Fixes #1424 

Instead of running `BuildImagesAsync()` under authentication the whole time, defer login to only when we need to pull cached images in the case of a cache hit. That should be the only place we need credentials during the actual building of images, since we already pulled the base images with `PullBaseImagesAsync()`.

This has the added benefit of running the rest of the build command without any Docker credentials, since they shouldn't be necessary (and should fail the build).