### PR TITLE
Improve missing tags error message and add Windows test for tags metadata generator

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/McrTagsMetadataGenerator.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/McrTagsMetadataGenerator.cs
@@ -83,11 +83,16 @@ namespace Microsoft.DotNet.ImageBuilder
 
             if (missingTags.Count > 0)
             {
-                string missingTagsString =
-                    string.Join(Environment.NewLine, missingTags.Select(info => info.FormattedDocumentedTags));
+                IEnumerable<string> missingTagsPerImage = missingTags.Select(imageDocInfo =>
+                    $"""
+                    Repo: {_repo.Name}, Platform: {imageDocInfo.Platform.GetOSDisplayName()} {imageDocInfo.Platform.Model.Architecture}
+                    Missing Tags: {imageDocInfo.FormattedDocumentedTags}
+                    """);
+
+                string missingTagsString = string.Join(Environment.NewLine, missingTagsPerImage);
 
                 throw new InvalidOperationException(
-                    $"The following tags are not included in the tags metadata: {Environment.NewLine}{missingTags}");
+                    $"The following tags are not included in the tags metadata: {Environment.NewLine}{missingTagsString}{Environment.NewLine}");
             }
 
             string metadata = yaml.ToString();


### PR DESCRIPTION
- Created a much more actionable error message for when tags are missing.
- Slight refactoring of the tests to support more flexible platforms, and using simpler computation to get the expected tags.