### PR TITLE
Allow multi-arch tags in MCR tags metadata templates

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateReadmesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateReadmesCommand.cs
@@ -21,25 +21,19 @@ using YamlDotNet.Serialization.NamingConventions;
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     [Export(typeof(ICommand))]
-    public partial class GenerateReadmesCommand : GenerateArtifactsCommand<GenerateReadmesOptions, GenerateReadmesOptionsBuilder>
+    [method: ImportingConstructor]
+    public partial class GenerateReadmesCommand(IEnvironmentService environmentService)
+        : GenerateArtifactsCommand<GenerateReadmesOptions, GenerateReadmesOptionsBuilder>(environmentService)
     {
         private const string ArtifactName = "Readme";
         private const string LinuxTableHeader = "Tags | Dockerfile | OS Version\n-----------| -------------| -------------";
         private const string WindowsTableHeader = "Tag | Dockerfile\n---------| ---------------";
-
-        private readonly IGitService _gitService;
 
         private static Dictionary<string, int> ArchSortKeys = new() {
             { "amd64", 0 },
             { "arm64", 1 },
             { "arm32", 2 }
         };
-
-        [ImportingConstructor]
-        public GenerateReadmesCommand(IEnvironmentService environmentService, IGitService gitService) : base(environmentService)
-        {
-            _gitService = gitService ?? throw new ArgumentNullException(nameof(gitService));
-        }
 
         protected override string Description =>
             "Generates the Readmes from the Cottle based templates (http://r3c.github.io/cottle/) and updates the tag listing section";

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateReadmesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateReadmesCommand.cs
@@ -29,12 +29,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private const string LinuxTableHeader = "Tags | Dockerfile | OS Version\n-----------| -------------| -------------";
         private const string WindowsTableHeader = "Tag | Dockerfile\n---------| ---------------";
 
-        private static Dictionary<string, int> ArchSortKeys = new() {
-            { "amd64", 0 },
-            { "arm64", 1 },
-            { "arm32", 2 }
-        };
-
         protected override string Description =>
             "Generates the Readmes from the Cottle based templates (http://r3c.github.io/cottle/) and updates the tag listing section";
 
@@ -159,15 +153,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             StringBuilder tables = new();
 
             IEnumerable<IGrouping<(string OS, string Architecture, string? OsVersion), TagGroup>> tagGroupsGroupedByOsArch =
-                tagGroups
-                    // Linux should be listed before Windows, then sort by Windows versions
-                    .OrderByDescending(tg => tg.OS == "linux"
-                        ? int.MaxValue
-                        : GetWindowsVersionSortingKey(tg.OsVersion ?? string.Empty))
-                    // amd64 > arm64 > arm32
-                    .OrderBy(tg => ArchSortKeys.GetValueOrDefault(tg.Architecture, int.MaxValue))
-                    .OrderBy(tg => tg.OS == "linux" ? 0 : 1)
-                    .GroupBy(tagGroup => (tagGroup.OS, tagGroup.Architecture, tagGroup.OS == "windows" ? tagGroup.OsVersion : null));
+                tagGroups.GroupBy(tagGroup =>
+                    (tagGroup.OS, tagGroup.Architecture, tagGroup.OS == "windows" ? tagGroup.OsVersion : null));
 
             bool isFirstTable = true;
             foreach (IGrouping<(string OS, string Architecture, string? OsVersion), TagGroup> groupedTagGroups in tagGroupsGroupedByOsArch)

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateReadmesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateReadmesCommand.cs
@@ -32,9 +32,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         protected override string Description =>
             "Generates the Readmes from the Cottle based templates (http://r3c.github.io/cottle/) and updates the tag listing section";
 
-        [GeneratedRegex(@"\d{4}")]
-        private static partial Regex WindowsVersionRegex { get; }
-
         public override async Task ExecuteAsync()
         {
             Logger.WriteHeading("GENERATING READMES");
@@ -151,12 +148,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private static string GenerateTables(IEnumerable<TagGroup> tagGroups)
         {
             StringBuilder tables = new();
-
-            IEnumerable<IGrouping<(string OS, string Architecture, string? OsVersion), TagGroup>> tagGroupsGroupedByOsArch =
-                tagGroups.GroupBy(tagGroup =>
-                    (tagGroup.OS, tagGroup.Architecture, tagGroup.OS == "windows" ? tagGroup.OsVersion : null));
-
+            IEnumerable<IGrouping<(string OS, string Architecture, string? OsVersion), TagGroup>> tagGroupsGroupedByOsArch = tagGroups
+                .GroupBy(tagGroup => (tagGroup.OS, tagGroup.Architecture, tagGroup.OS == "windows" ? tagGroup.OsVersion : null));
             bool isFirstTable = true;
+
             foreach (IGrouping<(string OS, string Architecture, string? OsVersion), TagGroup> groupedTagGroups in tagGroupsGroupedByOsArch)
             {
                 if (isFirstTable)
@@ -191,7 +186,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             // Group tags by custom sub table title (e.g. Preview tags). Those tags without a custom sub table title will be listed first.
             List<IGrouping<string, TagGroup>> tagGroupGroupings = tagGroups
-                .GroupBy(tagGroup => tagGroup.CustomSubTableTitle)
+                .GroupBy(tg => tg.CustomSubTableTitle)
                 .OrderBy(group => group.Key)
                 .ToList();
 
@@ -234,12 +229,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             }
 
             return row;
-        }
-
-        private static int GetWindowsVersionSortingKey(string osVersion)
-        {
-            int version = int.Parse(WindowsVersionRegex.Match(osVersion).Value);
-            return version == 1809 ? 2019 : version;
         }
 
         private class TagMetadataManifest

--- a/src/Microsoft.DotNet.ImageBuilder/src/McrTagsMetadataGenerator.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/McrTagsMetadataGenerator.cs
@@ -77,10 +77,15 @@ namespace Microsoft.DotNet.ImageBuilder
             // leaving us with a list of imageDocInfos that were not used in metadata generation
             yaml.Append(_manifest.VariableHelper.SubstituteValues(template, GetVariableValue));
 
-            if (_imageDocInfos.Count > 0)
+            IReadOnlyList<ImageDocumentationInfo> missingTags = _imageDocInfos
+                .Where(docInfo => docInfo.DocumentedTags.Any())
+                .ToList();
+
+            if (missingTags.Count > 0)
             {
-                string missingTags = string.Join(
-                    Environment.NewLine, _imageDocInfos.Select(info => info.FormattedDocumentedTags));
+                string missingTagsString =
+                    string.Join(Environment.NewLine, missingTags.Select(info => info.FormattedDocumentedTags));
+
                 throw new InvalidOperationException(
                     $"The following tags are not included in the tags metadata: {Environment.NewLine}{missingTags}");
             }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/McrTags/TagGroup.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/McrTags/TagGroup.cs
@@ -3,12 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using YamlDotNet.Serialization;
 
 namespace Microsoft.DotNet.ImageBuilder.Models.McrTags
 {
-    [DebuggerDisplay("{OS}-{Architecture}-{OsVersion}")]
     public class TagGroup
     {
         public List<string> Tags { get; set; }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Models/McrTags/TagGroup.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Models/McrTags/TagGroup.cs
@@ -3,10 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using YamlDotNet.Serialization;
 
 namespace Microsoft.DotNet.ImageBuilder.Models.McrTags
 {
+    [DebuggerDisplay("{OS}-{Architecture}-{OsVersion}")]
     public class TagGroup
     {
         public List<string> Tags { get; set; }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/PlatformInfo.cs
@@ -36,6 +36,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         public string? FinalStageFromImage { get; private set; } = string.Empty;
         public IEnumerable<string> ExternalFromImages { get; private set; } = Enumerable.Empty<string>();
         public IEnumerable<string> InternalFromImages { get; private set; } = Enumerable.Empty<string>();
+        public bool IsWindows => Model.OS == OS.Windows;
         public Platform Model { get; private set; }
         public IEnumerable<string> OverriddenFromImages { get => _overriddenFromImages; }
         public string FullRepoModelName { get; set; }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
@@ -18,8 +18,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         public const string RepoVariableTypeId = "Repo";
         private const string VariableGroupName = "variable";
 
-        private static readonly string s_tagVariablePattern = $"\\$\\((?<{VariableGroupName}>[\\w:\\-.|]+)\\)";
-        private static readonly string s_timeStamp = DateTime.UtcNow.ToString("yyyyMMddHHmmss");
+        private static readonly string s_tagVariablePattern = $"\\$\\((?<{VariableGroupName}>[\\w:\\-.| ]+)\\)";
 
         private Func<string, RepoInfo> GetRepoById { get; set; }
         private Manifest Manifest { get; set; }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateReadmesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateReadmesCommandTests.cs
@@ -198,13 +198,12 @@ ABC-123";
             string manifestPath = Path.Combine(tempFolderContext.Path, "manifest.json");
             File.WriteAllText(manifestPath, JsonConvert.SerializeObject(manifest));
 
-            Mock<IGitService> gitServiceMock = new Mock<IGitService>();
             _environmentServiceMock = new Mock<IEnvironmentService>();
             _environmentServiceMock
                 .Setup(o => o.Exit(1))
                 .Throws(_exitException);
 
-            GenerateReadmesCommand command = new GenerateReadmesCommand(_environmentServiceMock.Object, gitServiceMock.Object);
+            GenerateReadmesCommand command = new GenerateReadmesCommand(_environmentServiceMock.Object);
             command.Options.Manifest = manifestPath;
             command.Options.AllowOptionalTemplates = allowOptionalTemplates;
             command.Options.Validate = validate;

--- a/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ManifestHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ManifestHelper.cs
@@ -13,22 +13,22 @@ namespace Microsoft.DotNet.ImageBuilder.Tests.Helpers
 {
     public static class ManifestHelper
     {
-        public static Manifest CreateManifest(params Repo[] repos)
+        public static Manifest CreateManifest(params IEnumerable<Repo> repos)
         {
             return new Manifest
             {
-                Repos = repos
+                Repos = repos.ToArray()
             };
         }
 
-        public static Repo CreateRepo(string name, params Image[] images)
+        public static Repo CreateRepo(string name, params IEnumerable<Image> images)
         {
             return CreateRepo(name, images, readme: null);
         }
 
         public static Repo CreateRepo(
             string name,
-            Image[] images,
+            IEnumerable<Image> images,
             string readme = null,
             string readmeTemplate = null,
             string mcrTagsMetadataTemplate = null)
@@ -46,20 +46,20 @@ namespace Microsoft.DotNet.ImageBuilder.Tests.Helpers
             {
                 Name = name,
                 Id = name,
-                Images = images,
+                Images = images.ToArray(),
                 McrTagsMetadataTemplate = mcrTagsMetadataTemplate,
                 Readmes = readmes
             };
         }
 
-        public static Image CreateImage(params Platform[] platforms) =>
+        public static Image CreateImage(params IEnumerable<Platform> platforms) =>
             CreateImage(platforms, (IDictionary<string, Tag>)null);
 
-        public static Image CreateImage(Platform[] platforms, IDictionary<string, Tag> sharedTags = null, string productVersion = null)
+        public static Image CreateImage(IEnumerable<Platform> platforms, IDictionary<string, Tag> sharedTags = null, string productVersion = null)
         {
             return new Image
             {
-                Platforms = platforms,
+                Platforms = platforms.ToArray(),
                 SharedTags = sharedTags,
                 ProductVersion = productVersion
             };
@@ -73,7 +73,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests.Helpers
             Architecture architecture = Architecture.AMD64,
             string variant = null,
             CustomBuildLegGroup[] customBuildLegGroups = null,
-            string dockerfileTemplatePath = null)
+            string dockerfileTemplatePath = null,
+            TagDocumentationType tagDocumentationType = TagDocumentationType.Documented)
         {
             return new Platform
             {
@@ -81,7 +82,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests.Helpers
                 DockerfileTemplate = dockerfileTemplatePath,
                 OsVersion = osVersion,
                 OS = os,
-                Tags = tags.ToDictionary(tag => tag, tag => new Tag()),
+                Tags = tags.ToDictionary(tag => tag, tag => new Tag() { DocType = tagDocumentationType }),
                 Architecture = architecture,
                 Variant = variant,
                 CustomBuildLegGroups = customBuildLegGroups ?? Array.Empty<CustomBuildLegGroup>()

--- a/src/Microsoft.DotNet.ImageBuilder/tests/Microsoft.DotNet.ImageBuilder.Tests.csproj
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/Microsoft.DotNet.ImageBuilder.Tests.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Moq" Version="4.18.1" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
This change allows patterns like:

`aspire-dashboard-tags.yml`
```yaml
$(McrTagsYmlRepo:aspire-dashboard)
$(McrTagsYmlTagGroup:8)
```

`monitor-tags.yml`
```yaml
$(McrTagsYmlRepo:monitor)
$(McrTagsYmlTagGroup:9.0)
$(McrTagsYmlTagGroup:8.1-preview-ubuntu-chiseled|.NET Monitor Preview Tags)
$(McrTagsYmlTagGroup:8.1-preview-cbl-mariner-distroless|.NET Monitor Preview Tags)
$(McrTagsYmlTagGroup:8.0-ubuntu-chiseled)
$(McrTagsYmlTagGroup:8.0-cbl-mariner-distroless)
$(McrTagsYmlTagGroup:6.3-alpine)
$(McrTagsYmlTagGroup:6.3-ubuntu-chiseled)
$(McrTagsYmlTagGroup:6.3-cbl-mariner)
$(McrTagsYmlTagGroup:6.3-cbl-mariner-distroless)
```

`runtime-tags.yml`:
```yaml
$(McrTagsYmlRepo:runtime)
$(McrTagsYmlTagGroup:9.0-bookworm-slim)
$(McrTagsYmlTagGroup:9.0-alpine3.20)
$(McrTagsYmlTagGroup:9.0-noble)
$(McrTagsYmlTagGroup:9.0-noble-chiseled)
$(McrTagsYmlTagGroup:9.0-noble-chiseled-extra)
$(McrTagsYmlTagGroup:9.0-azurelinux3.0)
$(McrTagsYmlTagGroup:9.0-azurelinux3.0-distroless)
$(McrTagsYmlTagGroup:9.0-azurelinux3.0-distroless-extra)
$(McrTagsYmlTagGroup:8.0-bookworm-slim)
<snip>
```

This works by checking if the tag in the variable is multi-arch or not, and if so, adds yaml tag groups for each architecture. This meant we needed a different solution for custom tag tables - I added the option to put that inline with the variable (which you can see above).

I made sure that using the multi-arch tags didn't change the readme output or sorting. In order to do that I had to add some sorting logic to the readme tags table generation - but it's just automating what we were already doing by hand.