### PR TITLE
Add extra quoting for federated token file path

### DIFF
--- a/eng/common/templates/steps/init-docker-windows.yml
+++ b/eng/common/templates/steps/init-docker-windows.yml
@@ -51,7 +51,7 @@ steps:
         $authedImageBuilderCmds = @(
           '$env:AZURE_TENANT_ID = $env:tenantId'
           '$env:AZURE_CLIENT_ID = $env:servicePrincipalId'
-          '$env:AZURE_FEDERATED_TOKEN_FILE' + " = $tokenHostFilePath"
+          '$env:AZURE_FEDERATED_TOKEN_FILE = ' + "'" + "$tokenHostFilePath" + "'"
           $runImageBuilderCmd
         )
 


### PR DESCRIPTION
This PR fixes an issue that was encountered when publishing Server 2025 images: https://dev.azure.com/dnceng/internal/_build/results?buildId=2589255&view=logs&j=11434e3e-4fd8-538e-73a7-1fa357b5715e&t=ac305b46-e5f7-5446-77d9-86c252a1ec29&l=49 [internal MSFT link]

```
C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command ". 'C:\a\_work\_temp\azureclitaskscript1732567089292.ps1'"
Program 'token' failed to run: The operation attempted is not supportedAt 
C:\a\_work\_temp\azureclitaskscript1732567089291_inlinescript.ps1:1 char:179
+ ... lId; $env:AZURE_FEDERATED_TOKEN_FILE = C:\a\_work\_temp\token; C:\a\_ ...
+                                            ~~~~~~~~~~~~~~~~~~~~~~.
At C:\a\_work\_temp\azureclitaskscript1732567089291_inlinescript.ps1:1 char:145
+ ... rincipalId; $env:AZURE_FEDERATED_TOKEN_FILE = C:\a\_work\_temp\token; ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ResourceUnavailable: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : NativeCommandFailed
```

For some reason, Windows PowerShell was interpreting the path (`C:\a\_work\_temp\token`) as a path to an executable. Wrapping it in single quotes avoids this. I am not sure what the reason for the behavior change is.

Here's a pipeline run where I tested out this fix: https://dev.azure.com/dnceng/internal/_build/results?buildId=2589326&view=logs&j=11434e3e-4fd8-538e-73a7-1fa357b5715e&t=ac305b46-e5f7-5446-77d9-86c252a1ec29 [internal MSFT link]