### PR TITLE
Image caching fix for locally built images

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -338,6 +338,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                                 _imageDigestCache,
                                 _imageNameResolver.Value,
                                 sourceRepoUrl: Options.SourceRepoUrl,
+                                isLocalBaseImageExpected: true,
                                 isDryRun: Options.IsDryRun);
 
                             if (cacheResult.State.HasFlag(ImageCacheState.Cached))

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateBuildMatrixCommand.cs
@@ -469,6 +469,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         _imageDigestCache,
                         _imageNameResolver.Value,
                         Options.SourceRepoUrl,
+                        isLocalBaseImageExpected: false,
                         Options.IsDryRun);
 
                     bool includePlatformInMatrix = !cacheResult.State.HasFlag(ImageCacheState.Cached);

--- a/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
@@ -1085,6 +1085,13 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             null, "runtimeDepsCommitSha-1",
             null, "runtimeCommitSha-1",
             false, false)]
+        [InlineData(
+            "All previously published, commit diff for runtime-deps",
+            "sha256:baseImageSha", "sha256:baseImageSha",
+            "sha256:runtimeDepsImageSha-1", "sha256:runtimeDepsImageSha-1",
+            "runtimeDepsCommitSha-1", "runtimeDepsCommitSha-2",
+            "runtimeCommitSha", "runtimeCommitSha",
+            false, false)]
         public async Task BuildCommand_Caching(
             string scenario,
             string sourceBaseImageSha,
@@ -1125,7 +1132,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 localImageDigestResults:
                 [
                     new($"{runtimeDepsRepoQualified}:{tag}", runtimeDepsDigest),
-                    new($"{overridePrefix}{runtimeDepsRepo}:{tag}", runtimeDepsDigest),
+                    new($"{overridePrefix}{runtimeDepsRepo}:{tag}", runtimeDepsDigest, OnCallCount: 2),
                     new($"{runtimeRepoQualified}:{tag}", runtimeDigest),
                     new($"{overridePrefix}{runtimeRepo}:{tag}", runtimeDigest),
                     new(baseImageTag, runtimeDepsBaseImageDigest),
@@ -1443,11 +1450,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     new($"{runtimeDepsRepo}:{linuxTag}", runtimeDepsLinuxDigest),
                     new($"{runtimeDepsRepo}:{windowsTag}", runtimeDepsWindowsDigest),
                     new($"{runtimeDeps2Repo}:{linuxTag}", runtimeDeps2Digest),
-                ],
-                externalImageDigestResults:
-                [
-                    new(linuxBaseImageTag, runtimeDepsLinuxBaseImageDigestSha),
-                    new(windowsBaseImageTag, runtimeDepsWindowsBaseImageDigestSha),
+                    new(linuxBaseImageTag, runtimeDepsLinuxBaseImageDigest),
+                    new(windowsBaseImageTag, runtimeDepsWindowsBaseImageDigest),
                 ]);
             Mock<IManifestServiceFactory> manifestServiceFactoryMock = CreateManifestServiceFactoryMock(manifestServiceMock);
 
@@ -2516,10 +2520,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 localImageDigestResults:
                 [
                     new($"{runtimeDepsRepo}:{tag}", runtimeDepsDigest),
-                ],
-                externalImageDigestResults:
-                [
-                    new(baseImageTag, runtimeDepsLinuxBaseImageDigestSha),
+                    new(baseImageTag, runtimeDepsLinuxBaseImageDigest),
                 ]);
 
             DateTime createdDate = DateTime.Now;
@@ -2740,10 +2741,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 [
                     new($"{runtimeDepsRepo}:{tag}", runtimeDepsLinuxDigest),
                     new($"{runtimeDeps2Repo}:{tag}", runtimeDeps2Digest),
-                ],
-                externalImageDigestResults:
-                [
-                    new(baseImageTag, runtimeDepsLinuxBaseImageDigestSha),
+                    new(baseImageTag, runtimeDepsLinuxBaseImageDigest),
                 ]);
 
             DateTime createdDate = DateTime.Now;

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateBuildMatrixCommandTests.cs
@@ -164,6 +164,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     It.IsAny<ImageDigestCache>(),
                     It.IsAny<ImageNameResolver>(),
                     It.IsAny<string>(),
+                    It.IsAny<bool>(),
                     It.IsAny<bool>()))
                 .ReturnsAsync(new ImageCacheResult(cacheState, false, null));
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/docker-tools/issues/1516

In the scenario where this issue was discovered, it was the runtime image whose base runtime-deps image was being inspected to determine whether it had changed. So it was querying the registry the runtime-deps digest instead of accounting for the new locally built version of runtime-deps. Since runtime-deps was rebuilt then runtime should also be rebuilt. But since it had the digest from the registry and that matched what was in the image info, then it just used the cached image for runtime.

This fixes the logic by accounting for two different scenarios. In the build scenario, all base images will have either been built locally (if they are .NET base images) or pre-emptively pulled. Prior to this fix, the logic was not accounting for a locally built image at all and would always query the registry. So for build, it should check for the local image. But for the matrix generation command, there are no builds happening so it must query the registry all the time to get the digest.

Related: https://github.com/dotnet/docker-tools/issues/1517