### PR TITLE
Fix parameter type and base template in cleanup-acr-images-custom pipeline

### DIFF
--- a/eng/pipelines/cleanup-acr-images-custom-official.yml
+++ b/eng/pipelines/cleanup-acr-images-custom-official.yml
@@ -24,10 +24,10 @@ parameters:
   - pruneEol
 - name: age
   displayName: Age
-  type: int
+  type: number
 
 extends:
-  template: /eng/docker-tools/templates/1es-official.yml@self
+  template: /eng/docker-tools/templates/1es.yml@self
   parameters:
     serviceConnections:
     - name: $(clean.serviceConnectionName)


### PR DESCRIPTION
`int` is not a valid parameter type. `number` is, however. It parses correctly now.

https://learn.microsoft.com/en-us/azure/devops/pipelines/process/template-parameters?view=azure-devops#parameter-data-types

I also migrated this to the base 1es.yml template as part of https://github.com/dotnet/docker-tools/issues/1892.