### PR TITLE
Support custom init steps for matrix job

### DIFF
--- a/eng/common/templates/jobs/generate-matrix.yml
+++ b/eng/common/templates/jobs/generate-matrix.yml
@@ -6,6 +6,7 @@ parameters:
   isTestStage: false
   internalProjectName: null
   noCache: false
+  customInitSteps: []
   commonInitStepsForMatrixAndBuild: []
 
 jobs:
@@ -15,6 +16,7 @@ jobs:
   - ${{ parameters.commonInitStepsForMatrixAndBuild }}
   - template: /eng/common/templates/steps/retain-build.yml@self
   - template: /eng/common/templates/steps/init-docker-linux.yml@self
+  - ${{ parameters.customInitSteps }}
   - template: /eng/common/templates/steps/validate-branch.yml@self
     parameters:
       internalProjectName: ${{ parameters.internalProjectName }}

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -4,6 +4,7 @@ parameters:
   buildMatrixCustomBuildLegGroupArgs: ""
   testMatrixCustomBuildLegGroupArgs: ""
   customCopyBaseImagesInitSteps: []
+  customGenerateMatrixInitSteps: []
   customBuildInitSteps: []
   customTestInitSteps: []
   customPublishInitSteps: []
@@ -83,6 +84,7 @@ stages:
       customBuildLegGroupArgs: ${{ parameters.buildMatrixCustomBuildLegGroupArgs }}
       internalProjectName: ${{ parameters.internalProjectName }}
       noCache: ${{ parameters.noCache }}
+      customInitSteps: ${{ parameters.customGenerateMatrixInitSteps }}
       commonInitStepsForMatrixAndBuild:
       - template: /eng/common/templates/steps/common-init-for-matrix-and-build.yml@self
         parameters:
@@ -257,6 +259,7 @@ stages:
         isTestStage: true
         internalProjectName: ${{ parameters.internalProjectName }}
         publicProjectName: ${{ parameters.publicProjectName }}
+        customInitSteps: ${{ parameters.customGenerateMatrixInitSteps }}
         commonInitStepsForMatrixAndBuild:
         - template: /eng/common/templates/steps/common-init-for-matrix-and-build.yml@self
           parameters:

--- a/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
@@ -8,6 +8,7 @@ parameters:
   buildMatrixCustomBuildLegGroupArgs: ""
   testMatrixCustomBuildLegGroupArgs: ""
   customCopyBaseImagesInitSteps: []
+  customGenerateMatrixInitSteps: []
   customBuildInitSteps: []
   customTestInitSteps: []
   customPublishInitSteps: []
@@ -27,6 +28,7 @@ stages:
     internalProjectName: ${{ parameters.internalProjectName }}
     publicProjectName: ${{ parameters.publicProjectName }}
     isInternalServicingValidation: ${{ parameters.isInternalServicingValidation }}
+    customGenerateMatrixInitSteps: ${{ parameters.customGenerateMatrixInitSteps }}
     buildMatrixCustomBuildLegGroupArgs: ${{ parameters.buildMatrixCustomBuildLegGroupArgs }}
     testMatrixCustomBuildLegGroupArgs: ${{ parameters.testMatrixCustomBuildLegGroupArgs }}
     customCopyBaseImagesInitSteps: ${{ parameters.customCopyBaseImagesInitSteps}}


### PR DESCRIPTION
This adds support for being able to supply custom init steps for matrix jobs.

This is a backport of the changes from https://github.com/dotnet/dotnet-docker/pull/5968.