### PR TITLE
Switch dependabot config to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,10 @@ updates:
       - "/src/Microsoft.DotNet.ImageBuilder/"
       - "/eng/src/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
+      time: "00:00"
+      tz: "America/Los_Angeles"
     commit-message:
       prefix: "[dependabot]"
   - package-ecosystem: "github-actions"
@@ -16,3 +19,5 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+      time: "00:00"
+      tz: "America/Los_Angeles"


### PR DESCRIPTION
Dependabot updates have been too frequent. This PR switches them from daily to weekly on Mondays. I also set the time of day so that new PRs should be ready to review by the time work starts on Mondays.