### PR TITLE
Fix Publish job to use NetCore-Public pool in PR validation

### DIFF
--- a/eng/docker-tools/templates/stages/dotnet/publish.yml
+++ b/eng/docker-tools/templates/stages/dotnet/publish.yml
@@ -49,7 +49,9 @@ stages:
       ${{ if ne(parameters.pool, '') }}:
         ${{ parameters.pool }}
       ${{ elseif eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
-        vmImage: $(defaultLinuxAmd64PoolImage)
+        name: $(linuxAmd64PublicPoolName)
+        demands: ImageOverride -equals $(linuxAmd64PublicPoolImage)
+        os: linux
       ${{ elseif eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
         name: $(linuxAmd64InternalPoolName)
         image: $(linuxAmd64InternalPoolImage)


### PR DESCRIPTION
Port of https://github.com/dotnet/dotnet-docker/pull/6994

The publish job in `dotnet-docker-nightly-pr` was running on Microsoft-hosted `ubuntu-latest` while all other stages ran on the `NetCore-Public/Azure Linux 3` pool.

### Changes

Updated `eng/docker-tools/templates/stages/dotnet/publish.yml` to use the same pool configuration as build-and-test stages for public projects.