### PR TITLE
Pass publishConfig through set-dry-run.yml template

### DIFF
--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -81,6 +81,8 @@ jobs:
       publicSourceBranch: $(publicSourceBranch)
 
   - template: /eng/common/templates/steps/set-dry-run.yml@self
+    parameters:
+      publishConfig: ${{ parameters.publishConfig }}
 
   - script: echo "##vso[task.setvariable variable=imageQueueTime]$(date --rfc-2822)"
     displayName: Set Publish Variables

--- a/eng/common/templates/steps/set-dry-run.yml
+++ b/eng/common/templates/steps/set-dry-run.yml
@@ -1,7 +1,6 @@
 parameters:
   name: publishConfig
   type: object
-  default: null
 
 steps:
 - powershell: |


### PR DESCRIPTION
Fixes #1781. This was left out of https://github.com/dotnet/docker-tools/pull/1771.

I also removed the default value so it will error if it's not passed in.