### PR TITLE
Update pipeline for changes to image info commands

### DIFF
--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -107,21 +107,29 @@ jobs:
   - script: mkdir -p $(Build.ArtifactStagingDirectory)/eol-annotation-data
     displayName: Create EOL Annotation Data Directory
   - script: >
-      $(runImageBuilderCmd) publishImageInfo
-      '$(imageInfoContainerDir)/image-info.json'
-      '$(gitHubVersionsRepoInfo.userName)'
-      '$(gitHubVersionsRepoInfo.email)'
-      '$(gitHubVersionsRepoInfo.accessToken)'
-      --git-owner '$(gitHubVersionsRepoInfo.org)'
-      --git-repo '$(gitHubVersionsRepoInfo.repo)'
-      --git-branch '$(gitHubVersionsRepoInfo.branch)'
-      --git-path '$(gitHubImageInfoVersionsPath)'
-      --image-info-orig-path '$(artifactsPath)/eol-annotation-data/image-info-old.json'
-      --image-info-update-path '$(artifactsPath)/eol-annotation-data/image-info-new.json'
-      $(dryRunArg)
-      $(imageBuilder.commonCmdArgs)
+      curl -fSL
+      --output $(imageInfoHostDir)/full-image-info-orig.json
+      https://raw.githubusercontent.com/$(gitHubVersionsRepoInfo.org)/$(gitHubVersionsRepoInfo.repo)/refs/heads/$(gitHubVersionsRepoInfo.branch)/$(gitHubImageInfoVersionsPath)
     condition: and(succeeded(), eq(variables['publishImageInfo'], 'true'))
-    displayName: Publish Image Info
+    displayName: Download Latest Image Info
+  - script: >
+      $(runImageBuilderCmd) mergeImageInfo
+      $(imageInfoContainerDir)
+      $(imageInfoContainerDir)/full-image-info-new.json
+      $(manifestVariables)
+      $(dryRunArg)
+      --manifest $(manifest)
+      --publish
+      --initial-image-info-path $(imageInfoContainerDir)/full-image-info-orig.json
+    condition: and(succeeded(), eq(variables['publishImageInfo'], 'true'))
+    displayName: Merge Image Info
+  - template: /eng/common/templates/steps/publish-artifact.yml@self
+    parameters:
+      path: $(imageInfoHostDir)
+      artifactName: image-info-temp-$(System.JobAttempt)
+      displayName: Publish Image Info File Artifact
+      internalProjectName: ${{ parameters.internalProjectName }}
+      publicProjectName: ${{ parameters.publicProjectName }}
   - template: /eng/common/templates/steps/run-imagebuilder.yml@self
     parameters:
       displayName: Ingest Kusto Image Info
@@ -148,8 +156,8 @@ jobs:
       args: >
         generateEolAnnotationData
         '$(artifactsPath)/eol-annotation-data/eol-annotation-data.json'
-        '$(artifactsPath)/eol-annotation-data/image-info-old.json'
-        '$(artifactsPath)/eol-annotation-data/image-info-new.json'
+        '$(imageInfoContainerDir)/full-image-info-orig.json'
+        '$(imageInfoContainerDir)/full-image-info-new.json'
         '$(acr.server)'
         '$(publishRepoPrefix)'
         $(generateEolAnnotationDataExtraOptions)
@@ -166,6 +174,20 @@ jobs:
     parameters:
       internalProjectName: ${{ parameters.internalProjectName }}
       dataFile: $(artifactsPath)/eol-annotation-data/eol-annotation-data.json
+  - script: >
+      $(runImageBuilderCmd) publishImageInfo
+      '$(imageInfoContainerDir)/full-image-info-new.json'
+      '$(gitHubVersionsRepoInfo.userName)'
+      '$(gitHubVersionsRepoInfo.email)'
+      '$(gitHubVersionsRepoInfo.accessToken)'
+      --git-owner '$(gitHubVersionsRepoInfo.org)'
+      --git-repo '$(gitHubVersionsRepoInfo.repo)'
+      --git-branch '$(gitHubVersionsRepoInfo.branch)'
+      --git-path '$(gitHubImageInfoVersionsPath)'
+      $(dryRunArg)
+      $(imageBuilder.commonCmdArgs)
+    condition: and(succeeded(), eq(variables['publishImageInfo'], 'true'))
+    displayName: Publish Image Info
   - script: >
       $(runImageBuilderCmd) postPublishNotification
       '$(publishNotificationRepoName)'

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2570468
+  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2575886
   imageNames.imageBuilder: $(imageNames.imageBuilderName)
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner2.0-docker-testrunner


### PR DESCRIPTION
Fixes #1470 

This is in response to the changes to the commands in https://github.com/dotnet/docker-tools/pull/1488.

It changes the Publish stage to first take the image info produced by the build and merge it into the latest image info from the versions repo. Later in the pipeline (after EOL annotations have been published), it will push the merged image info file to the versions repo.