### PR TITLE
Use pool vars in secret sync pipeline

### DIFF
--- a/eng/pipelines/secret-management-weekly.yml
+++ b/eng/pipelines/secret-management-weekly.yml
@@ -8,15 +8,18 @@ schedules:
     - main
   always: true
 
+variables:
+- template: templates/variables/common.yml
+
 stages:
 - stage: SynchronizeSecrets
   jobs:
   - job: Synchronize
     displayName: Synchronize secrets
     pool:
-      name: NetCore1ESPool-Internal
-      demands: ImageOverride -equals 1es-windows-2019
-
+      name: $(default1ESInternalPoolName)
+      image: $(default1ESInternalPoolImage)
+      os: linux
     steps:
     - task: UseDotNet@2
       displayName: Install .NET 8.0 SDK


### PR DESCRIPTION
Related to https://github.com/dotnet/docker-tools/issues/1227

I'm going back through the docker repos to ensure that there's no left-over image names and agent pools that need to use the shared variables.

[Pipeline run with changes](https://dev.azure.com/dnceng/internal/_build/results?buildId=2537265&view=logs&j=df0a3355-897e-53ae-288d-2f16ccab2822)