### PR TITLE
Update Image Builder tag reference

### DIFF
--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2708614
+  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2718660
   imageNames.imageBuilder: $(imageNames.imageBuilderName)
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux3.0-docker-testrunner


### PR DESCRIPTION
This commit was accidentally overwritten from https://github.com/dotnet/docker-tools/pull/1710, which is causing the [eng-validation](https://dev.azure.com/dnceng/internal/_build/results?buildId=2719401&view=results) pipeline to fail internally.