### PR TITLE
Gracefully handle missing image info in publish commands

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
@@ -44,7 +44,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             if (!File.Exists(Options.ImageInfoPath))
             {
-                LoggerService.WriteMessage("Image info file not found. Skipping image copy.");
+                LoggerService.WriteMessage(PipelineHelper.FormatWarningCommand(
+                    "Image info file not found. Skipping image copy."));
+                return;
             }
 
             ResourceIdentifier resourceId = ContainerRegistryResource.CreateResourceIdentifier(

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyAcrImagesCommand.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Azure.Core;
@@ -40,6 +41,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public override async Task ExecuteAsync()
         {
             LoggerService.WriteHeading("COPYING IMAGES");
+
+            if (!File.Exists(Options.ImageInfoPath))
+            {
+                LoggerService.WriteMessage("Image info file not found. Skipping image copy.");
+            }
 
             ResourceIdentifier resourceId = ContainerRegistryResource.CreateResourceIdentifier(
                 Options.Subscription, Options.ResourceGroup, CopyImageService.GetBaseAcrName(Options.SourceRegistry));

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestCommand.cs
@@ -53,6 +53,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             _loggerService.WriteHeading("GENERATING MANIFESTS");
 
+            if (!File.Exists(Options.ImageInfoPath))
+            {
+                _loggerService.WriteMessage("Image info file not found. Skipping manifest publishing.");
+            }
+
             // Prepopulate the credential cache with the container registry scope so that the OIDC token isn't expired by the time we
             // need to query the registry at the end of the command.
             if (!Options.IsDryRun)

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishManifestCommand.cs
@@ -55,7 +55,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             if (!File.Exists(Options.ImageInfoPath))
             {
-                _loggerService.WriteMessage("Image info file not found. Skipping manifest publishing.");
+                _loggerService.WriteMessage(PipelineHelper.FormatWarningCommand(
+                    "Image info file not found. Skipping manifest publishing."));
+                return;
             }
 
             // Prepopulate the credential cache with the container registry scope so that the OIDC token isn't expired by the time we

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/TrimUnchangedPlatformsCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/TrimUnchangedPlatformsCommand.cs
@@ -31,7 +31,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             if (!File.Exists(Options.ImageInfoPath))
             {
-                _loggerService.WriteMessage("Image info file not found. Skipping trimming unchanged platforms.");
+                _loggerService.WriteMessage(PipelineHelper.FormatWarningCommand(
+                    "Image info file not found. Skipping trimming unchanged platforms."));
+                return;
             }
 
             string imageInfoContents = await File.ReadAllTextAsync(Options.ImageInfoPath);

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/TrimUnchangedPlatformsCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/TrimUnchangedPlatformsCommand.cs
@@ -29,6 +29,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             _loggerService.WriteHeading("TRIMMING UNCHANGED PLATFORMS");
 
+            if (!File.Exists(Options.ImageInfoPath))
+            {
+                _loggerService.WriteMessage("Image info file not found. Skipping trimming unchanged platforms.");
+            }
+
             string imageInfoContents = await File.ReadAllTextAsync(Options.ImageInfoPath);
             ImageArtifactDetails imageArtifactDetails = JsonConvert.DeserializeObject<ImageArtifactDetails>(imageInfoContents);
             RemoveUnchangedPlatforms(imageArtifactDetails);

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/WaitForMcrImageIngestionCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/WaitForMcrImageIngestionCommand.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
@@ -32,6 +33,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public override async Task ExecuteAsync()
         {
             _loggerService.WriteHeading("WAITING FOR IMAGE INGESTION");
+
+            if (!File.Exists(Options.ImageInfoPath))
+            {
+                _loggerService.WriteMessage("Image info file not found. Skipping image ingestion wait.");
+            }
 
             if (!Options.IsDryRun)
             {

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/WaitForMcrImageIngestionCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/WaitForMcrImageIngestionCommand.cs
@@ -36,7 +36,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             if (!File.Exists(Options.ImageInfoPath))
             {
-                _loggerService.WriteMessage("Image info file not found. Skipping image ingestion wait.");
+                _loggerService.WriteMessage(PipelineHelper.FormatWarningCommand(
+                    "Image info file not found. Skipping image ingestion wait."));
+                return;
             }
 
             if (!Options.IsDryRun)

--- a/src/Microsoft.DotNet.ImageBuilder/src/PipelineHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/PipelineHelper.cs
@@ -10,5 +10,6 @@ namespace Microsoft.DotNet.ImageBuilder
             $"##vso[task.setvariable variable={variableName};isoutput=true]{value}";
 
         public static string FormatErrorCommand(string message) => $"##[error]{message}";
+        public static string FormatWarningCommand(string message) => $"##[warning]{message}";
     }
 }


### PR DESCRIPTION
Related to the suggestion in https://github.com/dotnet/docker-tools/pull/1494/files#r1841053475, this updates publish-related commands to gracefully handle an image info file that doesn't exist and just no-op in that scenario.