### PR TITLE
Fix dry run handling in generateEolAnnotationData

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateEolAnnotationDataCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateEolAnnotationDataCommand.cs
@@ -94,9 +94,14 @@ public class GenerateEolAnnotationDataCommand : Command<GenerateEolAnnotationDat
                 .Select(name => Options.RegistryOptions.RepoPrefix + name);
             IEnumerable<(string Digest, string? Tag)> registryDigests = await GetAllImageDigestsFromRegistry(repoNames);
 
-            IEnumerable<string> supportedDigests = newImageArtifactDetails
-                .ApplyRegistryOverride(Options.RegistryOptions)
-                .GetAllDigests();
+            if (!Options.IsDryRun)
+            {
+                // Only apply the registry override if it's not a dry run. This is because it relies on the input image info file
+                // to have populated digest values but that won't be the case in a dry run.
+                newImageArtifactDetails = newImageArtifactDetails.ApplyRegistryOverride(Options.RegistryOptions);
+            }
+
+            IEnumerable<string> supportedDigests = newImageArtifactDetails.GetAllDigests();
 
             IEnumerable<EolDigestData> unsupportedDigests = GetUnsupportedDigests(registryDigests, supportedDigests);
 


### PR DESCRIPTION
The following exception occurs when executing the `generateEolAnnotationData` command with dry run enabled:

```
Error occurred while generating EOL annotation data: System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at Microsoft.DotNet.ImageBuilder.Commands.RegistryOptions.ApplyOverrideToDigest(String fullyQualifiedDigest, String repoName) in /image-builder/src/Commands/RegistryOptions.cs:line 31
   at Microsoft.DotNet.ImageBuilder.ImageInfoHelper.ApplyRegistryOverride(ImageArtifactDetails imageInfo, RegistryOptions overrideOptions) in /image-builder/src/ImageInfoHelper.cs:line 48
   at Microsoft.DotNet.ImageBuilder.Commands.GenerateEolAnnotationDataCommand.GetDigestsToAnnotate() in /image-builder/src/Commands/GenerateEolAnnotationDataCommand.cs:line 95
Unhandled exception: System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at Microsoft.DotNet.ImageBuilder.Commands.RegistryOptions.ApplyOverrideToDigest(String fullyQualifiedDigest, String repoName) in /image-builder/src/Commands/RegistryOptions.cs:line 31
   at Microsoft.DotNet.ImageBuilder.ImageInfoHelper.ApplyRegistryOverride(ImageArtifactDetails imageInfo, RegistryOptions overrideOptions) in /image-builder/src/ImageInfoHelper.cs:line 48
   at Microsoft.DotNet.ImageBuilder.Commands.GenerateEolAnnotationDataCommand.GetDigestsToAnnotate() in /image-builder/src/Commands/GenerateEolAnnotationDataCommand.cs:line 95
   at Microsoft.DotNet.ImageBuilder.Commands.GenerateEolAnnotationDataCommand.<ExecuteAsync>b__11_0() in /image-builder/src/Commands/GenerateEolAnnotationDataCommand.cs:line 59
   at Microsoft.DotNet.ImageBuilder.RegistryCredentialsProviderExtensions.ExecuteWithCredentialsAsync(IRegistryCredentialsProvider credsProvider, Boolean isDryRun, Func`1 action, RegistryCredentialsOptions credentialsOptions, String registryName, String ownedAcr) in /image-builder/src/RegistryCredentialsProviderExtensions.cs:line 30
   at Microsoft.DotNet.ImageBuilder.Commands.GenerateEolAnnotationDataCommand.ExecuteAsync() in /image-builder/src/Commands/GenerateEolAnnotationDataCommand.cs:line 57
```

This occurs because the input image info file contains empty digest values, which is expected in a dry run. But the logic for applying a registry override to those values expect them to be fully qualified digest values. So that logic should be skipped.