### PR TITLE
Split merging of image info from publishing

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/MergeImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/MergeImageInfoCommand.cs
@@ -9,7 +9,9 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
+using Microsoft.DotNet.ImageBuilder.ViewModel;
 
+#nullable enable
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     [Export(typeof(ICommand))]
@@ -24,9 +26,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 "*.json",
                 SearchOption.AllDirectories);
 
-            List<ImageArtifactDetails> srcImageArtifactDetailsList = imageInfoFiles
+            List<(string Path, ImageArtifactDetails ImageArtifactDetails)> srcImageArtifactDetailsList = imageInfoFiles
                 .OrderBy(file => file) // Ensure the files are ordered for testing consistency between OS's.
-                .Select(imageDataPath => ImageInfoHelper.LoadFromFile(imageDataPath, Manifest))
+                .Select(imageDataPath => (imageDataPath, ImageInfoHelper.LoadFromFile(imageDataPath, Manifest, skipManifestValidation: Options.IsPublishScenario)))
                 .ToList();
 
             if (!srcImageArtifactDetailsList.Any())
@@ -35,16 +37,90 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     $"No JSON files found in source folder '{Options.SourceImageInfoFolderPath}'");
             }
 
-            ImageArtifactDetails targetImageArtifactDetails = new ImageArtifactDetails();
-            foreach (ImageArtifactDetails srcImageArtifactDetails in srcImageArtifactDetailsList)
+            ImageInfoMergeOptions options = new()
             {
-                ImageInfoHelper.MergeImageArtifactDetails(srcImageArtifactDetails, targetImageArtifactDetails);
+                IsPublish = Options.IsPublishScenario
+            };
+
+            ImageArtifactDetails targetImageArtifactDetails;
+            if (Options.InitialImageInfoPath != null)
+            {
+                targetImageArtifactDetails = srcImageArtifactDetailsList.First(item => item.Path == Options.InitialImageInfoPath).ImageArtifactDetails;
+
+                if (Options.IsPublishScenario)
+                {
+                    RemoveOutOfDateContent(targetImageArtifactDetails);
+                }
+            }
+            else
+            {
+                targetImageArtifactDetails = new ImageArtifactDetails();
+            }
+
+            foreach (ImageArtifactDetails srcImageArtifactDetails in
+                srcImageArtifactDetailsList
+                    .Select(item => item.ImageArtifactDetails)
+                    .Where(details => details != targetImageArtifactDetails))
+            {
+                ImageInfoHelper.MergeImageArtifactDetails(srcImageArtifactDetails, targetImageArtifactDetails, options);
             }
 
             string destinationContents = JsonHelper.SerializeObject(targetImageArtifactDetails) + Environment.NewLine;
             File.WriteAllText(Options.DestinationImageInfoPath, destinationContents);
 
             return Task.CompletedTask;
