### PR TITLE
Revert "[main] Update Image Builder tag reference"

### DIFF
--- a/eng/docker-tools/templates/variables/docker-images.yml
+++ b/eng/docker-tools/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2872360
+  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2862284
   imageNames.imageBuilder: $(imageNames.imageBuilderName)
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux3.0-docker-testrunner


### PR DESCRIPTION
dotnet/docker-tools#1894 was mistakenly merged even though it had a "do not merge" label.

The ImageBuilder update actually requires https://github.com/dotnet/docker-tools/pull/1900 to be completed first.