### PR TITLE
Use 1ES pipeline templates for official packages pipeline

### DIFF
--- a/eng/pipelines/docker-tools-packages-official.yml
+++ b/eng/pipelines/docker-tools-packages-official.yml
@@ -30,11 +30,14 @@ resources:
 variables:
 - template: /eng/pipelines/templates/variables/packages-build-pools.yml@self
 
-stages:
-- stage: build
-  displayName: Build and publish packages
-  jobs:
-  - template: /eng/pipelines/templates/jobs/build-and-publish-packages.yml@self
-    parameters:
-      containerResource: LinuxContainer
-      enablePublish: true
+extends:
+  template: /eng/docker-tools/templates/1es.yml@self
+  parameters:
+    stages:
+    - stage: build
+      displayName: Build and publish packages
+      jobs:
+      - template: /eng/pipelines/templates/jobs/build-and-publish-packages.yml@self
+        parameters:
+          containerResource: LinuxContainer
+          enablePublish: true


### PR DESCRIPTION
Fixes the following failure in the new pipeline, `docker-tools-packages-official`:

> A task is missing. The pipeline references a task called '1ES.PublishBuildArtifacts'. This usually indicates the task isn't installed, and you may be able to install it from the Marketplace: https://marketplace.visualstudio.com. (Task version 1, job 'Asset_Registry_Publish', step ''.)

From build#2852209