### PR TITLE
Update other GitHub token arguments

### DIFF
--- a/eng/pipelines/templates/jobs/check-base-image-updates.yml
+++ b/eng/pipelines/templates/jobs/check-base-image-updates.yml
@@ -27,7 +27,7 @@ jobs:
       getStaleImages
       $(dotnetDockerBot.userName)
       $(dotnetDockerBot.email)
-      $(BotAccount-dotnet-docker-bot-PAT)
+      --gh-token $(BotAccount-dotnet-docker-bot-PAT)
       staleImagePaths
       ${{ parameters.customGetStaleImagesArgs }}
       --subscriptions-path ${{ parameters.subscriptionsPath }}
@@ -42,7 +42,7 @@ jobs:
       $(System.AccessToken)
       dnceng
       internal
-      --git-token '$(BotAccount-dotnet-docker-bot-PAT)'
+      --gh-token '$(BotAccount-dotnet-docker-bot-PAT)'
       --git-owner 'dotnet'
       --git-repo '$(internalGitHubRepo)'
       --subscriptions-path ${{ parameters.subscriptionsPath }}


### PR DESCRIPTION
A couple of GitHub token arguments were not defined as Azure Pipeline variables, so they were missed in https://github.com/dotnet/docker-tools/pull/1662. This PR updates them to use the new option format.