### PR TITLE
Add gitHubVersionsRepoInfo.authArgs configurable variable

### DIFF
--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -192,7 +192,7 @@ jobs:
       '$(System.AccessToken)'
       '$(azdoOrgName)'
       '$(System.TeamProject)'
-      --gh-token '$(gitHubNotificationsRepoInfo.accessToken)'
+      $(gitHubNotificationsRepoInfo.authArgs)
       '$(gitHubNotificationsRepoInfo.org)'
       '$(gitHubNotificationsRepoInfo.repo)'
       --repo-prefix '$(publishRepoPrefix)'

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -174,7 +174,7 @@ jobs:
       '$(imageInfoContainerDir)/full-image-info-new.json'
       '$(gitHubVersionsRepoInfo.userName)'
       '$(gitHubVersionsRepoInfo.email)'
-      --gh-token '$(gitHubVersionsRepoInfo.accessToken)'
+      $(gitHubVersionsRepoInfo.authArgs)
       --git-owner '$(gitHubVersionsRepoInfo.org)'
       --git-repo '$(gitHubVersionsRepoInfo.repo)'
       --git-branch '$(gitHubVersionsRepoInfo.branch)'

--- a/eng/common/templates/steps/publish-readmes.yml
+++ b/eng/common/templates/steps/publish-readmes.yml
@@ -9,7 +9,7 @@ steps:
     --registry-override '$(acr.server)'
     '$(mcrDocsRepoInfo.userName)'
     '$(mcrDocsRepoInfo.email)'
-    --gh-token '$(mcrDocsRepoInfo.accessToken)'
+    $(mcrDocsRepoInfo.authArgs)
     '$(publicGitRepoUri)'
     ${{ parameters.dryRunArg }}
     $(manifestVariables)

--- a/eng/common/templates/variables/dotnet/build-test-publish.yml
+++ b/eng/common/templates/variables/dotnet/build-test-publish.yml
@@ -14,8 +14,8 @@ variables:
 - name: officialRepoPrefixes
   value: public/,internal/private/,unlisted/
 
-- name: mcrDocsRepoInfo.accessToken
-  value: $(BotAccount-dotnet-docker-bot-PAT)
+- name: mcrDocsRepoInfo.authArgs
+  value: --gh-token '$(BotAccount-dotnet-docker-bot-PAT)'
 - name: mcrDocsRepoInfo.userName
   value: $(dotnetDockerBot.userName)
 - name: mcrDocsRepoInfo.email
@@ -27,8 +27,8 @@ variables:
   value: dotnet
 - name: gitHubNotificationsRepoInfo.repo
   value: dotnet-docker-internal
-- name: gitHubNotificationsRepoInfo.accessToken
-  value: $(BotAccount-dotnet-docker-bot-PAT)
+- name: gitHubNotificationsRepoInfo.authArgs
+  value: --gh-token '$(BotAccount-dotnet-docker-bot-PAT)'
 
 - name: gitHubVersionsRepoInfo.org
   value: dotnet

--- a/eng/common/templates/variables/dotnet/build-test-publish.yml
+++ b/eng/common/templates/variables/dotnet/build-test-publish.yml
@@ -38,8 +38,8 @@ variables:
   value: main
 - name: gitHubVersionsRepoInfo.path
   value: ${{ variables.commonVersionsImageInfoPath }}
-- name: gitHubVersionsRepoInfo.accessToken
-  value: $(BotAccount-dotnet-docker-bot-PAT)
+- name: gitHubVersionsRepoInfo.authArgs
+  value: --gh-token '$(BotAccount-dotnet-docker-bot-PAT)'
 - name: gitHubVersionsRepoInfo.userName
   value: $(dotnetDockerBot.userName)
 - name: gitHubVersionsRepoInfo.email


### PR DESCRIPTION
Add `gitHubVersionsRepoInfo.authArgs` that we can change in microsoft/go-images to use an app rather than a token.

Override tested with:

```yml
- name: gitHubVersionsRepoInfo.authArgs
  value: >-
    --gh-private-key '$(BotAccount-bot-for-go-private-key)'
    --gh-app-client-id '$(BotAccount-bot-for-go-client-id)'
    --gh-app-installation-id '$(BotAccount-bot-for-go-installation)'
```

https://dev.azure.com/dnceng/internal/_build/results?buildId=2688959&view=results