### PR TITLE
Use low-privilege secrets in import-image pipeline

### DIFF
--- a/eng/pipelines/import-image.yml
+++ b/eng/pipelines/import-image.yml
@@ -16,13 +16,13 @@ parameters:
 
 variables:
 - template: /eng/pipelines/templates/variables/common.yml@self
-# Uses DockerHub registry creds to avoid rate limiting
-- template: /eng/common/templates/variables/dotnet/secrets.yml@self
 - ${{ if eq(parameters.isDockerHubImage, 'true') }}:
+  # Uses DockerHub registry credentials to avoid rate limiting
+  - group: Dotnet-Docker-Secrets-Low
   - name: normalizedImageName
     value: ${{ format('docker.io/{0}', parameters.imageName) }}
   - name: extraImportOptions
-    value: --username $(dotnetDockerHubBot.userName) --password $(BotAccount-dotnet-dockerhub-bot-PAT)
+    value: --username $(dotnet-dockerhub-bot-username) --password $(dotnet-dockerhub-bot-pat-low)
 - ${{ else }}:
   - name: normalizedImageName
     value: ${{ parameters.imageName }}


### PR DESCRIPTION
This pipeline was using the full secrets variable group, but since it only needs read access to DockerHub, it can be moved to the low-privilege secrets group that was introduced with https://github.com/dotnet/docker-tools/pull/1794.