### PR TITLE
Add support for testing of internal builds

### DIFF
--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -10,12 +10,14 @@ parameters:
   publicProjectName: null
   internalVersionsRepoRef: null
   publicVersionsRepoRef: null
+  isInternalServicingValidation: false
 
 jobs:
 - job: ${{ parameters.name }}
-  condition: and(${{ parameters.matrix }}, not(canceled()), in(dependencies.PreBuildValidation.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))
+  condition: and(${{ parameters.matrix }}, not(canceled()), or(in(dependencies.PreBuildValidation.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'), eq(${{ parameters.isInternalServicingValidation }}, 'true')))
   dependsOn:
-  - PreBuildValidation
+  - ${{ if eq(parameters.isInternalServicingValidation, 'false') }}:
+    - PreBuildValidation
   - CopyBaseImages
   - GenerateBuildMatrix
   pool: ${{ parameters.pool }}
@@ -97,7 +99,7 @@ jobs:
       # all we need is for that value to be in a PowerShell variable, we can get that by the fact that AzDO automatically creates
       # the environment variable for us.
       $imageBuilderBuildArgs = "$env:IMAGEBUILDERBUILDARGS $(imageBuilder.queueArgs) --image-info-output-path $(imageInfoContainerDir)/$(legName)-image-info.json"
-      if ($env:SYSTEM_TEAMPROJECT -eq "${{ parameters.internalProjectName }}" -and $env:BUILD_REASON -ne "PullRequest") {
+      if ($env:SYSTEM_TEAMPROJECT -eq "${{ parameters.internalProjectName }}" -and $env:BUILD_REASON -ne "PullRequest" -and "${{ parameters.isInternalServicingValidation }}" -ne "true") {
         $imageBuilderBuildArgs = "$imageBuilderBuildArgs --registry-override $(acr-staging.server) --repo-prefix $(stagingRepoPrefix) --source-repo-prefix $(mirrorRepoPrefix) --push"
       }
 
@@ -141,7 +143,7 @@ jobs:
       displayName: Publish Image Info File Artifact
       internalProjectName: ${{ parameters.internalProjectName }}
       publicProjectName: ${{ parameters.publicProjectName }}
-  - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
+  - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest'), eq(parameters.isInternalServicingValidation, 'false')) }}:
     # The following task depends on the SBOM Manifest Generator task installed on the agent.
     # This task is auto-injected by 1ES Pipeline Templates so we don't need to install it ourselves.
     - powershell: |
@@ -193,11 +195,11 @@ jobs:
         }
       displayName: Generate SBOMs
       condition: and(succeeded(), ne(variables['BuildImages.builtImages'], ''))
-  - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+  - ${{ if or(eq(variables['Build.Reason'], 'PullRequest'), eq(parameters.isInternalServicingValidation, 'true')) }}:
     - template: /eng/common/templates/jobs/${{ format('../steps/test-images-{0}-client.yml', parameters.dockerClientOS) }}@self
       parameters:
         condition: ne(variables.testScriptPath, '')
-  - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
+  - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest'), eq(parameters.isInternalServicingValidation, 'false')) }}:
     - template: /eng/common/templates/steps/publish-artifact.yml@self
       parameters:
         path: $(sbomDirectory)

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -25,6 +25,8 @@ parameters:
   internalVersionsRepoRef: null
   publicVersionsRepoRef: null
 
+  isInternalServicingValidation: false
+
   linuxAmd64Pool:
     vmImage: $(defaultLinuxAmd64PoolImage)
   linuxArm32Pool:
@@ -48,24 +50,25 @@ stages:
 - stage: Build
   condition: and(succeeded(), contains(variables['stages'], 'build'))
   jobs:
-  - template: /eng/common/templates/jobs/test-images-linux-client.yml@self
-    parameters:
-      name: PreBuildValidation
-      pool: ${{ parameters.linuxAmd64Pool }}
-      testJobTimeout: ${{ parameters.linuxAmdTestJobTimeout }}
-      preBuildValidation: true
-      internalProjectName: ${{ parameters.internalProjectName }}
-      customInitSteps:
-        - ${{ parameters.customTestInitSteps }}
-        # These variables are normally set by the matrix. Since this test job is not generated
-        # by a matrix, we need to set them manually. They can be set to empty values since their
-        # values aren't actually used for the pre-build tests.
-        - powershell: |
-            echo "##vso[task.setvariable variable=productVersion]"
-            echo "##vso[task.setvariable variable=imageBuilderPaths]"
-            echo "##vso[task.setvariable variable=osVersions]"
-            echo "##vso[task.setvariable variable=architecture]"
-          displayName: Initialize Test Variables
+  - ${{ if eq(parameters.isInternalServicingValidation, 'false') }}:
+    - template: /eng/common/templates/jobs/test-images-linux-client.yml@self
+      parameters:
+        name: PreBuildValidation
+        pool: ${{ parameters.linuxAmd64Pool }}
+        testJobTimeout: ${{ parameters.linuxAmdTestJobTimeout }}
+        preBuildValidation: true
+        internalProjectName: ${{ parameters.internalProjectName }}
+        customInitSteps:
+          - ${{ parameters.customTestInitSteps }}
+          # These variables are normally set by the matrix. Since this test job is not generated
+          # by a matrix, we need to set them manually. They can be set to empty values since their
+          # values aren't actually used for the pre-build tests.
+          - powershell: |
+              echo "##vso[task.setvariable variable=productVersion]"
+              echo "##vso[task.setvariable variable=imageBuilderPaths]"
+              echo "##vso[task.setvariable variable=osVersions]"
+              echo "##vso[task.setvariable variable=architecture]"
+            displayName: Initialize Test Variables
   - template: /eng/common/templates/jobs/copy-base-images-staging.yml@self
     parameters:
       name: CopyBaseImages
@@ -94,6 +97,7 @@ stages:
       publicProjectName: ${{ parameters.publicProjectName }}
       internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
       publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
+      isInternalServicingValidation: ${{ parameters.isInternalServicingValidation }}
   - template: /eng/common/templates/jobs/build-images.yml@self
     parameters:
       name: Linux_arm64
@@ -107,6 +111,7 @@ stages:
       publicProjectName: ${{ parameters.publicProjectName }}
       internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
       publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
+      isInternalServicingValidation: ${{ parameters.isInternalServicingValidation }}
   - template: /eng/common/templates/jobs/build-images.yml@self
     parameters:
       name: Linux_arm32
@@ -120,6 +125,7 @@ stages:
       publicProjectName: ${{ parameters.publicProjectName }}
       internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
       publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
+      isInternalServicingValidation: ${{ parameters.isInternalServicingValidation }}
   - template: /eng/common/templates/jobs/build-images.yml@self
     parameters:
       name: Windows1809_amd64
@@ -133,6 +139,7 @@ stages:
       publicProjectName: ${{ parameters.publicProjectName }}
       internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
       publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
+      isInternalServicingValidation: ${{ parameters.isInternalServicingValidation }}
   - template: /eng/common/templates/jobs/build-images.yml@self
     parameters:
       name: Windows2022_amd64
@@ -146,6 +153,7 @@ stages:
       publicProjectName: ${{ parameters.publicProjectName }}
       internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
       publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
+      isInternalServicingValidation: ${{ parameters.isInternalServicingValidation }}
   - template: /eng/common/templates/jobs/build-images.yml@self
     parameters:
       name: Windows2025_amd64
@@ -172,6 +180,7 @@ stages:
       publicProjectName: ${{ parameters.publicProjectName }}
       internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
       publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
+      isInternalServicingValidation: ${{ parameters.isInternalServicingValidation }}
 
 ################################################################################
 # Post-Build
@@ -189,7 +198,7 @@ stages:
 ################################################################################
 # Test Images
 ################################################################################
-- ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
+- ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest'), eq(parameters.isInternalServicingValidation, 'false')) }}:
   - stage: Test
     dependsOn: Post_Build
     condition: "
@@ -272,44 +281,45 @@ stages:
 ################################################################################
 # Publish Images
 ################################################################################
-- stage: Publish
-  ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
-    dependsOn: Test
-  ${{ else }}:
-    dependsOn: Post_Build
-  condition: "
-    and(
-      not(canceled()),
+- ${{ if eq(parameters.isInternalServicingValidation, 'false') }}:
+  - stage: Publish
+    ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
+      dependsOn: Test
+    ${{ else }}:
+      dependsOn: Post_Build
+    condition: "
       and(
-        contains(variables['stages'], 'publish'),
-        or(
+        not(canceled()),
+        and(
+          contains(variables['stages'], 'publish'),
           or(
-            and(
-              and(
-                contains(variables['stages'], 'build'),
-                succeeded('Post_Build')),
-              and(
-                contains(variables['stages'], 'test'),
-                in(dependencies.Test.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))),
             or(
               and(
-                not(contains(variables['stages'], 'build')),
+                and(
+                  contains(variables['stages'], 'build'),
+                  succeeded('Post_Build')),
                 and(
                   contains(variables['stages'], 'test'),
                   in(dependencies.Test.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))),
-              and(
-                not(contains(variables['stages'], 'test')),
+              or(
                 and(
-                  contains(variables['stages'], 'build'),
-                  succeeded('Post_Build'))))),
-          not(
-            or(
-              contains(variables['stages'], 'build'),
-              contains(variables['stages'], 'test'))))))"
-  jobs:
-  - template: /eng/common/templates/jobs/publish.yml@self
-    parameters:
-      pool: ${{ parameters.linuxAmd64Pool }}
-      internalProjectName: ${{ parameters.internalProjectName }}
-      customPublishVariables: ${{ parameters.customPublishVariables }}
-      customInitSteps: ${{ parameters.customPublishInitSteps }}
+                  not(contains(variables['stages'], 'build')),
+                  and(
+                    contains(variables['stages'], 'test'),
+                    in(dependencies.Test.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))),
+                and(
+                  not(contains(variables['stages'], 'test')),
+                  and(
+                    contains(variables['stages'], 'build'),
+                    succeeded('Post_Build'))))),
+            not(
+              or(
+                contains(variables['stages'], 'build'),
+                contains(variables['stages'], 'test'))))))"
+    jobs:
+    - template: /eng/common/templates/jobs/publish.yml@self
+      parameters:
+        pool: ${{ parameters.linuxAmd64Pool }}
+        internalProjectName: ${{ parameters.internalProjectName }}
+        customPublishVariables: ${{ parameters.customPublishVariables }}
+        customInitSteps: ${{ parameters.customPublishInitSteps }}

