### PR TITLE
Handle dry run for EOL annotation

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/LifecycleMetadataService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/LifecycleMetadataService.cs
@@ -70,7 +70,15 @@ public class LifecycleMetadataService : ILifecycleMetadataService
                 return false;
             }
 
-            lifecycleArtifactManifest = JsonConvert.DeserializeObject<Manifest>(output ?? string.Empty) ?? throw new Exception("Unable to deserialize manifest");
+            lifecycleArtifactManifest = JsonConvert.DeserializeObject<Manifest>(output ?? string.Empty)
+                ?? throw new Exception(
+                    $"""
+                    Unable to deserialize lifecycle metadata manifest from 'oras' output:
+                    
+                    {output}
+                    
+                    """
+                );
         }
         catch (InvalidOperationException ex)
         {

--- a/src/Microsoft.DotNet.ImageBuilder/src/LifecycleMetadataService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/LifecycleMetadataService.cs
@@ -64,6 +64,12 @@ public class LifecycleMetadataService : ILifecycleMetadataService
                 ],
                 isDryRun: isDryRun);
 
+            if (isDryRun)
+            {
+                lifecycleArtifactManifest = null;
+                return false;
+            }
+
             lifecycleArtifactManifest = JsonConvert.DeserializeObject<Manifest>(output ?? string.Empty) ?? throw new Exception("Unable to deserialize manifest");
         }
         catch (InvalidOperationException ex)


### PR DESCRIPTION
The changes from https://github.com/dotnet/docker-tools/pull/1768 are causing an error in dry runs:

```
-- EXECUTING [DRY RUN]: oras attach --artifact-type application/vnd.microsoft.artifact.lifecycle --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=2025-08-20" --format json $(acr-staging.server)/mirror/ubuntu.azurecr.io/ubuntu:noble
Unhandled exception: System.Exception: Unable to deserialize manifest
   at Microsoft.DotNet.ImageBuilder.LifecycleMetadataService.AnnotateEolDigest(String digest, DateOnly date, Boolean isDryRun, Manifest& lifecycleArtifactManifest) in /image-builder/src/LifecycleMetadataService.cs:line 67
   at Microsoft.DotNet.ImageBuilder.Commands.CopyBaseImagesCommand.ExecuteAsync() in /image-builder/src/Commands/CopyBaseImagesCommand.cs:line 88
```

This handles that by avoid the attempt to deserialize the result.