### PR TITLE
Fix test stage matrix generation

### DIFF
--- a/eng/common/templates/jobs/generate-matrix.yml
+++ b/eng/common/templates/jobs/generate-matrix.yml
@@ -53,15 +53,10 @@ jobs:
       $(commonMatrixAndBuildOptions)
       $(additionalGenerateBuildMatrixOptions)"
     displayName: Set GenerateBuildMatrix Command
-  - ${{ if eq(parameters.isTestStage, false) }}:
-    - template: /eng/common/templates/steps/run-imagebuilder.yml@self
-      parameters:
-        name: matrix
-        displayName: Generate ${{ parameters.matrixType }} Matrix
-        serviceConnection: $(build.serviceConnectionName)
-        internalProjectName: internal
-        args: $(generateBuildMatrixCommand)
-  - ${{ else }}:
-    - script: $(generateBuildMatrixCommand)
-      displayName: Generate ${{ parameters.matrixType }} Matrix
+  - template: /eng/common/templates/steps/run-imagebuilder.yml@self
+    parameters:
       name: matrix
+      displayName: Generate ${{ parameters.matrixType }} Matrix
+      serviceConnection: $(build.serviceConnectionName)
+      internalProjectName: internal
+      args: $(generateBuildMatrixCommand)

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -248,6 +248,12 @@ stages:
         isTestStage: true
         internalProjectName: ${{ parameters.internalProjectName }}
         publicProjectName: ${{ parameters.publicProjectName }}
+        commonInitStepsForMatrixAndBuild:
+        - template: /eng/common/templates/steps/common-init-for-matrix-and-build.yml@self
+          parameters:
+            noCache: ${{ parameters.noCache }}
+            internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
+            publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
     - template: /eng/common/templates/jobs/test-images-linux-client.yml@self
       parameters:
         name: Linux_amd64


### PR DESCRIPTION
The changes from https://github.com/dotnet/docker-tools/pull/1459 cause a failure during the Test stage ([example build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2556433&view=results) - internal link): `generateBuildMatrix: command not found`.

This is because it's attempting to run the command directly from the agent rather than from the container. This was a result of a mistake in the YAML. It was attempting to condition the logic differently depending on whether it was generating a matrix for the test stage or not. But that was unnecessary. In both build stage and test stage scenarios, it can use the same template logic for running the command.

Another issue was that `Set GenerateBuildMatrix Command` step had a silent failure: `commonMatrixAndBuildOptions: command not found`. This is because the common init steps were not being passed to the generate-matrix.yml template for the test stage. That's been fixed as well.