+        }
+
+        private void RemoveOutOfDateContent(ImageArtifactDetails imageArtifactDetails)
+        {
+            for (int repoIndex = imageArtifactDetails.Repos.Count - 1; repoIndex >= 0; repoIndex--)
+            {
+                RepoData repoData = imageArtifactDetails.Repos[repoIndex];
+
+                // Since the registry name is not represented in the image info, make sure to compare the repo name with the
+                // manifest's repo model name which isn't registry-qualified.
+                RepoInfo? manifestRepo = Manifest.AllRepos.FirstOrDefault(manifestRepo => manifestRepo.Name == repoData.Repo);
+
+                // If there doesn't exist a matching repo in the manifest, remove it from the image info
+                if (manifestRepo is null)
+                {
+                    imageArtifactDetails.Repos.Remove(repoData);
+                    continue;
+                }
+
+                for (int imageIndex = repoData.Images.Count - 1; imageIndex >= 0; imageIndex--)
+                {
+                    ImageData imageData = repoData.Images[imageIndex];
+                    ImageInfo manifestImage = imageData.ManifestImage;
+
+                    // If there doesn't exist a matching image in the manifest, remove it from the image info
+                    if (manifestImage is null)
+                    {
+                        repoData.Images.Remove(imageData);
+                        continue;
+                    }
+
+                    for (int platformIndex = imageData.Platforms.Count - 1; platformIndex >= 0; platformIndex--)
+                    {
+                        PlatformData platformData = imageData.Platforms[platformIndex];
+                        PlatformInfo? manifestPlatform = manifestImage.AllPlatforms
+                            .FirstOrDefault(manifestPlatform => platformData.PlatformInfo == manifestPlatform);
+
+                        // If there doesn't exist a matching platform in the manifest, remove it from the image info
+                        if (manifestPlatform is null)
+                        {
+                            imageData.Platforms.Remove(platformData);
+                        }
+                    }
+                }
+            }
+
+            if (imageArtifactDetails.Repos.Count == 0)
+            {
+                // Failsafe to prevent wiping out the image info due to a bug in the logic
+                throw new InvalidOperationException(
+                    "Removal of out-of-date content resulted in there being no content remaining in the target image info file. Something is probably wrong with the logic.");
+            }
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/MergeImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/MergeImageInfoCommand.cs
@@ -28,7 +28,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             List<(string Path, ImageArtifactDetails ImageArtifactDetails)> srcImageArtifactDetailsList = imageInfoFiles
                 .OrderBy(file => file) // Ensure the files are ordered for testing consistency between OS's.
-                .Select(imageDataPath => (imageDataPath, ImageInfoHelper.LoadFromFile(imageDataPath, Manifest, skipManifestValidation: Options.IsPublishScenario)))
+                .Select(imageDataPath =>
+                    (imageDataPath, ImageInfoHelper.LoadFromFile(
+                                        imageDataPath,
+                                        Manifest,
+                                        skipManifestValidation: Options.IsPublishScenario)))
                 .ToList();
 
             if (!srcImageArtifactDetailsList.Any())

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/MergeImageInfoOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/MergeImageInfoOptions.cs
@@ -4,7 +4,7 @@
 
 using System.Collections.Generic;
 using System.CommandLine;
-using System.Linq;
+using static Microsoft.DotNet.ImageBuilder.Commands.CliHelper;
 
 #nullable enable
 namespace Microsoft.DotNet.ImageBuilder.Commands
@@ -14,21 +14,30 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public string SourceImageInfoFolderPath { get; set; } = string.Empty;
 
         public string DestinationImageInfoPath { get; set; } = string.Empty;
+
+        public string? InitialImageInfoPath { get; set; }
+
+        public bool IsPublishScenario { get; set; }
     }
 
     public class MergeImageInfoOptionsBuilder : ManifestOptionsBuilder
     {
         public override IEnumerable<Argument> GetCliArguments() =>
-            base.GetCliArguments()
-                .Concat(
-                    new Argument[]
-                    {
-                        new Argument<string>(nameof(MergeImageInfoOptions.SourceImageInfoFolderPath),
-                            "Folder path containing image info files"),
-                        new Argument<string>(nameof(MergeImageInfoOptions.DestinationImageInfoPath),
-                            "Path to store the merged image info content"),
-                    }
-                );
+            [
+                ..base.GetCliArguments(),
+                new Argument<string>(nameof(MergeImageInfoOptions.SourceImageInfoFolderPath),
+                    "Folder path containing image info files"),
+                new Argument<string>(nameof(MergeImageInfoOptions.DestinationImageInfoPath),
+                    "Path to store the merged image info content")
+            ];
+
+        public override IEnumerable<Option> GetCliOptions() =>
+            [
+                ..base.GetCliOptions(),
+                CreateOption<bool>("publish", nameof(MergeImageInfoOptions.IsPublishScenario),
+                    "Whether the files are being merged as part of publishing to a repo"),
+                CreateOption<string?>("initial-image-info-path", nameof(MergeImageInfoOptions.InitialImageInfoPath),
+                    "Path to the image info file to be used as the initial merge target"),
+            ];
     }
 }
-#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
@@ -5,11 +5,8 @@
 using System;
 using System.ComponentModel.Composition;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using LibGit2Sharp;
-using Microsoft.DotNet.ImageBuilder.Models.Image;
-using Microsoft.DotNet.ImageBuilder.ViewModel;
 
 #nullable enable
 namespace Microsoft.DotNet.ImageBuilder.Commands
@@ -58,20 +55,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
                 Uri imageInfoPathIdentifier = GitHelper.GetBlobUrl(Options.GitOptions);
 
