### PR TITLE
Revert "Set EOL annotation for staged images and mirrored base images" (#1768)

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/AnnotateEolDigestsCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/AnnotateEolDigestsCommand.cs
@@ -126,10 +126,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 return;
             }
 
-            if (!_lifecycleMetadataService.IsDigestAnnotatedForEol(digestData.Digest, Options.IsDryRun, out Manifest? existingAnnotationManifest))
+            if (!_lifecycleMetadataService.IsDigestAnnotatedForEol(digestData.Digest, _loggerService, Options.IsDryRun, out Manifest? existingAnnotationManifest))
             {
                 _loggerService.WriteMessage($"Annotating EOL for digest '{digestData.Digest}', date '{eolDate}'");
-                if (_lifecycleMetadataService.AnnotateEolDigest(digestData.Digest, eolDate.Value, Options.IsDryRun, out Manifest? createdAnnotationManifest))
+                if (_lifecycleMetadataService.AnnotateEolDigest(digestData.Digest, eolDate.Value, _loggerService, Options.IsDryRun, out Manifest? createdAnnotationManifest))
                 {
                     _createdAnnotationDigests.Add(createdAnnotationManifest.Reference);
                 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/BuildCommand.cs
@@ -23,12 +23,12 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private readonly IDockerService _dockerService;
         private readonly ILoggerService _loggerService;
         private readonly IGitService _gitService;
+        private readonly IProcessService _processService;
         private readonly Lazy<ICopyImageService> _copyImageService;
         private readonly Lazy<IManifestService> _manifestService;
         private readonly IRegistryCredentialsProvider _registryCredentialsProvider;
         private readonly IAzureTokenCredentialProvider _tokenCredentialProvider;
         private readonly IImageCacheService _imageCacheService;
-        private readonly ILifecycleMetadataService _lifecycleMetadataService;
         private readonly ImageDigestCache _imageDigestCache;
         private readonly List<TagInfo> _processedTags = new List<TagInfo>();
         private readonly HashSet<PlatformData> _builtPlatforms = new();
@@ -48,20 +48,20 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             IDockerService dockerService,
             ILoggerService loggerService,
             IGitService gitService,
+            IProcessService processService,
             ICopyImageServiceFactory copyImageServiceFactory,
             IManifestServiceFactory manifestServiceFactory,
             IRegistryCredentialsProvider registryCredentialsProvider,
             IAzureTokenCredentialProvider tokenCredentialProvider,
-            IImageCacheService imageCacheService,
-            ILifecycleMetadataService lifecycleMetadataService)
+            IImageCacheService imageCacheService)
         {
             _dockerService = new DockerServiceCache(dockerService ?? throw new ArgumentNullException(nameof(dockerService)));
             _loggerService = loggerService ?? throw new ArgumentNullException(nameof(loggerService));
             _gitService = gitService ?? throw new ArgumentNullException(nameof(gitService));
+            _processService = processService ?? throw new ArgumentNullException(nameof(processService));
             _registryCredentialsProvider = registryCredentialsProvider ?? throw new ArgumentNullException(nameof(registryCredentialsProvider));
             _tokenCredentialProvider = tokenCredentialProvider ?? throw new ArgumentNullException(nameof(tokenCredentialProvider));
             _imageCacheService = imageCacheService ?? throw new ArgumentNullException(nameof(imageCacheService));
-            _lifecycleMetadataService = lifecycleMetadataService ?? throw new ArgumentNullException(nameof(lifecycleMetadataService));
 
             // Lazily create services which need access to options
             ArgumentNullException.ThrowIfNull(copyImageServiceFactory);
@@ -738,15 +738,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 foreach (TagInfo tag in _processedTags)
                 {
                     _dockerService.PushImage(tag.FullyQualifiedName, Options.IsDryRun);
-
-                    // Immediately set the staged image as EOL to prevent it from being picked up by scanning.
-                    // We only care about scanning for the images hosted by MAR. Not all staged images make it to MAR,
-                    // and, for those that do, they may be replaced by more up-to-date images later on.
-                    _lifecycleMetadataService.AnnotateEolDigest(
-                        tag.FullyQualifiedName,
-                        DateOnly.FromDateTime(DateTime.UtcNow),
-                        Options.IsDryRun,
-                        out _);
                 }
             }
         }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CleanAcrImagesCommand.cs
