### PR TITLE
Add string replace command to cottle templates

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateArtifactsCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateArtifactsCommand.cs
@@ -151,6 +151,17 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                                 args.Count > 2 ? args[2].AsString : null,
                                 trimTemplate: true).Result,
                         min: 1,
+                        max: 3)),
+                ["replace"] = Value.FromFunction(
+                    Function.CreatePure(
+                        (state, args) =>
+                        {
+                            string source = args[0].AsString;
+                            string oldValue = args[1].AsString;
+                            string newValue = args[2].AsString;
+                            return Value.FromString(source.Replace(oldValue, newValue));
+                        },
+                        min: 3,
                         max: 3))
             };
         }
@@ -192,7 +203,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             try
             {
-                IDocument document = Document.CreateDefault(template, _config).DocumentOrThrow;                
+                IDocument document = Document.CreateDefault(template, _config).DocumentOrThrow;
                 artifact = document.Render(Context.CreateBuiltin(symbols));
 
                 if (Options.IsVerbose)

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateReadmesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateReadmesCommandTests.cs
@@ -12,6 +12,7 @@ using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
 using Moq;
 using Newtonsoft.Json;
+using Shouldly;
 using Xunit;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
 
@@ -56,6 +57,23 @@ Referenced Template Content";
 
             generatedReadme = File.ReadAllText(Path.Combine(tempFolderContext.Path, RepoReadmePath));
             Assert.Equal(ExpectedRepoReadme.NormalizeLineEndings(generatedReadme), generatedReadme);
+        }
+
+        [Fact]
+        public async Task GenerateReadmesCommand_StringReplace()
+        {
+            const string Template = """
+                {{replace("Hello world!", "world", ".NET")}}
+                """;
+            const string Expected = "Hello .NET!";
+
+            using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
+            GenerateReadmesCommand command = InitializeCommand(tempFolderContext, Template);
+
+            await command.ExecuteAsync();
+
+            string generatedReadme = File.ReadAllText(Path.Combine(tempFolderContext.Path, ProductFamilyReadmePath));
+            generatedReadme.ShouldBe(Expected);
         }
 
         [Fact]


### PR DESCRIPTION
Cottle did not have a plain string find-and-replace function. This PR adds a custom `replace` function. Having this would make some parts of working with Dockerfile templates much simpler.