### PR TITLE
Allow official build and publish pipelines to run on internal/release/ branches

### DIFF
--- a/eng/common/templates/steps/validate-branch.yml
+++ b/eng/common/templates/steps/validate-branch.yml
@@ -15,6 +15,7 @@ steps:
       if (-not $isOfficialRepoPrefix)
       {
         echo "This build will not publish to an official repo prefix, continuing."
+        echo "Publish repo prefix: ${{ parameters.publishConfig.publishAcr.repoPrefix }}"
         echo "Official repo prefixes: $(officialRepoPrefixes)"
         exit 0
       }


### PR DESCRIPTION
This PR is https://github.com/dotnet/dotnet-docker/pull/6713 but moved to the correct repo.
I addressed the review feedback from https://github.com/dotnet/dotnet-docker/pull/6713#discussion_r2422081002 in a new commit.

This PR also fixes https://github.com/dotnet/docker-tools/issues/1795 by removing the branch override feature as suggested in https://github.com/dotnet/docker-tools/issues/1795#issuecomment-3267438747.