### PR TITLE
Support path filters for matrix trimming

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
@@ -407,9 +407,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         private async Task<IEnumerable<PlatformInfo>> GetPlatformsAsync()
         {
+            IEnumerable<PlatformInfo> filteredPlatforms = Manifest.GetFilteredPlatforms().ToList();
+
             if (_imageArtifactDetails.Value is null)
             {
-                return Manifest.GetFilteredPlatforms();
+                return filteredPlatforms;
             }
 
             IEnumerable<(PlatformInfo PlatformInfo, ImageData ImageData, PlatformData PlatformData)> platformMappings =
@@ -417,7 +419,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     .SelectMany(repo => repo.Images)
                     .SelectMany(image =>
                         image.Platforms
-                            .Where(platform => !platform.IsUnchanged && platform.PlatformInfo is not null)
+                            .Where(platform =>
+                                !platform.IsUnchanged &&
+                                platform.PlatformInfo is not null &&
+                                filteredPlatforms.Contains(platform.PlatformInfo))
                             .Select(platform => (platform.PlatformInfo!, image, platform)));
 
             if (!Options.TrimCachedImages)


### PR DESCRIPTION
The changes in https://github.com/dotnet/docker-tools/pull/1449 didn't correctly handle the scenario where path filters are provided to the `generateBuildMatrix` command (e.g. `--path <value>`). It was essentially ignoring what was filtered by those options and only processing the content of the provided image info file. This causes more images to be built than are intended.