### PR TITLE
Support new Dockerfiles in matrix trimming

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
@@ -194,6 +194,33 @@ namespace Microsoft.DotNet.ImageBuilder
             return LoadFromContent(File.ReadAllText(path), manifest, skipManifestValidation, useFilteredManifest);
         }
 
+        /// <summary>
+        /// Finds the <see cref="PlatformData"/> that matches the given <see cref="PlatformInfo"/>.
+        /// </summary>
+        /// <param name="platform">Platform being searched.</param>
+        /// <param name="repo">Repo that corresponds to the platform.</param>
+        /// <param name="imageArtifactDetails">Image info content.</param>
+        public static (PlatformData Platform, ImageData Image)? GetMatchingPlatformData(PlatformInfo platform, RepoInfo repo, ImageArtifactDetails imageArtifactDetails)
+        {
+            RepoData? repoData = imageArtifactDetails.Repos.FirstOrDefault(s => s.Repo == repo.Name);
+            if (repoData == null || repoData.Images == null)
+            {
+                return null;
+            }
+
+            foreach (ImageData imageData in repoData.Images)
+            {
+                PlatformData? platformData = imageData.Platforms
+                    .FirstOrDefault(platformData => platformData.PlatformInfo == platform);
+                if (platformData != null)
+                {
+                    return (platformData, imageData);
+                }
+            }
+
+            return null;
+        }
+
         public static void MergeImageArtifactDetails(ImageArtifactDetails src, ImageArtifactDetails target, ImageInfoMergeOptions options = null)
         {
             if (options == null)


### PR DESCRIPTION
Fixes https://github.com/dotnet/docker-tools/issues/1476

The matrix trimming logic was using the image info file as its source for processing Dockerfiles to be trimmed or not. This meant that any new Dockerfiles which have not yet been built/published were not being included because they were not represented in the image info file yet.

These changes update the logic to use the manifest as the source and then to look up the corresponding image info data from that. By using the manifest as the source, we're sure to process all Dockerfiles. This includes a bit of refactoring to share common code with the `getStaleImages` command which needs to use the same logic.