### PR TITLE
Revert "Update public Amd64 build image to Azure-Linux-3-Amd64-Public" (d6402b17)

### DIFF
--- a/eng/docker-tools/templates/stages/dotnet/build-and-test.yml
+++ b/eng/docker-tools/templates/stages/dotnet/build-and-test.yml
@@ -70,9 +70,7 @@ stages:
       ${{ if ne(parameters.linuxAmd64Pool, '') }}:
         ${{ parameters.linuxAmd64Pool }}
       ${{ elseif eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
-        name: $(linuxAmd64PublicPoolName)
-        demands: ImageOverride -equals $(linuxAmd64PublicPoolImage)
-        os: linux
+        vmImage: $(defaultLinuxAmd64PoolImage)
       ${{ elseif eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
         name: $(linuxAmd64InternalPoolName)
         image: $(linuxAmd64InternalPoolImage)

--- a/eng/docker-tools/templates/variables/dotnet/common.yml
+++ b/eng/docker-tools/templates/variables/dotnet/common.yml
@@ -15,10 +15,6 @@ variables:
 
 - name: linuxAmd64InternalPoolImage
   value: 1es-ubuntu-2204
-- name: linuxAmd64PublicPoolImage
-  value: Azure-Linux-3-Amd64-Public
-- name: linuxAmd64PublicPoolName
-  value: NetCore-Public
 - name: linuxAmd64InternalPoolName
   value: NetCore1ESPool-Internal
 


### PR DESCRIPTION
This reverts commit d6402b17768572dcfe8a574b5fac3a3b9afe44d6. Accidentally pushed directly to main through GitHub UI. 

Related: https://github.com/dotnet/dotnet-docker-internal/issues/8660