### PR TITLE
Fix functionality of --no-version-logging CLI option

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/Command.TOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/Command.TOptions.cs
@@ -47,7 +47,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             cmd.Handler = CommandHandler.Create<TOptions>(options =>
             {
-                if (!Options.NoVersionLogging)
+                if (!options.NoVersionLogging)
                 {
                     LogDockerVersions();
                 }


### PR DESCRIPTION
Related: #1508 

This CLI option never worked because of a typo/logic error. It tried to access the instance variable `Options` before `Initialize`, so it always returned false and never actually skipped the logging.