@@ -295,7 +295,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         private bool HasExpiredEol(ArtifactManifestProperties manifest, int expirationDays)
         {
-            if(_lifecycleMetadataService.IsDigestAnnotatedForEol(manifest.RegistryLoginServer + "/" + manifest.RepositoryName + "@" + manifest.Digest, isDryRun: false, out Manifest? lifecycleArtifactManifest) &&
+            if(_lifecycleMetadataService.IsDigestAnnotatedForEol(manifest.RegistryLoginServer + "/" + manifest.RepositoryName + "@" + manifest.Digest, _loggerService, isDryRun: false, out Manifest? lifecycleArtifactManifest) &&
                 lifecycleArtifactManifest?.Annotations != null)
             {
                 return IsExpired(DateTimeOffset.Parse(lifecycleArtifactManifest.Annotations[LifecycleMetadataService.EndOfLifeAnnotation]), expirationDays);

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyBaseImagesCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/CopyBaseImagesCommand.cs
@@ -17,18 +17,15 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     public class CopyBaseImagesCommand : CopyImagesCommand<CopyBaseImagesOptions, CopyBaseImagesOptionsBuilder>
     {
         private readonly IGitService _gitService;
-        private readonly ILifecycleMetadataService _lifecycleMetadataService;
 
         [ImportingConstructor]
         public CopyBaseImagesCommand(
             ICopyImageServiceFactory copyImageServiceFactory,
             ILoggerService loggerService,
-            IGitService gitService,
-            ILifecycleMetadataService lifecycleMetadataService)
+            IGitService gitService)
             : base(copyImageServiceFactory, loggerService)
         {
             _gitService = gitService;
-            _lifecycleMetadataService = lifecycleMetadataService;
         }
 
         protected override string Description => "Copies external base images from their source registry to ACR";
@@ -72,25 +69,12 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 fullRegistryName = Options.RegistryOverride;
             }
 
-            IEnumerable<Task<string>> copyImageTasks = manifests
+            IEnumerable<Task> copyImageTasks = manifests
                 .SelectMany(manifest => GetFromImages(manifest))
                 .Distinct()
                 .Select(fromImage => CopyImageAsync(fromImage, fullRegistryName));
 
             await Task.WhenAll(copyImageTasks);
-
-            // Immediately set the copied images as EOL to prevent them from being picked up by scanning.
-            // We only care about scanning for the published product images which include layers of these base images
-            // that will be included as part of the scanning.
-            foreach (Task<string> copyImageTask in copyImageTasks)
-            {
-                string imageTag = copyImageTask.Result;
-                _lifecycleMetadataService.AnnotateEolDigest(
-                    imageTag,
-                    DateOnly.FromDateTime(DateTime.UtcNow),
-                    Options.IsDryRun,
-                    out _);
-            }
         }
 
         private IEnumerable<string> GetFromImages(ManifestInfo manifest) =>
@@ -98,7 +82,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 .Select(fromImage => Options.BaseImageOverrideOptions.ApplyBaseImageOverride(fromImage))
                 .Where(fromImage => !fromImage.StartsWith(manifest.Model.Registry));
 
-        private async Task<string> CopyImageAsync(string fromImage, string destinationRegistryName)
+        private Task CopyImageAsync(string fromImage, string destinationRegistryName)
         {
             fromImage = DockerHelper.NormalizeRepo(fromImage);
 
@@ -114,12 +98,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 };
             }
 
