### PR TITLE
Use new ImageArtifactDetails deserialization method ImageInfoHelper

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ImageInfoHelper.cs
@@ -115,8 +115,7 @@ namespace Microsoft.DotNet.ImageBuilder
         public static ImageArtifactDetails DeserializeImageArtifactDetails(string path)
         {
             string imageInfoText = File.ReadAllText(path);
-
-            return JsonConvert.DeserializeObject<ImageArtifactDetails>(imageInfoText) ??
+            return ImageArtifactDetails.FromJson(imageInfoText) ??
                 throw new InvalidDataException($"Unable to deserialize image info file {path}");
         }
 


### PR DESCRIPTION
Related: https://github.com/dotnet/docker-tools/pull/1604

Fixes PublishEolAnnotations command failure in https://github.com/dotnet/dotnet-docker/pull/6376

PublishEolAnnotationsCommand references the DeserializeImageArtifactDetails method, which wasn't updated to use the new `FromJson` method added in #1604.