### PR TITLE
Trim matrix based on image cache state

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -5,10 +5,8 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
@@ -32,7 +30,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private readonly ImageDigestCache _imageDigestCache;
         private readonly List<TagInfo> _processedTags = new List<TagInfo>();
         private readonly HashSet<PlatformData> _builtPlatforms = new();
-        private readonly Lazy<ImageNameResolver> _imageNameResolver;
+        private readonly Lazy<ImageNameResolverForBuild> _imageNameResolver;
 
         /// <summary>
         /// Maps a source digest from the image info file to the corresponding digest in the copied location for image caching.
@@ -69,7 +67,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 manifestServiceFactory.Create(ownedAcr: Options.RegistryOverride, Options.CredentialsOptions));
             _imageDigestCache = new ImageDigestCache(_manifestService);
 
-            _imageNameResolver = new Lazy<ImageNameResolver>(() =>
+            _imageNameResolver = new Lazy<ImageNameResolverForBuild>(() =>
                 new ImageNameResolverForBuild(Options.BaseImageOverrideOptions, Manifest, Options.RepoPrefix, Options.SourceRepoPrefix));
         }
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixOptions.cs
@@ -18,40 +18,51 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public int ProductVersionComponents { get; set; }
         public string? ImageInfoPath { get; set; }
         public IEnumerable<string> DistinctMatrixOsVersions { get; set; } = Enumerable.Empty<string>();
-
-        public GenerateBuildMatrixOptions() : base()
-        {
-        }
+        public BaseImageOverrideOptions BaseImageOverrideOptions { get; set; } = new();
+        public string? SourceRepoPrefix { get; set; }
+        public string? SourceRepoUrl { get; set; }
+        public RegistryCredentialsOptions CredentialsOptions { get; set; } = new();
+        public bool TrimCachedImages { get; set; }
     }
 
     public class GenerateBuildMatrixOptionsBuilder : ManifestOptionsBuilder
     {
         private const MatrixType DefaultMatrixType = MatrixType.PlatformDependencyGraph;
 
-        private readonly ManifestFilterOptionsBuilder _manifestFilterOptionsBuilder =
-            new ManifestFilterOptionsBuilder();
+        private readonly ManifestFilterOptionsBuilder _manifestFilterOptionsBuilder = new();
+        private readonly BaseImageOverrideOptionsBuilder _baseImageOverrideOptionsBuilder = new();
+        private readonly RegistryCredentialsOptionsBuilder _registryCredentialsOptionsBuilder = new();
 
         public override IEnumerable<Option> GetCliOptions() =>
-            base.GetCliOptions()
-                .Concat(_manifestFilterOptionsBuilder.GetCliOptions())
-                .Concat(
-                    new Option[]
-                    {
-                        CreateOption("type", nameof(GenerateBuildMatrixOptions.MatrixType),
-                            $"Type of matrix to generate. {EnumHelper.GetHelpTextOptions(DefaultMatrixType)}", DefaultMatrixType),
-                        CreateMultiOption<string>("custom-build-leg-group", nameof(GenerateBuildMatrixOptions.CustomBuildLegGroups),
-                            "Name of custom build leg group to use."),
-                        CreateOption("product-version-components", nameof(GenerateBuildMatrixOptions.ProductVersionComponents),
-                            "Number of components of the product version considered to be significant", 2),
-                        CreateOption<string?>("image-info", nameof(GenerateBuildMatrixOptions.ImageInfoPath),
-                            "Path to image info file"),
-                        CreateMultiOption<string>("distinct-matrix-os-version", nameof(GenerateBuildMatrixOptions.DistinctMatrixOsVersions),
-                            "OS version to be contained in its own distinct matrix"),
-                    });
+            [
+                ..base.GetCliOptions(),
+                .._manifestFilterOptionsBuilder.GetCliOptions(),
+                .._baseImageOverrideOptionsBuilder.GetCliOptions(),
+                .._registryCredentialsOptionsBuilder.GetCliOptions(),
+                CreateOption("type", nameof(GenerateBuildMatrixOptions.MatrixType),
+                    $"Type of matrix to generate. {EnumHelper.GetHelpTextOptions(DefaultMatrixType)}", DefaultMatrixType),
+                CreateMultiOption<string>("custom-build-leg-group", nameof(GenerateBuildMatrixOptions.CustomBuildLegGroups),
+                    "Name of custom build leg group to use."),
+                CreateOption("product-version-components", nameof(GenerateBuildMatrixOptions.ProductVersionComponents),
+                    "Number of components of the product version considered to be significant", 2),
+                CreateOption<string?>("image-info", nameof(GenerateBuildMatrixOptions.ImageInfoPath),
+                    "Path to image info file"),
+                CreateMultiOption<string>("distinct-matrix-os-version", nameof(GenerateBuildMatrixOptions.DistinctMatrixOsVersions),
+                    "OS version to be contained in its own distinct matrix"),
+                CreateOption<string?>("source-repo-prefix", nameof(GenerateBuildMatrixOptions.SourceRepoPrefix),
+                    "Prefix to add to the external base image names when pulling them"),
+                CreateOption<string?>("source-repo", nameof(BuildOptions.SourceRepoUrl),
+                    "Repo URL of the Dockerfile sources"),
+                CreateOption<bool>("trim-cached-images", nameof(GenerateBuildMatrixOptions.TrimCachedImages),
+                    "Whether to trim cached images from the set of paths"),
+            ];
 
         public override IEnumerable<Argument> GetCliArguments() =>
-            base.GetCliArguments()
-                .Concat(_manifestFilterOptionsBuilder.GetCliArguments());
+            [
+                ..base.GetCliArguments(),
+                .._manifestFilterOptionsBuilder.GetCliArguments(),
+                .._baseImageOverrideOptionsBuilder.GetCliArguments(),
+                .._registryCredentialsOptionsBuilder.GetCliArguments()
+            ];
     }
 }
