### PR TITLE
Fix GitHub App auth for Git push in PublishImageInfoCommand

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
@@ -47,13 +47,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 string authToken = await _octokitClientFactory.CreateGitHubTokenAsync(Options.GitOptions.GitHubAuthOptions);
                 CredentialsHandler credentials = GetCredentials(authToken);
 
-                CloneOptions cloneOptions = new()
+                CloneOptions cloneOptions = new(new() { CredentialsProvider = credentials })
                 {
                     BranchName = Options.GitOptions.Branch,
-                    FetchOptions = new FetchOptions
-                    {
-                        CredentialsProvider = credentials
-                    }
                 };
 
                 using IRepository repo = _gitService.CloneRepository(
@@ -112,7 +108,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private static CredentialsHandler GetCredentials(string token) =>
             (_, _, _) => new UsernamePasswordCredentials
             {
-                Username = "x-access-token",
+                Username = "_", // A placeholder is required, but GitHub doesn't care what it is.
                 Password = token
             };
     }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
@@ -16,19 +16,21 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     public class PublishImageInfoCommand : ManifestCommand<PublishImageInfoOptions, PublishImageInfoOptionsBuilder>
     {
         private readonly IGitService _gitService;
+        private readonly IOctokitClientFactory _octokitClientFactory;
         private readonly ILoggerService _loggerService;
         private const string CommitMessage = "Merging Docker image info updates from build";
 
         [ImportingConstructor]
-        public PublishImageInfoCommand(IGitService gitService, ILoggerService loggerService)
+        public PublishImageInfoCommand(IGitService gitService, IOctokitClientFactory octokitClientFactory, ILoggerService loggerService)
         {
             _gitService = gitService ?? throw new ArgumentNullException(nameof(gitService));
+            _octokitClientFactory = octokitClientFactory ?? throw new ArgumentNullException(nameof(octokitClientFactory));
             _loggerService = loggerService ?? throw new ArgumentNullException(nameof(loggerService));
         }
 
         protected override string Description => "Publishes a build's merged image info.";
 
-        public override Task ExecuteAsync()
+        public override async Task ExecuteAsync()
         {
             _loggerService.WriteHeading("PUBLISHING IMAGE INFO");
 
@@ -42,17 +44,26 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             {
                 _loggerService.WriteSubheading("Cloning GitHub repo");
 
-                CloneOptions cloneOptions = new() { BranchName = Options.GitOptions.Branch };
-                cloneOptions.FetchOptions.CredentialsProvider = GetCredentials(Options.GitOptions.GitHubAuthOptions);
+                string authToken = await _octokitClientFactory.CreateGitHubTokenAsync(Options.GitOptions.GitHubAuthOptions);
+                CredentialsHandler credentials = GetCredentials(authToken);
 
-                using IRepository repo =_gitService.CloneRepository(
+                CloneOptions cloneOptions = new()
+                {
+                    BranchName = Options.GitOptions.Branch,
+                    FetchOptions = new FetchOptions
+                    {
+                        CredentialsProvider = credentials
+                    }
+                };
+
+                using IRepository repo = _gitService.CloneRepository(
                     $"https://github.com/{Options.GitOptions.Owner}/{Options.GitOptions.Repo}",
                     repoPath,
                     cloneOptions);
 
                 Uri imageInfoPathIdentifier = GitHelper.GetBlobUrl(Options.GitOptions);
 
-                UpdateGitRepos(repoPath, repo);
+                UpdateGitRepos(repoPath, repo, credentials);
             }
             finally
             {
@@ -61,11 +72,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     FileHelper.ForceDeleteDirectory(repoPath);
                 }
             }
-
-            return Task.CompletedTask;
         }
 
-        private void UpdateGitRepos(string repoPath, IRepository repo)
+        private void UpdateGitRepos(string repoPath, IRepository repo, CredentialsHandler credentials)
         {
             string imageInfoPath = Path.Combine(repoPath, Options.GitOptions.Path);
 
@@ -93,18 +102,18 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             repo.Network.Push(branch,
                 new PushOptions
                 {
-                    CredentialsProvider = GetCredentials(Options.GitOptions.GitHubAuthOptions)
+                    CredentialsProvider = credentials
                 });
 
             Uri gitHubCommitUrl = GitHelper.GetCommitUrl(Options.GitOptions, commit.Sha);
             _loggerService.WriteMessage($"The '{Options.GitOptions.Path}' file was updated: {gitHubCommitUrl}");
         }
 
-        private static CredentialsHandler GetCredentials(GitHubAuthOptions gitHubAuthOptions) =>
-            (url, user, cred) => new UsernamePasswordCredentials
+        private static CredentialsHandler GetCredentials(string token) =>
+            (_, _, _) => new UsernamePasswordCredentials
             {
-                Username = gitHubAuthOptions.AuthToken,
-                Password = string.Empty
+                Username = "x-access-token",
+                Password = token
             };
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
@@ -47,10 +47,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 string authToken = await _octokitClientFactory.CreateGitHubTokenAsync(Options.GitOptions.GitHubAuthOptions);
                 CredentialsHandler credentials = GetCredentials(authToken);
 
-                CloneOptions cloneOptions = new(new() { CredentialsProvider = credentials })
+                CloneOptions cloneOptions = new CloneOptions
                 {
-                    BranchName = Options.GitOptions.Branch,
+                    BranchName = Options.GitOptions.Branch
                 };
+                cloneOptions.FetchOptions.CredentialsProvider = credentials;
 
                 using IRepository repo = _gitService.CloneRepository(
                     $"https://github.com/{Options.GitOptions.Owner}/{Options.GitOptions.Repo}",

--- a/src/Microsoft.DotNet.ImageBuilder/tests/PublishImageInfoCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/PublishImageInfoCommandTests.cs
@@ -149,7 +149,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         actualImageArtifactDetailsContents = File.ReadAllText(path);
                     });
 
-                PublishImageInfoCommand command = new(gitServiceMock.Object, Mock.Of<ILoggerService>());
+                PublishImageInfoCommand command = new(gitServiceMock.Object, Mock.Of<IOctokitClientFactory>(), Mock.Of<ILoggerService>());
                 command.Options.ImageInfoPath = file;
                 command.Options.GitOptions = gitOptions;
                 command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");


### PR DESCRIPTION
fixes: https://github.com/dotnet/dotnet-docker-internal/issues/7806

When using GitHub App credentials, the image builder correctly generates an installation access token but was not using it during Git operations. Instead, the push relied on GitHubAuthOptions.AuthToken, which is empty in GitHub App scenarios. This caused LibGit2Sharp to fail with repeated redirects due to missing or invalid credentials.

This change ensures the installation token is retrieved via CreateGitHubTokenAsync and injected into both CloneOptions and PushOptions as a UsernamePasswordCredentials with the required "x-access-token" format.