### PR TITLE
Disable 1ES PT automatic SBOM generation in favor of manual SBOM generation for container images

### DIFF
--- a/eng/common/templates/1es.yml
+++ b/eng/common/templates/1es.yml
@@ -32,6 +32,13 @@ parameters:
     name: $(defaultSourceAnalysisPoolName)
     image: $(defaultSourceAnalysisPoolImage)
     os: windows
+# Container image SBOMs are generated manually during the build job. 1ESPT's
+# automatic SBOM generation only adds unnecessary steps and artifacts to
+# builds. SBOM is not needed for JSON outputs. If a pipeline outputs binary
+# artifacts that ship to customers, then set this parameter to true.
+- name: enableSbom
+  type: boolean
+  default: false
 
 resources:
   repositories:
@@ -47,10 +54,8 @@ extends:
     templateParameters:
       pool: ${{ parameters.pool }}
       sdl:
-        # Required for unofficial pipelines because we rely on the ManifestGeneratorTask that is
-        # automatically installed by 1ES pipeline templates
         sbom:
-          enabled: true
+          enabled: ${{ parameters.enableSbom }}
         binskim:
           enabled: true
         componentgovernance:


### PR DESCRIPTION
Fixes:
- https://github.com/dotnet/docker-tools/issues/1331

Also contributes to:
- https://github.com/dotnet/docker-tools/issues/1407

Successful unofficial pipeline run with these changes: https://dev.azure.com/dnceng/internal/_build/results?buildId=2789605&view=results [internal link]