### PR TITLE
Minor improvements to import-image pipeline

### DIFF
--- a/eng/pipelines/import-image.yml
+++ b/eng/pipelines/import-image.yml
@@ -30,6 +30,7 @@ extends:
   parameters:
     stages:
     - stage: Import
+      dependsOn: []
       jobs:
       - job: Import
         steps:

--- a/eng/pipelines/import-image.yml
+++ b/eng/pipelines/import-image.yml
@@ -1,5 +1,7 @@
 # Imports an image from a 3rd party registry to the public mirror registry
 
+name: $(Date:yyyyMMdd).$(Rev:r)-${{ replace(replace(parameters.imageName, '/', '_'), ':', '_') }}
+
 trigger: none
 pr: none
 


### PR DESCRIPTION
- Fix build parallelism with service connection stage
- Add custom build number
  - This makes it where you can tell what was imported by looking at the pipeline run. For example, importing `library/alpine:3.22` appends `-library_alpine_3.22` to the end of the build number. 