### PR TITLE
Use CDN url for dotnet-install script instead of dot.net

### DIFF
--- a/eng/common/Install-DotNetSdk.ps1
+++ b/eng/common/Install-DotNetSdk.ps1
@@ -37,7 +37,7 @@ $DotnetInstallScriptPath = Join-Path -Path $InstallPath -ChildPath $DotnetInstal
 
 if (!(Test-Path $DotnetInstallScriptPath)) {
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
-    & "$PSScriptRoot/Invoke-WithRetry.ps1" "Invoke-WebRequest 'https://dot.net/v1/$DotnetInstallScript' -OutFile $DotnetInstallScriptPath"
+    & "$PSScriptRoot/Invoke-WithRetry.ps1" "Invoke-WebRequest 'https://builds.dotnet.microsoft.com/dotnet/scripts/v1/$DotnetInstallScript' -OutFile $DotnetInstallScriptPath"
 }
 
 $DotnetChannel = "9.0"


### PR DESCRIPTION
dot.net just redirects to the CDN and it's currently having issues. Using the CDN directly was recommended by dnceng.