### PR TITLE
Add GitHub App support

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/Command.TOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/Command.TOptions.cs
@@ -40,6 +40,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 cmd.AddOption(option);
             }
 
+            foreach (var validator in OptionsBuilder.GetValidators())
+            {
+                cmd.AddValidator(validator);
+            }
+
             cmd.Handler = CommandHandler.Create<TOptions>(options =>
             {
                 if (!Options.NoVersionLogging)
@@ -69,4 +74,3 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public abstract Task ExecuteAsync();
     }
 }
-#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesCommand.cs
@@ -158,11 +158,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         private async Task<ImageArtifactDetails> GetImageInfoForSubscriptionAsync(Models.Subscription.Subscription subscription, ManifestInfo manifest)
         {
-            ITreesClient treesClient = _octokitClientFactory.CreateTreesClient(Options.GitOptions.GitHubAuthOptions);
+            ITreesClient treesClient = await _octokitClientFactory.CreateTreesClientAsync(Options.GitOptions.GitHubAuthOptions);
             string fileSha = await treesClient.GetFileShaAsync(
                 subscription.ImageInfo.Owner, subscription.ImageInfo.Repo, subscription.ImageInfo.Branch, subscription.ImageInfo.Path);
 
-            IBlobsClient blobsClient = _octokitClientFactory.CreateBlobsClient(Options.GitOptions.GitHubAuthOptions);
+            IBlobsClient blobsClient = await _octokitClientFactory.CreateBlobsClientAsync(Options.GitOptions.GitHubAuthOptions);
             string imageDataJson = await blobsClient.GetFileContentAsync(subscription.ImageInfo.Owner, subscription.ImageInfo.Repo, fileSha);
 
             return ImageInfoHelper.LoadFromContent(imageDataJson, manifest, skipManifestValidation: true);

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GetStaleImagesOptions.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.CommandLine;
+using System.CommandLine.Parsing;
 using System.Linq;
 
 #nullable enable
@@ -52,6 +53,12 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         new Argument<string>(nameof(GetStaleImagesOptions.VariableName),
                             "The Azure Pipeline variable name to assign the image paths to")
                     }));
+
+        public override IEnumerable<ValidateSymbol<CommandResult>> GetValidators() =>
+            [
+                ..base.GetValidators(),
+                .._gitOptionsBuilder.GetValidators()
+            ];
+
     }
 }
-#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GitOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GitOptions.cs
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         private readonly List<Argument> _arguments = [];
 
-        private List<ValidateSymbol<CommandResult>> _validators = [];
+        private readonly List<ValidateSymbol<CommandResult>> _validators = [];
 
         private GitOptionsBuilder()
         {

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestOptions.cs
@@ -78,7 +78,5 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     CreateDictionaryOption("var", nameof(ManifestOptions.Variables),
                         "Named variables to substitute into the manifest (<name>=<value>)")
                 });
-
-        public override IEnumerable<ValidateSymbol<CommandResult>> GetValidators() => base.GetValidators();
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ManifestOptions.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.CommandLine;
+using System.CommandLine.Parsing;
 using System.Linq;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
 using static Microsoft.DotNet.ImageBuilder.Commands.CliHelper;
@@ -77,6 +78,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     CreateDictionaryOption("var", nameof(ManifestOptions.Variables),
                         "Named variables to substitute into the manifest (<name>=<value>)")
                 });
+
+        public override IEnumerable<ValidateSymbol<CommandResult>> GetValidators() => base.GetValidators();
     }
 }
-#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/Options.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/Options.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.CommandLine;
-using System.Linq;
-using System.Reflection;
+using System.CommandLine.Parsing;
 using static Microsoft.DotNet.ImageBuilder.Commands.CliHelper;
 
 #nullable enable
@@ -46,5 +44,16 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     propertyName: nameof(Options.NoVersionLogging),
                     description: "Disable automatic logging of Docker version information")
             ];
+
+        /// <summary>
+        /// Optional delegates for performing additional validation of arguments and options.
+        /// </summary>
+        /// <remarks>
+        /// The delegate should return null if validation passes, or a string with the error message if it fails.
+        /// Validation failures will manifest the same way as any other command line parsing errors, like missing
+        /// required arguments or options for example.
+        /// </remarks>
+        /// <returns>Collection of ValidateSymbol delegates</returns>
+        public virtual IEnumerable<ValidateSymbol<CommandResult>> GetValidators() => [];
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PostPublishNotificationCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PostPublishNotificationCommand.cs
@@ -120,7 +120,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             // In the case where the publish build was queued by AutoBuilder, this finds the GitHub issue associated
             // with that queued build.
 
