### PR TITLE
Allow images to be excluded from cleaning

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesCommand.cs
@@ -51,6 +51,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         public override async Task ExecuteAsync()
         {
+            if (Options.ImagesToExclude.Any() && Options.Action == CleanAcrImagesAction.Delete)
+            {
+                throw new NotSupportedException("Excluding images is not supported when deleting repositories");
+            }
+
             Regex repoNameFilterRegex = new(ManifestFilter.GetFilterRegexPattern(Options.RepoName));
 
             _loggerService.WriteHeading("FINDING IMAGES TO CLEAN");

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesCommand.cs
@@ -168,25 +168,30 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 return;
             }
 
-            ConcurrentBag<ArtifactManifestProperties> expiredTestImages = [];
+            ConcurrentBag<ArtifactManifestProperties> expiredImages = [];
             await Parallel.ForEachAsync(allManifests, async (manifest, token) =>
             {
-                if (await canDeleteManifest(manifest))
+                if (!IsExcludedManifest(manifest) && await canDeleteManifest(manifest))
                 {
-                    expiredTestImages.Add(manifest);
+                    expiredImages.Add(manifest);
                 }
             });
 
             // If all the images in the repo are expired, delete the whole repo instead of 
             // deleting each individual image.
-            if (expiredTestImages.Count == manifestCount)
+            if (expiredImages.Count == manifestCount)
             {
                 await DeleteRepositoryAsync(acrClient, deletedRepos, repository);
                 return;
             }
 
-            await DeleteManifestsAsync(acrContentClient, deletedImages, repository, expiredTestImages);
+            await DeleteManifestsAsync(acrContentClient, deletedImages, repository, expiredImages);
         }
+
+        private bool IsExcludedManifest(ArtifactManifestProperties manifest) =>
+            Options.ImagesToExclude
+                .Select(exclusion => ImageName.Parse(exclusion))
+                .Any(exclusion => exclusion.Repo == manifest.RepositoryName && (exclusion.Digest == manifest.Digest || manifest.Tags.Contains(exclusion.Tag)));
 
         private async Task DeleteManifestsAsync(
             IContainerRegistryContentClient acrContentClient, List<string> deletedImages, ContainerRepository repository, IEnumerable<ArtifactManifestProperties> manifests)

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesOptions.cs
@@ -19,6 +19,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public string Subscription { get; set; }
         public string ResourceGroup { get; set; }
         public string RegistryName { get; set; }
+        public string[] ImagesToExclude { get; set; } = [];
     }
 
     public class CleanAcrImagesOptionsBuilder : CliOptionsBuilder
@@ -57,7 +58,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         CreateOption("action", nameof(CleanAcrImagesOptions.Action),
                             EnumHelper.GetHelpTextOptions(DefaultCleanAcrImagesAction), DefaultCleanAcrImagesAction),
                         CreateOption("age", nameof(CleanAcrImagesOptions.Age),
-                            $"Minimum age (days) of repo or images to be deleted (default: {DefaultAge})", DefaultAge)
+                            $"Minimum age (days) of repo or images to be deleted (default: {DefaultAge})", DefaultAge),
+                        CreateMultiOption<string>("exclude", nameof(CleanAcrImagesOptions.ImagesToExclude),
+                            $"Name of image to exclude from cleaning (does not apply when using the '{nameof(CleanAcrImagesAction.Delete)}' action)"),
                     });
     }
 


### PR DESCRIPTION
On rare occasions, there may be specific images that should be excluded from being cleaned by the `cleanAcrImages` command.

This adds a new `--exclude` option to the command that provides a way for the caller to provide an image name that will be excluded from being cleaned. Multiple `--exclude` options can be provided if necessary. This supports an image name that is referenced by tag or digest.