### PR TITLE
Revert "[main] Update Image Builder tag reference (#1769)"

### DIFF
--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2776519
+  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2770436
   imageNames.imageBuilder: $(imageNames.imageBuilderName)
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux3.0-docker-testrunner


### PR DESCRIPTION
This reverts commit 315d3bf3b9efc87e16bdd1aa112539526991a109.

Related to https://github.com/dotnet/docker-tools/pull/1772. We also need to revert the tag update to get back to a working pipeline so that we can publish the fixed Image Builder image.