-            IGitHubClient gitHubClient = _octokitClientFactory.CreateGitHubClient(Options.GitOptions.GitHubAuthOptions);
+            IGitHubClient gitHubClient = await _octokitClientFactory.CreateGitHubClientAsync(Options.GitOptions.GitHubAuthOptions);
             RepositoryIssueRequest issueRequest = new()
             {
                 Filter = IssueFilter.All,

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PostPublishNotificationOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PostPublishNotificationOptions.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.CommandLine;
+using System.CommandLine.Parsing;
 using System.Linq;
 using static Microsoft.DotNet.ImageBuilder.Commands.CliHelper;
 
@@ -64,6 +65,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 })
                 .Concat(_azdoOptionsBuilder.GetCliArguments())
                 .Concat(_gitOptionsBuilder.GetCliArguments());
+
+        public override IEnumerable<ValidateSymbol<CommandResult>> GetValidators() =>
+            [
+                ..base.GetValidators(),
+                .._gitOptionsBuilder.GetValidators()
+            ];
     }
 }
-#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoOptions.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.CommandLine;
+using System.CommandLine.Parsing;
 
 #nullable enable
 namespace Microsoft.DotNet.ImageBuilder.Commands
@@ -27,6 +28,12 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             [
                 ..base.GetCliArguments(),
                 .._gitOptionsBuilder.GetCliArguments()
+            ];
+
+        public override IEnumerable<ValidateSymbol<CommandResult>> GetValidators() =>
+            [
+                ..base.GetValidators(),
+                .._gitOptionsBuilder.GetValidators()
             ];
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsCommand.cs
@@ -10,7 +10,6 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
 using Microsoft.DotNet.VersionTools.Automation;
 using Microsoft.DotNet.VersionTools.Automation.GitHubApi;

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsCommand.cs
@@ -59,7 +59,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             if (!Options.IsDryRun)
             {
-                using IGitHubClient gitHubClient = _gitHubClientFactory.GetClient(Options.GitOptions, Options.IsDryRun);
+                using IGitHubClient gitHubClient = await _gitHubClientFactory.GetClientAsync(Options.GitOptions, Options.IsDryRun);
 
                 await RetryHelper.GetWaitAndRetryPolicy<HttpRequestException>(_loggerService).ExecuteAsync(async () =>
                 {

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsOptions.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.CommandLine;
+using System.CommandLine.Parsing;
 using System.Linq;
 
 using static Microsoft.DotNet.ImageBuilder.Commands.CliHelper;
@@ -50,6 +51,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                             "Repo URL of the Dockerfile sources")
                     ]
                 );
+
+        public override IEnumerable<ValidateSymbol<CommandResult>> GetValidators() =>
+        [
+            ..base.GetValidators(),
+            .._gitOptionsBuilder.GetValidators()
+        ];
     }
 }
-#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/QueueBuildOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/QueueBuildOptions.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.CommandLine;
+using System.CommandLine.Parsing;
 using System.Linq;
 using static Microsoft.DotNet.ImageBuilder.Commands.CliHelper;
 
@@ -45,6 +46,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             base.GetCliArguments()
                 .Concat(_azdoOptionsBuilder.GetCliArguments())
                 .Concat(_gitOptionsBuilder.GetCliArguments());
+
+        public override IEnumerable<ValidateSymbol<CommandResult>> GetValidators() =>
+            [
+                ..base.GetValidators(),
+                .._gitOptionsBuilder.GetValidators()
+            ];
     }
 }
-#nullable disable