-            string destinationTag = $"{Options.RepoPrefix}{fromImage}";
-
-            await ImportImageAsync(destinationTag, destinationRegistryName, srcImage,
+            return ImportImageAsync($"{Options.RepoPrefix}{fromImage}", destinationRegistryName, srcImage,
                 srcRegistryName: registry, sourceCredentials: importSourceCreds);
-
-            return $"{destinationRegistryName}/{destinationTag}";
         }
     }
 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateEolAnnotationDataCommand.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/Commands/GenerateEolAnnotationDataCommand.cs
@@ -113,7 +113,7 @@ public class GenerateEolAnnotationDataCommand : Command<GenerateEolAnnotationDat
             Parallel.ForEach(unsupportedDigests, digest =>
             {
                 _loggerService.WriteMessage($"Checking digest for existing annotation: {digest.Digest}");
-                if (!_lifecycleMetadataService.IsDigestAnnotatedForEol(digest.Digest, Options.IsDryRun, out _))
+                if (!_lifecycleMetadataService.IsDigestAnnotatedForEol(digest.Digest, _loggerService, Options.IsDryRun, out _))
                 {
                     digetsToAnnotate.Add(digest);
                 }

--- a/src/Microsoft.DotNet.ImageBuilder/src/ILifecycleMetadataService.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ILifecycleMetadataService.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.ImageBuilder;
 
 public interface ILifecycleMetadataService
 {
-    bool IsDigestAnnotatedForEol(string digest, bool isDryRun, [MaybeNullWhen(false)] out Manifest lifecycleArtifactManifest);
+    bool IsDigestAnnotatedForEol(string digest, ILoggerService loggerService, bool isDryRun, [MaybeNullWhen(false)] out Manifest lifecycleArtifactManifest);
 
-    bool AnnotateEolDigest(string digest, DateOnly date, bool isDryRun, [MaybeNullWhen(false)] out Manifest lifecycleArtifactManifest);
+    bool AnnotateEolDigest(string digest, DateOnly date, ILoggerService loggerService, bool isDryRun, [MaybeNullWhen(false)] out Manifest lifecycleArtifactManifest);
 }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/AnnotateEolDigestsCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/AnnotateEolDigestsCommandTests.cs
@@ -50,9 +50,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             Manifest manifest;
             lifecycleMetadataServiceMock.Verify(
-                o => o.AnnotateEolDigest("digest1", _globalDate, It.IsAny<bool>(), out manifest));
+                o => o.AnnotateEolDigest("digest1", _globalDate, It.IsAny<ILoggerService>(), It.IsAny<bool>(), out manifest));
             lifecycleMetadataServiceMock.Verify(
-                o => o.AnnotateEolDigest("digest2", _specificDigestDate, It.IsAny<bool>(), out manifest));
+                o => o.AnnotateEolDigest("digest2", _specificDigestDate, It.IsAny<ILoggerService>(), It.IsAny<bool>(), out manifest));
 
             string[] expectedAnnotationDigests =
                 [
@@ -105,7 +105,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             Manifest manifest;
             lifecycleMetadataServiceMock.Verify(
-                o => o.AnnotateEolDigest(It.IsAny<string>(), It.IsAny<DateOnly>(), It.IsAny<bool>(), out manifest),
+                o => o.AnnotateEolDigest(It.IsAny<string>(), It.IsAny<DateOnly>(), It.IsAny<ILoggerService>(), It.IsAny<bool>(), out manifest),
                 Times.Never());
         }
 
@@ -127,7 +127,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             Manifest manifest;
             lifecycleMetadataServiceMock.Verify(
-                o => o.AnnotateEolDigest(It.IsAny<string>(), It.IsAny<DateOnly>(), It.IsAny<bool>(), out manifest),
+                o => o.AnnotateEolDigest(It.IsAny<string>(), It.IsAny<DateOnly>(), It.IsAny<ILoggerService>(), It.IsAny<bool>(), out manifest),
                 Times.Never());
         }
 
