### PR TITLE
Add ImageBuilder container build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-# docker-tools
-This is a repo to house some common tools for use in the various .NET Docker repos. 
+# Docker Tools
 
-# Image Builder
+This is a repo to house some common tools for use in the various .NET Docker repos.
+
+## Image Builder
+
 A tool used to build and publish Docker images.
 
 The Image Builder tool can be acquired via a Docker image available at [mcr.microsoft.com/dotnet-buildtools/image-builder](https://mcr.microsoft.com/v2/dotnet-buildtools/image-builder/tags/list) or built from source via the [build script](./src/Microsoft.DotNet.ImageBuilder/build.ps1).
@@ -14,4 +16,4 @@ The full list of supported commands can be seen by running the tool.
 
 The list of support command options can be seen by specifying the `-h` command option.  The following illustrates how to list the build options.
 
-- Linux container environment: `docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock mcr.microsoft.com/dotnet-buildtools/image-builder:debian-20190223173930 build -h` 
+- Linux container environment: `docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock mcr.microsoft.com/dotnet-buildtools/image-builder:debian-20190223173930 build -h`

--- a/src/Microsoft.DotNet.ImageBuilder/README.md
+++ b/src/Microsoft.DotNet.ImageBuilder/README.md
@@ -6,19 +6,19 @@ ImageBuilder is a tool used to build and publish Docker images.
 
 All commands are relative to the root of the repo.
 
-### Linux
+### Build a single-platform image
 
-#### Build a single-platform Linux image
+Using Linux or Windows, simply run the build script:
 
 ```pwsh
-# Build the image
-docker build -t "${REPO}:${TAG}-linux-amd64" -f .\src\Microsoft.DotNet.ImageBuilder\Dockerfile.linux .\src\Microsoft.DotNet.ImageBuilder\
+# From src/Microsoft.DotNet.ImageBuilder
+pwsh -f build.ps1
 
-# Push the tag
-docker push "${REPO}:${TAG}-linux-amd64"
+# From the root of the repo
+pwsh -wd ./src/Microsoft.DotNet.ImageBuilder/ -f src/Microsoft.DotNet.ImageBuilder/build.ps1
 ```
 
-#### Build a multi-arch Linux image
+### Build a multi-arch Linux image
 
 If you don't need to test on Windows, this is the easiest way to create a multi-arch manifest list.
 
@@ -27,22 +27,9 @@ If you don't need to test on Windows, this is the easiest way to create a multi-
 docker buildx build [--push,--load] --platform [linux/amd64,linux/arm64] -t "${REPO}:${TAG}" -f .\src\Microsoft.DotNet.ImageBuilder\Dockerfile.linux .\src\Microsoft.DotNet.ImageBuilder\
 ```
 
-### Windows
-
-```pwsh
-# Choose one of each
-$WINDOWS_BASE=["servercore:ltsc2016-amd64","nanoserver:1809-amd64","nanoserver:ltsc2022-amd64"]
-$WINDOWS_SDK=["nanoserver-1809","nanoserver-ltsc2022"]
-
-docker build --build-arg WINDOWS_BASE="${WINDOWS_BASE}" --build-arg WINDOWS_SDK="${WINDOWS_SDK}" -t "${REPO}:${TAG}-windows-amd64" -f .\src\Microsoft.DotNet.ImageBuilder\Dockerfile.windows .\src\Microsoft.DotNet.ImageBuilder\
-
-# Push the tag
-docker push "${REPO}:${TAG}-windows-amd64"
-```
-
 ### Create a multi-platform manifest list
 
-First, build Linux and Windows images separately.
+First, build and push Linux and Windows images separately.
 Gather the specific digests for the images you want to put into one manifest list.
 Then, create the manifest list and push it:
 

--- a/src/Microsoft.DotNet.ImageBuilder/README.md
+++ b/src/Microsoft.DotNet.ImageBuilder/README.md
@@ -1,0 +1,52 @@
+# ImageBuilder
+
+ImageBuilder is a tool used to build and publish Docker images.
+
+## Building the ImageBuilder container image
+
+All commands are relative to the root of the repo.
+
+### Linux
+
+#### Build a single-platform Linux image
+
+```pwsh
+# Build the image
+docker build -t "${REPO}:${TAG}-linux-amd64" -f .\src\Microsoft.DotNet.ImageBuilder\Dockerfile.linux .\src\Microsoft.DotNet.ImageBuilder\
+
+# Push the tag
+docker push "${REPO}:${TAG}-linux-amd64"
+```
+
+#### Build a multi-arch Linux image
+
+If you don't need to test on Windows, this is the easiest way to create a multi-arch manifest list.
+
+```pwsh
+# Build the image. Choose one or both platforms, and optionally push to a registry or load the image locally.
+docker buildx build [--push,--load] --platform [linux/amd64,linux/arm64] -t "${REPO}:${TAG}" -f .\src\Microsoft.DotNet.ImageBuilder\Dockerfile.linux .\src\Microsoft.DotNet.ImageBuilder\
+```
+
+### Windows
+
+```pwsh
+# Choose one of each
+$WINDOWS_BASE=["servercore:ltsc2016-amd64","nanoserver:1809-amd64","nanoserver:ltsc2022-amd64"]
+$WINDOWS_SDK=["nanoserver-1809","nanoserver-ltsc2022"]
+
+docker build --build-arg WINDOWS_BASE="${WINDOWS_BASE}" --build-arg WINDOWS_SDK="${WINDOWS_SDK}" -t "${REPO}:${TAG}-windows-amd64" -f .\src\Microsoft.DotNet.ImageBuilder\Dockerfile.windows .\src\Microsoft.DotNet.ImageBuilder\
+
+# Push the tag
+docker push "${REPO}:${TAG}-windows-amd64"
+```
+
+### Create a multi-platform manifest list
+
+First, build Linux and Windows images separately.
+Gather the specific digests for the images you want to put into one manifest list.
+Then, create the manifest list and push it:
+
+```pwsh
+docker manifest create "${REPO}:${TAG}" "${REPO}@sha256:abcde12345" "${REPO}@sha256:fghij67890"
+docker manifest push "${REPO}:${TAG}"
+```


### PR DESCRIPTION
This PR documents the workflow for building ImageBuilder for the purposes of testing changes in pipelines. It covers single-platform, multi-arch, and multi-platform (Windows + Linux) container image builds.