### PR TITLE
Consume image info output of publishImageInfo command

### DIFF
--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -106,10 +106,8 @@ jobs:
     parameters:
       dryRunArg: $(dryRunArg)
       condition: and(succeeded(), eq(variables['publishReadme'], 'true'))
-  - script: |
-      mkdir -p $(Build.ArtifactStagingDirectory)/eol-annotation-data
-      curl -fSL --output $(Build.ArtifactStagingDirectory)/eol-annotation-data/image-info-old.json $(imageInfoRawContentUrl)
-    displayName: Download Original Image Info File
+  - script: mkdir -p $(Build.ArtifactStagingDirectory)/eol-annotation-data
+    displayName: Create EOL Annotation Data Directory
   - script: >
       $(runImageBuilderCmd) publishImageInfo
       '$(imageInfoContainerDir)/image-info.json'
@@ -120,12 +118,12 @@ jobs:
       --git-repo '$(gitHubVersionsRepoInfo.repo)'
       --git-branch '$(gitHubVersionsRepoInfo.branch)'
       --git-path '$(gitHubImageInfoVersionsPath)'
+      --image-info-orig-path '$(artifactsPath)/eol-annotation-data/image-info-old.json'
+      --image-info-update-path '$(artifactsPath)/eol-annotation-data/image-info-new.json'
       $(dryRunArg)
       $(imageBuilder.commonCmdArgs)
     condition: and(succeeded(), eq(variables['publishImageInfo'], 'true'))
     displayName: Publish Image Info
-  - script: curl -fSL --output $(Build.ArtifactStagingDirectory)/eol-annotation-data/image-info-new.json $(imageInfoRawContentUrl)
-    displayName: Download Updated Image Info File
   - template: /eng/common/templates/steps/run-imagebuilder.yml@self
     parameters:
       displayName: Ingest Kusto Image Info

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -28,8 +28,6 @@ jobs:
     value: $(artifactsPath)/imageInfo
   - name: sourceBuildIdOutputDir
     value: $(Build.ArtifactStagingDirectory)/sourceBuildId
-  - name: imageInfoRawContentUrl
-    value: https://raw.githubusercontent.com/$(gitHubVersionsRepoInfo.org)/$(gitHubVersionsRepoInfo.repo)/$(gitHubVersionsRepoInfo.branch)/$(gitHubImageInfoVersionsPath)
   - ${{ parameters.customPublishVariables }}
   steps:
   - template: /eng/common/templates/steps/retain-build.yml@self

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2532486
+  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2536886
   imageNames.imageBuilder: $(imageNames.imageBuilderName)
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner2.0-docker-testrunner


### PR DESCRIPTION
Fixes https://github.com/dotnet/docker-tools/issues/1433

This uses the new options added in https://github.com/dotnet/docker-tools/pull/1434 to get the content of the image info file before and after it gets updated by the `publishImageInfo` command. This provides accurate content of these files that the existing pipeline steps which use `curl` to download the file do not. So those steps have been removed as well.