### PR TITLE
Add missing parameters prefix to clean-acr-images displayName template

### DIFF
--- a/eng/common/templates/steps/clean-acr-images.yml
+++ b/eng/common/templates/steps/clean-acr-images.yml
@@ -11,9 +11,9 @@ steps:
     parameters:
       # Options are documented in CleanAcrImagesOptions.cs
       ${{ if eq(parameters.action, 'delete') }}:
-        displayName: "Delete ${{ repo }}"
+        displayName: "Delete ${{ parameters.repo }}"
       ${{ elseif parameters.age }}:
-        displayName: "Clean ${{ repo }} (${{ parameters.action }} > ${{ parameters.age }}d)"
+        displayName: "Clean ${{ parameters.repo }} (${{ parameters.action }} > ${{ parameters.age }}d)"
       ${{ else }}:
         displayName: "Clean ${{ parameters.repo }} (${{ parameters.action }})"
       serviceConnections:


### PR DESCRIPTION
#1828 broke the cleanup-acr-images-official pipeline with the following error:

```
/eng/common/templates/steps/clean-acr-images.yml (Line: 14, Col: 22): Unrecognized value: 'repo'. Located at position 22 within expression: format('Delete {0}', repo). For more help, refer to https://go.microsoft.com/fwlink/?linkid=842996
```

[source pipeline run](https://dev.azure.com/dnceng/internal/_build?definitionId=951)

`repo` is a parameter to the template but it was missing the `parameters.` prefix in the displayName.