### PR TITLE
Add "[DRY RUN]" to process execution output logging

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
@@ -75,7 +75,8 @@ namespace Microsoft.DotNet.ImageBuilder
         {
             info.RedirectStandardError = true;
             executeMessageOverride ??= $"{info.FileName} {info.Arguments}";
-            s_loggerService.WriteSubheading($"EXECUTING: {executeMessageOverride}");
+            string prefix = isDryRun ? "EXECUTING [DRY RUN]" : "EXECUTING";
+            s_loggerService.WriteSubheading($"{prefix}: {executeMessageOverride}");
 
             if (isDryRun)
             {
@@ -91,7 +92,7 @@ namespace Microsoft.DotNet.ImageBuilder
             if (processResult.Process.ExitCode != 0)
             {
                 string exceptionMsg = errorMessage ?? $@"Failed to execute {info.FileName} {info.Arguments}
-                
+
                 {processResult.StandardError}";
 
                 throw new InvalidOperationException(exceptionMsg);


### PR DESCRIPTION
When the `--dry-run` option is passed, it's useful to know whether or not a given command was actually executed when inspecting logs.

Related: https://github.com/dotnet/docker-tools/pull/1691