### PR TITLE
Add ACR clean action to pipeline step display names

### DIFF
--- a/eng/common/templates/steps/clean-acr-images.yml
+++ b/eng/common/templates/steps/clean-acr-images.yml
@@ -9,7 +9,13 @@ parameters:
 steps:
   - template: /eng/common/templates/steps/run-imagebuilder.yml@self
     parameters:
-      displayName: Clean ACR Images - ${{ parameters.repo }}
+      # Options are documented in CleanAcrImagesOptions.cs
+      ${{ if eq(parameters.action, 'delete') }}:
+        displayName: "Delete ${{ repo }}"
+      ${{ elseif parameters.age }}:
+        displayName: "Clean ${{ repo }} (${{ parameters.action }} > ${{ parameters.age }}d)"
+      ${{ else }}:
+        displayName: "Clean ${{ parameters.repo }} (${{ parameters.action }})"
       serviceConnections:
       - name: acr
         id: ${{ parameters.publishConfig.cleanServiceConnection.id }}

--- a/eng/pipelines/templates/steps/set-eol-annotations.yml
+++ b/eng/pipelines/templates/steps/set-eol-annotations.yml
@@ -6,7 +6,7 @@ parameters:
 steps:
   - template: /eng/common/templates/steps/run-imagebuilder.yml@self
     parameters:
-      displayName: Generate EOL Annotations (${{ parameters.acr.server }})
+      displayName: "Generate EOL Data for all images in ${{ parameters.acr.server }}"
       serviceConnections:
       - name: acr
         id: ${{ parameters.acr.serviceConnection.id }}

--- a/src/ImageBuilder/Commands/CleanAcrImagesOptions.cs
+++ b/src/ImageBuilder/Commands/CleanAcrImagesOptions.cs
@@ -60,7 +60,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         ];
     }
 
-    // Keep these values in sync with eng/pipelines/cleanup-acr-images-custom-official.yml
+    // Keep the following templates in sync with these values:
+    // - eng/pipelines/cleanup-acr-images-custom-official.yml
+    // - eng/common/templates/steps/clean-acr-images.yml
     public enum CleanAcrImagesAction
     {
         /// <summary>


### PR DESCRIPTION
The goal of this change is to make it easier to tell what the ACR cleanup pipelines are doing at a glance from the Azure Pipelines UI.