### PR TITLE
Remove default dependency on Docker CLI for generating Dockerfiles

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/Command.TOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/Command.TOptions.cs
@@ -42,6 +42,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             cmd.Handler = CommandHandler.Create<TOptions>(options =>
             {
+                if (Options.CIMode)
+                {
+                    LogDockerVersions();
+                }
+
                 Initialize(options);
                 return ExecuteAsync();
             });
@@ -52,6 +57,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         protected virtual void Initialize(TOptions options)
         {
             Options = options;
+        }
+
+        private static void LogDockerVersions()
+        {
+            // Capture the Docker version and info in the output.
+            ExecuteHelper.Execute(fileName: "docker", args: "version", isDryRun: false);
+            ExecuteHelper.Execute(fileName: "docker", args: "info", isDryRun: false);
         }
 
         public abstract Task ExecuteAsync();

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/Command.TOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/Command.TOptions.cs
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             cmd.Handler = CommandHandler.Create<TOptions>(options =>
             {
-                if (Options.CIMode)
+                if (!Options.NoVersionLogging)
                 {
                     LogDockerVersions();
                 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/DockerfileFilterOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/DockerfileFilterOptions.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.CommandLine;
+using static Microsoft.DotNet.ImageBuilder.Commands.CliHelper;
+
+#nullable enable
+namespace Microsoft.DotNet.ImageBuilder.Commands;
+
+public class DockerfileFilterOptions
+{
+    public IEnumerable<string> Paths { get; set; } = [];
+    public IEnumerable<string> ProductVersions { get; set; } = [];
+}
+
+public class DockerfileFilterOptionsBuilder
+{
+    public const string PathOptionName = "path";
+
+    public IEnumerable<Option> GetCliOptions() =>
+        [
+            CreateMultiOption<string>(
+                alias: PathOptionName,
+                propertyName: nameof(DockerfileFilterOptions.Paths),
+                description:
+                    "Directory paths containing the Dockerfiles to build - wildcard chars * and ? supported (default is to build all)"),
+            CreateMultiOption<string>(
+                alias: "version",
+                propertyName: nameof(DockerfileFilterOptions.ProductVersions),
+                description: "Product versions of the Dockerfiles to build - wildcard chars * and ? supported (default is to build all)")
+        ];
+
+    public IEnumerable<Argument> GetCliArguments() => [];
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
@@ -213,7 +213,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             string pathArgs = dockerfilePaths
                 .Distinct()
-                .Select(path => $"{CliHelper.FormatAlias(ManifestFilterOptionsBuilder.PathOptionName)} {path}")
+                .Select(path => $"{CliHelper.FormatAlias(DockerfileFilterOptionsBuilder.PathOptionName)} {path}")
                 .Aggregate((working, next) => $"{working} {next}");
             leg.Variables.Add(("imageBuilderPaths", pathArgs));
         }
@@ -231,7 +231,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             leg.Variables.Add(("architecture", platformGrouping.Key.Architecture.GetDockerName()));
 
             string[] osVersions = subgraph
-                .Select(platform => $"{CliHelper.FormatAlias(ManifestFilterOptionsBuilder.OsVersionOptionName)} {platform.Model.OsVersion}")
+                .Select(platform => $"{CliHelper.FormatAlias(PlatformFilterOptionsBuilder.OsVersionOptionName)} {platform.Model.OsVersion}")
                 .Distinct()
                 .ToArray();
             leg.Variables.Add(("osVersions", string.Join(" ", osVersions)));

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateDockerfilesOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateDockerfilesOptions.cs
@@ -4,14 +4,13 @@
 
 using System.Collections.Generic;
 using System.CommandLine;
-using System.Linq;
 
 #nullable enable
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
-    public class GenerateDockerfilesOptions : GenerateArtifactsOptions, IFilterableOptions
+    public class GenerateDockerfilesOptions : GenerateArtifactsOptions, IDockerfileFilterableOptions
     {
-        public ManifestFilterOptions FilterOptions { get; set; } = new ManifestFilterOptions();
+        public DockerfileFilterOptions Dockerfile { get; set; } = new DockerfileFilterOptions();
 
         public GenerateDockerfilesOptions() : base()
         {
@@ -20,16 +19,18 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
     public class GenerateDockerfilesOptionsBuilder : GenerateArtifactsOptionsBuilder
     {
-        private readonly ManifestFilterOptionsBuilder _manifestFilterOptionsBuilder =
-            new ManifestFilterOptionsBuilder();
+        private readonly DockerfileFilterOptionsBuilder _dockerfileFilterOptionsBuilder = new();
 
         public override IEnumerable<Option> GetCliOptions() =>
-            base.GetCliOptions()
-                .Concat(_manifestFilterOptionsBuilder.GetCliOptions());
+        [
+            ..base.GetCliOptions(),
+            .._dockerfileFilterOptionsBuilder.GetCliOptions(),
+        ];
 
         public override IEnumerable<Argument> GetCliArguments() =>
-            base.GetCliArguments()
-                .Concat(_manifestFilterOptionsBuilder.GetCliArguments());
+        [
+            ..base.GetCliArguments(),
+            .._dockerfileFilterOptionsBuilder.GetCliArguments(),
+        ];
     }
 }
-#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/IFilterableOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/IFilterableOptions.cs
@@ -8,4 +8,14 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     {
         ManifestFilterOptions FilterOptions { get; }
     }
+
+    public interface IPlatformFilterableOptions
+    {
+        PlatformFilterOptions Platform { get; }
+    }
+
+    public interface IDockerfileFilterableOptions
+    {
+        DockerfileFilterOptions Dockerfile { get; }
+    }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestFilterOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestFilterOptions.cs
@@ -2,48 +2,45 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.CommandLine;
-using System.Linq;
-using Microsoft.DotNet.ImageBuilder.ViewModel;
-using static Microsoft.DotNet.ImageBuilder.Commands.CliHelper;
 
 #nullable enable
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     public class ManifestFilterOptions
     {
-        public string Architecture { get; set; } = string.Empty;
-        public string OsType { get; set; } = string.Empty;
-        public IEnumerable<string> OsVersions { get; set; } = Array.Empty<string>();
-        public IEnumerable<string> Paths { get; set; } = Array.Empty<string>();
-        public IEnumerable<string> ProductVersions { get; set; } = Array.Empty<string>();
+        public PlatformFilterOptions Platform { get; set; } = new();
+
+        public DockerfileFilterOptions Dockerfile { get; set; } = new();
+
+        public string Architecture => Platform.Architecture;
+
+        public string OsType => Platform.OsType;
+
+        public IEnumerable<string> OsVersions => Platform.OsVersions;
+
+        public IEnumerable<string> Paths => Dockerfile.Paths;
+
+        public IEnumerable<string> ProductVersions => Dockerfile.ProductVersions;
     }
 
     public class ManifestFilterOptionsBuilder
     {
-        public const string PathOptionName = "path";
-        public const string OsVersionOptionName = "os-version";
+        private readonly PlatformFilterOptionsBuilder _platformFilterOptionsBuilder = new();
+
+        private readonly DockerfileFilterOptionsBuilder _dockerfileFilterOptionsBuilder = new();
 
         public IEnumerable<Option> GetCliOptions() =>
-            new Option[]
-            {
-                CreateOption("architecture", nameof(ManifestFilterOptions.Architecture),
-                    "Architecture of Dockerfiles to operate on - wildcard chars * and ? supported (default is current OS architecture)",
-                    () => DockerHelper.Architecture.GetDockerName()),
-                CreateOption("os-type", nameof(ManifestFilterOptions.OsType),
-                    "OS type (linux/windows) of the Dockerfiles to build - wildcard chars * and ? supported (default is the Docker OS)",
-                    () => DockerHelper.OS.GetDockerName()),
-                CreateMultiOption<string>(OsVersionOptionName, nameof(ManifestFilterOptions.OsVersions),
-                    "OS versions of the Dockerfiles to build - wildcard chars * and ? supported (default is to build all)"),
-                CreateMultiOption<string>(PathOptionName, nameof(ManifestFilterOptions.Paths),
-                    "Directory paths containing the Dockerfiles to build - wildcard chars * and ? supported (default is to build all)"),
-                CreateMultiOption<string>("version", nameof(ManifestFilterOptions.ProductVersions),
-                    "Product versions of the Dockerfiles to build - wildcard chars * and ? supported (default is to build all)")
-            };
+        [
+            .._platformFilterOptionsBuilder.GetCliOptions(),
+            .._dockerfileFilterOptionsBuilder.GetCliOptions(),
+        ];
 
-        public IEnumerable<Argument> GetCliArguments() => Enumerable.Empty<Argument>();
+        public IEnumerable<Argument> GetCliArguments() =>
+        [
+            .._platformFilterOptionsBuilder.GetCliArguments(),
+            .._dockerfileFilterOptionsBuilder.GetCliArguments(),
+        ];
     }
 }
-#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestFilterOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestFilterOptions.cs
@@ -13,16 +13,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public PlatformFilterOptions Platform { get; set; } = new();
 
         public DockerfileFilterOptions Dockerfile { get; set; } = new();
-
-        public string Architecture => Platform.Architecture;
-
-        public string OsType => Platform.OsType;
-
-        public IEnumerable<string> OsVersions => Platform.OsVersions;
-
-        public IEnumerable<string> Paths => Dockerfile.Paths;
-
-        public IEnumerable<string> ProductVersions => Dockerfile.ProductVersions;
     }
 
     public class ManifestFilterOptionsBuilder

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestOptions.cs
@@ -27,14 +27,35 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             if (this is IFilterableOptions options)
             {
-                ManifestFilterOptions filterOptions = options.FilterOptions;
-                filter.IncludeArchitecture = filterOptions.Platform.Architecture;
-                filter.IncludeOsType = filterOptions.Platform.OsType;
-                filter.IncludeOsVersions = filterOptions.Platform.OsVersions;
-                filter.IncludePaths = filterOptions.Dockerfile.Paths;
-                filter.IncludeProductVersions = filterOptions.Dockerfile.ProductVersions;
+                filter = SetPlatformFilters(filter, options.FilterOptions.Platform);
+                filter = SetDockerfileFilters(filter, options.FilterOptions.Dockerfile);
             }
 
+            if (this is IPlatformFilterableOptions platformFilterOptions)
+            {
+                filter = SetPlatformFilters(filter, platformFilterOptions.Platform);
+            }
+
+            if (this is IDockerfileFilterableOptions dockerfileFilterOptions)
+            {
+                filter = SetDockerfileFilters(filter, dockerfileFilterOptions.Dockerfile);
+            }
+
+            return filter;
+        }
+
+        private static ManifestFilter SetDockerfileFilters(ManifestFilter filter, DockerfileFilterOptions options)
+        {
+            filter.IncludePaths = options.Paths;
+            filter.IncludeProductVersions = options.ProductVersions;
+            return filter;
+        }
+
+        private static ManifestFilter SetPlatformFilters(ManifestFilter filter, PlatformFilterOptions options)
+        {
+            filter.IncludeArchitecture = options.Architecture;
+            filter.IncludeOsType = options.OsType;
+            filter.IncludeOsVersions = options.OsVersions;
             return filter;
         }
     }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestOptions.cs
