### PR TITLE
Reduce concurrent delete requests

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesCommand.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private readonly ILifecycleMetadataService _lifecycleMetadataService;
         private readonly IRegistryCredentialsProvider _registryCredentialsProvider;
 
-        private const int MaxConcurrentDeleteRequestsPerRepo = 10;
+        private const int MaxConcurrentDeleteRequestsPerRepo = 5;
 
         [ImportingConstructor]
         public CleanAcrImagesCommand(


### PR DESCRIPTION
Ran into another issue with the ACR getting in a bad state from image deletion. Related to https://github.com/dotnet/docker-tools/pull/1401. Reducing the concurrent request count down some more to try to prevent this from happening.