--- a/src/Microsoft.DotNet.ImageBuilder/src/GitHubClientFactory.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/GitHubClientFactory.cs
@@ -12,20 +12,24 @@ using Microsoft.DotNet.VersionTools.Automation.GitHubApi;
 namespace Microsoft.DotNet.ImageBuilder
 {
     [Export(typeof(IGitHubClientFactory))]
-    internal class GitHubClientFactory : IGitHubClientFactory
+    [method: ImportingConstructor]
+    internal class GitHubClientFactory(
+        ILoggerService loggerService,
+        IOctokitClientFactory octokitClientFactory)
+        : IGitHubClientFactory
     {
-        private readonly ILoggerService _loggerService;
+        private readonly ILoggerService _loggerService = loggerService
+            ?? throw new ArgumentNullException(nameof(loggerService));
 
-        [ImportingConstructor]
-        public GitHubClientFactory(ILoggerService loggerService)
-        {
-            _loggerService = loggerService ?? throw new ArgumentNullException(nameof(loggerService));
-        }
+        private readonly IOctokitClientFactory _octokitClientFactory = octokitClientFactory
+            ?? throw new ArgumentNullException(nameof(octokitClientFactory));
 
         public IGitHubClient GetClient(GitOptions gitOptions, bool isDryRun)
         {
+            var token = _octokitClientFactory.CreateGitHubToken(gitOptions.GitHubAuthOptions);
+
             var auth = new GitHubAuth(
-                authToken: gitOptions.GitHubAuthOptions.AuthToken,
+                authToken: token,
                 user: gitOptions.Username,
                 email: gitOptions.Email);
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/GitHubClientFactory.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/GitHubClientFactory.cs
@@ -24,9 +24,9 @@ namespace Microsoft.DotNet.ImageBuilder
         private readonly IOctokitClientFactory _octokitClientFactory = octokitClientFactory
             ?? throw new ArgumentNullException(nameof(octokitClientFactory));
 
-        public IGitHubClient GetClient(GitOptions gitOptions, bool isDryRun)
+        public async Task<IGitHubClient> GetClientAsync(GitOptions gitOptions, bool isDryRun)
         {
-            var token = _octokitClientFactory.CreateGitHubToken(gitOptions.GitHubAuthOptions);
+            var token = await _octokitClientFactory.CreateGitHubTokenAsync(gitOptions.GitHubAuthOptions);
 
             var auth = new GitHubAuth(
                 authToken: token,

--- a/src/Microsoft.DotNet.ImageBuilder/src/Helpers/JwtHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Helpers/JwtHelper.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.IO;
+using System.Security.Cryptography;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Microsoft.DotNet.ImageBuilder.Helpers;
+
+public static class JwtHelper
+{
+    public static string CreateJwt(string issuer, string pemKeyFilePath, TimeSpan timeout)
+    {
+        string keyText = File.ReadAllText(pemKeyFilePath);
+
+        RsaSecurityKey rsaSecurityKey;
+        using (var rsa = RSA.Create(4096))
+        {
+            rsa.ImportFromPem(keyText);
+            rsaSecurityKey = new RsaSecurityKey(rsa.ExportParameters(true));
+        };
+
+        var now = DateTime.UtcNow;
+        var signingCredentials = new SigningCredentials(rsaSecurityKey, SecurityAlgorithms.RsaSha256);
+
+        var descriptor = new SecurityTokenDescriptor
+        {
+            IssuedAt = now,
+            Expires = now + timeout,
+            Issuer = issuer,
+            SigningCredentials = signingCredentials
+        };
+
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var jwt = tokenHandler.CreateJwtSecurityToken(descriptor);
+        return tokenHandler.WriteToken(jwt);
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/IGitHubClientFactory.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/IGitHubClientFactory.cs
@@ -4,11 +4,12 @@
 
 using Microsoft.DotNet.ImageBuilder.Commands;
 using Microsoft.DotNet.VersionTools.Automation.GitHubApi;
+using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.ImageBuilder
 {
     public interface IGitHubClientFactory
     {
-        IGitHubClient GetClient(GitOptions gitOptions, bool isDryRun);
+        Task<IGitHubClient> GetClientAsync(GitOptions gitOptions, bool isDryRun);
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/IOctokitClientFactory.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/IOctokitClientFactory.cs
@@ -14,4 +14,6 @@ public interface IOctokitClientFactory
     IBlobsClient CreateBlobsClient(GitHubAuthOptions authOptions);
 
     ITreesClient CreateTreesClient(GitHubAuthOptions authOptions);
+
+    string CreateGitHubToken(GitHubAuthOptions authOptions);
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/IOctokitClientFactory.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/IOctokitClientFactory.cs
@@ -3,17 +3,18 @@
 
 using Microsoft.DotNet.ImageBuilder.Commands;
 using Octokit;
+using System.Threading.Tasks;
 
 #nullable enable
 namespace Microsoft.DotNet.ImageBuilder;
 
 public interface IOctokitClientFactory
 {
-    IGitHubClient CreateGitHubClient(GitHubAuthOptions authOptions);
+    Task<IGitHubClient> CreateGitHubClientAsync(GitHubAuthOptions authOptions);
 
-    IBlobsClient CreateBlobsClient(GitHubAuthOptions authOptions);
+    Task<IBlobsClient> CreateBlobsClientAsync(GitHubAuthOptions authOptions);
 
-    ITreesClient CreateTreesClient(GitHubAuthOptions authOptions);
+    Task<ITreesClient> CreateTreesClientAsync(GitHubAuthOptions authOptions);
 
-    string CreateGitHubToken(GitHubAuthOptions authOptions);
+    Task<string> CreateGitHubTokenAsync(GitHubAuthOptions authOptions);
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/NotificationService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/NotificationService.cs
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.ImageBuilder
             bool isDryRun,
             IEnumerable<string>? comments = null)
         {
-            IGitHubClient github = _octokitClientFactory.CreateGitHubClient(gitHubAuth);
+            IGitHubClient github = await _octokitClientFactory.CreateGitHubClientAsync(gitHubAuth);
 
             Issue? issue = null;
             if (!isDryRun)

--- a/src/Microsoft.DotNet.ImageBuilder/src/OctokitClientFactory.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/OctokitClientFactory.cs
@@ -95,18 +95,6 @@ namespace Microsoft.DotNet.ImageBuilder
             return authOptions.AuthToken;
         }
 
-        public IGitHubClient CreateGitHubClient(GitHubAuthOptions authOptions) =>
-            CreateGitHubClientAsync(authOptions).GetAwaiter().GetResult();
-
-        public ITreesClient CreateTreesClient(GitHubAuthOptions authOptions) =>
-            CreateTreesClientAsync(authOptions).GetAwaiter().GetResult();
-
-        public IBlobsClient CreateBlobsClient(GitHubAuthOptions authOptions) =>
-            CreateBlobsClientAsync(authOptions).GetAwaiter().GetResult();
-
-        public string CreateGitHubToken(GitHubAuthOptions authOptions) =>
-            CreateGitHubTokenAsync(authOptions).GetAwaiter().GetResult();
-
         private async Task<ApiConnection> CreateApiConnectionAsync(GitHubAuthOptions authOptions)
         {
             var credentials = await CreateCredentialsAsync(authOptions);

--- a/src/Microsoft.DotNet.ImageBuilder/src/OctokitClientFactory.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/OctokitClientFactory.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.ImageBuilder
         {
             var client = new GitHubClient(s_productHeaderValue)
             {
-                Credentials = new Credentials(authOptions.AuthToken)
+                Credentials = GetCredentials(authOptions)
             };
 
             return client;
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.ImageBuilder
 
         private static Credentials GetCredentials(GitHubAuthOptions authOptions)
         {
-            if (authOptions.IsPrivateKeyAuth)
+            if (authOptions.IsGitHubAppAuth)
             {
                 throw new NotImplementedException("""
                     Private key authentication is not implemented.
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.ImageBuilder
                     """);
             }
 
-            return new Credentials(authOptions.AuthToken, AuthenticationType.Bearer);
+            return new Credentials(authOptions.AuthToken);
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/OctokitClientFactory.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/OctokitClientFactory.cs
@@ -2,57 +2,189 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.Linq;
 using System.Reflection;
+using System.Text.Json;
+using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Commands;
+using Microsoft.DotNet.ImageBuilder.Helpers;
 using Octokit;
 
 #nullable enable
 namespace Microsoft.DotNet.ImageBuilder
 {
     [Export(typeof(IOctokitClientFactory))]
-    public class OctokitClientFactory : IOctokitClientFactory
+    [method: ImportingConstructor]
+    public class OctokitClientFactory(ILoggerService loggerService) : IOctokitClientFactory
     {
         private static readonly ProductHeaderValue s_productHeaderValue =
             new(name: Assembly.GetExecutingAssembly().GetName().Name);
 
-        public IGitHubClient CreateGitHubClient(GitHubAuthOptions authOptions)
-        {
-            var client = new GitHubClient(s_productHeaderValue)
-            {
-                Credentials = GetCredentials(authOptions)
-            };
+        private readonly ILoggerService _loggerService = loggerService;
 
+        public async Task<IGitHubClient> CreateGitHubClientAsync(GitHubAuthOptions authOptions)
+        {
+            var credentials = await CreateCredentialsAsync(authOptions);
+            var client = CreateClient(credentials);
             return client;
         }
 
-        public IBlobsClient CreateBlobsClient(GitHubAuthOptions authOptions) =>
-            new BlobsClient(CreateApiConnection(authOptions));
+        public async Task<IBlobsClient> CreateBlobsClientAsync(GitHubAuthOptions authOptions)
+        {
+            var apiConnection = await CreateApiConnectionAsync(authOptions);
+            return new BlobsClient(apiConnection);
+        }
+
+        public async Task<ITreesClient> CreateTreesClientAsync(GitHubAuthOptions authOptions)
+        {
+            var apiConnection = await CreateApiConnectionAsync(authOptions);
+            return new TreesClient(apiConnection);
+        }
+
+        public IGitHubClient CreateGitHubClient(GitHubAuthOptions authOptions) =>
+            CreateGitHubClientAsync(authOptions).GetAwaiter().GetResult();
 
         public ITreesClient CreateTreesClient(GitHubAuthOptions authOptions) =>
-            new TreesClient(CreateApiConnection(authOptions));
+            CreateTreesClientAsync(authOptions).GetAwaiter().GetResult();
 
-        private static ApiConnection CreateApiConnection(GitHubAuthOptions authOptions)
+        public IBlobsClient CreateBlobsClient(GitHubAuthOptions authOptions) =>
+            CreateBlobsClientAsync(authOptions).GetAwaiter().GetResult();
+
+        private async Task<ApiConnection> CreateApiConnectionAsync(GitHubAuthOptions authOptions)
         {
+            var credentials = await CreateCredentialsAsync(authOptions);
             var connection = new Connection(s_productHeaderValue)
             {
-                Credentials = GetCredentials(authOptions),
+                Credentials = credentials
             };
 
             return new ApiConnection(connection);
         }
 
-        private static Credentials GetCredentials(GitHubAuthOptions authOptions)
+        private async Task<Credentials> CreateCredentialsAsync(GitHubAuthOptions authOptions)
+        {
+            var token = await CreateTokenAsync(authOptions);
+            return CreateCredentials(token);
+        }
+
+        /// <summary>
+        /// Creates a GitHub token for the specified authentication options.
+        /// </summary>
+        /// <remarks>
+        /// If authOptions specifies a GitHub App, a JWT token is created using
+        /// the private key and client ID of the GitHub App.
+        /// </remarks>
+        /// <param name="authOptions"></param>
+        /// <returns>
+        /// A GitHub token created according to the authentication options.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if no installations are found for the GitHub App specified by authOptions.
+        /// </exception>
+        private async Task<string> CreateTokenAsync(GitHubAuthOptions authOptions)
         {
             if (authOptions.IsGitHubAppAuth)
             {
-                throw new NotImplementedException("""
-                    Private key authentication is not implemented.
-                    Please see https://github.com/dotnet/docker-tools/issues/1656.
-                    """);
+                /**
+                    Basic steps for GitHub App authentication:
+                    1. Create a JWT token using the private key and client ID of the GitHub App.
+                    2. Use the JWT token to authenticate as the GitHub App. This only allows you to query basic
+                       information about the App itself.
+                    3. Use the GitHub App client to get an token for a specific App installation.
+                **/
+
+                var jwt = CreateJwt(authOptions.ClientId, authOptions.PrivateKeyFilePath);
+                var appCredentials = CreateCredentials(jwt);
+                var appClient = CreateClient(appCredentials);
+                var appInfo = await GetCurrentAppInfoAsync(appClient.Credentials);
+
+                Installation? appInstallation = appInfo.Installations.FirstOrDefault()
+                    ?? throw new InvalidOperationException(
+                        $"""
+                        No installations found for GitHub App.
+                        Ensure the App is installed on the organization you are trying to access.
+
+                        {appInfo}
+                        """);
+
+                var installationToken = await appClient.GitHubApps.CreateInstallationToken(appInstallation.Id);
+
+                _loggerService.WriteMessage(
+                    $"GitHub App token created for App ID {appInstallation.AppId} and installation "
+                    + $"{appInstallation.Id} with expiration {installationToken.ExpiresAt}");
+
+                return installationToken.Token;
             }
 
-            return new Credentials(authOptions.AuthToken);
+            return authOptions.AuthToken;
         }
+
+        /// <summary>
+        /// Creates a JWT that can be used to authenticate as a GitHub App.
+        /// </summary>
+        /// <param name="clientId">The Client ID of the GitHub App. This is unique per App.</param>
+        /// <param name="privateKeyFilePath">Path to the .pem file which contains the private key for the App.</param>
+        /// <returns></returns>
+        private static string CreateJwt(string clientId, string privateKeyFilePath)
+        {
+            // https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app#about-json-web-tokens-jwts
+            // > [The expiration time] must be no more than 10 minutes into the future.
+            // Use 9 minutes to be safe.
+            var timeout = TimeSpan.FromMinutes(9);
+            return JwtHelper.CreateJwt(clientId, privateKeyFilePath, timeout);
+        }
+
+        /// <summary>
+        /// Creates a GitHub client with common product header value
+        /// </summary>
+        /// <param name="credentials"></param>
+        /// <returns></returns>
+        private static GitHubClient CreateClient(Credentials credentials) =>
+            new GitHubClient(s_productHeaderValue)
+            {
+                Credentials = credentials
+            };
+
+        /// <summary>
+        /// Creates GitHub credentials with the correct authentication type
+        /// </summary>
+        /// <param name="token">The token to use for the credentials</param>
+        /// <returns>The credentials</returns>
+        private static Credentials CreateCredentials(string token) =>
+            new Credentials(token, AuthenticationType.Bearer);
+
+        private static async Task<GitHubAppInfoResult> GetCurrentAppInfoAsync(Credentials credentials)
+        {
+            var client = CreateClient(credentials);
+            var currentApp = await client.GitHubApps.GetCurrent();
+            var installations = await client.GitHubApps.GetAllInstallationsForCurrent();
+            return new GitHubAppInfoResult(currentApp, installations);
+        }
+
+        private record GitHubAppInfoResult(
+            GitHubApp CurrentApp,
+            IReadOnlyList<Installation> Installations)
+        {
+            private static readonly JsonSerializerOptions s_jsonOptions = new() { WriteIndented = true };
+
+            public override string ToString()
+            {
+                string appInfoText = JsonSerializer.Serialize(CurrentApp, s_jsonOptions);
+                string installationsText = JsonSerializer.Serialize(Installations, s_jsonOptions);
+
+                return $"""
+
+                App: {CurrentApp.Name}
+                ---
+
+                App Info: {appInfoText}
+
+                App Installations: {installationsText}
+
+                """;
+            }
+        };
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/OctokitClientFactory.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/OctokitClientFactory.cs
@@ -43,32 +43,6 @@ namespace Microsoft.DotNet.ImageBuilder
             return new TreesClient(apiConnection);
         }
 
-        public IGitHubClient CreateGitHubClient(GitHubAuthOptions authOptions) =>
-            CreateGitHubClientAsync(authOptions).GetAwaiter().GetResult();
-
-        public ITreesClient CreateTreesClient(GitHubAuthOptions authOptions) =>
-            CreateTreesClientAsync(authOptions).GetAwaiter().GetResult();
-
-        public IBlobsClient CreateBlobsClient(GitHubAuthOptions authOptions) =>
-            CreateBlobsClientAsync(authOptions).GetAwaiter().GetResult();
-
-        private async Task<ApiConnection> CreateApiConnectionAsync(GitHubAuthOptions authOptions)
-        {
-            var credentials = await CreateCredentialsAsync(authOptions);
-            var connection = new Connection(s_productHeaderValue)
-            {
-                Credentials = credentials
-            };
-
-            return new ApiConnection(connection);
-        }
-
-        private async Task<Credentials> CreateCredentialsAsync(GitHubAuthOptions authOptions)
-        {
-            var token = await CreateTokenAsync(authOptions);
-            return CreateCredentials(token);
-        }
-
         /// <summary>
         /// Creates a GitHub token for the specified authentication options.
         /// </summary>
@@ -83,7 +57,7 @@ namespace Microsoft.DotNet.ImageBuilder
         /// <exception cref="InvalidOperationException">
         /// Thrown if no installations are found for the GitHub App specified by authOptions.
         /// </exception>
-        private async Task<string> CreateTokenAsync(GitHubAuthOptions authOptions)
+        public async Task<string> CreateGitHubTokenAsync(GitHubAuthOptions authOptions)
         {
             if (authOptions.IsGitHubAppAuth)
             {
@@ -119,6 +93,35 @@ namespace Microsoft.DotNet.ImageBuilder
             }
 
             return authOptions.AuthToken;
+        }
+
+        public IGitHubClient CreateGitHubClient(GitHubAuthOptions authOptions) =>
+            CreateGitHubClientAsync(authOptions).GetAwaiter().GetResult();
+
+        public ITreesClient CreateTreesClient(GitHubAuthOptions authOptions) =>
+            CreateTreesClientAsync(authOptions).GetAwaiter().GetResult();
+
+        public IBlobsClient CreateBlobsClient(GitHubAuthOptions authOptions) =>
+            CreateBlobsClientAsync(authOptions).GetAwaiter().GetResult();
+
+        public string CreateGitHubToken(GitHubAuthOptions authOptions) =>
+            CreateGitHubTokenAsync(authOptions).GetAwaiter().GetResult();
+
+        private async Task<ApiConnection> CreateApiConnectionAsync(GitHubAuthOptions authOptions)
+        {
+            var credentials = await CreateCredentialsAsync(authOptions);
+            var connection = new Connection(s_productHeaderValue)
+            {
+                Credentials = credentials
+            };
+
+            return new ApiConnection(connection);
+        }
+
+        private async Task<Credentials> CreateCredentialsAsync(GitHubAuthOptions authOptions)
+        {
+            var token = await CreateGitHubTokenAsync(authOptions);
+            return CreateCredentials(token);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.ImageBuilder/src/SystemCommandLineExtensions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/SystemCommandLineExtensions.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.CommandLine;
+using System.CommandLine.Parsing;
+
+namespace Microsoft.DotNet.ImageBuilder;
+
+public static class SystemCommandLineExtensions
+{
+    public static bool Has(this CommandResult commandResult, IOption option) =>
+        commandResult.FindResultFor(option)?.Tokens?.Count > 0;
+}

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GetStaleImagesCommandTests.cs
@@ -1824,11 +1824,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
                 Mock<IOctokitClientFactory> octokitClientFactoryMock = new();
                 octokitClientFactoryMock
-                    .Setup(o => o.CreateTreesClient(It.IsAny<GitHubAuthOptions>()))
-                    .Returns(treesClientMock.Object);
+                    .Setup(o => o.CreateTreesClientAsync(It.IsAny<GitHubAuthOptions>()))
+                    .ReturnsAsync(treesClientMock.Object);
                 octokitClientFactoryMock
-                    .Setup(o => o.CreateBlobsClient(It.IsAny<GitHubAuthOptions>()))
-                    .Returns(blobsClientMock.Object);
+                    .Setup(o => o.CreateBlobsClientAsync(It.IsAny<GitHubAuthOptions>()))
+                    .ReturnsAsync(blobsClientMock.Object);
 
                 return octokitClientFactoryMock.Object;
             }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/PublishMcrDocsCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/PublishMcrDocsCommandTests.cs
@@ -232,8 +232,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         {
             Mock<IGitHubClientFactory> gitHubClientFactoryMock = new();
             gitHubClientFactoryMock
-                            .Setup(o => o.GetClient(It.IsAny<GitOptions>(), false))
-                            .Returns(gitHubClientMock.Object);
+                            .Setup(o => o.GetClientAsync(It.IsAny<GitOptions>(), false))
+                            .ReturnsAsync(gitHubClientMock.Object);
             return gitHubClientFactoryMock.Object;
         }
     }


### PR DESCRIPTION
Related: https://github.com/dotnet/docker-tools/issues/1637, https://github.com/dotnet/docker-tools/issues/1656, https://github.com/dotnet/dotnet-docker-internal/issues/7468

I tested this with a personal app installed on my account. It works with both Octokit and M.DN.VersionTools.Automation clients.

The GitHubAuth options needed to be refactored as well, since with #1660 I forgot that you also need the App Client ID for app authentication. I added support for arbitrary custom option validation to make that easier. The GH Auth option aliases were also renamed to give them all a common `gh-*` prefix to make them easier to see together in the CLI help output. This work is all in the first commit and can be reviewed separately.

Todo:
- [x] Async all the methods in `IOctokitClientFactory` and get rid of the synchronous versions