-#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/ImageNameResolver.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ImageNameResolver.cs
@@ -10,17 +10,18 @@ namespace Microsoft.DotNet.ImageBuilder;
 public abstract class ImageNameResolver
 {
     private readonly BaseImageOverrideOptions _baseImageOverrideOptions;
-    private readonly ManifestInfo _manifest;
     private readonly string? _repoPrefix;
     private readonly string? _sourceRepoPrefix;
 
     public ImageNameResolver(BaseImageOverrideOptions baseImageOverrideOptions, ManifestInfo manifest, string? repoPrefix, string? sourceRepoPrefix)
     {
         _baseImageOverrideOptions = baseImageOverrideOptions;
-        _manifest = manifest;
+        Manifest = manifest;
         _repoPrefix = repoPrefix;
         _sourceRepoPrefix = sourceRepoPrefix;
     }
+
+    protected ManifestInfo Manifest { get; }
 
     /// <summary>
     /// Returns the tag to use for interacting with the image of a FROM instruction that has been pulled or built locally.
@@ -29,7 +30,7 @@ public abstract class ImageNameResolver
     public string GetFromImageLocalTag(string fromImage) =>
         // Provides the overridable value of the registry (e.g. dotnetdocker.azurecr.io) because that is the registry that
         // would be used for tags that exist locally.
-        GetFromImageTag(fromImage, _manifest.Registry);
+        GetFromImageTag(fromImage, Manifest.Registry);
 
     /// <summary>
     /// Returns the tag to use for pulling the image of a FROM instruction.
@@ -40,7 +41,7 @@ public abstract class ImageNameResolver
         // are classified as external within the model but they are owned internally and not mirrored. An example of
         // this is sample images. By comparing their base image tag to that raw registry value from the manifest, we
         // can know that these are owned internally and not to attempt to pull them from the mirror location.
-        GetFromImageTag(fromImage, _manifest.Model.Registry);
+        GetFromImageTag(fromImage, Manifest.Model.Registry);
 
     /// <summary>
     /// Returns the tag that represents the publicly available tag of a FROM instruction.
@@ -60,7 +61,7 @@ public abstract class ImageNameResolver
         }
         else
         {
-            return $"{_manifest.Model.Registry}/{trimmed}";
+            return $"{Manifest.Model.Registry}/{trimmed}";
         }
     }
 
@@ -79,24 +80,24 @@ public abstract class ImageNameResolver
         fromImage = _baseImageOverrideOptions.ApplyBaseImageOverride(fromImage);
 
         if ((registry is not null && DockerHelper.IsInRegistry(fromImage, registry)) ||
-            DockerHelper.IsInRegistry(fromImage, _manifest.Model.Registry)
+            DockerHelper.IsInRegistry(fromImage, Manifest.Model.Registry)
             || _sourceRepoPrefix is null)
         {
             return fromImage;
         }
 
         string srcImage = TrimInternallyOwnedRegistryAndRepoPrefix(DockerHelper.NormalizeRepo(fromImage));
