### PR TITLE
Add internal build storage account options to Build command

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/AzureScopes.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/AzureScopes.cs
@@ -10,4 +10,5 @@ internal static class AzureScopes
     public const string DefaultAzureManagementScope = "https://management.azure.com" + ScopeSuffix;
     public const string ContainerRegistryScope = "https://containerregistry.azure.net" + ScopeSuffix;
     public const string McrStatusScope = "api://c00053c3-a979-4ee6-b94e-941881e62d8e" + ScopeSuffix;
+    public const string StorageAccountScope = "https://storage.azure.com" + ScopeSuffix;
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/AzureTokenCredentialProvider.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/AzureTokenCredentialProvider.cs
@@ -40,7 +40,12 @@ internal class AzureTokenCredentialProvider : IAzureTokenCredentialProvider
             {
                 TokenCredential? credential = null;
 
-                if (serviceConnection is not null)
+                if (serviceConnection is not null
+                    // System.CommandLine can instantiate this class with default values (null) when it is not provided
+                    // on the command line, so we need to check for null values.
+                    && !string.IsNullOrEmpty(serviceConnection.ClientId)
+                    && !string.IsNullOrEmpty(serviceConnection.TenantId)
+                    && !string.IsNullOrEmpty(serviceConnection.ServiceConnectionId))
                 {
                     if (string.IsNullOrWhiteSpace(_systemAccessToken))
                     {

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
@@ -31,6 +31,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public string? OutputVariableName { get; set; }
         public string? Subscription { get; set; }
         public string? ResourceGroup { get; set; }
+        public bool Internal { get; set; }
     }
 
     public class BuildOptionsBuilder : ManifestOptionsBuilder
@@ -51,7 +52,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 propertyName: nameof(BuildOptions.AcrServiceConnection)),
             .._serviceConnectionOptionsBuilder.GetCliOptions(
                 alias: "storage-service-connection",
-                propertyName: nameof(BuildOptions.StorageServiceConnection)),
+                propertyName: nameof(BuildOptions.StorageServiceConnection),
+                description: "Storage account to use for internal builds."),
 
             CreateOption<bool>("push", nameof(BuildOptions.IsPushEnabled),
                 "Push built images to Docker registry"),
@@ -79,6 +81,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 "Azure subscription to operate on"),
             CreateOption<string>("acr-resource-group", nameof(BuildOptions.ResourceGroup),
                 "Azure resource group to operate on"),
+            CreateOption<bool>("internal", nameof(BuildOptions.Internal),
+                "When true, all Dockerfiles will be passed the build arg ACCESSTOKEN containing the access token "
+                + "for the storage account specified by the storage-service-connection option. If used without the "
+                + "option, then it will use the system's default Azure credential instead."),
         ];
 
         public override IEnumerable<Argument> GetCliArguments() =>

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildOptions.cs
@@ -16,6 +16,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public BaseImageOverrideOptions BaseImageOverrideOptions { get; set; } = new();
         public RegistryCredentialsOptions CredentialsOptions { get; set; } = new();
         public ServiceConnectionOptions? AcrServiceConnection { get; set; }
+        public ServiceConnectionOptions? StorageServiceConnection { get; set; }
 
         public bool IsPushEnabled { get; set; }
         public bool IsRetryEnabled { get; set; }
@@ -48,6 +49,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             .._serviceConnectionOptionsBuilder.GetCliOptions(
                 alias: "acr-service-connection",
                 propertyName: nameof(BuildOptions.AcrServiceConnection)),
+            .._serviceConnectionOptionsBuilder.GetCliOptions(
+                alias: "storage-service-connection",
+                propertyName: nameof(BuildOptions.StorageServiceConnection)),
 
             CreateOption<bool>("push", nameof(BuildOptions.IsPushEnabled),
                 "Push built images to Docker registry"),

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/ServiceConnectionOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/ServiceConnectionOptions.cs
@@ -18,12 +18,23 @@ public record ServiceConnectionOptions(
 
 public class ServiceConnectionOptionsBuilder
 {
-    public IEnumerable<Option> GetCliOptions(string alias, string propertyName) =>
-    [
-        CreateOption(
+    public IEnumerable<Option> GetCliOptions(string alias, string propertyName, string description = "")
+    {
+        const string FormatDescription = "Format: \"{tenantId}:{clientId}:{serviceConnectionId}\".";
+
+        if (!string.IsNullOrEmpty(description))
+        {
+            description += " " + FormatDescription;
+        }
+        else
+        {
+            description = FormatDescription;
+        }
+
+        var option = CreateOption(
             alias,
             propertyName,
-            "Service connection information in the format \"${tenantId}:${clientId}:${serviceConnectionId}\"",
+            description,
             parseArg: result =>
             {
                 var token = result.Tokens.Single();
@@ -33,6 +44,8 @@ public class ServiceConnectionOptionsBuilder
                     TenantId: serviceConnectionInfo[0],
                     ClientId: serviceConnectionInfo[1],
                     ServiceConnectionId: serviceConnectionInfo[2]);
-            })
-    ];
+            });
+
+        return [option];
+    }
 }


### PR DESCRIPTION
- Adds storage account service connection option to Build command
- Adds internal build option to Build command

This PR is in draft mode because it is missing unit tests and because it hasn't been tested end-to-end yet. In order to test this fully, I'm working on adding support to [update-dependencies](https://github.com/dotnet/dotnet-docker/tree/main/eng/update-dependencies) for the new staging storage account. Then, a full test of the staging pipeline can be ran.

Related:
- https://github.com/dotnet/dotnet-docker-internal/issues/7413
- https://github.com/dotnet/dotnet-docker/pull/6472