### PR TITLE
Remove unnecessary pinned package versions

### DIFF
--- a/eng/src/file-pusher/file-pusher.csproj
+++ b/eng/src/file-pusher/file-pusher.csproj
@@ -13,9 +13,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
     <PackageReference Include="System.Diagnostics.TextWriterTraceListener" Version="4.3.0" />
-
-    <!-- CVE-2024-38095: Upgrade version of System.Formats.Asn1 implicitly referenced by Microsoft.DotNet.VersionTools -->
-    <PackageReference Include="System.Formats.Asn1" Version="6.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Microsoft.DotNet.ImageBuilder.csproj
@@ -27,8 +27,6 @@
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="YamlDotNet" Version="16.2.1" />
 
-    <!-- Upgrade implicit Azure.Core reference due to https://github.com/Azure/azure-sdk-for-net/issues/44901 -->
-    <PackageReference Include="Azure.Core" Version="1.41.0" />
     <!-- CVE-2024-0056: Upgrade System.Data.SqlClient implicitly referenced by Microsoft.TeamFoundationServer.Client -->
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
     <!-- CVE-2024-38095: Upgrade version of System.Formats.Asn1 implicitly referenced by Microsoft.DotNet.VersionTools -->


### PR DESCRIPTION
I verified that these package versions are no longer needed for the issues/CVEs mentioned in the comments, due to changes in other package versions.