### PR TITLE
Add dependabot configuration for updating GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,8 @@ updates:
       interval: "daily"
     commit-message:
       prefix: "[dependabot]"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"


### PR DESCRIPTION
Part of https://github.com/dotnet/dotnet-docker-internal/issues/6178. This will automatically update any GitHub Actions the repo is using.