### PR TITLE
Optimize service connection setup stage

### DIFF
--- a/eng/common/templates/1es-official.yml
+++ b/eng/common/templates/1es-official.yml
@@ -62,8 +62,9 @@ extends:
         tsa:
           enabled: true
     stages:
-    - template: /eng/common/templates/stages/setup-service-connections.yml@self
-      parameters:
-        pool: ${{ parameters.pool }}
-        serviceConnections: ${{ parameters.serviceConnections }}
+    - ${{ if gt(length(parameters.serviceConnections), 0) }}:
+      - template: /eng/common/templates/stages/setup-service-connections.yml@self
+        parameters:
+          pool: ${{ parameters.pool }}
+          serviceConnections: ${{ parameters.serviceConnections }}
     - ${{ parameters.stages }}

--- a/eng/common/templates/1es-unofficial.yml
+++ b/eng/common/templates/1es-unofficial.yml
@@ -71,8 +71,9 @@ extends:
         tsa:
           enabled: true
     stages:
-    - template: /eng/common/templates/stages/setup-service-connections.yml@self
-      parameters:
-        pool: ${{ parameters.pool }}
-        serviceConnections: ${{ parameters.serviceConnections }}
+    - ${{ if gt(length(parameters.serviceConnections), 0) }}:
+      - template: /eng/common/templates/stages/setup-service-connections.yml@self
+        parameters:
+          pool: ${{ parameters.pool }}
+          serviceConnections: ${{ parameters.serviceConnections }}
     - ${{ parameters.stages }}

--- a/eng/common/templates/stages/setup-service-connections.yml
+++ b/eng/common/templates/stages/setup-service-connections.yml
@@ -22,7 +22,7 @@ stages:
     displayName: Setup service connections
     pool: ${{ parameters.pool }}
     steps:
-
+    - checkout: none
     - ${{ each serviceConnection in parameters.serviceConnections }}:
       - task: AzureCLI@2
         displayName: Setup ${{ serviceConnection.name }}


### PR DESCRIPTION
If no service connections are specified, this stage shouldn't be included. Also, it doesn't need to check out the repo (saves 40-50 seconds).