@@ -28,11 +28,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             if (this is IFilterableOptions options)
             {
                 ManifestFilterOptions filterOptions = options.FilterOptions;
-                filter.IncludeArchitecture = filterOptions.Architecture;
-                filter.IncludeOsType = filterOptions.OsType;
-                filter.IncludeOsVersions = filterOptions.OsVersions;
-                filter.IncludePaths = filterOptions.Paths;
-                filter.IncludeProductVersions = filterOptions.ProductVersions;
+                filter.IncludeArchitecture = filterOptions.Platform.Architecture;
+                filter.IncludeOsType = filterOptions.Platform.OsType;
+                filter.IncludeOsVersions = filterOptions.Platform.OsVersions;
+                filter.IncludePaths = filterOptions.Dockerfile.Paths;
+                filter.IncludeProductVersions = filterOptions.Dockerfile.ProductVersions;
             }
 
             return filter;

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/Options.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/Options.cs
@@ -16,6 +16,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     {
         public bool IsDryRun { get; set; }
         public bool IsVerbose { get; set; }
+        public bool CIMode { get; set; }
     }
 
     public class CliOptionsBuilder
@@ -39,7 +40,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 CreateOption<bool>(
                     alias: "verbose",
                     propertyName: nameof(Options.IsVerbose),
-                    description: "Show details about the tasks run")
+                    description: "Show details about the tasks run"),
+                CreateOption<bool>(
+                    alias: "ci",
+                    propertyName: nameof(Options.CIMode),
+                    description: "Enable additional logging useful for CI scenarios")
             ];
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/Options.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/Options.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     {
         public bool IsDryRun { get; set; }
         public bool IsVerbose { get; set; }
-        public bool CIMode { get; set; }
+        public bool NoVersionLogging { get; set; }
     }
 
     public class CliOptionsBuilder
