### PR TITLE
Use base64 encoded private key for GitHub App auth

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GitOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GitOptions.cs
@@ -27,16 +27,16 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
     public record GitHubAuthOptions(
         string AuthToken = "",
-        string PrivateKeyFilePath = "",
+        string PrivateKey = "",
         string ClientId = "")
     {
         public bool IsGitHubAppAuth =>
-            !string.IsNullOrEmpty(PrivateKeyFilePath) &&
+            !string.IsNullOrEmpty(PrivateKey) &&
             !string.IsNullOrEmpty(ClientId);
 
         public bool HasCredentials =>
             !string.IsNullOrEmpty(AuthToken) ||
-            (!string.IsNullOrEmpty(PrivateKeyFilePath) && !string.IsNullOrEmpty(ClientId));
+            (!string.IsNullOrEmpty(PrivateKey) && !string.IsNullOrEmpty(ClientId));
     }
 
     public class GitOptionsBuilder : CliOptionsBuilder
@@ -113,11 +113,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 nameof(GitHubAuthOptions.AuthToken),
                 "GitHub Personal Access Token (PAT)");
 
-            const string PrivateKeyAlias = "gh-private-key-file";
+            const string PrivateKeyAlias = "gh-private-key";
             var privateKeyOption = CreateOption<string>(
                 PrivateKeyAlias,
-                nameof(GitHubAuthOptions.PrivateKeyFilePath),
-                "Path to the private key file (.pem) for GitHub App authentication");
+                nameof(GitHubAuthOptions.PrivateKey),
+                "Base64-encoded private key (pem format) for GitHub App authentication");
 
             const string ClientIdAlias = "gh-app-client-id";
             var clientIdOption = CreateOption<string>(

--- a/src/Microsoft.DotNet.ImageBuilder/src/Helpers/JwtHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Helpers/JwtHelper.cs
@@ -13,14 +13,17 @@ namespace Microsoft.DotNet.ImageBuilder.Helpers;
 
 public static class JwtHelper
 {
-    public static string CreateJwt(string issuer, string pemKeyFilePath, TimeSpan timeout)
+    /// <summary>
+    /// Creates a JWT token using the provided issuer and base64 encoded private key (PEM format).
+    /// </summary>
+    public static string CreateJwt(string issuer, string base64PrivateKey, TimeSpan timeout)
     {
-        string keyText = File.ReadAllText(pemKeyFilePath);
+        string privateKey = DecodeBase64String(base64PrivateKey);
 
         RsaSecurityKey rsaSecurityKey;
         using (var rsa = RSA.Create(4096))
         {
-            rsa.ImportFromPem(keyText);
+            rsa.ImportFromPem(privateKey);
             rsaSecurityKey = new RsaSecurityKey(rsa.ExportParameters(true));
         };
 
@@ -38,5 +41,11 @@ public static class JwtHelper
         var tokenHandler = new JwtSecurityTokenHandler();
         var jwt = tokenHandler.CreateJwtSecurityToken(descriptor);
         return tokenHandler.WriteToken(jwt);
+    }
+
+    private static string DecodeBase64String(string input)
+    {
+        byte[] data = Convert.FromBase64String(input);
+        return System.Text.Encoding.UTF8.GetString(data);
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/OctokitClientFactory.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/OctokitClientFactory.cs
@@ -69,7 +69,7 @@ namespace Microsoft.DotNet.ImageBuilder
                     3. Use the GitHub App client to get an token for a specific App installation.
                 **/
 
-                var jwt = CreateJwt(authOptions.ClientId, authOptions.PrivateKeyFilePath);
+                var jwt = CreateJwt(authOptions.ClientId, authOptions.PrivateKey);
                 var appCredentials = CreateCredentials(jwt);
                 var appClient = CreateClient(appCredentials);
                 var appInfo = await GetCurrentAppInfoAsync(appClient.Credentials);
@@ -116,15 +116,15 @@ namespace Microsoft.DotNet.ImageBuilder
         /// Creates a JWT that can be used to authenticate as a GitHub App.
         /// </summary>
         /// <param name="clientId">The Client ID of the GitHub App. This is unique per App.</param>
-        /// <param name="privateKeyFilePath">Path to the .pem file which contains the private key for the App.</param>
+        /// <param name="privateKey">Base-64 encoded private key (PEM format) for the App.</param>
         /// <returns></returns>
-        private static string CreateJwt(string clientId, string privateKeyFilePath)
+        private static string CreateJwt(string clientId, string privateKey)
         {
             // https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app#about-json-web-tokens-jwts
             // > [The expiration time] must be no more than 10 minutes into the future.
             // Use 9 minutes to be safe.
             var timeout = TimeSpan.FromMinutes(9);
-            return JwtHelper.CreateJwt(clientId, privateKeyFilePath, timeout);
+            return JwtHelper.CreateJwt(clientId, privateKey, timeout);
         }
 
         /// <summary>


### PR DESCRIPTION
Requested by @dagood.

Using base64 encoded key is better because:
- We don't have to store the key on-disk
- Avoids issues with line-breaks and other escape characters when passing the key via CLI

Related: #1663