### PR TITLE
Clean dotnet/framework images that are EOL

### DIFF
--- a/eng/pipelines/cleanup-acr-images.yml
+++ b/eng/pipelines/cleanup-acr-images.yml
@@ -66,6 +66,15 @@ jobs:
   - template: ../common/templates/steps/clean-acr-images.yml
     parameters:
       internalProjectName: ${{ variables.internalProjectName }}
+      repo: "public/dotnet/framework/*"
+      subscription: $(acr.subscription)
+      resourceGroup: $(acr.resourceGroup)
+      acr: $(acr.server)
+      action: pruneEol
+      age: 15
+  - template: ../common/templates/steps/clean-acr-images.yml
+    parameters:
+      internalProjectName: ${{ variables.internalProjectName }}
       repo: "public/dotnet-buildtools/prereqs"
       subscription: $(acr.subscription)
       resourceGroup: $(acr.resourceGroup)


### PR DESCRIPTION
Configures the clean pipeline to target all EOL images in the `dotnet/framework/*` repos.