@@ -176,7 +176,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             };
 
             lifecycleMetadataServiceMock
-                .Setup(o => o.AnnotateEolDigest(It.Is<string>(digest => digest.Contains("digest1")), It.IsAny<DateOnly>(), It.IsAny<bool>(), out digest1Annotation))
+                .Setup(o => o.AnnotateEolDigest(It.Is<string>(digest => digest.Contains("digest1")), It.IsAny<DateOnly>(), It.IsAny<ILoggerService>(), It.IsAny<bool>(), out digest1Annotation))
                 .Returns(digestAnnotationIsSuccessful);
 
             Manifest digest2Annotation = new()
@@ -185,7 +185,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             };
 
             lifecycleMetadataServiceMock
-                .Setup(o => o.AnnotateEolDigest(It.Is<string>(digest => digest.Contains("digest2")), It.IsAny<DateOnly>(), It.IsAny<bool>(), out digest2Annotation))
+                .Setup(o => o.AnnotateEolDigest(It.Is<string>(digest => digest.Contains("digest2")), It.IsAny<DateOnly>(), It.IsAny<ILoggerService>(), It.IsAny<bool>(), out digest2Annotation))
                 .Returns(digestAnnotationIsSuccessful);
 
             return lifecycleMetadataServiceMock;
@@ -212,7 +212,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             }
 
             lifecycleMetadataServiceMock
-                .Setup(o => o.IsDigestAnnotatedForEol(digest, It.IsAny<bool>(), out manifest))
+                .Setup(o => o.IsDigestAnnotatedForEol(digest, It.IsAny<ILoggerService>(), It.IsAny<bool>(), out manifest))
                 .Returns(digestAlreadyAnnotated);
         }
     }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/CleanAcrImagesCommandTest.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/CleanAcrImagesCommandTest.cs
@@ -446,7 +446,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             }
 
             lifecycleMetadataServiceMock
-                .Setup(o => o.IsDigestAnnotatedForEol(reference, It.IsAny<bool>(), out manifest))
+                .Setup(o => o.IsDigestAnnotatedForEol(reference, It.IsAny<ILoggerService>(), It.IsAny<bool>(), out manifest))
                 .Returns(digestAlreadyAnnotated);
         }
     }

--- a/src/Microsoft.DotNet.ImageBuilder/tests/CopyBaseImagesCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/CopyBaseImagesCommandTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.IO;
 using System.Threading.Tasks;
 using Azure.ResourceManager.ContainerRegistry.Models;
@@ -12,9 +11,9 @@ using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
 using Moq;
 using Newtonsoft.Json;
 using Xunit;
-using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.CopyImageHelper;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.DockerfileHelper;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
+using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.CopyImageHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
@@ -28,14 +27,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
             Mock<IEnvironmentService> environmentServiceMock = new();
             Mock<ICopyImageService> copyImageServiceMock = new();
-            Mock<ILifecycleMetadataService> lifecycleMetadataServiceMock = new();
             var copyImageServiceFactoryMock = CreateCopyImageServiceFactoryMock(copyImageServiceMock.Object);
 
             CopyBaseImagesCommand command = new(
-                copyImageServiceFactoryMock.Object,
-                Mock.Of<ILoggerService>(),
-                Mock.Of<IGitService>(),
-                lifecycleMetadataServiceMock.Object);
+                copyImageServiceFactoryMock.Object, Mock.Of<ILoggerService>(), Mock.Of<IGitService>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.Subscription = subscriptionId;
             command.Options.ResourceGroup = "my resource group";
@@ -105,29 +100,6 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             }
 
             copyImageServiceMock.VerifyNoOtherCalls();
