### PR TITLE
Improve documentation for import-image pipeline parameters

### DIFF
--- a/eng/pipelines/import-image.yml
+++ b/eng/pipelines/import-image.yml
@@ -7,7 +7,11 @@ pr: none
 
 parameters:
 - name: imageName
-  displayName: Image name to be imported (for Docker Hub, use <repo>:<tag>; for others, use <registry>/<repo>:<tag>)
+  displayName: >-
+    Name and tag of the image to be imported.
+    If the image is from Docker Hub, use <repo>:<tag>.
+    If the image is from an official Docker Hub registry, make sure to include the library/ prefix.
+    If the image is from another registry, use <registry>/<repo>:<tag>.
   type: string
 - name: isDockerHubImage
   displayName: Is the image from Docker Hub?


### PR DESCRIPTION
#1847 is not an issue with any service or with our pipeline. All of our calls to import the image were missing the `library/` prefix. I improved the parameter's displayName to help prevent this in the future.

Related: https://github.com/Azure/acr/issues/457