### PR TITLE
Add more logging to IngestKustoImageInfo command

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/IngestKustoImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/IngestKustoImageInfoCommand.cs
@@ -129,7 +129,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             if (!Options.IsDryRun)
             {
-                await _kustoClient.IngestFromCsvAsync(info, Options.Cluster, Options.Database, table, Options.IsDryRun);
+                await _kustoClient.IngestFromCsvAsync(info, Options.Cluster, Options.Database, table);
+            }
+            else
+            {
+                _loggerService.WriteMessage($"(Dry run) Skipping ingestion of data into {table}.");
             }
         }
     }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Services/IKustoClient.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Services/IKustoClient.cs
@@ -8,7 +8,6 @@ namespace Microsoft.DotNet.ImageBuilder.Services
 {
     public interface IKustoClient
     {
-        Task IngestFromCsvAsync(
-            string csv, string cluster, string database, string table, bool isDryRun);
+        Task IngestFromCsvAsync(string csv, string cluster, string database, string table);
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/IngestKustoImageInfoCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/IngestKustoImageInfoCommandTests.cs
@@ -274,12 +274,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Mock<IKustoClient> kustoClientMock = new();
             kustoClientMock
                 .Setup(o => o.IngestFromCsvAsync(
-                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
-                .Callback<string, string, string, string, bool>(
-                    (csv, cluster, database, table, isDryRun) =>
-                    {
-                        ingestedData.Add(table, csv);
-                    });
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Callback<string, string, string, string>(
+                    (csv, cluster, database, table) => ingestedData.Add(table, csv));
             IngestKustoImageInfoCommand command = new(Mock.Of<ILoggerService>(), kustoClientMock.Object);
             command.Options.ImageInfoPath = imageInfoPath;
             command.Options.Manifest = manifestPath;
@@ -296,7 +293,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             _outputHelper.WriteLine($"Actual Layer Data: {Environment.NewLine}{ingestedData[command.Options.LayerTable]}");
 
             kustoClientMock.Verify(o => o.IngestFromCsvAsync(
-                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()));
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()));
             Assert.Equal(expectedImageData, ingestedData[command.Options.ImageTable]);
             Assert.Equal(expectedLayerData, ingestedData[command.Options.LayerTable]);
         }


### PR DESCRIPTION
- There was no logging when actually ingesting info into Kusto, or when skipping ingestion during a dry-run.
- The dryRun parameter of `IngestFromCsvAsync` was redundant. There is only one call-site for this command, which is already skipped during a dry-run.