### PR TITLE
Use default unique ID in ImageBuilder pipeline variables

### DIFF
--- a/eng/pipelines/templates/variables/image-builder.yml
+++ b/eng/pipelines/templates/variables/image-builder.yml
@@ -1,7 +1,7 @@
 parameters:
 - name: sourceBuildPipelineRunId
   type: string
-  default: ''
+  default: '$(Build.BuildId)'
 
 variables:
 - template: /eng/pipelines/templates/variables/build-test-publish.yml@self


### PR DESCRIPTION
This should fix the PR validation failure that's happening in https://github.com/dotnet/docker-tools/pull/1719. The sourceBuildPipelineRunId wasn't being passed to eng/pipelines/templates/variables/image-builder.yml for PR validation. This PR makes the build ID the default in the image-builder variables template, since that's the template that depends on it.