### PR TITLE
Separate mirrorRepoPrefix for public and internal mirror repos

### DIFF
--- a/eng/docker-tools/templates/stages/dotnet/publish-config-nonprod.yml
+++ b/eng/docker-tools/templates/stages/dotnet/publish-config-nonprod.yml
@@ -52,7 +52,7 @@ stages:
     publishConfig:
       InternalMirrorRegistry:
         server: $(acr-staging-test.server)
-        repoPrefix: $(mirrorRepoPrefix)
+        repoPrefix: $(internalMirrorRepoPrefix)
         resourceGroup: $(testResourceGroup)
         subscription: $(testSubscription)
         serviceConnection:
@@ -63,6 +63,7 @@ stages:
 
       PublicMirrorRegistry:
         server: $(public-mirror.server)
+        repoPrefix: $(publicMirrorRepoPrefix)
         resourceGroup: $(public-mirror.resourceGroup)
         subscription: $(public-mirror.subscription)
         serviceConnection:

--- a/eng/docker-tools/templates/stages/dotnet/publish-config-prod.yml
+++ b/eng/docker-tools/templates/stages/dotnet/publish-config-prod.yml
@@ -52,7 +52,7 @@ stages:
     publishConfig:
       InternalMirrorRegistry:
         server: $(acr-staging.server)
-        repoPrefix: $(mirrorRepoPrefix)
+        repoPrefix: $(internalMirrorRepoPrefix)
         resourceGroup: $(acr-staging.resourceGroup)
         subscription: $(acr-staging.subscription)
         serviceConnection:
@@ -63,7 +63,7 @@ stages:
 
       PublicMirrorRegistry:
         server: $(public-mirror.server)
-        repoPrefix: $(mirrorRepoPrefix)
+        repoPrefix: $(publicMirrorRepoPrefix)
         resourceGroup: $(public-mirror.resourceGroup)
         subscription: $(public-mirror.subscription)
         serviceConnection:

--- a/eng/docker-tools/templates/variables/common.yml
+++ b/eng/docker-tools/templates/variables/common.yml
@@ -33,8 +33,10 @@ variables:
 - name: officialBranches
   # comma-delimited list of branch names
   value: main
-- name: mirrorRepoPrefix
+- name: internalMirrorRepoPrefix
   value: 'mirror/'
+- name: publicMirrorRepoPrefix
+  value: ''
 - name: cgBuildGrepArgs
   value: "''"
 - name: test.init

--- a/eng/pipelines/mirror-base-images.yml
+++ b/eng/pipelines/mirror-base-images.yml
@@ -19,8 +19,6 @@ variables:
 - template: /eng/pipelines/templates/variables/common.yml@self
 # Uses DockerHub registry creds to avoid rate limiting
 - template: /eng/docker-tools/templates/variables/dotnet/secrets.yml@self
-- name: mirrorRepoPrefix
-  value: ""
 
 extends:
   template: /eng/docker-tools/templates/1es.yml@self


### PR DESCRIPTION
#1917 uses the same prefix variable for public/internal mirror repos, when in reality they are different. We don't use a prefix for the public repo (we use an empty string as the prefix).

It looks like previously, we relied on overriding the `mirrorRepoPrefix` variable in the mirror-base-images-public pipeline. A better solution here is to explicitly set two different variables.