### PR TITLE
Fix dry run logic in publishImageInfo

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
@@ -71,10 +71,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     $"The '{imageInfoPathIdentifier}' file has been updated with the following content:" +
                         Environment.NewLine + imageInfoContent + Environment.NewLine);
 
-                if (!Options.IsDryRun)
-                {
-                    UpdateGitRepos(imageInfoContent, repoPath, repo);
-                }
+                UpdateGitRepos(imageInfoContent, repoPath, repo);
             }
             finally
             {
@@ -108,6 +105,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             if (Options.UpdatedImageInfoOutputPath is not null)
             {
                 File.Copy(imageInfoPath, Options.UpdatedImageInfoOutputPath, overwrite: true);
+            }
+
+            if (Options.IsDryRun)
+            {
+                return;
             }
 
             _gitService.Stage(repo, imageInfoPath);


### PR DESCRIPTION
The changes from https://github.com/dotnet/docker-tools/pull/1434 cause issues in the pipeline when dry run is enabled because the `generateEolAnnotationData` command that gets executed after it expects those files to exist. But in dry run, those files are not written to.

This is fixed by moving the check for dry run so that it is after those files get written to.