### PR TITLE
Register missing ImageBuilder commands

### DIFF
--- a/src/Microsoft.DotNet.ImageBuilder/src/ImageBuilder.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ImageBuilder.cs
@@ -64,6 +64,7 @@ public static class ImageBuilder
             builder.AddSingleton<ICommand, GetBaseImageStatusCommand>();
             builder.AddSingleton<ICommand, GetStaleImagesCommand>();
             builder.AddSingleton<ICommand, IngestKustoImageInfoCommand>();
+            builder.AddSingleton<ICommand, MergeImageInfoCommand>();
             builder.AddSingleton<ICommand, PostPublishNotificationCommand>();
             builder.AddSingleton<ICommand, PublishImageInfoCommand>();
             builder.AddSingleton<ICommand, PublishManifestCommand>();

--- a/src/Microsoft.DotNet.ImageBuilder/src/ImageBuilder.cs
+++ b/src/Microsoft.DotNet.ImageBuilder/src/ImageBuilder.cs
@@ -60,6 +60,7 @@ public static class ImageBuilder
             builder.AddSingleton<ICommand, GenerateDockerfilesCommand>();
             builder.AddSingleton<ICommand, GenerateEolAnnotationDataForAllImagesCommand>();
             builder.AddSingleton<ICommand, GenerateEolAnnotationDataForPublishCommand>();
+            builder.AddSingleton<ICommand, GenerateReadmesCommand>();
             builder.AddSingleton<ICommand, GenerateSigningPayloadsCommand>();
             builder.AddSingleton<ICommand, GetBaseImageStatusCommand>();
             builder.AddSingleton<ICommand, GetStaleImagesCommand>();


### PR DESCRIPTION
These two commands were missed from DI registration in #1786. This time, I validated that all commands were registered by comparing ImageBuilder's `--help` output before and after the changes.