### PR TITLE
Update image-builder tag

### DIFF
--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2694940
+  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2697325
   imageNames.imageBuilder: $(imageNames.imageBuilderName)
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux3.0-docker-testrunner


### PR DESCRIPTION
The pipeline to publish the image-builder image is failing needing the fix from https://github.com/dotnet/docker-tools/pull/1682. The image with the fix has been pushed so I'm manually updating to reference it.