### PR TITLE
Pass storage account scope to GetToken in Build command

### DIFF
--- a/src/ImageBuilder/Commands/BuildCommand.cs
+++ b/src/ImageBuilder/Commands/BuildCommand.cs
@@ -86,11 +86,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     return null;
                 }
 
-                var tokenCredential = _tokenCredentialProvider.GetCredential(
-                    Options.StorageServiceConnection,
-                    AzureScopes.StorageAccountScope);
-
-                var token = tokenCredential.GetToken(new TokenRequestContext(), CancellationToken.None).Token;
+                var tokenCredential = _tokenCredentialProvider.GetCredential(Options.StorageServiceConnection);
+                var requestContext = new TokenRequestContext([AzureScopes.StorageAccountScope]);
+                var tokenObject = tokenCredential.GetToken(requestContext, CancellationToken.None);
+                var token = tokenObject.Token;
                 return token;
             });
         }


### PR DESCRIPTION
[During release staging](https://dev.azure.com/dnceng/internal/internal%20Team/_build/results?buildId=2875760&view=logs&j=fc59f0f2-c1bd-58ae-b870-833d1e8a924c&t=8d53baa0-ff68-5ea5-041a-af0e08303d7f&l=148), authentication to the staging storage account was failing.

This is because of the changes to token caching from https://github.com/dotnet/docker-tools/pull/1879. Previously we needed to pass the token scope as an argument to the `GetCredential()` method, since that method would create both the credential and the token in order to cache the token up front. But the scope is only needed to create the token. Since we no longer cache the token, we need to pass in the scope to the credential's `GetToken` method instead. The scope argument to `GetCredential()` is not used.

This is a targeted fix to unblock release staging. A follow-up PR will contain a proper refactor to remove the unused argument from `TokenCredentialProvider.GetCredential`.