### PR TITLE
Fix path to build script in build.ps1

### DIFF
--- a/src/build.ps1
+++ b/src/build.ps1
@@ -1,7 +1,7 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-& ./../../eng/docker-tools/build.ps1 `
+& ./../eng/docker-tools/build.ps1 `
     -Manifest src/manifest.json `
     -OptionalImageBuilderArgs "--var UniqueId=$(Get-Date -Format yyyyMMddHHmmss)" `
     -Paths "*"


### PR DESCRIPTION
This script contained the wrong path. The issue was introduced in https://github.com/dotnet/docker-tools/commit/1b1e3e9b8e099f333ed3eecf430510f40e219daa.