### PR TITLE
Use unique artifact name for annotations

### DIFF
--- a/eng/common/templates/steps/annotate-eol-digests.yml
+++ b/eng/common/templates/steps/annotate-eol-digests.yml
@@ -28,7 +28,7 @@ steps:
   - template: /eng/common/templates/steps/publish-artifact.yml@self
     parameters:
       path: $(Build.ArtifactStagingDirectory)/annotation-digests
-      artifactName: annotation-digests-$(System.JobAttempt)
+      artifactName: annotation-digests-${{ parameters.acr.server }}-$(System.JobAttempt)
       displayName: Publish Annotation Digests List (${{ parameters.acr.server }})
       internalProjectName: internal
       publicProjectName: public


### PR DESCRIPTION
The changes from https://github.com/dotnet/docker-tools/pull/1810 cause the following error in the `Annotations` job when publishing the annotation artifact for the public mirror ACR: `##[error]Artifact annotation-digests-1 already exists for build 2801090`.

This is because it's the second time that annotations are being published in the same job and, in both instances, the artifact name is the same between them.

Fixed by using the ACR name in the artifact name to provide uniqueness.

The artifact is only meant for manual troubleshooting. No automation currently reads this artifact.