### PR TITLE
Use official pipeline template for eng validation

### DIFF
--- a/eng/pipelines/dotnet-docker-tools-eng-validation.yml
+++ b/eng/pipelines/dotnet-docker-tools-eng-validation.yml
@@ -13,7 +13,7 @@ variables:
 - template: /eng/pipelines/templates/variables/eng-validation.yml@self
 
 extends:
-  template: /eng/common/templates/1es-unofficial.yml@self
+  template: /eng/common/templates/1es-official.yml@self
   parameters:
     stages:
     - template: /eng/common/templates/stages/dotnet/build-test-publish-repo.yml@self


### PR DESCRIPTION
This pipeline was using the incorrect template according to its "production/non-production" status.