### PR TITLE
Add retries to dotnet-install script invocation

### DIFF
--- a/eng/common/Install-DotNetSdk.ps1
+++ b/eng/common/Install-DotNetSdk.ps1
@@ -45,11 +45,11 @@ $DotnetChannel = "9.0"
 $InstallFailed = $false
 if ($IsRunningOnUnix) {
     & chmod +x $DotnetInstallScriptPath
-    & $DotnetInstallScriptPath --channel $DotnetChannel --install-dir $InstallPath
+    & "$PSScriptRoot/Invoke-WithRetry.ps1" "$DotnetInstallScriptPath --channel $DotnetChannel --install-dir $InstallPath"
     $InstallFailed = ($LASTEXITCODE -ne 0)
 }
 else {
-    & $DotnetInstallScriptPath -Channel $DotnetChannel -InstallDir $InstallPath
+    & "$PSScriptRoot/Invoke-WithRetry.ps1" "$DotnetInstallScriptPath -Channel $DotnetChannel -InstallDir $InstallPath"
     $InstallFailed = (-not $?)
 }
 


### PR DESCRIPTION
Fixes #1644

Add retries to dotnet-install script invocation in `Install-DotNetSdk.ps1`.

* Wrap the invocation of the dotnet-install script with the `Invoke-WithRetry.ps1` script.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dotnet/docker-tools/pull/1645?shareId=39687453-91c3-40ed-a4bb-e6c4d2fc95c0).