### PR TITLE
Do not fail PublishImageInfo command when there are no changes to commit

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
@@ -81,6 +81,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             if (Options.IsDryRun)
             {
+                _loggerService.WriteMessage("Skipping commit and push due to dry run.");
                 return;
             }
 
@@ -90,7 +91,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             Commit commit;
             try
             {
+                _loggerService.WriteSubheading("Committing changes...");
                 commit = repo.Commit(CommitMessage, sig, sig);
+                _loggerService.WriteMessage($"Created commit {commit.Sha}: '{commit.Message}'");
             }
             catch (EmptyCommitException)
             {
@@ -108,7 +111,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 });
 
             Uri gitHubCommitUrl = GitHelper.GetCommitUrl(Options.GitOptions, commit.Sha);
-            _loggerService.WriteMessage($"The '{Options.GitOptions.Path}' file was updated: {gitHubCommitUrl}");
+            _loggerService.WriteMessage(
+                $"The '{Options.GitOptions.Path}' file was updated. Remote URL: {gitHubCommitUrl}");
         }
 
         private async Task<CredentialsHandler> GetCredentialsAsync()

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs
@@ -86,7 +86,17 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             _gitService.Stage(repo, imageInfoPath);
             Signature sig = new(Options.GitOptions.Username, Options.GitOptions.Email, DateTimeOffset.Now);
-            Commit commit = repo.Commit(CommitMessage, sig, sig);
+
+            Commit commit;
+            try
+            {
+                commit = repo.Commit(CommitMessage, sig, sig);
+            }
+            catch (EmptyCommitException)
+            {
+                _loggerService.WriteMessage("No changes detected in the image info file. Skipping commit and push.");
+                return;
+            }
 
             Branch branch = repo.Branches[Options.GitOptions.Branch];
 

--- a/src/Microsoft.DotNet.ImageBuilder/src/GitService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/GitService.cs
@@ -23,7 +23,6 @@ namespace Microsoft.DotNet.ImageBuilder
         {
             _logger.WriteMessage($"Cloning repository {sourceUrl} to {workdirPath}");
             Repository.Clone(sourceUrl, workdirPath, options);
-            _logger.WriteMessage($"Cloned repository {sourceUrl} to {workdirPath}");
             return new Repository(workdirPath);
         }
 
@@ -33,6 +32,7 @@ namespace Microsoft.DotNet.ImageBuilder
             // Due to the Stage method's dependency on the Diff class, it prevents it from being easily used
             // with its default implementation due to https://github.com/libgit2/libgit2sharp/issues/1856.
 
+            _logger.WriteMessage($"Staging {path} in repository {repository.Info.WorkingDirectory}");
             LibGit2Sharp.Commands.Stage(repository, path);
         }
     }

--- a/src/Microsoft.DotNet.ImageBuilder/src/GitService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/GitService.cs
@@ -2,14 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.ComponentModel.Composition;
 using LibGit2Sharp;
 
 namespace Microsoft.DotNet.ImageBuilder
 {
     [Export(typeof(IGitService))]
-    public class GitService : IGitService
+    [method: ImportingConstructor]
+    public class GitService(ILoggerService logger) : IGitService
     {
+        private readonly ILoggerService _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
         public string GetCommitSha(string filePath, bool useFullHash = false)
         {
             return GitHelper.GetCommitSha(filePath, useFullHash);
@@ -17,7 +21,9 @@ namespace Microsoft.DotNet.ImageBuilder
 
         public IRepository CloneRepository(string sourceUrl, string workdirPath, CloneOptions options)
         {
+            _logger.WriteMessage($"Cloning repository {sourceUrl} to {workdirPath}");
             Repository.Clone(sourceUrl, workdirPath, options);
+            _logger.WriteMessage($"Cloned repository {sourceUrl} to {workdirPath}");
             return new Repository(workdirPath);
         }
 


### PR DESCRIPTION
Before these changes, running PublishImageInfo would fail if there were no changes to commit. Now, it should skip committing and publishing and write a log message instead. I also added more logging to the command in general.