### PR TITLE
Use official pipeline template for base image mirroring

### DIFF
--- a/eng/pipelines/mirror-base-images.yml
+++ b/eng/pipelines/mirror-base-images.yml
@@ -21,7 +21,7 @@ variables:
   value: ""
 
 extends:
-  template: /eng/common/templates/1es-unofficial.yml@self
+  template: /eng/common/templates/1es-official.yml@self
   parameters:
     stages:
     - stage: MirrorBaseImages


### PR DESCRIPTION
Matches the template to its "production" classification.