### PR TITLE
Use Azure DevOps logger formatting commands

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
@@ -135,11 +135,14 @@ namespace Microsoft.DotNet.ImageBuilder
             StringBuilder stdError = new StringBuilder();
             process.ErrorDataReceived += getDataReceivedHandler(stdError, Console.Error);
 
-            process.Start();
-            processStartedCallback?.Invoke(process);
-            process.BeginOutputReadLine();
-            process.BeginErrorReadLine();
-            process.WaitForExit();
+            using (new LoggingGroup("Command output"))
+            {
+                process.Start();
+                processStartedCallback?.Invoke(process);
+                process.BeginOutputReadLine();
+                process.BeginErrorReadLine();
+                process.WaitForExit();
+            }
 
             return new ProcessResult(process, stdOutput.ToString().Trim(), stdError.ToString().Trim());
         }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
@@ -134,7 +134,7 @@ namespace Microsoft.DotNet.ImageBuilder
             StringBuilder stdError = new StringBuilder();
             process.ErrorDataReceived += getDataReceivedHandler(stdError, Console.Error);
 
-            using (new LoggingGroup("Command output"))
+            using (s_loggerService.LogGroup("Command output"))
             {
                 process.Start();
                 processStartedCallback?.Invoke(process);

--- a/src/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
@@ -76,7 +76,6 @@ namespace Microsoft.DotNet.ImageBuilder
             info.RedirectStandardError = true;
             executeMessageOverride ??= $"{info.FileName} {info.Arguments}";
             string prefix = isDryRun ? "Executing (dry-run)" : "Executing";
-
             s_loggerService.WriteCommand($"{prefix}: {executeMessageOverride}");
 
             if (isDryRun)

--- a/src/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ExecuteHelper.cs
@@ -75,8 +75,9 @@ namespace Microsoft.DotNet.ImageBuilder
         {
             info.RedirectStandardError = true;
             executeMessageOverride ??= $"{info.FileName} {info.Arguments}";
-            string prefix = isDryRun ? "EXECUTING [DRY RUN]" : "EXECUTING";
-            s_loggerService.WriteSubheading($"{prefix}: {executeMessageOverride}");
+            string prefix = isDryRun ? "Executing (dry-run)" : "Executing";
+
+            s_loggerService.WriteCommand($"{prefix}: {executeMessageOverride}");
 
             if (isDryRun)
             {
@@ -87,13 +88,16 @@ namespace Microsoft.DotNet.ImageBuilder
             stopwatch.Start();
             ProcessResult processResult = executor(info);
             stopwatch.Stop();
-            s_loggerService.WriteSubheading($"EXECUTION ELAPSED TIME: {stopwatch.Elapsed}");
+            s_loggerService.WriteMessage($"Execution elapsed time: {stopwatch.Elapsed}");
 
             if (processResult.Process.ExitCode != 0)
             {
-                string exceptionMsg = errorMessage ?? $@"Failed to execute {info.FileName} {info.Arguments}
+                string exceptionMsg = errorMessage ??
+                    $"""
+                    Failed to execute {executeMessageOverride}
 
-                {processResult.StandardError}";
+                    {processResult.StandardError}
+                    """;
 
                 throw new InvalidOperationException(exceptionMsg);
             }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ILoggerService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ILoggerService.cs
@@ -4,16 +4,15 @@
 
 #nullable enable
 
-namespace Microsoft.DotNet.ImageBuilder
+namespace Microsoft.DotNet.ImageBuilder;
+
+public interface ILoggerService
 {
-    public interface ILoggerService
-    {
-        void WriteError(string error);
-        void WriteHeading(string heading);
-        void WriteMessage(string? message = null);
-        void WriteSubheading(string subheading);
-        void WriteWarning(string message);
-        void WriteDebug(string message);
-        void WriteCommand(string command);
-    }
+    void WriteError(string error);
+    void WriteHeading(string heading);
+    void WriteMessage(string? message = null);
+    void WriteSubheading(string subheading);
+    void WriteWarning(string message);
+    void WriteDebug(string message);
+    void WriteCommand(string command);
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ILoggerService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ILoggerService.cs
@@ -4,15 +4,66 @@
 
 #nullable enable
 
+using System;
+
 namespace Microsoft.DotNet.ImageBuilder;
 
 public interface ILoggerService
 {
+    /// <summary>
+    /// Writes an error message to the log.
+    /// </summary>
+    /// <param name="error">The error message to log.</param>
     void WriteError(string error);
+
+    /// <summary>
+    /// Writes a heading to the log, typically used for major sections or
+    /// operations.
+    /// </summary>
+    /// <param name="heading">The heading text to log.</param>
     void WriteHeading(string heading);
+
+    /// <summary>
+    /// Writes a general message to the log.
+    /// </summary>
+    /// <param name="message">The message to log. Can be null.</param>
     void WriteMessage(string? message = null);
+
+    /// <summary>
+    /// Writes a subheading to the log, typically used for sub-sections within
+    /// a headed section.
+    /// </summary>
+    /// <param name="subheading">The subheading text to log.</param>
     void WriteSubheading(string subheading);
+
+    /// <summary>
+    /// Writes a warning message to the log.
+    /// </summary>
+    /// <param name="message">The warning message to log.</param>
     void WriteWarning(string message);
+
+    /// <summary>
+    /// Writes a debug message to the log that might only be shown in verbose
+    /// logging modes.
+    /// </summary>
+    /// <param name="message">The debug message to log.</param>
     void WriteDebug(string message);
+
+    /// <summary>
+    /// Writes a command execution message to the log. This does not actually
+    /// execute the command or capture its output. It is intended to record
+    /// that a command was executed.
+    /// </summary>
+    /// <param name="command">
+    /// The command to log, including executable name and all arguments
+    /// </param>
     void WriteCommand(string command);
+
+    /// <summary>
+    /// Creates a logical grouping of log messages. Useful for grouping large
+    /// amounts of related text, like executable/process output.
+    /// </summary>
+    /// <param name="name">The name of the group.</param>
+    /// <returns>An IDisposable that when disposed will end the group.</returns>
+    IDisposable LogGroup(string name);
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ILoggerService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ILoggerService.cs
@@ -2,14 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace Microsoft.DotNet.ImageBuilder
 {
     public interface ILoggerService
     {
         void WriteError(string error);
         void WriteHeading(string heading);
-        void WriteMessage();
-        void WriteMessage(string message);
+        void WriteMessage(string? message = null);
         void WriteSubheading(string subheading);
+        void WriteWarning(string message);
+        void WriteDebug(string message);
+        void WriteCommand(string command);
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Logger.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Logger.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 
 namespace Microsoft.DotNet.ImageBuilder
@@ -20,12 +22,7 @@ namespace Microsoft.DotNet.ImageBuilder
             Console.WriteLine(new string('-', heading.Length));
         }
 
-        public static void WriteMessage()
-        {
-            Console.WriteLine();
-        }
-
-        public static void WriteMessage(string message)
+        public static void WriteMessage(string? message = null)
         {
             Console.WriteLine(message);
         }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Logger.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Logger.cs
@@ -10,7 +10,7 @@ namespace Microsoft.DotNet.ImageBuilder
     {
         public static void WriteError(string error)
         {
-            Console.Error.WriteLine(error);
+            Console.Error.WriteLine($"##[error]{error}");
         }
 
         public static void WriteHeading(string heading)
@@ -32,7 +32,22 @@ namespace Microsoft.DotNet.ImageBuilder
 
         public static void WriteSubheading(string subheading)
         {
-            WriteMessage($"-- {subheading}");
+            WriteMessage($"##[section]{subheading}");
+        }
+
+        public static void WriteCommand(string command)
+        {
+            WriteMessage($"##[command]{command}");
+        }
+
+        public static void WriteWarning(string message)
+        {
+            WriteMessage($"##[warning]{message}");
+        }
+
+        public static void WriteDebug(string message)
+        {
+            WriteMessage($"##[debug]{message}");
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Logger.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Logger.cs
@@ -6,45 +6,44 @@
 
 using System;
 
-namespace Microsoft.DotNet.ImageBuilder
+namespace Microsoft.DotNet.ImageBuilder;
+
+public static class Logger
 {
-    public static class Logger
+    public static void WriteError(string error)
     {
-        public static void WriteError(string error)
-        {
-            Console.Error.WriteLine($"##[error]{error}");
-        }
+        Console.Error.WriteLine($"##[error]{error}");
+    }
 
-        public static void WriteHeading(string heading)
-        {
-            Console.WriteLine();
-            Console.WriteLine(heading);
-            Console.WriteLine(new string('-', heading.Length));
-        }
+    public static void WriteHeading(string heading)
+    {
+        Console.WriteLine();
+        Console.WriteLine(heading);
+        Console.WriteLine(new string('-', heading.Length));
+    }
 
-        public static void WriteMessage(string? message = null)
-        {
-            Console.WriteLine(message);
-        }
+    public static void WriteMessage(string? message = null)
+    {
+        Console.WriteLine(message);
+    }
 
-        public static void WriteSubheading(string subheading)
-        {
-            WriteMessage($"##[section]{subheading}");
-        }
+    public static void WriteSubheading(string subheading)
+    {
+        WriteMessage($"##[section]{subheading}");
+    }
 
-        public static void WriteCommand(string command)
-        {
-            WriteMessage($"##[command]{command}");
-        }
+    public static void WriteCommand(string command)
+    {
+        WriteMessage($"##[command]{command}");
+    }
 
-        public static void WriteWarning(string message)
-        {
-            WriteMessage($"##[warning]{message}");
-        }
+    public static void WriteWarning(string message)
+    {
+        WriteMessage($"##[warning]{message}");
+    }
 
-        public static void WriteDebug(string message)
-        {
-            WriteMessage($"##[debug]{message}");
-        }
+    public static void WriteDebug(string message)
+    {
+        WriteMessage($"##[debug]{message}");
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/LoggerService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/LoggerService.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.ComponentModel.Composition;
 
 namespace Microsoft.DotNet.ImageBuilder
@@ -19,12 +21,7 @@ namespace Microsoft.DotNet.ImageBuilder
             Logger.WriteHeading(heading);
         }
 
-        public void WriteMessage()
-        {
-            Logger.WriteMessage();
-        }
-
-        public void WriteMessage(string message)
+        public void WriteMessage(string? message = null)
         {
             Logger.WriteMessage(message);
         }
@@ -32,6 +29,21 @@ namespace Microsoft.DotNet.ImageBuilder
         public void WriteSubheading(string subheading)
         {
             Logger.WriteSubheading(subheading);
+        }
+
+        public void WriteCommand(string command)
+        {
+            Logger.WriteCommand(command);
+        }
+
+        public void WriteWarning(string message)
+        {
+            Logger.WriteWarning(message);
+        }
+
+        public void WriteDebug(string message)
+        {
+            Logger.WriteDebug(message);
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/LoggerService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/LoggerService.cs
@@ -4,6 +4,7 @@
 
 #nullable enable
 
+using System;
 using System.ComponentModel.Composition;
 
 namespace Microsoft.DotNet.ImageBuilder
@@ -11,39 +12,52 @@ namespace Microsoft.DotNet.ImageBuilder
     [Export(typeof(ILoggerService))]
     internal class LoggerService : ILoggerService
     {
+        /// <inheritdoc />
         public void WriteError(string error)
         {
             Logger.WriteError(error);
         }
 
+        /// <inheritdoc />
         public void WriteHeading(string heading)
         {
             Logger.WriteHeading(heading);
         }
 
+        /// <inheritdoc />
         public void WriteMessage(string? message = null)
         {
             Logger.WriteMessage(message);
         }
 
+        /// <inheritdoc />
         public void WriteSubheading(string subheading)
         {
             Logger.WriteSubheading(subheading);
         }
 
+        /// <inheritdoc />
         public void WriteCommand(string command)
         {
             Logger.WriteCommand(command);
         }
 
+        /// <inheritdoc />
         public void WriteWarning(string message)
         {
             Logger.WriteWarning(message);
         }
 
+        /// <inheritdoc />
         public void WriteDebug(string message)
         {
             Logger.WriteDebug(message);
+        }
+
+        /// <inheiritdoc />
+        public IDisposable LogGroup(string name)
+        {
+            return new LoggingGroup(name, this);
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/LoggingGroup.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/LoggingGroup.cs
@@ -17,15 +17,19 @@ namespace Microsoft.DotNet.ImageBuilder;
 /// </remarks>
 internal sealed class LoggingGroup : IDisposable
 {
+    private readonly ILoggerService _logger;
+
     /// <summary>
     /// Creates a new collapsible logging group. When this object is created,
     /// all subsequent logging output will be inside this group until this
     /// object is disposed.
     /// </summary>
-    /// <param name="groupName">The name of the logging group.</param>
-    public LoggingGroup(string name)
+    /// <param name="groupName">The name of the logging group</param>
+    /// <param name="loggerService">The logger service to use for output</param>
+    public LoggingGroup(string name, ILoggerService loggerService)
     {
-        Console.WriteLine($"##[group]{name}");
+        _logger = loggerService;
+        _logger.WriteMessage($"##[group]{name}");
     }
 
     /// <summary>
@@ -33,6 +37,6 @@ internal sealed class LoggingGroup : IDisposable
     /// </summary>
     public void Dispose()
     {
-        Console.WriteLine($"##[endgroup]");
+        _logger.WriteMessage($"##[endgroup]");
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/LoggingGroup.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/LoggingGroup.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+
+namespace Microsoft.DotNet.ImageBuilder;
+
+/// <summary>
+/// Manages an Azure Pipelines collapsible logging group.
+/// Disposing of the object closes the logging group.
+/// </summary>
+/// <remarks>
+/// See https://learn.microsoft.com/azure/devops/pipelines/scripts/logging-commands
+/// </remarks>
+internal sealed class LoggingGroup : IDisposable
+{
+    /// <summary>
+    /// Creates a new collapsible logging group. When this object is created,
+    /// all subsequent logging output will be inside this group until this
+    /// object is disposed.
+    /// </summary>
+    /// <param name="groupName">The name of the logging group.</param>
+    public LoggingGroup(string name)
+    {
+        Console.WriteLine($"##[group]{name}");
+    }
+
+    /// <summary>
+    /// Ends the current collapsible logging group.
+    /// </summary>
+    public void Dispose()
+    {
+        Console.WriteLine($"##[endgroup]");
+    }
+}

--- a/src/Microsoft.DotNet.ImageBuilder/src/LoggingGroup.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/LoggingGroup.cs
@@ -11,9 +11,11 @@ namespace Microsoft.DotNet.ImageBuilder;
 /// <summary>
 /// Manages an Azure Pipelines collapsible logging group.
 /// Disposing of the object closes the logging group.
+/// See https://learn.microsoft.com/azure/devops/pipelines/scripts/logging-commands
 /// </summary>
 /// <remarks>
-/// See https://learn.microsoft.com/azure/devops/pipelines/scripts/logging-commands
+/// Only one LoggingGroup can be open at a time. If a second group is created
+/// without closing the first, then the first group will not be collapsible.
 /// </remarks>
 internal sealed class LoggingGroup : IDisposable
 {


### PR DESCRIPTION
This is an attempt at making ImageBuilder's logging output easier to parse by using Azure Pipelines' built-in log formatting commands: https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#logging-command-format

The big one is the collapsible groups. If this makes any individual commands harder to read, we can adjust the output of those commands as necessary in follow-ups.