-        return $"{_manifest.Registry}/{_sourceRepoPrefix}{srcImage}";
+        return $"{Manifest.Registry}/{_sourceRepoPrefix}{srcImage}";
     }
 
-    private string TrimInternallyOwnedRegistryAndRepoPrefix(string imageTag) =>
+    protected string TrimInternallyOwnedRegistryAndRepoPrefix(string imageTag) =>
         IsInInternallyOwnedRegistry(imageTag) ?
             DockerHelper.TrimRegistry(imageTag).TrimStart(_repoPrefix) :
             imageTag;
 
     private bool IsInInternallyOwnedRegistry(string imageTag) =>
-        DockerHelper.IsInRegistry(imageTag, _manifest.Registry) ||
-        DockerHelper.IsInRegistry(imageTag, _manifest.Model.Registry);
+        DockerHelper.IsInRegistry(imageTag, Manifest.Registry) ||
+        DockerHelper.IsInRegistry(imageTag, Manifest.Model.Registry);
 }
 
 public class ImageNameResolverForBuild : ImageNameResolver
@@ -122,6 +123,40 @@ public class ImageNameResolverForBuild : ImageNameResolver
         if (platform.IsInternalFromImage(imageName))
         {
             return imageName;
+        }
+        else
+        {
+            return GetFromImagePullTag(imageName);
+        }
+    }
+}
+
+public class ImageNameResolverForMatrix : ImageNameResolver
+{
+    public ImageNameResolverForMatrix(
+        BaseImageOverrideOptions baseImageOverrideOptions,
+        ManifestInfo manifest,
+        string? repoPrefix,
+        string? sourceRepoPrefix)
+        : base(baseImageOverrideOptions, manifest, repoPrefix, sourceRepoPrefix)
+    {
+    }
+
+    public override string GetFinalStageImageNameForDigestQuery(PlatformInfo platform)
+    {
+        // For matrix generation scenarios, we want to query for the digest of the image according
+        // to whether it's internal or not, just like we do for build. But the target location will
+        // be different. For internal images, we want to query mcr.microsoft.com (e.g.
+        // mcr.microsoft.com/dotnet/sdk/8.0). For external images,
+        // we want to query the mirror location in the ACR (e.g.
+        // dotnetdockerstaging.azurecr.io/mirror/amd64/alpine:3.20)
+
+        string imageName = platform.FinalStageFromImage ?? string.Empty;
+
+        if (platform.IsInternalFromImage(imageName))
+        {
+            string trimmedImageName = TrimInternallyOwnedRegistryAndRepoPrefix(DockerHelper.NormalizeRepo(imageName));
+            return $"{Manifest.Model.Registry}/{trimmedImageName}";
         }
         else
         {

--- a/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ManifestServiceHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ManifestServiceHelper.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
 using Moq;
@@ -46,6 +47,11 @@ internal static class ManifestServiceHelper
         IEnumerable<ImageLayersResults>? imageLayersResults = null)
     {
         Mock<IManifestService> manifestServiceMock = new();
+
+        // By default, have it throw an exception which indicates that the manifest was not found
+        manifestServiceMock
+            .Setup(o => o.GetManifestDigestShaAsync(It.IsAny<string>(), It.IsAny<bool>()))
+            .ThrowsAsync(new Exception());
 
         localImageDigestResults ??= [];
         externalImageDigestResults ??= [];

--- a/src/Microsoft.DotNet.ImageBuilder/tests/PublishManifestCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/PublishManifestCommandTests.cs
@@ -294,6 +294,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 .Setup(o => o.GetManifestAsync(It.IsAny<string>(), false))
                 .ReturnsAsync(new ManifestQueryResult("digest", new JsonObject()));
 
+            manifestService
+                .Setup(o => o.GetManifestDigestShaAsync(It.IsAny<string>(), It.IsAny<bool>()))
+                .ReturnsAsync(Guid.NewGuid().ToString());
+
             Mock<IDockerService> dockerServiceMock = new();
 
             PublishManifestCommand command = new PublishManifestCommand(


### PR DESCRIPTION
Contributes to #1417

This adds trimming logic to Image Builder's matrix generation. This trimming will optimize the number of build jobs that get created. It prevents scenarios of spinning up jobs that are essentially no-ops because the images they process may all be cached.

It trims the set of Dockerfiles based on whether cached images already exist for those Dockerfiles. Once that set of Dockerfiles is determined, then it proceeds with its usual logic, potentially expanding the set of Dockerfiles that get included. So the final matrix result may include images which are cached, but those are necessary to be included based on the build requirements.

