### PR TITLE
Declare service connections in eng-validation pipeline

### DIFF
--- a/eng/pipelines/dotnet-docker-tools-eng-validation.yml
+++ b/eng/pipelines/dotnet-docker-tools-eng-validation.yml
@@ -15,6 +15,12 @@ variables:
 extends:
   template: /eng/common/templates/1es-official.yml@self
   parameters:
+    serviceConnections:
+    - name: $(internal-mirror.serviceConnectionName)
+    - name: $(build.serviceConnectionName)
+    - name: $(publish.serviceConnectionName)
+    - name: $(kusto.serviceConnectionName)
+    - name: $(marStatus.serviceConnectionName)
     stages:
     - template: /eng/common/templates/stages/dotnet/build-test-publish-repo.yml@self
       parameters:


### PR DESCRIPTION
These changes were missing from https://github.com/dotnet/docker-tools/pull/1710, which updated the image-builder pipeline with service connection declarations but left out the eng-validation pipeline.