### PR TITLE
Add option to override commit for new images in image info

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/MergeImageInfoCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/MergeImageInfoCommand.cs
@@ -129,11 +129,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     ImageData? initialImage = initialRepo?.Images.FirstOrDefault(i => i.ProductVersion == currentImage.ProductVersion);
                     foreach (PlatformData currentPlatform in currentImage.Platforms)
                     {
-                        PlatformData? initialPlatform = initialImage?.Platforms.FirstOrDefault(p =>
-                            p.Dockerfile == currentPlatform.Dockerfile &&
-                            p.Architecture == currentPlatform.Architecture &&
-                            p.OsType == currentPlatform.OsType &&
-                            p.OsVersion == currentPlatform.OsVersion);
+                        PlatformData? initialPlatform = initialImage?.Platforms.FirstOrDefault(p => p.CompareTo(currentPlatform) == 0);
 
                         // If platform doesn't exist in initial or has been updated (different digest or commit), override CommitUrl
                         if (initialPlatform == null ||

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/MergeImageInfoOptions.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/MergeImageInfoOptions.cs
@@ -18,6 +18,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public string? InitialImageInfoPath { get; set; }
 
         public bool IsPublishScenario { get; set; }
+
+        public string? CommitOverride { get; set; }
     }
 
     public class MergeImageInfoOptionsBuilder : ManifestOptionsBuilder
@@ -38,6 +40,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     "Whether the files are being merged as part of publishing to a repo"),
                 CreateOption<string?>("initial-image-info-path", nameof(MergeImageInfoOptions.InitialImageInfoPath),
                     "Path to the image info file to be used as the initial merge target"),
+                CreateOption<string?>("commit-override", nameof(MergeImageInfoOptions.CommitOverride),
+                    "Override the commit in the commitUrl property for images that were updated compared to the"
+                    + " initial image info"),
             ];
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/MergeImageInfoFilesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/MergeImageInfoFilesCommandTests.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Commands;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
@@ -21,7 +20,7 @@ using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
-    public partial class MergeImageInfoFilesCommandTests
+    public class MergeImageInfoFilesCommandTests
     {
         [Fact]
         public async Task MergeImageInfoFilesCommand_HappyPath()


### PR DESCRIPTION
Part of https://github.com/dotnet/dotnet-docker/issues/6559.

The next step will be to add an option to the pipeline for triggering this behavior.