### PR TITLE
Remove workaround for BuildKit Dockerfile caching issue

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,5 +24,9 @@
         }
     },
     "remoteUser": "app",
-    "onCreateCommand": "sudo chsh -s /bin/bash app"
+    "onCreateCommand": "sudo chsh -s /bin/bash app",
+    "tasks": {
+      "test": "dotnet test ./src/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.sln",
+      "build": "dotnet build ./src/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.sln"
+    }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/DockerService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/DockerService.cs
@@ -48,13 +48,6 @@ namespace Microsoft.DotNet.ImageBuilder
 
             string dockerArgs = $"build --platform {platform} {tagArgs} -f {dockerfilePath}{buildArgsString} {buildContextPath}";
 
-            // Workaround for https://github.com/moby/buildkit/issues/1368
-            // BuildKit caches Dockerfiles based on file size and timestamp.
-            // In case we need to build two Dockerfiles that are the same size,
-            // we need to set the timestamp manually so that we build the
-            // correct Dockerfile.
-            File.SetLastWriteTimeUtc(dockerfilePath, DateTime.UtcNow);
-
             if (isRetryEnabled)
             {
                 return ExecuteHelper.ExecuteWithRetry("docker", dockerArgs, isDryRun);


### PR DESCRIPTION
Fixes #1174

Remove workaround for BuildKit Dockerfile caching issue.

* Remove the code that sets the timestamp of the Dockerfile manually from `src/Microsoft.DotNet.ImageBuilder/src/DockerService.cs`.
* Add `tasks` section to `.devcontainer/devcontainer.json` with `test` and `build` commands.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dotnet/docker-tools/pull/1603?shareId=6e251f9a-ff1e-4444-90c3-00ad6d03500d).