### PR TITLE
Show different output when copying images during dry-run

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/CopyImageService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/CopyImageService.cs
@@ -69,10 +69,13 @@ public class CopyImageService : ICopyImageService
         };
         importImageContent.TargetTags.AddRange(destTagNames);
 
-        string formattedDestTagNames = string.Join(
-            ", ", destTagNames.Select(tag => $"'{DockerHelper.GetImageName(destAcrName, tag)}'").ToArray());
-        _loggerService.WriteMessage(
-            $"Importing {formattedDestTagNames} from '{DockerHelper.GetImageName(srcRegistryName, srcTagName)}'");
+        string action = isDryRun ? "(Dry run) Would have imported" : "Importing";
+        string sourceImageName = DockerHelper.GetImageName(srcRegistryName, srcTagName);
+        var destinationImageNames = destTagNames
+            .Select(tag => $"'{DockerHelper.GetImageName(destAcrName, tag)}'")
+            .ToList();
+        string formattedDestinationImages = string.Join(", ", destinationImageNames);
+        _loggerService.WriteMessage($"{action} {formattedDestinationImages} from '{sourceImageName}'");
 
         if (!isDryRun)
         {
@@ -86,13 +89,17 @@ public class CopyImageService : ICopyImageService
             }
             catch (Exception e)
             {
-                string errorMsg = $"Importing Failure: {formattedDestTagNames}";
+                string errorMsg = $"Importing Failure: {formattedDestinationImages}";
                 errorMsg += Environment.NewLine + e.ToString();
 
                 _loggerService.WriteMessage(errorMsg);
 
                 throw;
             }
+        }
+        else
+        {
+            _loggerService.WriteMessage("Importing skipped due to dry run.");
         }
     }
 }


### PR DESCRIPTION
During a dry run of image copy commands, the output currently looks like this:

```console
Importing '${acrName}/${publishRepoPrefix}/dotnet/nightly/runtime-deps:9.0-alpine3.21-aot-arm32v7' from '${imageStagingPath}/dotnet/nightly/runtime-deps:9.0-alpine3.21-aot-arm32v7'
```

That's misleading since it is not actually importing anything during a dry-run. This PR changes the output to be more clear that it's a dry run. Something like:

```console
(Dry run) Would have imported '${acrName}/${publishRepoPrefix}/dotnet/nightly/runtime-deps:9.0-alpine3.21-aot-arm32v7' from '${imageStagingPath}/dotnet/nightly/runtime-deps:9.0-alpine3.21-aot-arm32v7'
```