### PR TITLE
Add special logic to handle tsa config in common build template

### DIFF
--- a/eng/common/templates/steps/common-init-for-matrix-and-build.yml
+++ b/eng/common/templates/steps/common-init-for-matrix-and-build.yml
@@ -60,3 +60,14 @@ steps:
     echo "##vso[task.setvariable variable=versionsBasePath]$versionsBasePath"
     echo "##vso[task.setvariable variable=pipelineDisabledCache]$pipelineDisabledCache"
   displayName: Set Common Variables for Matrix and Build
+
+  # Special logic is needed to copy the tsaoptions.json file to a well known location for the 1ES PT.
+  # This template has multiple checkouts and AzDO doesn't have support for dynamically determining the
+  # default repo path therefore the 1es-official logic can't calculate the repo's tsa config file path.
+- task: CopyFiles@2
+  displayName: Copy TSA Config
+  inputs:
+    SourceFolder: '$(Build.Repository.LocalPath)/$(Build.Repository.Name)'
+    Contents: '.config/tsaoptions.json'
+    TargetFolder: '$(Build.SourcesDirectory)'
+  condition: eq(${{ parameters.noCache }}, false)

--- a/eng/common/templates/steps/common-init-for-matrix-and-build.yml
+++ b/eng/common/templates/steps/common-init-for-matrix-and-build.yml
@@ -61,13 +61,13 @@ steps:
     echo "##vso[task.setvariable variable=pipelineDisabledCache]$pipelineDisabledCache"
   displayName: Set Common Variables for Matrix and Build
 
+- ${{ if eq(parameters.noCache, false) }}:
   # Special logic is needed to copy the tsaoptions.json file to a well known location for the 1ES PT.
   # This template has multiple checkouts and AzDO doesn't have support for dynamically determining the
   # default repo path therefore the 1es-official logic can't calculate the repo's tsa config file path.
-- task: CopyFiles@2
-  displayName: Copy TSA Config
-  inputs:
-    SourceFolder: '$(Build.Repository.LocalPath)/$(Build.Repository.Name)'
-    Contents: '.config/tsaoptions.json'
-    TargetFolder: '$(Build.SourcesDirectory)'
-  condition: eq(${{ parameters.noCache }}, false)
+  - task: CopyFiles@2
+    displayName: Copy TSA Config
+    inputs:
+      SourceFolder: '$(Build.Repository.LocalPath)/$(Build.Repository.Name)'
+      Contents: '.config/tsaoptions.json'
+      TargetFolder: '$(Build.SourcesDirectory)'


### PR DESCRIPTION
Fixes https://github.com/dotnet/dotnet-docker/issues/5967

The underlying issue was that the tsa config's path location is variable depending on whether or not the pipeline has multiple repos. The AzDO checkout step behaves differently if there are multiple repos being cloned versus a single.  There is no built in variables to determine the default repos path.  

Because of this the tsa config file's path cannot be easily determined in the [1es-official.yml](https://github.com/MichaelSimons/docker-tools/blob/f69f0104ba2243990cc29fd7e69e67afa626fcb1/eng/common/templates/1es-official.yml#L57-L58) in order to specify a custom config path parameter.  Given the 1es-official template is used in a variety of scenarios and that our build logic is encapsulated in templates, it makes it difficult to cleanly implement a robust solution therefore it was decided to copy the tsa config option in the build scenario when multiple repos are involved.

I did test this within the buildtools repo with and without a tsaoptions.json file.