### PR TITLE
Add pipeline option for overriding image info commit SHA 

### DIFF
--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -7,6 +7,9 @@ parameters:
   sourceBuildPipelineRunId: ""
   versionsRepoRef: null
   versionsRepoPath: ""
+  # When true, overrides the commit SHA in merged image info files to use the current repository commit.
+  # This ensures that updated images reference the correct commit in their commitUrl properties.
+  overrideImageInfoCommit: false
 
 jobs:
 - job: Publish
@@ -33,6 +36,11 @@ jobs:
     value: $(artifactsPath)/imageInfo
   - name: sourceBuildIdOutputDir
     value: $(Build.ArtifactStagingDirectory)/sourceBuildId
+  - name: commitOverrideArg
+    ${{ if eq(parameters.overrideImageInfoCommit, true) }}:
+      value: --commit-override $(Build.SourceVersion)
+    ${{ else }}:
+      value: ''
   - ${{ parameters.customPublishVariables }}
 
   steps:
@@ -167,6 +175,7 @@ jobs:
       --manifest $(manifest)
       --publish
       --initial-image-info-path $(imageInfoContainerDir)/full-image-info-orig.json
+      $(commitOverrideArg)
     condition: and(succeeded(), eq(variables['publishImageInfo'], 'true'))
     displayName: Merge Image Info
 

--- a/eng/common/templates/stages/publish.yml
+++ b/eng/common/templates/stages/publish.yml
@@ -17,6 +17,12 @@ parameters:
   versionsRepoRef: null
   versionsRepoPath: "versions"
 
+  # When true, any updated images will have the SHA in their commit URL updated
+  # to the commit that this pipeline is running on, instead of the commit they
+  # were built from. Use in combination with isStandalonePublish to ensure that
+  # internally built images still reference public Dockerfiles.
+  overrideImageInfoCommit: false
+
 ################################################################################
 # Publish Images
 ################################################################################
@@ -70,3 +76,4 @@ stages:
         sourceBuildPipelineRunId: ${{ parameters.sourceBuildPipelineRunId }}
         versionsRepoRef: ${{ parameters.versionsRepoRef }}
         versionsRepoPath: ${{ parameters.versionsRepoPath }}
+        overrideImageInfoCommit: ${{ parameters.overrideImageInfoCommit }}


### PR DESCRIPTION
This PR is part of https://github.com/dotnet/dotnet-docker/issues/6559.
This depends on new version of ImageBuilder with the `--commit-override` CLI option from #1749. Which will be published shortly.