@@ -42,9 +42,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     propertyName: nameof(Options.IsVerbose),
                     description: "Show details about the tasks run"),
                 CreateOption<bool>(
-                    alias: "ci",
-                    propertyName: nameof(Options.CIMode),
-                    description: "Enable additional logging useful for CI scenarios")
+                    alias: "no-version-logging",
+                    propertyName: nameof(Options.NoVersionLogging),
+                    description: "Disable automatic logging of Docker version information")
             ];
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PlatformFilterOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PlatformFilterOptions.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.CommandLine;
+using Microsoft.DotNet.ImageBuilder.ViewModel;
+using static Microsoft.DotNet.ImageBuilder.Commands.CliHelper;
+
+#nullable enable
+namespace Microsoft.DotNet.ImageBuilder.Commands;
+
+public class PlatformFilterOptions
+{
+    public string Architecture { get; set; } = string.Empty;
+    public string OsType { get; set; } = string.Empty;
+    public IEnumerable<string> OsVersions { get; set; } = [];
+
+}
+
+public class PlatformFilterOptionsBuilder
+{
+    public const string OsVersionOptionName = "os-version";
+    public IEnumerable<Option> GetCliOptions() =>
+        [
+            CreateOption(
+                alias: "architecture",
+                propertyName: nameof(PlatformFilterOptions.Architecture),
+                description: "Architecture of Dockerfiles to operate on - wildcard chars * and ? supported (default is current OS architecture)",
+                defaultValue: () => DockerHelper.Architecture.GetDockerName()),
+            CreateOption(
+                alias: "os-type",
+                propertyName: nameof(PlatformFilterOptions.OsType),
+                description: "OS type (linux/windows) of the Dockerfiles to build - wildcard chars * and ? supported (default is the Docker OS)",
+                defaultValue: () => DockerHelper.OS.GetDockerName()),
+            CreateMultiOption<string>(
+                alias: OsVersionOptionName,
+                propertyName: nameof(PlatformFilterOptions.OsVersions),
+                description: "OS versions of the Dockerfiles to build - wildcard chars * and ? supported (default is to build all)"),
+        ];
+
+    public IEnumerable<Argument> GetCliArguments() => [];
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PlatformFilterOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PlatformFilterOptions.cs
@@ -21,6 +21,7 @@ public class PlatformFilterOptions
 public class PlatformFilterOptionsBuilder
 {
     public const string OsVersionOptionName = "os-version";
+
     public IEnumerable<Option> GetCliOptions() =>
         [
             CreateOption(

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/QueueBuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/QueueBuildCommand.cs
@@ -67,7 +67,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             // This data comes from the GetStaleImagesCommand and represents a mapping of a subscription to the Dockerfile paths
             // of the images that need to be built. A given subscription may have images that are spread across Linux/Windows, AMD64/ARM
-            // which means that the paths collected for that subscription were spread across multiple jobs.  Each of the items in the 
+            // which means that the paths collected for that subscription were spread across multiple jobs.  Each of the items in the
             // Enumerable here represents the data collected by one job.  We need to consolidate the paths for a given subscription since
             // they could be spread across multiple items in the Enumerable.
             return Options.AllSubscriptionImagePaths
@@ -92,7 +92,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             }
 
             string formattedPathsToRebuild = pathsToRebuild
-                .Select(path => $"{CliHelper.FormatAlias(ManifestFilterOptionsBuilder.PathOptionName)} '{path}'")
+                .Select(path => $"{CliHelper.FormatAlias(DockerfileFilterOptionsBuilder.PathOptionName)} '{path}'")
                 .Aggregate((p1, p2) => $"{p1} {p2}");
 
             string parameters = "{\"" + subscription.PipelineTrigger.PathVariable + "\": \"" + formattedPathsToRebuild + "\"}";

--- a/src/Microsoft.DotNet.ImageBuilder/src/ImageBuilder.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ImageBuilder.cs
@@ -54,15 +54,6 @@ namespace Microsoft.DotNet.ImageBuilder
                     .UseDefaults()
                     .UseMiddleware(context =>
                     {
-                        if (context.ParseResult.CommandResult.Command != rootCliCommand)
-                        {
-                            // Capture the Docker version and info in the output.
-                            ExecuteHelper.Execute(fileName: "docker", args: "version", isDryRun: false);
-                            ExecuteHelper.Execute(fileName: "docker", args: "info", isDryRun: false);
-                        }
-                    })
-                    .UseMiddleware(context =>
-                    {
                         context.BindingContext.AddModelBinder(new ModelBinder<AzdoOptions>());
                         context.BindingContext.AddModelBinder(new ModelBinder<GitOptions>());
                         context.BindingContext.AddModelBinder(new ModelBinder<ManifestFilterOptions>());

--- a/src/Microsoft.DotNet.ImageBuilder/src/SubscriptionHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/SubscriptionHelper.cs
@@ -47,7 +47,7 @@ namespace Microsoft.DotNet.ImageBuilder
         {
             // If the command is filtered with an OS type that does not match the OsType filter of the subscription,
             // then there are no images that need to be inspected.
-            string osTypeRegexPattern = ManifestFilter.GetFilterRegexPattern(filterOptions.OsType);
+            string osTypeRegexPattern = ManifestFilter.GetFilterRegexPattern(filterOptions.Platform.OsType);
             if (!string.IsNullOrEmpty(subscription.OsType) &&
                 !Regex.IsMatch(subscription.OsType, osTypeRegexPattern, RegexOptions.IgnoreCase))
             {

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 command.Options.ProductVersionComponents = 3;
                 if (filterPaths != null)
                 {
-                    command.Options.FilterOptions.Paths = filterPaths.Replace("--path ", "").Split(" ");
+                    command.Options.FilterOptions.Dockerfile.Paths = filterPaths.Replace("--path ", "").Split(" ");
                 }
 
                 const string runtimeDepsRelativeDir = "2.1.1/runtime-deps/os";
@@ -108,7 +108,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 command.Options.MatrixType = MatrixType.PlatformDependencyGraph;
                 if (filterPaths != null)
                 {
-                    command.Options.FilterOptions.Paths = filterPaths.Replace("--path ", "").Split(" ");
+                    command.Options.FilterOptions.Dockerfile.Paths = filterPaths.Replace("--path ", "").Split(" ");
                 }
 
                 const string runtimeDepsRelativeDir = "1.0/runtimedeps/os/amd64";
@@ -258,7 +258,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             command.Options.MatrixType = MatrixType.PlatformDependencyGraph;
             command.Options.ImageInfoPath = Path.Combine(tempFolderContext.Path, "imageinfo.json");
             command.Options.TrimCachedImages = true;
-            command.Options.FilterOptions.Paths = inputPathFilters.Split(" ", StringSplitOptions.RemoveEmptyEntries);
+            command.Options.FilterOptions.Dockerfile.Paths = inputPathFilters.Split(" ", StringSplitOptions.RemoveEmptyEntries);
 
             File.WriteAllText(Path.Combine(tempFolderContext.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));
 

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
@@ -1768,7 +1768,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     this.ManifestServiceFactoryMock.Object, this.loggerServiceMock.Object, this.octokitClientFactory, this.gitService);
                 command.Options.SubscriptionOptions.SubscriptionsPath = this.subscriptionsPath;
                 command.Options.VariableName = VariableName;
-                command.Options.FilterOptions.OsType = this.osType;
+                command.Options.FilterOptions.Platform.OsType = this.osType;
                 command.Options.GitOptions.Email = "test";
                 command.Options.GitOptions.Username = "test";
                 command.Options.GitOptions.AuthToken = "test";

--- a/src/Microsoft.DotNet.ImageBuilder/tests/QueueBuildCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/QueueBuildCommandTests.cs
@@ -694,7 +694,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 IList<string> paths = pathString
                     .Split(" ", StringSplitOptions.RemoveEmptyEntries)
                     .Select(p => p.Trim().Trim('\''))
-                    .Except(new string[] { CliHelper.FormatAlias(ManifestFilterOptionsBuilder.PathOptionName) })
+                    .Except([ CliHelper.FormatAlias(DockerfileFilterOptionsBuilder.PathOptionName) ])
                     .ToList();
                 return CompareLists(expectedPaths, paths);
             }


### PR DESCRIPTION
This PR contains some changes needed to accomplish [Consider using Docker custom build outputs (`--output`) for generated Dockerfiles and Readmes (dotnet/dotnet-docker#5654)](https://github.com/dotnet/dotnet-docker/issues/5654), by fixing [ImageBuilder requires Docker to run all commands, even if they don't use it (#1428)](https://github.com/dotnet/docker-tools/issues/1428).

These changes shouldn't cause breaks for any features used by any commands. It does remove some filtering options from `GenerateDockerfiles`, but those options were unused.

Commits are separated into buildable chunks that each pass all tests, if that makes reviewing easier.

## The problem

- https://github.com/dotnet/dotnet-docker/issues/5654 requires commands be used in a Dockerfile build and not a running container.
- In order to use ImageBuilder inside a Dockerfile build, we can't use any `docker` CLI commands because we aren't going to bind-mount the Docker socket.
- `docker version` and `docker info` are run for every command.
- Some commands call the `docker` CLI to figure out the default value for some options (arch and OS version).

## Solution

- `docker version` and `docker info` are run for every command.
  - This is turned into a new option, `--ci` that is allowed for every command, that we can use in shared pipeline templates
- Some commands call the `docker` CLI to figure out the default value for some options (arch and OS version).
  - The arch and OS version filters are not useful for all commands. So, we can split `ManifestFilterOptions` into two separate sets of options: `PlatformFilterOptions` and `DockerfileFilterOptions`. Then, for `GenerateDockerfiles`, we use only `DockerfileFilterOptions` so that it won't call the `docker` CLI anymore.

## Using the new ImageBuilder

Here's an example Dockerfile that we would use to generate Readmes and Dockerfiles. (additional work is needed to pass in `branch` via an `ARG`, also should really use `COPY --link`)

```Dockerfile
FROM mcr.microsoft.com/dotnet-buildtools/image-builder:linux-amd64 AS imagebuilder
WORKDIR /repo
COPY . .

# generate-dockerfiles generates Dockerfiles from templates
FROM imagebuilder AS generate-dockerfiles
RUN [ \
    "/image-builder/Microsoft.DotNet.ImageBuilder", \
    "generateDockerfiles", \
    "--var", "branch=nightly" ]

# generate-readmes generates Readmes from templates
FROM imagebuilder AS generate-readmes
RUN [ \
    "/image-builder/Microsoft.DotNet.ImageBuilder", \
    "generateReadmes", \
    "--manifest", "manifest.json", \
    "--var", "branch=nightly", \
    "'https://github.com/dotnet/dotnet-docker'" ]
RUN [ \
    "/image-builder/Microsoft.DotNet.ImageBuilder", \
    "generateReadmes", \
    "--manifest", "manifest.samples.json", \
    "--var", "branch=main", \
    "'https://github.com/dotnet/dotnet-docker'" ]

# generate-dockerfiles-output contains generated Dockerfiles
FROM scratch AS generate-dockerfiles-output
COPY --from=generate-dockerfiles /repo/src src

# generate-readmes-output contains generated Readmes
FROM scratch AS generate-readmes-output
COPY --from=generate-readmes /repo/*.md ./
COPY --from=generate-readmes /repo/.portal-docs ./.portal-docs
```

## Results

`--no-cache` used for all Docker build commands, including those in PowerShell scripts. Measured with `Measure-Command` in PowerShell.

| Command | Execution time |
| --- | --- |
| `.\eng\dockerfile-templates\get-generateddockerfiles.ps1` | 7.78 seconds |
| `.\eng\readme-templates\get-generatedreadmes.ps1` | 16.28 seconds |
| `docker build --no-cache --target=generate-dockerfiles-output -f .\Dockerfile -o . .` | **5.23** seconds |
| `docker build --no-cache --target=generate-readmes-output -f .\Dockerfile -o . .` | **5.13** seconds |

### Caveats

Doesn't work on Windows since BuildKit doesn't support WCOW yet.

## Try it out

(cloning not required)

```pwsh
# Build ImageBuilder
docker build -t imagebuilder -f ./Dockerfile.linux https://github.com/lbussell/docker-tools.git#ci-mode-2:src/Microsoft.DotNet.ImageBuilder/

$dockerfile="https://raw.githubusercontent.com/lbussell/docker-tools/refs/heads/ci-demo/src/Microsoft.DotNet.ImageBuilder/Dockerfile.demo"

# See available options...
docker build -q --call=targets -f $dockerfile .

# Use the new Dockerfile to generate contents
docker build --no-cache --target=generate-dockerfiles-output -f $dockerfile -o . .
docker build --no-cache --target=generate-readmes-output -f $dockerfile -o . .
```
