### PR TITLE
Remove manifest-tool installation from Windows Dockerfile

### DIFF
--- a/src/Dockerfile.windows
+++ b/src/Dockerfile.windows
@@ -16,24 +16,6 @@ RUN dotnet restore -r win-x64 ./ImageBuilder/Microsoft.DotNet.ImageBuilder.cspro
 COPY . ./
 RUN dotnet publish ./ImageBuilder/Microsoft.DotNet.ImageBuilder.csproj -c Release -o out -r win-x64 --no-restore --self-contained
 
-# install manifest-tool
-RUN pwsh -Command " `
-        $ErrorActionPreference = 'Stop'; `
-        $ProgressPreference = 'SilentlyContinue'; `
-        $manifestToolVersion = '2.0.6'; `
-        Invoke-WebRequest `
-            -UseBasicParsing `
-            -Uri "https://github.com/estesp/manifest-tool/releases/download/v$manifestToolVersion/binaries-manifest-tool-$manifestToolVersion.tar.gz" `
-            -OutFile binaries-manifest-tool.tar.gz; `
-        $sha = '4d8a502f2d3b82a50cfde65274ff6df7ef6fe441dc65b96b595a70cc64ece5bc'; `
-        if ((Get-FileHash binaries-manifest-tool.tar.gz -Algorithm sha256).Hash -ne $sha) { `
-            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
-            exit 1; `
-        }; `
-        tar -zxf binaries-manifest-tool.tar.gz -C out manifest-tool-windows-amd64.exe; `
-        Move-Item out/manifest-tool-windows-amd64.exe out/manifest-tool.exe; `
-        Remove-Item binaries-manifest-tool.tar.gz;"
-
 # build runtime image
 FROM mcr.microsoft.com/windows/$WINDOWS_BASE
 WORKDIR /image-builder


### PR DESCRIPTION
The manifest-tool hasn't been used for a long time. It was removed from the Linux Dockerfile in https://github.com/dotnet/docker-tools/pull/1089 but not from the Windows Dockerfile.

This resolves some vulnerabilities that are showing up due to the installation of this tool.