### PR TITLE
Refactor PullBaseImages method and build command caching test

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -607,7 +607,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 IEnumerable<string> platformExternalFromImages = platform.ExternalFromImages.Distinct();
                 externalFromImages.UnionWith(platformExternalFromImages);
 
-                var tagsToPull = platformExternalFromImages.Select(_imageNameResolver.Value.GetFromImagePullTag);
+                IEnumerable<string> tagsToPull =
+                    platformExternalFromImages.Select(_imageNameResolver.Value.GetFromImagePullTag);
                 foreach (string pullTag in tagsToPull)
                 {
                     if (pulledTags.Add(pullTag))

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -592,70 +592,74 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         private async Task PullBaseImagesAsync()
         {
-            if (!Options.IsSkipPullingEnabled)
+            Logger.WriteHeading("PULLING LATEST BASE IMAGES");
+
+            if (Options.IsSkipPullingEnabled)
             {
-                Logger.WriteHeading("PULLING LATEST BASE IMAGES");
+                Logger.WriteMessage("No external base images to pull");
+                return;
+            }
 
-                HashSet<string> pulledTags = new();
-                HashSet<string> externalFromImages = new();
+            HashSet<string> pulledTags = [];
+            HashSet<string> externalFromImages = [];
+            foreach (PlatformInfo platform in Manifest.GetFilteredPlatforms())
+            {
+                IEnumerable<string> platformExternalFromImages = platform.ExternalFromImages.Distinct();
+                externalFromImages.UnionWith(platformExternalFromImages);
 
-                foreach (PlatformInfo platform in Manifest.GetFilteredPlatforms())
+                var tagsToPull = platformExternalFromImages.Select(_imageNameResolver.Value.GetFromImagePullTag);
+                foreach (string pullTag in tagsToPull)
                 {
-                    IEnumerable<string> platformExternalFromImages = platform.ExternalFromImages.Distinct();
-                    externalFromImages.UnionWith(platformExternalFromImages);
-
-                    foreach (string pullTag in platformExternalFromImages.Select(tag => _imageNameResolver.Value.GetFromImagePullTag(tag)))
+                    if (pulledTags.Add(pullTag))
                     {
-                        if (!pulledTags.Contains(pullTag))
-                        {
-                            pulledTags.Add(pullTag);
-
-                            // Pull the image, specifying its platform to ensure we get the necessary image in the case of a
-                            // multi-arch tag.
-                            _dockerService.PullImage(pullTag, platform.PlatformLabel, Options.IsDryRun);
-                        }
+                        // Pull the image, specifying its platform to ensure we get the necessary image in the case of
+                        // a multi-arch tag.
+                        _dockerService.PullImage(pullTag, platform.PlatformLabel, Options.IsDryRun);
                     }
-                }
-
-                if (pulledTags.Any())
-                {
-                    IEnumerable<string> finalStageExternalFromImages = Manifest.GetFilteredPlatforms()
-                        .Where(platform => platform.FinalStageFromImage is not null && !platform.IsInternalFromImage(platform.FinalStageFromImage))
-                        .Select(platform => _imageNameResolver.Value.GetFromImagePullTag(platform.FinalStageFromImage!))
-                        .Distinct();
-
-                    if (!finalStageExternalFromImages.IsSubsetOf(pulledTags))
-                    {
-                        throw new InvalidOperationException(
-                            "The following tags are identified as final stage tags but were not pulled:" +
-                            Environment.NewLine +
-                            string.Join(", ", finalStageExternalFromImages.Except(pulledTags).ToArray()));
-                    }
-
-                    await Parallel.ForEachAsync(finalStageExternalFromImages, async (fromImage, cancellationToken) =>
-                    {
-                        // Ensure the digest of the pulled image is retrieved right away after pulling so it's available in
-                        // the DockerServiceCache for later use.  The longer we wait to get the digest after pulling, the
-                        // greater chance the tag could be updated resulting in a different digest returned than what was
-                        // originally pulled.
-                        await _imageDigestCache.GetLocalImageDigestAsync(fromImage, Options.IsDryRun);
-                    });
-
-                    // Tag the images that were pulled from the mirror as they are referenced in the Dockerfiles
-                    Parallel.ForEach(externalFromImages, fromImage =>
-                    {
-                        string pullTag = _imageNameResolver.Value.GetFromImagePullTag(fromImage);
-                        if (pullTag != fromImage)
-                        {
-                            _dockerService.CreateTag(pullTag, fromImage, Options.IsDryRun);
-                        }
-                    });
-                }
-                else
-                {
-                    Logger.WriteMessage("No external base images to pull");
                 }
             }
+
+            if (pulledTags.Count <= 0)
+            {
+                Logger.WriteMessage("No external base images to pull");
+                return;
+            }
+
+            IEnumerable<string> finalStageExternalFromImages =
+                Manifest.GetFilteredPlatforms()
+                    .Where(platform =>
+                        platform.FinalStageFromImage is not null &&
+                        !platform.IsInternalFromImage(platform.FinalStageFromImage))
+                    .Select(platform =>
+                        _imageNameResolver.Value.GetFromImagePullTag(platform.FinalStageFromImage!))
+                    .Distinct();
+
+            if (!finalStageExternalFromImages.IsSubsetOf(pulledTags))
+            {
+                throw new InvalidOperationException(
+                    "The following tags are identified as final stage tags but were not pulled:" +
+                    Environment.NewLine +
+                    string.Join(", ", finalStageExternalFromImages.Except(pulledTags).ToArray()));
+            }
+
+            await Parallel.ForEachAsync(finalStageExternalFromImages, async (fromImage, cancellationToken) =>
+            {
+                // Ensure the digest of the pulled image is retrieved right away after pulling so it's available in
+                // the DockerServiceCache for later use.  The longer we wait to get the digest after pulling, the
+                // greater chance the tag could be updated resulting in a different digest returned than what was
+                // originally pulled.
+                await _imageDigestCache.GetLocalImageDigestAsync(fromImage, Options.IsDryRun);
+            });
+
+            // Tag the images that were pulled from the mirror as they are referenced in the Dockerfiles
+            Parallel.ForEach(externalFromImages, fromImage =>
+            {
+                string pullTag = _imageNameResolver.Value.GetFromImagePullTag(fromImage);
+                if (pullTag != fromImage)
+                {
+                    _dockerService.CreateTag(pullTag, fromImage, Options.IsDryRun);
+                }
+            });
         }
 
         private IEnumerable<PlatformData> GetProcessedPlatforms() => _imageArtifactDetails?.Repos

--- a/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
@@ -1230,11 +1230,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             File.WriteAllText(Path.Combine(tempFolderContext.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));
 
             // Set up source image info file
+            ImageArtifactDetails sourceImageArtifactDetails = new();
 
-            List<RepoData> sourceRepos = [];
             if (sourceBaseImageSha != null)
             {
-                sourceRepos.Add(
+                sourceImageArtifactDetails.Repos.Add(
                     CreateRepoData(
                         runtimeDepsRepo,
                         CreateImageData(
@@ -1250,7 +1250,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             if (sourceRuntimeDepsImageSha != null)
             {
-                sourceRepos.Add(
+                sourceImageArtifactDetails.Repos.Add(
                     CreateRepoData(
                         runtimeRepo,
                         CreateImageData(
@@ -1262,11 +1262,6 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                                 simpleTags: [tag],
                                 commitUrl: $"{command.Options.SourceRepoUrl}/blob/{sourceRuntimeCommitSha}/{runtimeDockerfileRelativePath}"))));
             }
-
-            ImageArtifactDetails sourceImageArtifactDetails = new()
-            {
-                Repos = [.. sourceRepos],
-            };
 
             string sourceImageArtifactDetailsOutput = JsonHelper.SerializeObject(sourceImageArtifactDetails);
             File.WriteAllText(command.Options.ImageInfoSourcePath, sourceImageArtifactDetailsOutput);
@@ -1321,7 +1316,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             if (isRuntimeDepsCached)
             {
                 VerifyImportImage(copyImageServiceMock, command,
-                    new string[] { $"{repoPrefixOverride}{runtimeDepsRepo}:{tag}", $"{repoPrefixOverride}{runtimeDepsRepo}:shared" },
+                    [$"{repoPrefixOverride}{runtimeDepsRepo}:{tag}", $"{repoPrefixOverride}{runtimeDepsRepo}:shared"],
                     DockerHelper.TrimRegistry(runtimeDepsDigest),
                     registryOverride,
                     registry);
@@ -1330,7 +1325,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             if (isRuntimeCached)
             {
                 VerifyImportImage(copyImageServiceMock, command,
-                    new string[] { $"{repoPrefixOverride}{runtimeRepo}:{tag}" },
+                    [$"{repoPrefixOverride}{runtimeRepo}:{tag}"],
                     DockerHelper.TrimRegistry(runtimeDigest),
                     registryOverride,
                     registry);

--- a/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Azure.ResourceManager.ContainerRegistry.Models;
+using FluentAssertions;
 using Microsoft.DotNet.ImageBuilder.Commands;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
@@ -17,6 +18,7 @@ using Moq;
 using Newtonsoft.Json;
 using Xunit;
 using Xunit.Abstractions;
+using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ImageInfoHelper;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestServiceHelper;
 
@@ -1042,6 +1044,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             "sha256:runtimeDepsImageSha-1", "sha256:runtimeDepsImageSha-1",
             "runtimeDepsCommitSha-1", "runtimeDepsCommitSha-1",
             "runtimeCommitSha-1", "runtimeCommitSha-1",
+            "",
+            false,
             true, true)]
         [InlineData(
             "All previously published, diffs for all image digests and commit SHAs",
@@ -1049,6 +1053,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             "sha256:runtimeDepsImageSha-1", "sha256:runtimeDepsImageSha-2",
             "runtimeDepsCommitSha-1", "runtimeDepsCommitSha-2",
             "runtimeCommitSha-1", "runtimeCommitSha-2",
+            "",
+            false,
             false, false)]
         [InlineData(
             "All previously published, diff for runtimeDeps image digest",
@@ -1056,6 +1062,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             "sha256:runtimeDepsImageSha-1", "sha256:runtimeDepsImageSha-2",
             "runtimeDepsCommitSha-1", "runtimeDepsCommitSha-1",
             "runtimeCommitSha-1", "runtimeCommitSha-1",
+            "",
+            false,
             true, false)]
         [InlineData(
             "All previously published, diff for runtime commit SHA",
@@ -1063,6 +1071,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             "sha256:runtimeDepsImageSha-1", "sha256:runtimeDepsImageSha-1",
             "runtimeDepsCommitSha-1", "runtimeDepsCommitSha-1",
             "runtimeCommitSha-1", "runtimeCommitSha-2",
+            "",
+            false,
             true, false)]
         [InlineData(
             "All previously published, diff for base image digest",
@@ -1070,6 +1080,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             "sha256:runtimeDepsImageSha-1", "sha256:runtimeDepsImageSha-2",
             "runtimeDepsCommitSha-1", "runtimeDepsCommitSha-1",
             "runtimeCommitSha-1", "runtimeCommitSha-1",
+            "",
+            false,
             false, false)]
         [InlineData(
             "Runtime not previously published",
@@ -1077,6 +1089,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             "sha256:runtimeDepsImageSha-1", "sha256:runtimeDepsImageSha-1",
             "runtimeDepsCommitSha-1", "runtimeDepsCommitSha-1",
             null, "runtimeCommitSha-1",
+            "",
+            false,
             true, false)]
         [InlineData(
             "No images previously published",
@@ -1084,6 +1098,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             null, "sha256:runtimeDepsImageSha-1",
             null, "runtimeDepsCommitSha-1",
             null, "runtimeCommitSha-1",
+            "",
+            false,
             false, false)]
         [InlineData(
             "All previously published, commit diff for runtime-deps",
@@ -1091,6 +1107,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             "sha256:runtimeDepsImageSha-1", "sha256:runtimeDepsImageSha-1",
             "runtimeDepsCommitSha-1", "runtimeDepsCommitSha-2",
             "runtimeCommitSha", "runtimeCommitSha",
+            "",
+            false,
             false, false)]
         public async Task BuildCommand_Caching(
             string scenario,
@@ -1102,6 +1120,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             string currentRuntimeDepsCommitSha,
             string sourceRuntimeCommitSha,
             string currentRuntimeCommitSha,
+            string pathArgs,
+            bool noCache,
             bool isRuntimeDepsCached,
             bool isRuntimeCached)
         {
@@ -1160,7 +1180,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             string runtimeDockerfileRelativePath = DockerfileHelper.CreateDockerfile(
                 "1.0/runtime/os", tempFolderContext, $"$REPO:{tag}");
 
-            Mock<IGitService> gitServiceMock = new Mock<IGitService>();
+            Mock<IGitService> gitServiceMock = new();
             gitServiceMock
                 .Setup(o => o.GetCommitSha(PathHelper.NormalizePath(Path.Combine(tempFolderContext.Path, runtimeDepsDockerfileRelativePath)), It.IsAny<bool>()))
                 .Returns(currentRuntimeDepsCommitSha);
@@ -1189,198 +1209,103 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             command.Options.RepoPrefix = repoPrefixOverride;
             command.Options.Subscription = "my-sub";
             command.Options.ResourceGroup = "resource-group";
+            command.Options.NoCache = noCache;
 
-            const string ProductVersion = "1.0.1";
+            // Set up manifest
+            Manifest manifest = CreateManifest(
+                CreateRepo(runtimeDepsRepo,
+                    CreateImage(
+                        sharedTags: ["shared"],
+                        CreatePlatform(
+                            runtimeDepsDockerfileRelativePath,
+                            tags: [tag]))),
+                CreateRepo(runtimeRepo,
+                    CreateImage(
+                        sharedTags: [],
+                        CreatePlatformWithRepoBuildArg(
+                            runtimeDockerfileRelativePath,
+                            repo: $"$(Repo:{runtimeDepsRepo})",
+                            tags: [tag]))));
+            manifest.Registry = registry;
+            File.WriteAllText(Path.Combine(tempFolderContext.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));
 
-            List<RepoData> sourceRepos = new List<RepoData>();
+            // Set up source image info file
+
+            List<RepoData> sourceRepos = [];
             if (sourceBaseImageSha != null)
             {
                 sourceRepos.Add(
-                    new RepoData
-                    {
-                        Repo = runtimeDepsRepo,
-                        Images =
-                        {
-                            new ImageData
-                            {
-                                ProductVersion = ProductVersion,
-                                Platforms =
-                                {
-                                    new PlatformData
-                                    {
-                                        Dockerfile = runtimeDepsDockerfileRelativePath,
-                                        Architecture = "amd64",
-                                        OsType = "Linux",
-                                        OsVersion = "focal",
-                                        Digest = runtimeDepsDigest,
-                                        BaseImageDigest = $"{baseImageRepo}@{sourceBaseImageSha}",
-                                        Created = createdDate.ToUniversalTime(),
-                                        SimpleTags =
-                                        {
-                                            tag
-                                        },
-                                        CommitUrl = $"{command.Options.SourceRepoUrl}/blob/{sourceRuntimeDepsCommitSha}/{runtimeDepsDockerfileRelativePath}",
-                                    }
-                                },
-                                Manifest = new ManifestData
-                                {
-                                    SharedTags =
-                                    {
-                                        "shared"
-                                    }
-                                }
-                            }
-                        }
-                    });
+                    CreateRepoData(
+                        runtimeDepsRepo,
+                        CreateImageData(
+                            sharedTags: ["shared"],
+                            CreatePlatform(
+                                dockerfile: runtimeDepsDockerfileRelativePath,
+                                digest: runtimeDepsDigest,
+                                baseImageDigest: $"{baseImageRepo}@{sourceBaseImageSha}",
+                                created: createdDate.ToUniversalTime(),
+                                simpleTags: [tag],
+                                commitUrl: $"{command.Options.SourceRepoUrl}/blob/{sourceRuntimeDepsCommitSha}/{runtimeDepsDockerfileRelativePath}"))));
             }
 
             if (sourceRuntimeDepsImageSha != null)
             {
                 sourceRepos.Add(
-                    new RepoData
-                    {
-                        Repo = runtimeRepo,
-                        Images =
-                        {
-                            new ImageData
-                            {
-                                ProductVersion = ProductVersion,
-                                Platforms =
-                                {
-                                    new PlatformData
-                                    {
-                                        Dockerfile = runtimeDockerfileRelativePath,
-                                        Architecture = "amd64",
-                                        OsType = "Linux",
-                                        OsVersion = "focal",
-                                        Digest = runtimeDigest,
-                                        BaseImageDigest = $"{runtimeDepsRepoQualified}@{sourceRuntimeDepsImageSha}",
-                                        Created = createdDate.ToUniversalTime(),
-                                        SimpleTags =
-                                        {
-                                            tag
-                                        },
-                                        CommitUrl = $"{command.Options.SourceRepoUrl}/blob/{sourceRuntimeCommitSha}/{runtimeDockerfileRelativePath}",
-                                    }
-                                }
-                            }
-                        }
-                    });
+                    CreateRepoData(
+                        runtimeRepo,
+                        CreateImageData(
+                            CreatePlatform(
+                                dockerfile: runtimeDockerfileRelativePath,
+                                digest: runtimeDigest,
+                                baseImageDigest: $"{runtimeDepsRepoQualified}@{sourceRuntimeDepsImageSha}",
+                                created: createdDate.ToUniversalTime(),
+                                simpleTags: [tag],
+                                commitUrl: $"{command.Options.SourceRepoUrl}/blob/{sourceRuntimeCommitSha}/{runtimeDockerfileRelativePath}"))));
             }
 
-            ImageArtifactDetails sourceImageArtifactDetails = new ImageArtifactDetails
+            ImageArtifactDetails sourceImageArtifactDetails = new()
             {
-                Repos = sourceRepos.ToList()
+                Repos = [.. sourceRepos],
             };
 
             string sourceImageArtifactDetailsOutput = JsonHelper.SerializeObject(sourceImageArtifactDetails);
             File.WriteAllText(command.Options.ImageInfoSourcePath, sourceImageArtifactDetailsOutput);
 
-            Manifest manifest = CreateManifest(
-                CreateRepo(runtimeDepsRepo,
-                    CreateImage(
-                        new Platform[]
-                        {
-                                CreatePlatform(runtimeDepsDockerfileRelativePath, new string[] { tag })
-                        },
-                        new Dictionary<string, Tag>
-                        {
-                                { "shared", new Tag() }
-                        },
-                        ProductVersion)),
-                CreateRepo(runtimeRepo,
-                    CreateImage(
-                        new Platform[]
-                        {
-                                CreatePlatformWithRepoBuildArg(runtimeDockerfileRelativePath, $"$(Repo:{runtimeDepsRepo})", new string[] { tag })
-                        },
-                        productVersion: ProductVersion))
-            );
-            manifest.Registry = registry;
+            // Set up expected output image info
+            ImageArtifactDetails expectedOutputImageArtifactDetails =
+                CreateImageArtifactDetails(
+                    CreateRepoData(
+                        runtimeDepsRepo,
+                        CreateImageData(
+                            sharedTags: ["shared"],
+                            CreatePlatform(
+                                dockerfile: runtimeDepsDockerfileRelativePath,
+                                digest: runtimeDepsDigest,
+                                baseImageDigest: runtimeDepsBaseImageDigest,
+                                created: createdDate.ToUniversalTime(),
+                                simpleTags: [tag],
+                                commitUrl: $"{command.Options.SourceRepoUrl}/blob/{currentRuntimeDepsCommitSha}/{runtimeDepsDockerfileRelativePath}",
+                                isUnchanged: isRuntimeDepsCached))),
+                    CreateRepoData(
+                        runtimeRepo,
+                        CreateImageData(
+                            CreatePlatform(
+                                dockerfile: runtimeDockerfileRelativePath,
+                                digest: runtimeDigest,
+                                baseImageDigest: runtimeDepsDigest,
+                                created: createdDate.ToUniversalTime(),
+                                simpleTags: [tag],
+                                commitUrl: $"{command.Options.SourceRepoUrl}/blob/{currentRuntimeCommitSha}/{runtimeDockerfileRelativePath}",
+                                isUnchanged: isRuntimeCached))));
 
-            File.WriteAllText(Path.Combine(tempFolderContext.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));
-
+            // Run command
             command.LoadManifest();
             await command.ExecuteAsync();
 
-            ImageArtifactDetails expectedOutputImageArtifactDetails = new ImageArtifactDetails
-            {
-                Repos = new List<RepoData>
-                {
-                    new RepoData
-                    {
-                        Repo = runtimeDepsRepo,
-                        Images =
-                        {
-                            new ImageData
-                            {
-                                ProductVersion = ProductVersion,
-                                Platforms =
-                                {
-                                    new PlatformData
-                                    {
-                                        Dockerfile = runtimeDepsDockerfileRelativePath,
-                                        Architecture = "amd64",
-                                        OsType = "Linux",
-                                        OsVersion = "focal",
-                                        Digest = runtimeDepsDigest,
-                                        BaseImageDigest = runtimeDepsBaseImageDigest,
-                                        Created = createdDate.ToUniversalTime(),
-                                        SimpleTags =
-                                        {
-                                            tag
-                                        },
-                                        CommitUrl = $"{command.Options.SourceRepoUrl}/blob/{currentRuntimeDepsCommitSha}/{runtimeDepsDockerfileRelativePath}",
-                                        IsUnchanged = isRuntimeDepsCached,
-                                    }
-                                },
-                                Manifest = new ManifestData
-                                {
-                                    SharedTags =
-                                    {
-                                        "shared"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    new RepoData
-                    {
-                        Repo = runtimeRepo,
-                        Images =
-                        {
-                            new ImageData
-                            {
-                                ProductVersion = ProductVersion,
-                                Platforms =
-                                {
-                                    new PlatformData
-                                    {
-                                        Dockerfile = runtimeDockerfileRelativePath,
-                                        Architecture = "amd64",
-                                        OsType = "Linux",
-                                        OsVersion = "focal",
-                                        Digest = runtimeDigest,
-                                        BaseImageDigest = runtimeDepsDigest,
-                                        Created = createdDate.ToUniversalTime(),
-                                        SimpleTags =
-                                        {
-                                            tag
-                                        },
-                                        CommitUrl = $"{command.Options.SourceRepoUrl}/blob/{currentRuntimeCommitSha}/{runtimeDockerfileRelativePath}",
-                                        IsUnchanged = isRuntimeCached,
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            };
-
-            string expectedOutput = JsonHelper.SerializeObject(expectedOutputImageArtifactDetails);
-            string actualOutput = File.ReadAllText(command.Options.ImageInfoOutputPath);
-
-            Assert.Equal(expectedOutput, actualOutput);
+            // Validate
+            string actualOutputText = File.ReadAllText(command.Options.ImageInfoOutputPath);
+            ImageArtifactDetails actualOutput = JsonConvert.DeserializeObject<ImageArtifactDetails>(actualOutputText);
+            actualOutput.Should().BeEquivalentTo(expectedOutputImageArtifactDetails);
 
             string runtimeDepsDigestDestCache = $"{overridePrefix}{DockerHelper.TrimRegistry(runtimeDepsDigest)}";
             Times expectedTimes = isRuntimeDepsCached ? Times.Once() : Times.Never();

--- a/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
@@ -1110,6 +1110,25 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             new string[] {},
             false,
             false, false)]
+        [InlineData(
+            "All unchanged, noCache set to true",
+            "sha256:baseImageSha", "sha256:baseImageSha",
+            "sha256:runtimeDepsImageSha", "sha256:runtimeDepsImageSha",
+            "runtimeDepsCommitSha", "runtimeDepsCommitSha",
+            "runtimeCommitSha", "runtimeCommitSha",
+            new string[] {},
+            true,
+            false, false)]
+        // Test failing due to https://github.com/dotnet/docker-tools/issues/1185
+        // [InlineData(
+        //     "All unchanged, noCache set to true, path filter set to runtime",
+        //     "sha256:baseImageSha", "sha256:baseImageSha",
+        //     "sha256:runtimeDepsImageSha", "sha256:runtimeDepsImageSha",
+        //     "runtimeDepsCommitSha", "runtimeDepsCommitSha",
+        //     "runtimeCommitSha", "runtimeCommitSha",
+        //     new string[] { "*1.0/runtime/os*" },
+        //     true,
+        //     true, false)]
         public async Task BuildCommand_Caching(
             string scenario,
             string sourceBaseImageSha,

--- a/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/BuildCommandTests.cs
@@ -1044,7 +1044,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             "sha256:runtimeDepsImageSha-1", "sha256:runtimeDepsImageSha-1",
             "runtimeDepsCommitSha-1", "runtimeDepsCommitSha-1",
             "runtimeCommitSha-1", "runtimeCommitSha-1",
-            "",
+            new string[] {},
             false,
             true, true)]
         [InlineData(
@@ -1053,7 +1053,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             "sha256:runtimeDepsImageSha-1", "sha256:runtimeDepsImageSha-2",
             "runtimeDepsCommitSha-1", "runtimeDepsCommitSha-2",
             "runtimeCommitSha-1", "runtimeCommitSha-2",
-            "",
+            new string[] {},
             false,
             false, false)]
         [InlineData(
@@ -1062,7 +1062,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             "sha256:runtimeDepsImageSha-1", "sha256:runtimeDepsImageSha-2",
             "runtimeDepsCommitSha-1", "runtimeDepsCommitSha-1",
             "runtimeCommitSha-1", "runtimeCommitSha-1",
-            "",
+            new string[] {},
             false,
             true, false)]
         [InlineData(
@@ -1071,7 +1071,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             "sha256:runtimeDepsImageSha-1", "sha256:runtimeDepsImageSha-1",
             "runtimeDepsCommitSha-1", "runtimeDepsCommitSha-1",
             "runtimeCommitSha-1", "runtimeCommitSha-2",
-            "",
+            new string[] {},
             false,
             true, false)]
         [InlineData(
@@ -1080,7 +1080,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             "sha256:runtimeDepsImageSha-1", "sha256:runtimeDepsImageSha-2",
             "runtimeDepsCommitSha-1", "runtimeDepsCommitSha-1",
             "runtimeCommitSha-1", "runtimeCommitSha-1",
-            "",
+            new string[] {},
             false,
             false, false)]
         [InlineData(
@@ -1089,7 +1089,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             "sha256:runtimeDepsImageSha-1", "sha256:runtimeDepsImageSha-1",
             "runtimeDepsCommitSha-1", "runtimeDepsCommitSha-1",
             null, "runtimeCommitSha-1",
-            "",
+            new string[] {},
             false,
             true, false)]
         [InlineData(
@@ -1098,7 +1098,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             null, "sha256:runtimeDepsImageSha-1",
             null, "runtimeDepsCommitSha-1",
             null, "runtimeCommitSha-1",
-            "",
+            new string[] {},
             false,
             false, false)]
         [InlineData(
@@ -1107,7 +1107,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             "sha256:runtimeDepsImageSha-1", "sha256:runtimeDepsImageSha-1",
             "runtimeDepsCommitSha-1", "runtimeDepsCommitSha-2",
             "runtimeCommitSha", "runtimeCommitSha",
-            "",
+            new string[] {},
             false,
             false, false)]
         public async Task BuildCommand_Caching(
@@ -1120,7 +1120,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             string currentRuntimeDepsCommitSha,
             string sourceRuntimeCommitSha,
             string currentRuntimeCommitSha,
-            string pathArgs,
+            string[] pathArgs,
             bool noCache,
             bool isRuntimeDepsCached,
             bool isRuntimeCached)
@@ -1210,6 +1210,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             command.Options.Subscription = "my-sub";
             command.Options.ResourceGroup = "resource-group";
             command.Options.NoCache = noCache;
+            command.Options.FilterOptions.Dockerfile.Paths = pathArgs;
 
             // Set up manifest
             Manifest manifest = CreateManifest(

--- a/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ImageInfoHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ImageInfoHelper.cs
@@ -139,7 +139,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests.Helpers
             DateTime? created = null,
             List<string> layers = null,
             bool isUnchanged = false,
-            string commitUrl = null)
+            string commitUrl = "")
         {
             if (digest is null)
             {

--- a/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ImageInfoHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ImageInfoHelper.cs
@@ -95,6 +95,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests.Helpers
             };
         }
 
+        public static ImageData CreateImageData(params List<PlatformData> platforms) =>
+            new()
+            {
+                Platforms = platforms
+            };
+
         public static ImageData CreateImageData(List<string> sharedTags, params List<PlatformData> platforms) =>
             new()
             {
@@ -132,7 +138,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests.Helpers
             string baseImageDigest = null,
             DateTime? created = null,
             List<string> layers = null,
-            bool isUnchanged = false)
+            bool isUnchanged = false,
+            string commitUrl = null)
         {
             if (digest is null)
             {
@@ -150,6 +157,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests.Helpers
                 Layers = layers ?? new List<string>(),
                 BaseImageDigest = baseImageDigest,
                 IsUnchanged = isUnchanged,
+                CommitUrl = commitUrl
             };
 
             if (created.HasValue)

--- a/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ImageInfoHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/Helpers/ImageInfoHelper.cs
@@ -141,10 +141,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests.Helpers
             bool isUnchanged = false,
             string commitUrl = "")
         {
-            if (digest is null)
-            {
-                digest = $"sha256:{new string(Enumerable.Repeat('0', 64).ToArray())}";
-            }
+            digest ??= $"sha256:{new string(Enumerable.Repeat('0', 64).ToArray())}";
 
             PlatformData platform = new()
             {
@@ -153,8 +150,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests.Helpers
                 Architecture = architecture,
                 OsType = osType,
                 OsVersion = osVersion,
-                SimpleTags = simpleTags ?? new List<string>(),
-                Layers = layers ?? new List<string>(),
+                SimpleTags = simpleTags ?? [],
+                Layers = layers ?? [],
                 BaseImageDigest = baseImageDigest,
                 IsUnchanged = isUnchanged,
                 CommitUrl = commitUrl


### PR DESCRIPTION
Related:
- #1185

To get a better understanding of #1185, I refactored both the `PullBaseImages` method as well as the build command's caching test.

For `PullBaseImages`, I tried to flatten the logic and fail early rather than having deeply nested conditionals. For the caching test, I used helper methods to shorten some of the object definitions and used Fluent Assertions to provide more actionable error messages.

Once I had a good understanding of how things worked, I added a failing test for #1185, which is commented out. I have a better idea of how to fix it in the `PullBaseImages` method now.