### PR TITLE
Update repo name variable used in Copy TSA Config

### DIFF
--- a/eng/common/templates/steps/common-init-for-matrix-and-build.yml
+++ b/eng/common/templates/steps/common-init-for-matrix-and-build.yml
@@ -68,6 +68,6 @@ steps:
   - task: CopyFiles@2
     displayName: Copy TSA Config
     inputs:
-      SourceFolder: '$(Build.Repository.LocalPath)/$(Build.Repository.Name)'
+      SourceFolder: '$(Build.Repository.LocalPath)/$(buildRepoName)'
       Contents: '.config/tsaoptions.json'
       TargetFolder: '$(Build.SourcesDirectory)'


### PR DESCRIPTION
This fixes an issue with https://github.com/dotnet/docker-tools/pull/1468.  Public GitHub repo names include the organization but that is trimmed from the git repo name.  This was tested in https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1212