### PR TITLE
Remove duplicate manifest directory in Readme path in PublishMcrDocs command

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishMcrDocsCommand.cs
@@ -165,11 +165,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             foreach (string readmePath in readmePaths)
             {
-                string fullPath = Path.Combine(Manifest.Directory, readmePath);
-
-                string updatedReadMe = File.ReadAllText(fullPath);
+                string updatedReadMe = File.ReadAllText(readmePath);
                 updatedReadMe = ReadmeHelper.UpdateTagsListing(updatedReadMe, McrTagsPlaceholder);
-                readmes.Add(GetGitObject(productRepo, fullPath, updatedReadMe));
+                readmes.Add(GetGitObject(productRepo, readmePath, updatedReadMe));
             }
 
             return readmes.ToArray();


### PR DESCRIPTION
This was a bug. It was causing issues when publishing readmes with the changes from https://github.com/dotnet/docker-tools/pull/1744. The Manifest directory is already prepended to the readme path in [ManifestInfo.Create](https://github.com/dotnet/docker-tools/blob/4617aa8afdeb9f27267e3f80dd7fc3f5cba1662e/src/Microsoft.DotNet.ImageBuilder/src/ViewModel/ManifestInfo.cs#L85-L89). It was applied a second time in PublishMcrDocsCommand, causing publishing to fail because it couldn't find the readme file.

Related: https://github.com/dotnet/dotnet-docker/pull/6563