### PR TITLE
Add clean leg for buildtools-prereqs

### DIFF
--- a/eng/pipelines/cleanup-acr-images.yml
+++ b/eng/pipelines/cleanup-acr-images.yml
@@ -63,6 +63,16 @@ jobs:
       acr: $(acr.server)
       action: pruneDangling
       age: 0
+  - template: ../common/templates/steps/clean-acr-images.yml
+    parameters:
+      internalProjectName: ${{ variables.internalProjectName }}
+      repo: "public/dotnet-buildtools/prereqs"
+      subscription: $(acr.subscription)
+      resourceGroup: $(acr.resourceGroup)
+      acr: $(acr.server)
+      action: pruneEol
+      age: 15
+      customArgs: --exclude $(excludedBuildToolsPrereqsImage)
   # Disabled due to https://github.com/dotnet/docker-tools/issues/797
   # - template: ../common/templates/steps/clean-acr-images.yml
   #   parameters:


### PR DESCRIPTION
This will cleanup old EOL images within the dotnet-buildtools/prereqs repo, excluding a custom defined image that will be defined via a variable in AzDO.