### PR TITLE
Accept string instead of long for `--gh-app-installation-id` CLI option

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GitOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GitOptions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         string AuthToken = "",
         string PrivateKey = "",
         string ClientId = "",
-        long? InstallationId = null)
+        string? InstallationId = null)
     {
         public bool IsGitHubAppAuth =>
             !string.IsNullOrEmpty(PrivateKey) &&
@@ -127,7 +127,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 "GitHub Client ID for GitHub App authentication");
 
             const string InstallationIdAlias = "gh-app-installation-id";
-            var installationIdOption = CreateOption<long?>(
+            var installationIdOption = CreateOption<string?>(
                 InstallationIdAlias,
                 nameof(GitHubAuthOptions.InstallationId),
                 "GitHub App installation ID to use (only required if app has more than one installation)");

--- a/src/Microsoft.DotNet.ImageBuilder/src/OctokitClientFactory.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/OctokitClientFactory.cs
@@ -75,11 +75,14 @@ namespace Microsoft.DotNet.ImageBuilder
                 var appInfo = await GetCurrentAppInfoAsync(appClient.Credentials);
 
                 Installation appInstallation;
-
-                if (authOptions.InstallationId is long providedId) {
-                    appInstallation = appInfo.Installations.FirstOrDefault(i => i.Id == providedId)
-                        ?? throw new InvalidOperationException($"No installation found with ID {providedId}.");
-                } else {
+                if (authOptions.InstallationId is string providedId)
+                {
+                    appInstallation = appInfo.Installations
+                        .FirstOrDefault(installation => installation.Id.ToString() == providedId)
+                            ?? throw new InvalidOperationException($"No installation found with ID {providedId}.");
+                }
+                else
+                {
                     appInstallation = appInfo.Installations.SingleOrDefault()
                         ?? throw new InvalidOperationException("Expected exactly one installation for GitHub App but "
                             + "found none or multiple. Provide an installation ID explicitly.");


### PR DESCRIPTION
When doing a dry-run, sometimes we want to pass in un-resolved AzDO variables instead of placeholder variables. For example, `"$(myGitHubAppInstallationId)"`. That would fail, however, because the `--gh-app-installation-id` option always expected an int/long. This allows it to accept a string instead so those dry-run scenarios don't rely on actually converting whatever you pass in to a valid int/long, they can just be ignored instead.

Also, some minor code formatting/readability tweaks.