-
-            DateOnly today = DateOnly.FromDateTime(DateTime.UtcNow);
-            Models.Oci.Manifest outManifest = null;
-
-            var expectedAnnotationTags = new string[]
-            {
-                $"{registry}/{command.Options.RepoPrefix}arm32v7/base:tag",
-                $"{registry}/{command.Options.RepoPrefix}library/base:tag",
-                $"{registry}/{command.Options.RepoPrefix}my-registry.com/repo:tag"
-            };
-
-            foreach (var expectedTag in expectedAnnotationTags)
-            {
-                lifecycleMetadataServiceMock.Verify(
-                    o => o.AnnotateEolDigest(
-                        expectedTag,
-                        // Account for edge case of day boundaries between command execution and this check
-                        It.Is<DateOnly>(date => date == today || date.AddDays(1) == today || date.AddDays(-1) == today),
-                        It.IsAny<bool>(),
-                        out outManifest));
-            }
-
-            lifecycleMetadataServiceMock.VerifyNoOtherCalls();
         }
 
         /// <summary>
@@ -154,10 +126,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             var copyImageServiceFactoryMock = CreateCopyImageServiceFactoryMock(copyImageServiceMock.Object);
 
             CopyBaseImagesCommand command = new(
-                copyImageServiceFactoryMock.Object,
-                Mock.Of<ILoggerService>(),
-                Mock.Of<IGitService>(),
-                Mock.Of<ILifecycleMetadataService>());
+                copyImageServiceFactoryMock.Object, Mock.Of<ILoggerService>(), Mock.Of<IGitService>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.Subscription = subscriptionId;
             command.Options.ResourceGroup = "my resource group";

--- a/src/Microsoft.DotNet.ImageBuilder/tests/GenerateEolAnnotationDataCommandTests.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/tests/GenerateEolAnnotationDataCommandTests.cs
@@ -432,7 +432,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Manifest lifecycleArtifactManifest;
             Mock<ILifecycleMetadataService> lifecycleMetadataServiceMock = new();
             lifecycleMetadataServiceMock
-                .Setup(o => o.IsDigestAnnotatedForEol(armDigest, It.IsAny<bool>(), out lifecycleArtifactManifest))
+                .Setup(o => o.IsDigestAnnotatedForEol(armDigest, It.IsAny<ILoggerService>(), It.IsAny<bool>(), out lifecycleArtifactManifest))
                 .Returns(true);
 
             IContainerRegistryContentClientFactory registryContentClientFactory = CreateContainerRegistryContentClientFactory(AcrName,
@@ -1060,13 +1060,13 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Mock<ILifecycleMetadataService> lifecycleMetadataServiceMock = new();
             Manifest lifecycleArtifactManifest;
             lifecycleMetadataServiceMock
-                .Setup(o => o.IsDigestAnnotatedForEol(It.IsAny<string>(), It.IsAny<bool>(), out lifecycleArtifactManifest))
+                .Setup(o => o.IsDigestAnnotatedForEol(It.IsAny<string>(), It.IsAny<ILoggerService>(), It.IsAny<bool>(), out lifecycleArtifactManifest))
                 .Returns(false);
 
             foreach (KeyValuePair<string, bool> digestAnnotated in digestAnnotatedMapping)
             { 
                 lifecycleMetadataServiceMock
-                    .Setup(o => o.IsDigestAnnotatedForEol(digestAnnotated.Key, It.IsAny<bool>(), out lifecycleArtifactManifest))
+                    .Setup(o => o.IsDigestAnnotatedForEol(digestAnnotated.Key, It.IsAny<ILoggerService>(), It.IsAny<bool>(), out lifecycleArtifactManifest))
                     .Returns(digestAnnotated.Value);
             }
             


### PR DESCRIPTION
This reverts commit ba17c975099ea57a81c6e10bb4228f4401243b5a because it causes build failures on Windows agents:

```
Unhandled exception: System.ComponentModel.Win32Exception (0x80004005): An error occurred trying to start process 'oras' with working directory 'D:\a\_work\1\s'. The operation completed successfully.
```

Related to #1768, https://github.com/dotnet/dotnet-docker-internal/issues/7673