--- a/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
@@ -18,6 +18,7 @@ parameters:
   linuxAmd64Pool: ""
   buildMatrixType: platformDependencyGraph
   testMatrixType: platformVersionedOs
+  isInternalServicingValidation: false
 
 stages:
 - template: /eng/common/templates/stages/build-test-publish-repo.yml@self
@@ -25,6 +26,7 @@ stages:
     noCache: ${{ parameters.noCache }}
     internalProjectName: ${{ parameters.internalProjectName }}
     publicProjectName: ${{ parameters.publicProjectName }}
+    isInternalServicingValidation: ${{ parameters.isInternalServicingValidation }}
     buildMatrixCustomBuildLegGroupArgs: ${{ parameters.buildMatrixCustomBuildLegGroupArgs }}
     testMatrixCustomBuildLegGroupArgs: ${{ parameters.testMatrixCustomBuildLegGroupArgs }}
     customCopyBaseImagesInitSteps: ${{ parameters.customCopyBaseImagesInitSteps}}


### PR DESCRIPTION
Backport of changes in `eng\common` from https://github.com/dotnet/dotnet-docker/pull/5928

These changes enable testing of internal builds in our pipelines:
- Update pipeline stages/steps/jobs for support of internal testing scenario
- Update pipeline for internal testing so it behaves as if it was a Pull request