### PR TITLE
Set pipeline result to warning when auto builder skips queuing a build

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/QueueBuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/QueueBuildCommand.cs
@@ -137,6 +137,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         {
                             _loggerService.WriteMessage(
                                 PipelineHelper.FormatErrorCommand("Unable to queue build due to too many recent build failures."));
+                            _loggerService.WriteMessage(PipelineHelper.SetResult(PipelineResult.SucceededWithIssues));
                         }
                         else
                         {

--- a/src/Microsoft.DotNet.ImageBuilder/src/PipelineHelper.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/PipelineHelper.cs
@@ -2,14 +2,45 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace Microsoft.DotNet.ImageBuilder
-{
-    public static class PipelineHelper
-    {
-        public static string FormatOutputVariable(string variableName, string value) =>
-            $"##vso[task.setvariable variable={variableName};isoutput=true]{value}";
+#nullable enable
 
-        public static string FormatErrorCommand(string message) => $"##[error]{message}";
-        public static string FormatWarningCommand(string message) => $"##[warning]{message}";
-    }
+namespace Microsoft.DotNet.ImageBuilder;
+
+/// <summary>
+/// Formats logging messages for Azure pipelines.
+/// </summary>
+/// <remarks>
+/// See https://learn.microsoft.com/azure/devops/pipelines/scripts/logging-commands
+/// </remarks>
+public static class PipelineHelper
+{
+    public static string FormatOutputVariable(string variableName, string value) =>
+        $"##vso[task.setvariable variable={variableName};isoutput=true]{value}";
+
+    public static string FormatErrorCommand(string message) => $"##[error]{message}";
+
+    public static string FormatWarningCommand(string message) => $"##[warning]{message}";
+
+    public static string SetResult(PipelineResult result) => result switch
+    {
+        PipelineResult.Succeeded => SetResult("Succeeded"),
+        PipelineResult.SucceededWithIssues => SetResult("SucceededWithIssues"),
+        PipelineResult.Failed => SetResult("Failed"),
+        _ => ""
+    };
+
+    private static string SetResult(string resultText) => $"##vso[task.complete result={resultText}]";
+}
+
+/// <summary>
+/// Represents the result of a pipeline operation.
+/// </summary>
+/// <remarks>
+/// See https://learn.microsoft.com/azure/devops/pipelines/scripts/logging-commands#properties-2
+/// </remarks>
+public enum PipelineResult
+{
+    Succeeded,
+    SucceededWithIssues,
+    Failed
 }


### PR DESCRIPTION
I did not notice that the `check-base-image-updates` pipeline was not queuing some builds because the pipeline reported a status of "success" (i.e. green checkmark). This PR will make the pipeline finish with status "succeeded with issues" (i.e. yellow exclamation point) whenever we know there are base image updates but decide not to queue a build for any reason.