### PR TITLE
Add additional retries to dotnet-install script invocation

### DIFF
--- a/eng/common/Install-DotNetSdk.ps1
+++ b/eng/common/Install-DotNetSdk.ps1
@@ -45,11 +45,11 @@ $DotnetChannel = "9.0"
 $InstallFailed = $false
 if ($IsRunningOnUnix) {
     & chmod +x $DotnetInstallScriptPath
-    & "$PSScriptRoot/Invoke-WithRetry.ps1" "$DotnetInstallScriptPath --channel $DotnetChannel --install-dir $InstallPath"
+    & "$PSScriptRoot/Invoke-WithRetry.ps1" "$DotnetInstallScriptPath --channel $DotnetChannel --install-dir $InstallPath" -Retries 5
     $InstallFailed = ($LASTEXITCODE -ne 0)
 }
 else {
-    & "$PSScriptRoot/Invoke-WithRetry.ps1" "$DotnetInstallScriptPath -Channel $DotnetChannel -InstallDir $InstallPath"
+    & "$PSScriptRoot/Invoke-WithRetry.ps1" "$DotnetInstallScriptPath -Channel $DotnetChannel -InstallDir $InstallPath" -Retries 5
     $InstallFailed = (-not $?)
 }
 


### PR DESCRIPTION
The default of 2 retries is still sometimes not enough ([see failure here](https://dev.azure.com/dnceng-public/public/_build/results?buildId=976323&view=logs&j=758d7417-7473-52bb-e4e7-358533cf3cc7&t=19da6720-ddc0-5c48-2855-b2005113be80&l=92)). This PR increases it to 5.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dotnet/docker-tools/pull/1646?shareId=e466c049-d407-43ff-a481-3fd674f3296c).