### PR TITLE
Add pre-release package version label

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,6 +8,7 @@
     <MinorVersion>1</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
+    <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
 
     <!-- Arcade features -->
     <UsingToolXliff>false</UsingToolXliff>


### PR DESCRIPTION
Before this change, the package version was incorrect. It was something like `Microsoft.DotNet.ImageBuilder.Models.0.1.660302.nupkg`.

After the change, it is correct: `Microsoft.DotNet.ImageBuilder.Models.0.1.0-beta.25605.1.nupkg`.

Validated by running `./build.sh -pack /p:OfficialBuild=true`.