### PR TITLE
Fix build command for local dev scenario

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -363,9 +363,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
                             if (Options.IsPushEnabled && platform.FinalStageFromImage is not null)
                             {
-                                platformData.BaseImageDigest =
-                                await _imageDigestCache.GetImageDigestAsync(
-                                    _imageNameResolver.Value.GetFromImageLocalTag(platform.FinalStageFromImage), Options.IsDryRun);
+                                platformData.BaseImageDigest = await _imageDigestCache.GetImageDigestAsync(
+                                    tag: _imageNameResolver.Value.GetFromImageLocalTag(platform.FinalStageFromImage),
+                                    Options.IsDryRun);
                             }
                         }
                     }


### PR DESCRIPTION
This fixes the following error when building in a local dev scenario:

```
Found published digest 'sha256:329a2269a558de2f9da355342b5328f62733af8c975075d5513fcb5a65717363' for tag
 'mcr.microsoft.com/dotnet/nightly/runtime-deps:8.0.8-bookworm-slim-amd64' but could not find a matching
 digest value from the set of locally pulled digests for this tag: 
mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:8421fbf62d06c7e340e75c0103a34cf15c260033891623148c48bb47f98a2086, <snipped lots of duplicates>. 
This most likely means that this tag has been updated since it was last pulled.
```

https://github.com/dotnet/docker-tools/pull/1418 made it so that `platformData` in `BuildImagesAsync()` is never null, even when building without the intent to push to a repo - that's fine, but it also removed a null check that was preventing us from reaching out to the registry during local builds. It's better to guard this against `IsPushEnabled`.

I actually suspect that we shouldn't need to condition this out for local builds, but there's something up with the logic that's making it fail, can't wrap my head around it quite yet this evening, and this change works for now.

Also cleaned up some minor whitespace, long line, and nullable checks that I saw.