### PR TITLE
Handle dry run for AnnotateEolDigestsCommand

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/AnnotateEolDigestsCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/AnnotateEolDigestsCommand.cs
@@ -111,6 +111,12 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         private void AnnotateDigest(EolDigestData digestData, DateOnly? globalEolDate)
         {
+            if (Options.IsDryRun)
+            {
+                _loggerService.WriteMessage($"[DRY RUN] Set EOL annotation for digest '{digestData.Digest}'");
+                return;
+            }
+
             DateOnly? eolDate = digestData.EolDate ?? globalEolDate;
             if (eolDate is null)
             {


### PR DESCRIPTION
Fixes the issue described in https://github.com/dotnet/dotnet-docker/pull/6048#issuecomment-2474425538.

The comment made there wasn't quite accurate. It's nothing to do with there being a null digest. It has to do with the fact that it's processing any data at all from the EOL annotation data file. Normally, there isn't any data in that file. When there is, it attempts to process that data in `AnnotateEolDigestsCommand` which doesn't handle it well in a dry run.

In general, we try to have as much logic as possible execute in the context of a dry run. But given that much of the logic of the `AnnotateEolDigestsCommand` is dependent on the results returns from `oras`, which doesn't actually get executed in a dry run`, it's not really feasible to execute much of it. So this short-circuits the logic and avoids all that in a dry run.