### PR TITLE
Re-enable pre-build validation for internal servicing testing

### DIFF
--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -13,10 +13,9 @@ parameters:
 
 jobs:
 - job: ${{ parameters.name }}
-  condition: and(${{ parameters.matrix }}, not(canceled()), or(in(dependencies.PreBuildValidation.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'), eq(${{ parameters.isInternalServicingValidation }}, 'true')))
+  condition: and(${{ parameters.matrix }}, not(canceled()), in(dependencies.PreBuildValidation.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))
   dependsOn:
-  - ${{ if eq(parameters.isInternalServicingValidation, 'false') }}:
-    - PreBuildValidation
+  - PreBuildValidation
   - CopyBaseImages
   - GenerateBuildMatrix
   pool: ${{ parameters.pool }}

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -51,25 +51,24 @@ stages:
 - stage: Build
   condition: and(succeeded(), contains(variables['stages'], 'build'))
   jobs:
-  - ${{ if eq(parameters.isInternalServicingValidation, 'false') }}:
-    - template: /eng/common/templates/jobs/test-images-linux-client.yml@self
-      parameters:
-        name: PreBuildValidation
-        pool: ${{ parameters.linuxAmd64Pool }}
-        testJobTimeout: ${{ parameters.linuxAmdTestJobTimeout }}
-        preBuildValidation: true
-        internalProjectName: ${{ parameters.internalProjectName }}
-        customInitSteps:
-          - ${{ parameters.customTestInitSteps }}
-          # These variables are normally set by the matrix. Since this test job is not generated
-          # by a matrix, we need to set them manually. They can be set to empty values since their
-          # values aren't actually used for the pre-build tests.
-          - powershell: |
-              echo "##vso[task.setvariable variable=productVersion]"
-              echo "##vso[task.setvariable variable=imageBuilderPaths]"
-              echo "##vso[task.setvariable variable=osVersions]"
-              echo "##vso[task.setvariable variable=architecture]"
-            displayName: Initialize Test Variables
+  - template: /eng/common/templates/jobs/test-images-linux-client.yml@self
+    parameters:
+      name: PreBuildValidation
+      pool: ${{ parameters.linuxAmd64Pool }}
+      testJobTimeout: ${{ parameters.linuxAmdTestJobTimeout }}
+      preBuildValidation: true
+      internalProjectName: ${{ parameters.internalProjectName }}
+      customInitSteps:
+        - ${{ parameters.customTestInitSteps }}
+        # These variables are normally set by the matrix. Since this test job is not generated
+        # by a matrix, we need to set them manually. They can be set to empty values since their
+        # values aren't actually used for the pre-build tests.
+        - powershell: |
+            echo "##vso[task.setvariable variable=productVersion]"
+            echo "##vso[task.setvariable variable=imageBuilderPaths]"
+            echo "##vso[task.setvariable variable=osVersions]"
+            echo "##vso[task.setvariable variable=architecture]"
+          displayName: Initialize Test Variables
   - template: /eng/common/templates/jobs/copy-base-images-staging.yml@self
     parameters:
       name: CopyBaseImages


### PR DESCRIPTION
This is a backport of https://github.com/dotnet/dotnet-docker/pull/5983/commits/a1e1e04d82916f0616effe5ff0f0aa4397a18623. This commit got lost in subsequent dotnet-docker /eng/common updates since it wasn't backported earlier.