### PR TITLE
Revert "Add back support for DockerfileGitCommitSha variable"

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/TagInfo.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/TagInfo.cs
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
                 Model = model,
                 BuildContextPath = buildContextPath
             };
-            tagInfo.Name = variableHelper.SubstituteValues(name, tagInfo.GetVariableValue);
+            tagInfo.Name = variableHelper.SubstituteValues(name);
             tagInfo.FullyQualifiedName = GetFullyQualifiedName(repoName, tagInfo.Name);
 
             if (model.Syndication != null)
@@ -54,20 +54,6 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         public static string GetFullyQualifiedName(string repoName, string tagName)
         {
             return $"{repoName}:{tagName}";
-        }
-
-        private string GetVariableValue(string variableType, string variableName)
-        {
-            string variableValue = null;
-
-            if (string.Equals(variableType, VariableHelper.SystemVariableTypeId, StringComparison.Ordinal)
-                && string.Equals(variableName, VariableHelper.DockerfileGitCommitShaVariableName, StringComparison.Ordinal)
-                && BuildContextPath != null)
-            {
-                variableValue = GitHelper.GetCommitSha(BuildContextPath);
-            }
-
-            return variableValue;
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/VariableHelper.cs
@@ -13,11 +13,9 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
     public class VariableHelper
     {
         private const char BuiltInDelimiter = ':';
-        public const string DockerfileGitCommitShaVariableName = "DockerfileGitCommitSha";
         public const string McrTagsYmlRepoTypeId = "McrTagsYmlRepo";
         public const string McrTagsYmlTagGroupTypeId = "McrTagsYmlTagGroup";
         public const string RepoVariableTypeId = "Repo";
-        public const string SystemVariableTypeId = "System";
         private const string VariableGroupName = "variable";
 
         private static readonly string s_tagVariablePattern = $"\\$\\((?<{VariableGroupName}>[\\w:\\-.| ]+)\\)";
@@ -107,14 +105,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
             string variableType = variableNameParts[0];
             variableName = variableNameParts[1];
 
-            if (string.Equals(variableType, SystemVariableTypeId, StringComparison.Ordinal))
-            {
-                if (getContextBasedSystemValue != null)
-                {
-                    variableValue = getContextBasedSystemValue(variableType, variableName);
-                }
-            }
-            else if (string.Equals(variableType, RepoVariableTypeId, StringComparison.Ordinal))
+            if (string.Equals(variableType, RepoVariableTypeId, StringComparison.Ordinal))
             {
                 variableValue = GetRepoById(variableName)?.QualifiedName;
             }


### PR DESCRIPTION
Reverts dotnet/docker-tools#1617

Reverting because these tags don't work the way we would like (see https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1378).