-                _loggerService.WriteSubheading("Calculating new image info content");
-                string? imageInfoContent = GetUpdatedImageInfo(repoPath);
-
-                if (imageInfoContent is null)
-                {
-                    _loggerService.WriteMessage($"No changes to the '{imageInfoPathIdentifier}' file were needed.");
-                    return Task.CompletedTask;
-                }
-
-                _loggerService.WriteMessage(
-                    $"The '{imageInfoPathIdentifier}' file has been updated with the following content:" +
-                        Environment.NewLine + imageInfoContent + Environment.NewLine);
-
-                UpdateGitRepos(imageInfoContent, repoPath, repo);
+                UpdateGitRepos(repoPath, repo);
             }
             finally
             {
@@ -84,7 +68,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             return Task.CompletedTask;
         }
 
-        private void UpdateGitRepos(string imageInfoContent, string repoPath, IRepository repo)
+        private void UpdateGitRepos(string repoPath, IRepository repo)
         {
             string imageInfoPath = Path.Combine(repoPath, Options.GitOptions.Path);
 
@@ -95,17 +79,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 Directory.CreateDirectory(imageInfoDir);
             }
 
-            if (Options.OriginalImageInfoOutputPath is not null)
-            {
-                File.Copy(imageInfoPath, Options.OriginalImageInfoOutputPath, overwrite: true);
-            }
-
-            File.WriteAllText(imageInfoPath, imageInfoContent);
-
-            if (Options.UpdatedImageInfoOutputPath is not null)
-            {
-                File.Copy(imageInfoPath, Options.UpdatedImageInfoOutputPath, overwrite: true);
-            }
+            File.Copy(Options.ImageInfoPath, imageInfoPath, overwrite: true);
 
             if (Options.IsDryRun)
             {
@@ -113,7 +87,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             }
 
             _gitService.Stage(repo, imageInfoPath);
-            Signature sig = new Signature(Options.GitOptions.Username, Options.GitOptions.Email, DateTimeOffset.Now);
+            Signature sig = new(Options.GitOptions.Username, Options.GitOptions.Email, DateTimeOffset.Now);
             Commit commit = repo.Commit(CommitMessage, sig, sig);
 
             Branch branch = repo.Branches[Options.GitOptions.Branch];
@@ -132,107 +106,5 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             Uri gitHubCommitUrl = GitHelper.GetCommitUrl(Options.GitOptions, commit.Sha);
             _loggerService.WriteMessage($"The '{Options.GitOptions.Path}' file was updated: {gitHubCommitUrl}");
         }
