### PR TITLE
Supply isInternalServicingValidation to Windows 2025 build job

### DIFF
--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -200,6 +200,7 @@ stages:
       publicProjectName: ${{ parameters.publicProjectName }}
       internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
       publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
+      isInternalServicingValidation: ${{ parameters.isInternalServicingValidation }}
   - template: /eng/common/templates/jobs/build-images.yml@self
     parameters:
       name: WindowsLtsc2016_amd64


### PR DESCRIPTION
This PR fixes the issue with missing parameter for Windows 2025 build job causing failure of internal servicing validation pipeline: https://dev.azure.com/dnceng/internal/_build/results?buildId=2557405&view=results

Windows 2025 job was added with https://github.com/dotnet/docker-tools/pull/1454

Internal servicing validation changes were in flight at the same time, and did not cover Windows 2025: https://github.com/dotnet/docker-tools/pull/1463