### PR TITLE
Fix service connection authentication for Windows build jobs

### DIFF
--- a/eng/common/templates/steps/init-docker-linux.yml
+++ b/eng/common/templates/steps/init-docker-linux.yml
@@ -59,8 +59,10 @@ steps:
         )
 
         $authedDockerRunArgs = @(
-          '-e SYSTEM_ACCESSTOKEN=$(System.AccessToken)'
-          '-e SYSTEM_OIDCREQUESTURI=$(System.OidcRequestUri)'
+          '-e'
+          'SYSTEM_ACCESSTOKEN=$env:SYSTEM_ACCESSTOKEN'
+          '-e'
+          'SYSTEM_OIDCREQUESTURI=$env:SYSTEM_OIDCREQUESTURI'
         )
 
         $dockerRunCmd = $dockerRunBaseCmd + $dockerRunArgs

--- a/eng/common/templates/steps/init-docker-windows.yml
+++ b/eng/common/templates/steps/init-docker-windows.yml
@@ -44,14 +44,5 @@ steps:
       targetType: 'inline'
       script: |
         $runImageBuilderCmd = "$(Build.BinariesDirectory)\.Microsoft.DotNet.ImageBuilder\Microsoft.DotNet.ImageBuilder.exe"
-
-        $authedImageBuilderCmds = @(
-          '$env:SYSTEM_ACCESSTOKEN = $(System.AccessToken)'
-          '$env:SYSTEM_OIDCREQUESTURI = $(System.OidcRequestUri)'
-          $runImageBuilderCmd
-        )
-
-        $runAuthedImageBuilderCmd = $($authedImageBuilderCmds -join "; ")
-
         Write-Host "##vso[task.setvariable variable=runImageBuilderCmd]$runImageBuilderCmd"
-        Write-Host "##vso[task.setvariable variable=runAuthedImageBuilderCmd]$runAuthedImageBuilderCmd"
+        Write-Host "##vso[task.setvariable variable=runAuthedImageBuilderCmd]$runImageBuilderCmd"

--- a/eng/common/templates/steps/run-imagebuilder.yml
+++ b/eng/common/templates/steps/run-imagebuilder.yml
@@ -42,6 +42,9 @@ steps:
     displayName: ${{ parameters.displayName }}
     continueOnError: ${{ parameters.continueOnError }}
     condition: ${{ parameters.condition }}
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+      SYSTEM_OIDCREQUESTURI: $(System.OidcRequestUri)
     inputs:
       targetType: 'inline'
       script: |


### PR DESCRIPTION
This is a follow-up to https://github.com/dotnet/docker-tools/pull/1714.

Windows build jobs were failing because the imagebuilder run command was incorrectly formatted. Since Windows does not currently run in containers, there is no longer a need to have different authenticated/unauthenticated commands, making init-docker-windows a lot simpler. Also, both Windows and Linux jobs now get the System.AccessToken directly from the environment in the run-imagebuilder template, instead of relying on encoding it in the runAuthedImageBuilderCmd variable.

Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2720027&view=logs&j=91b26311-6486-5794-a17b-4b6d2c23aaa2&t=44ef184b-cb45-543e-6cc4-fa9bc5753fb1

