### PR TITLE
Add .NET version channel parameter to CG pipeline

### DIFF
--- a/eng/common/Install-DotNetSdk.ps1
+++ b/eng/common/Install-DotNetSdk.ps1
@@ -11,11 +11,16 @@ Install the .NET Core SDK at the specified path.
 .PARAMETER InstallPath
 The path where the .NET Core SDK is to be installed.
 
+.PARAMETER Channel
+The version of the .NET Core SDK to be installed.
+
 #>
 [cmdletbinding()]
 param(
     [string]
-    $InstallPath
+    $InstallPath,
+    [string]
+    $Channel = "9.0"
 )
 
 Set-StrictMode -Version Latest
@@ -40,7 +45,7 @@ if (!(Test-Path $DotnetInstallScriptPath)) {
     & "$PSScriptRoot/Invoke-WithRetry.ps1" "Invoke-WebRequest 'https://builds.dotnet.microsoft.com/dotnet/scripts/v1/$DotnetInstallScript' -OutFile $DotnetInstallScriptPath"
 }
 
-$DotnetChannel = "9.0"
+$DotnetChannel = $Channel
 
 $InstallFailed = $false
 if ($IsRunningOnUnix) {

--- a/eng/common/templates/jobs/cg-build-projects.yml
+++ b/eng/common/templates/jobs/cg-build-projects.yml
@@ -7,6 +7,11 @@ parameters:
   type: boolean
   default: false
   displayName: CG Dry Run
+# See https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script#options for possible Channel values
+- name: dotnetVersionChannel
+  type: string
+  default: '9.0'
+  displayName: .NET Version
 
 jobs:
 - job: BuildProjects
@@ -17,7 +22,7 @@ jobs:
     os: linux
   steps:
   - powershell: >
-      ./eng/common/Install-DotNetSdk.ps1 /usr/share/.dotnet
+      ./eng/common/Install-DotNetSdk.ps1 -Channel ${{ parameters.dotnetVersionChannel }} -InstallPath "/usr/share/.dotnet"
     displayName: Run Dotnet Install Script
   - script: >
       find . -name '*.csproj' | grep $(cgBuildGrepArgs) | xargs -n 1 /usr/share/.dotnet/dotnet build
@@ -29,7 +34,7 @@ jobs:
     - powershell: |
         Write-Host "##vso[build.updatebuildnumber]$env:BUILD_BUILDNUMBER (Dry run)"
         Write-Host "##vso[build.addbuildtag]dry-run"
-        
+
         if ("$(officialBranches)".Split(',').Contains("$(Build.SourceBranch)"))
         {
           Write-Host "##vso[task.logissue type=error]Cannot run a CG dry-run build from an official branch ($(officialBranches))."


### PR DESCRIPTION
Since https://github.com/dotnet/dotnet-docker/pull/6348 added a .NET 10 project, we need CG pipeline to be able to build .NET 10 projects. However, we don't need to use .NET 10 across all downstream projects. So, this PR adds a parameter that allows pipelines to override the default .NET version.