### PR TITLE
Add timed logging to GetAllImageDigestsFromRegistryAsync

### DIFF
--- a/src/ImageBuilder/AcrContentClientFactory.cs
+++ b/src/ImageBuilder/AcrContentClientFactory.cs
@@ -12,11 +12,13 @@ namespace Microsoft.DotNet.ImageBuilder;
 
 internal class AcrContentClientFactory(
     IAzureTokenCredentialProvider tokenCredentialProvider,
-    IOptions<PublishConfiguration> publishConfigOptions)
+    IOptions<PublishConfiguration> publishConfigOptions,
+    ILoggerService loggerService)
     : IAcrContentClientFactory
 {
     private readonly IAzureTokenCredentialProvider _tokenCredentialProvider = tokenCredentialProvider;
     private readonly PublishConfiguration _publishConfig = publishConfigOptions.Value;
+    private readonly ILoggerService _loggerService = loggerService;
 
     public IAcrContentClient Create(Acr acr, string repositoryName)
     {
@@ -33,7 +35,7 @@ internal class AcrContentClientFactory(
             AzureScopes.ContainerRegistryScope);
 
         var client = new ContainerRegistryContentClient(acr.RegistryUri, repositoryName, tokenCredential);
-        var wrapper = new AcrContentClientWrapper(client);
+        var wrapper = new AcrContentClientWrapper(client, _loggerService);
         return wrapper;
     }
 }


### PR DESCRIPTION
This PR adds better logging to GetAllImageDigestsFromRegistryAsync, in an attempt to diagnose #1905, which is causing publishing failures due to pipeline timeouts (https://github.com/dotnet/dotnet-docker-internal/issues/9694)