### PR TITLE
Revert "Update default 1ES internal pool image to Azure Linux 3.0"

### DIFF
--- a/eng/docker-tools/templates/variables/common.yml
+++ b/eng/docker-tools/templates/variables/common.yml
@@ -66,7 +66,7 @@ variables:
 - name: default1ESInternalPoolName
   value: NetCore1ESPool-Internal
 - name: default1ESInternalPoolImage
-  value: Azure-Linux-3-Amd64
+  value: 1es-ubuntu-2204
 
 - template: /eng/docker-tools/templates/variables/sdl-pool.yml@self
 


### PR DESCRIPTION
Reverts dotnet/docker-tools#1895

The Azure-Linux-3-Amd64 image is now missing from NetCore1ESPool-Internal for an unknown reason. Context: [Teams thread (internal link)](https://teams.microsoft.com/l/message/19:afba3d1545dd45d7b79f34c1821f6055@thread.skype/1767819212540?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=4d73664c-9f2f-450d-82a5-c2f02756606d&parentMessageId=1767819212540&teamName=.NET%20Core%20Eng%20Services%20Partners&channelName=First%20Responders&createdTime=1767819212540)