### PR TITLE
publishImageInfo: output original and updated content of image info

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
@@ -98,7 +98,17 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 Directory.CreateDirectory(imageInfoDir);
             }
 
+            if (Options.OriginalImageInfoOutputPath is not null)
+            {
+                File.Copy(imageInfoPath, Options.OriginalImageInfoOutputPath, overwrite: true);
+            }
+
             File.WriteAllText(imageInfoPath, imageInfoContent);
+
+            if (Options.UpdatedImageInfoOutputPath is not null)
+            {
+                File.Copy(imageInfoPath, Options.UpdatedImageInfoOutputPath, overwrite: true);
+            }
 
             _gitService.Stage(repo, imageInfoPath);
             Signature sig = new Signature(Options.GitOptions.Username, Options.GitOptions.Email, DateTimeOffset.Now);

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoOptions.cs
@@ -4,7 +4,7 @@
 
 using System.Collections.Generic;
 using System.CommandLine;
-using System.Linq;
+using static Microsoft.DotNet.ImageBuilder.Commands.CliHelper;
 
 #nullable enable
 namespace Microsoft.DotNet.ImageBuilder.Commands
@@ -12,6 +12,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     public class PublishImageInfoOptions : ImageInfoOptions, IGitOptionsHost
     {
         public GitOptions GitOptions { get; set; } = new GitOptions();
+
+        public string? OriginalImageInfoOutputPath { get; set; }
+        public string? UpdatedImageInfoOutputPath { get; set; }
     }
 
     public class PublishImageInfoOptionsBuilder : ImageInfoOptionsBuilder
@@ -19,12 +22,20 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private readonly GitOptionsBuilder _gitOptionsBuilder = GitOptionsBuilder.BuildWithDefaults();
 
         public override IEnumerable<Option> GetCliOptions() =>
-            base.GetCliOptions()
-                .Concat(_gitOptionsBuilder.GetCliOptions());
+            [
+                ..base.GetCliOptions(),
+                .._gitOptionsBuilder.GetCliOptions(),
+                CreateOption<string?>("image-info-orig-path", nameof(PublishImageInfoOptions.OriginalImageInfoOutputPath),
+                    $"Path where the original image info content will be written to"),
+                CreateOption<string?>("image-info-update-path", nameof(PublishImageInfoOptions.UpdatedImageInfoOutputPath),
+                    $"Path where the updated image info content will be written to"),
+
+            ];
 
         public override IEnumerable<Argument> GetCliArguments() =>
-            base.GetCliArguments()
-                .Concat(_gitOptionsBuilder.GetCliArguments());
+            [
+                ..base.GetCliArguments(),
+                .._gitOptionsBuilder.GetCliArguments()
+            ];
     }
 }
-#nullable disable


### PR DESCRIPTION
Contributes to https://github.com/dotnet/docker-tools/issues/1433

This will provide a way for the pipeline to get the content of both the original and updated versions of the image info file as part of the invocation of the `publishImageInfo` command. This will provide accurate content of the file that downloading from `raw.githubusercontent.com` does not provide.