### PR TITLE
Update imagebuilder pipeline source name

### DIFF
--- a/eng/pipelines/update-image-builder-tag.yml
+++ b/eng/pipelines/update-image-builder-tag.yml
@@ -4,7 +4,7 @@ pr: none
 resources:
   pipelines:
   - pipeline: image-builder
-    source: docker-tools-imagebuilder
+    source: docker-tools-imagebuilder-official
     trigger:
       branches:
         include:


### PR DESCRIPTION
The imagebuilder pipeline was renamed to `docker-tools-imagebuilder-official`, which caused this pipeline to start failing. It would be better to reference the pipeline by its ID, but I couldn't find a way to do that for pipeline resources.