### PR TITLE
Enable EOL pruning for all dotnet repos

### DIFF
--- a/eng/pipelines/cleanup-acr-images.yml
+++ b/eng/pipelines/cleanup-acr-images.yml
@@ -30,16 +30,7 @@ jobs:
   - template: ../common/templates/steps/clean-acr-images.yml
     parameters:
       internalProjectName: ${{ variables.internalProjectName }}
-      repo: "public/dotnet/core*"
-      subscription: $(acr.subscription)
-      resourceGroup: $(acr.resourceGroup)
-      acr: $(acr.server)
-      action: pruneEol
-      age: 15
-  - template: ../common/templates/steps/clean-acr-images.yml
-    parameters:
-      internalProjectName: ${{ variables.internalProjectName }}
-      repo: "public/dotnet/nightly/*"
+      repo: "public/dotnet/*"
       subscription: $(acr.subscription)
       resourceGroup: $(acr.resourceGroup)
       acr: $(acr.server)
@@ -54,24 +45,6 @@ jobs:
       acr: $(acr.server)
       action: pruneAll
       age: 7
-  - template: ../common/templates/steps/clean-acr-images.yml
-    parameters:
-      internalProjectName: ${{ variables.internalProjectName }}
-      repo: "public/dotnet*/samples*"
-      subscription: $(acr.subscription)
-      resourceGroup: $(acr.resourceGroup)
-      acr: $(acr.server)
-      action: pruneDangling
-      age: 0
-  - template: ../common/templates/steps/clean-acr-images.yml
-    parameters:
-      internalProjectName: ${{ variables.internalProjectName }}
-      repo: "public/dotnet/framework/*"
-      subscription: $(acr.subscription)
-      resourceGroup: $(acr.resourceGroup)
-      acr: $(acr.server)
-      action: pruneEol
-      age: 15
   - template: ../common/templates/steps/clean-acr-images.yml
     parameters:
       internalProjectName: ${{ variables.internalProjectName }}


### PR DESCRIPTION
EOL annotations are in the process of being rolled out to the production `dotnet` repos. This requires having EOL images pruned from the ACR for perf reasons. This change enables pruning for those repos. It consolidates all the existing configurations for different repos (nightly, samples, framework), into one uber config for `public/dotnet/*`.