### PR TITLE
Move secrets into separate variable group

### DIFF
--- a/eng/common/templates/variables/dotnet/build-test-publish.yml
+++ b/eng/common/templates/variables/dotnet/build-test-publish.yml
@@ -23,11 +23,6 @@ variables:
 - name: officialRepoPrefixes
   value: public/,internal/private/,unlisted/
 
-- name: mcrDocsRepoInfo.authArgs
-  value: >-
-    --gh-private-key '$(GitHubApp-NET-Docker-MAR-Docs-Updater-PrivateKey)'
-    --gh-app-client-id '$(gitHubApp.marDocsUpdater.clientId)'
-    --gh-app-installation-id '$(gitHubApp.marDocsUpdater.microsoft.installationId)'
 - name: mcrDocsRepoInfo.userName
   value: $(gitHubApp.marDocsUpdater.userName)
 - name: mcrDocsRepoInfo.email
@@ -39,8 +34,6 @@ variables:
   value: dotnet
 - name: gitHubNotificationsRepoInfo.repo
   value: dotnet-docker-internal
-- name: gitHubNotificationsRepoInfo.authArgs
-  value: --gh-token '$(BotAccount-dotnet-docker-bot-PAT)'
 
 - name: gitHubVersionsRepoInfo.org
   value: dotnet
@@ -50,8 +43,6 @@ variables:
   value: main
 - name: gitHubVersionsRepoInfo.path
   value: ${{ variables.commonVersionsImageInfoPath }}
-- name: gitHubVersionsRepoInfo.authArgs
-  value: --gh-token '$(BotAccount-dotnet-docker-bot-PAT)'
 - name: gitHubVersionsRepoInfo.userName
   value: $(dotnetDockerBot.userName)
 - name: gitHubVersionsRepoInfo.email

--- a/eng/common/templates/variables/dotnet/build-test-publish.yml
+++ b/eng/common/templates/variables/dotnet/build-test-publish.yml
@@ -34,6 +34,12 @@ variables:
   value: dotnet
 - name: gitHubNotificationsRepoInfo.repo
   value: dotnet-docker-internal
+# $(gitHubNotificationsRepoInfo.authArgs) is needed by the "Post Publish
+# Notification" step in eng/common/templates/jobs/publish.yml#L271, even during
+# a dry-run. This value is a placeholder that gets replaced when referencing
+# the secrets.yml variable template.
+- name: gitHubNotificationsRepoInfo.authArgs
+  value: --gh-token 'placeholder'
 
 - name: gitHubVersionsRepoInfo.org
   value: dotnet

--- a/eng/common/templates/variables/dotnet/common.yml
+++ b/eng/common/templates/variables/dotnet/common.yml
@@ -16,6 +16,13 @@ variables:
 - name: internalProjectName
   value: internal
 
+# $(dockerHubRegistryCreds) is needed by the copy-base-images step in
+# eng/common/templates/stages/build-and-test.yml#L73-L78, even during a dry-run.
+# This is a placeholder that gets replaced when referencing the secrets.yml
+# variable template.
+- name: dockerHubRegistryCreds
+  value: --registry-creds 'docker.io=placeholder;placeholder'
+
 - name: linuxAmd64InternalPoolImage
   value: 1es-ubuntu-2204
 - name: linuxAmd64InternalPoolName

--- a/eng/common/templates/variables/dotnet/common.yml
+++ b/eng/common/templates/variables/dotnet/common.yml
@@ -15,8 +15,6 @@ variables:
   value: public
 - name: internalProjectName
   value: internal
-- name: dockerHubRegistryCreds
-  value: --registry-creds 'docker.io=$(dotnetDockerHubBot.userName);$(BotAccount-dotnet-dockerhub-bot-PAT)'
 
 - name: linuxAmd64InternalPoolImage
   value: 1es-ubuntu-2204
@@ -66,5 +64,3 @@ variables:
   value: Docker-2025-${{ variables['System.TeamProject'] }}
 
 - group: DotNet-Docker-Common-2
-- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-  - group: DotNet-Docker-Secrets