-
-        private string? GetUpdatedImageInfo(string repoPath)
-        {
-            ImageArtifactDetails srcImageArtifactDetails = ImageInfoHelper.LoadFromFile(Options.ImageInfoPath, Manifest);
-
-            string repoImageInfoPath = Path.Combine(repoPath, Options.GitOptions.Path);
-            string? originalTargetImageInfoContents = null;
-            if (File.Exists(repoImageInfoPath))
-            {
-                originalTargetImageInfoContents = File.ReadAllText(repoImageInfoPath);
-            }
-
-            ImageArtifactDetails newImageArtifactDetails;
-
-            if (originalTargetImageInfoContents != null)
-            {
-                ImageArtifactDetails targetImageArtifactDetails = ImageInfoHelper.LoadFromContent(
-                    originalTargetImageInfoContents, Manifest, skipManifestValidation: true);
-
-                RemoveOutOfDateContent(targetImageArtifactDetails);
-
-                ImageInfoMergeOptions options = new ImageInfoMergeOptions
-                {
-                    IsPublish = true
-                };
-
-                ImageInfoHelper.MergeImageArtifactDetails(srcImageArtifactDetails, targetImageArtifactDetails, options);
-
-                newImageArtifactDetails = targetImageArtifactDetails;
-            }
-            else
-            {
-                // If there is no existing file to update, there's nothing to merge with so the source data
-                // becomes the target data.
-                newImageArtifactDetails = srcImageArtifactDetails;
-            }
-
-            string newTargetImageInfoContents =
-                JsonHelper.SerializeObject(newImageArtifactDetails) + Environment.NewLine;
-
-            if (originalTargetImageInfoContents != newTargetImageInfoContents)
-            {
-                return newTargetImageInfoContents;
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        private void RemoveOutOfDateContent(ImageArtifactDetails imageArtifactDetails)
-        {
-            for (int repoIndex = imageArtifactDetails.Repos.Count - 1; repoIndex >= 0; repoIndex--)
-            {
-                RepoData repoData = imageArtifactDetails.Repos[repoIndex];
-
-                // Since the registry name is not represented in the image info, make sure to compare the repo name with the
-                // manifest's repo model name which isn't registry-qualified.
-                RepoInfo? manifestRepo = Manifest.AllRepos.FirstOrDefault(manifestRepo => manifestRepo.Name == repoData.Repo);
-
-                // If there doesn't exist a matching repo in the manifest, remove it from the image info
-                if (manifestRepo is null)
-                {
-                    imageArtifactDetails.Repos.Remove(repoData);
-                    continue;
-                }
-
-                for (int imageIndex = repoData.Images.Count - 1; imageIndex >= 0; imageIndex--)
-                {
-                    ImageData imageData = repoData.Images[imageIndex];
-                    ImageInfo manifestImage = imageData.ManifestImage;
-
-                    // If there doesn't exist a matching image in the manifest, remove it from the image info
-                    if (manifestImage is null)
-                    {
-                        repoData.Images.Remove(imageData);
-                        continue;
-                    }
-
-                    for (int platformIndex = imageData.Platforms.Count - 1; platformIndex >= 0; platformIndex--)
-                    {
-                        PlatformData platformData = imageData.Platforms[platformIndex];
-                        PlatformInfo? manifestPlatform = manifestImage.AllPlatforms
-                            .FirstOrDefault(manifestPlatform => platformData.PlatformInfo == manifestPlatform);
-
-                        // If there doesn't exist a matching platform in the manifest, remove it from the image info
-                        if (manifestPlatform is null)
-                        {
-                            imageData.Platforms.Remove(platformData);
-                        }
-                    }
-                }
-            }
-
-            if (imageArtifactDetails.Repos.Count == 0)
-            {
-                // Failsafe to prevent wiping out the image info due to a bug in the logic
-                throw new InvalidOperationException(
-                    "Removal of out-of-date content resulted in there being no content remaining in the target image info file. Something is probably wrong with the logic.");
-            }
-        }
     }
 }
-#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoOptions.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.CommandLine;
-using static Microsoft.DotNet.ImageBuilder.Commands.CliHelper;
 
 #nullable enable
 namespace Microsoft.DotNet.ImageBuilder.Commands
@@ -12,22 +11,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     public class PublishImageInfoOptions : ImageInfoOptions, IGitOptionsHost
     {
         public GitOptions GitOptions { get; set; } = new GitOptions();
-
-        /// <summary>
-        /// This will contain the content of the image info file from GitHub before it has been updated
-        /// by this command. It represents the full breadth of images supported by the repo. This differs
-        /// from the input image info file which only contains the images that were produced by the
-        /// current build.
-        /// </summary>
-        public string? OriginalImageInfoOutputPath { get; set; }
-
-        /// <summary>
-        /// This will contain the content of the image info file from GitHub after it has been updated
-        /// by this command. It represents the full breadth of images supported by the repo. This differs
-        /// from the input image info file which only contains the images that were produced by the
-        /// current build.
-        /// </summary>
-        public string? UpdatedImageInfoOutputPath { get; set; }
     }
 
     public class PublishImageInfoOptionsBuilder : ImageInfoOptionsBuilder
@@ -38,11 +21,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             [
                 ..base.GetCliOptions(),
                 .._gitOptionsBuilder.GetCliOptions(),
-                CreateOption<string?>("image-info-orig-path", nameof(PublishImageInfoOptions.OriginalImageInfoOutputPath),
-                    $"Path where the original image info content will be written to"),
-                CreateOption<string?>("image-info-update-path", nameof(PublishImageInfoOptions.UpdatedImageInfoOutputPath),
-                    $"Path where the updated image info content will be written to"),
-
             ];
 
         public override IEnumerable<Argument> GetCliArguments() =>


### PR DESCRIPTION
Contributes to #1470 

As described in https://github.com/dotnet/docker-tools/issues/1470#issuecomment-2436157156, this updates Image Builder so that it splits apart the merging of image info files from the act of publishing the image info file to the versions repo. That logic has been removed from the `publishImageInfo` command. Instead, the already existing `mergeImageInfo` command has been updated to handle the publish scenario. So now `mergeImageInfo` command can be used for merging image info fragments from multiple build jobs (Post-Build stage) as well as merging the final image info with the image info from the versions repo (Publish stage).