### PR TITLE
Prevent post-build fail on artifact download

### DIFF
--- a/eng/common/templates/jobs/post-build.yml
+++ b/eng/common/templates/jobs/post-build.yml
@@ -17,6 +17,8 @@ jobs:
   - template: /eng/common/templates/steps/download-build-artifact.yml@self
     parameters:
       targetPath: $(Build.ArtifactStagingDirectory)
+      # This can fail if no build jobs ran to produce any artifacts
+      continueOnError: true
   - powershell: |
       # Move all image-info artifacts to their own directory
       New-Item -ItemType Directory -Path $(imageInfosHostDir)

--- a/eng/common/templates/steps/download-build-artifact.yml
+++ b/eng/common/templates/steps/download-build-artifact.yml
@@ -2,6 +2,7 @@ parameters:
   targetPath: ""
   artifactName: ""
   condition: true
+  continueOnError: false
 
 steps:
 - task: DownloadPipelineArtifact@1
@@ -15,3 +16,4 @@ steps:
     artifactName: ${{ parameters.artifactName }}
   displayName: Download Build Artifact(s)
   condition: and(succeeded(), ${{ parameters.condition }})
+  continueOnError: ${{ parameters.continueOnError }}


### PR DESCRIPTION
Fixes #1477 

In some scenarios, a pipeline run doesn't actually run any build jobs due to matrix trimming. This prevents any pipeline artifacts from being published. The Post-Build stage needs to be resilient to this scenario and not fail when there are no artifacts to download.