--- a/eng/common/templates/variables/dotnet/secrets.yml
+++ b/eng/common/templates/variables/dotnet/secrets.yml
@@ -1,0 +1,17 @@
+variables:
+- group: DotNet-Docker-Secrets
+
+- name: dockerHubRegistryCreds
+  value: --registry-creds 'docker.io=$(dotnetDockerHubBot.userName);$(BotAccount-dotnet-dockerhub-bot-PAT)'
+
+- name: gitHubNotificationsRepoInfo.authArgs
+  value: --gh-token '$(BotAccount-dotnet-docker-bot-PAT)'
+
+- name: gitHubVersionsRepoInfo.authArgs
+  value: --gh-token '$(BotAccount-dotnet-docker-bot-PAT)'
+
+- name: mcrDocsRepoInfo.authArgs
+  value: >-
+    --gh-private-key '$(GitHubApp-NET-Docker-MAR-Docs-Updater-PrivateKey)'
+    --gh-app-client-id '$(gitHubApp.marDocsUpdater.clientId)'
+    --gh-app-installation-id '$(gitHubApp.marDocsUpdater.microsoft.installationId)'

--- a/eng/pipelines/check-base-image-updates.yml
+++ b/eng/pipelines/check-base-image-updates.yml
@@ -11,6 +11,8 @@ schedules:
 
 variables:
 - template: /eng/pipelines/templates/variables/common.yml@self
+# Uses GitHub token to access the versions repo
+- template: /eng/common/templates/variables/dotnet/secrets.yml@self
 
 extends:
   template: /eng/common/templates/1es-official.yml@self

--- a/eng/pipelines/dotnet-buildtools-image-builder-official.yml
+++ b/eng/pipelines/dotnet-buildtools-image-builder-official.yml
@@ -22,6 +22,9 @@ variables:
 - template: /eng/pipelines/templates/variables/image-builder.yml@self
   parameters:
     sourceBuildPipelineRunId: ${{ parameters.sourceBuildPipelineRunId }}
+# Uses GitHub token to access the versions repo
+# Also uses DockerHub registry creds to avoid rate limiting
+- template: /eng/common/templates/variables/dotnet/secrets.yml@self
 - name: publishEolAnnotations
   value: true
 

--- a/eng/pipelines/import-image.yml
+++ b/eng/pipelines/import-image.yml
@@ -16,6 +16,8 @@ parameters:
 
 variables:
 - template: /eng/pipelines/templates/variables/common.yml@self
+# Uses DockerHub registry creds to avoid rate limiting
+- template: /eng/common/templates/variables/dotnet/secrets.yml@self
 - ${{ if eq(parameters.isDockerHubImage, 'true') }}:
   - name: normalizedImageName
     value: ${{ format('docker.io/{0}', parameters.imageName) }}

--- a/eng/pipelines/mirror-base-images.yml
+++ b/eng/pipelines/mirror-base-images.yml
@@ -17,6 +17,8 @@ parameters:
 
 variables:
 - template: /eng/common/templates/variables/dotnet/common.yml@self
+# Uses DockerHub registry creds to avoid rate limiting
+- template: /eng/common/templates/variables/dotnet/secrets.yml@self
 - name: mirrorRepoPrefix
   value: ""
 

--- a/eng/pipelines/push-common-updates.yml
+++ b/eng/pipelines/push-common-updates.yml
@@ -9,7 +9,9 @@ trigger:
 pr: none
 
 variables:
-- template: templates/variables/common.yml
+- template: /eng/pipelines/templates/variables/common.yml
+# Uses GitHub token to submit pull requests
+- template: /eng/common/templates/variables/dotnet/secrets.yml@self
 
 jobs:
 - job: Build

--- a/eng/pipelines/update-image-builder-tag.yml
+++ b/eng/pipelines/update-image-builder-tag.yml
@@ -13,7 +13,9 @@ resources:
       - Publish
 
 variables:
-- template: templates/variables/common.yml
+- template: /eng/pipelines/templates/variables/common.yml
+# Uses GitHub token to submit pull requests
+- template: /eng/common/templates/variables/dotnet/secrets.yml@self
 
 jobs:
 - job: Build


### PR DESCRIPTION
Previously, the secrets variable group was referenced from all internal pipelines. This made some pipelines over-privileged. Now, secrets should be referenced only by pipelines that need them. Additionally, pipelines that need them should reference them at the top-level template only, so that it's obvious which ones are using secrets.