### PR TITLE
Remove StaticTokenCredential, let Azure SDK handle token refresh

### DIFF
--- a/src/ImageBuilder/Commands/BuildCommand.cs
+++ b/src/ImageBuilder/Commands/BuildCommand.cs
@@ -106,15 +106,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 _imageArtifactDetails = new ImageArtifactDetails();
             }
 
-            // Prepopulate the credential cache with the container registry scope so that the OIDC token isn't expired by the time we
-            // need to query the registry at the end of the command.
-            if (Options.IsPushEnabled)
-            {
-                _ = _tokenCredentialProvider.GetCredential(
-                    Options.AcrServiceConnection,
-                    AzureScopes.ContainerRegistryScope);
-            }
-
             await ExecuteWithDockerCredentialsAsync(PullBaseImagesAsync);
             await BuildImagesAsync();
 

--- a/src/ImageBuilder/Commands/PublishManifestCommand.cs
+++ b/src/ImageBuilder/Commands/PublishManifestCommand.cs
@@ -60,15 +60,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 return;
             }
 
-            // Prepopulate the credential cache with the container registry scope so that the OIDC token isn't expired by the time we
-            // need to query the registry at the end of the command.
-            if (!Options.IsDryRun)
-            {
-                _tokenCredentialProvider.GetCredential(
-                    Options.AcrServiceConnection,
-                    AzureScopes.ContainerRegistryScope);
-            }
-
             ImageArtifactDetails imageArtifactDetails = ImageInfoHelper.LoadFromFile(Options.ImageInfoPath, Manifest);
 
             await _registryCredentialsProvider.ExecuteWithCredentialsAsync(


### PR DESCRIPTION
Previously, AzureTokenCredentialProvider would use `WorkloadIdentityCredential` during builds. In order to work around Workload Identity Credential lifetimes, we implemented a StaticTokenCredential that immediately fetched the requested token and cached it forever (added with https://github.com/dotnet/docker-tools/pull/1321). WIF token lifetimes are documented [here](https://learn.microsoft.com/en-us/azure/devops/pipelines/release/troubleshoot-workload-identity?view=azure-devops#error-messages).

Since https://github.com/dotnet/docker-tools/pull/1712, we use `AzurePipelinesCredential` instead. `AzurePipelinesCredential` handles all of the lifetime/expiration concerns. We can use it directly and allow the Azure SDK to handle caching and automatic refresh when tokens are close to expiring. I have not found any documented restrictions on its lifetime. The System.AccessToken and the resulting AzurePipelinesCredential *should* be valid for the entire length of the pipeline job and no longer.

I have built a test version of ImageBuilder with this change and validated it against our longest running build job, here: https://dev.azure.com/dnceng/internal/_build/results?buildId=2854918&view=logs&j=5b10b89b-008d-5f76-ef8b-7fc595d90c00&t=a505c4d8-3f6e-56eb-f81a-e4be2494dd9a

It happily spends over 3 hours building images and then has no trouble pushing them.