### PR TITLE
Handle empty repo prefix for annotate-eol-digests.yml

### DIFF
--- a/eng/common/templates/steps/annotate-eol-digests.yml
+++ b/eng/common/templates/steps/annotate-eol-digests.yml
@@ -20,9 +20,9 @@ steps:
       condition: and(succeeded(), eq(variables['publishEolAnnotations'], 'true'))
       args: >-
         annotateEolDigests
-        ${{ parameters.dataFile }}
-        ${{ parameters.acr.server }}
-        ${{ parameters.acr.repoPrefix }}
+        "${{ parameters.dataFile }}"
+        "${{ parameters.acr.server }}"
+        "${{ parameters.acr.repoPrefix }}"
         $(artifactsPath)/annotation-digests/annotation-digests.txt
         $(dryRunArg)
   - template: /eng/common/templates/steps/publish-artifact.yml@self


### PR DESCRIPTION
The changes for https://github.com/dotnet/docker-tools/pull/1810 are failing when targeting the public mirror ACR with the following error: `Required argument missing for command: annotateEolDigests`.

This is because there is a repo prefix argument which is not specified. There is no repo prefix defined for the public mirror ACR, by design. The call to the command needs to handle this by using quotes as a placeholder for the argument.