### PR TITLE
Allow making CLI option with custom parser actually required

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CliHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CliHelper.cs
@@ -21,11 +21,17 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 Name = propertyName
             };
 
-        public static Option<T> CreateOption<T>(string alias, string propertyName, string description, ParseArgument<T> parseArg) =>
-            new Option<T>(FormatAlias(alias), parseArg, description: description)
-            {
-                Name = propertyName
-            };
+        public static Option<T> CreateOption<T>(
+            string alias,
+            string propertyName,
+            string description,
+            ParseArgument<T> parseArg,
+            bool isRequired = false) =>
+                new Option<T>(FormatAlias(alias), parseArg, description: description)
+                {
+                    IsRequired = isRequired,
+                    Name = propertyName
+                };
 
         public static Option<T> CreateOption<T>(string alias, string propertyName, string description, Func<string, T> convert,
             T defaultValue = default!) =>

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GitOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GitOptions.cs
@@ -100,6 +100,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 "github-auth",
                 nameof(GitOptions.GitHubAuthOptions),
                 "GitHub Personal Access Token (PAT) or private key file (.pem) [token=<token> | private-key-file=<path to .pem file>]",
+                isRequired: isRequired,
                 parseArg: argumentResult =>
                 {
                     var dictionary = argumentResult.Tokens
@@ -109,14 +110,17 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     string token = dictionary.GetValueOrDefault("token", "");
                     string privateKeyFile = dictionary.GetValueOrDefault("private-key-file", "");
 
+                    // While the command will fail if the option is not provided, it doesn't mean that the correct
+                    // key-value pair was provided. So we need to check that at least one of the two expected values
+                    // is provided. We don't need to check for mutual exclusivity, since only one argument will be
+                    // accepted.
                     if (isRequired && string.IsNullOrEmpty(token) && string.IsNullOrEmpty(privateKeyFile))
                     {
                         throw new ArgumentException("GitHub token or private key file must be provided.");
                     }
 
                     return new GitHubAuthOptions(token, privateKeyFile);
-                }
-            ));
+                }));
 
             return this;
         }


### PR DESCRIPTION
Follow-up to #1660, that change uses a CLI option with a custom parser. Sometimes we want the option to be actually required. We have to use `Option` because `Argument` cannot have a custom parser. Previously, if you made an `isRequired` option with a custom parser using our CliHelper method, it wouldn't enforce the required-ness. We have to flow through that option to the actual Options class.