### PR TITLE
Make EOL annotation ingestion pipeline task respect `waitForIngestionEnabled` variable

### DIFF
--- a/eng/common/templates/steps/annotate-eol-digests.yml
+++ b/eng/common/templates/steps/annotate-eol-digests.yml
@@ -38,7 +38,7 @@ steps:
         tenantId: $(marStatus.serviceConnection.tenantId)
         clientId: $(marStatus.serviceConnection.clientId)
       internalProjectName: internal
-      condition: and(succeeded(), eq(variables['publishEolAnnotations'], 'true'))
+      condition: and(succeeded(), eq(variables['publishEolAnnotations'], 'true'), eq(variables['waitForIngestionEnabled'], 'true'))
       args: >-
         waitForMarAnnotationIngestion
         $(artifactsPath)/annotation-digests/annotation-digests.txt


### PR DESCRIPTION
Previously, it was impossible to skip the "Wait for Annotation Ingestion" task, even if `waitForIngestionEnabled` was set to false. This adds the missing condition so that the task can be skipped in case there is a problem with the MAR status API.