### PR TITLE
Restore separate custom init step parameters (fix regression from #1963)

### DIFF
--- a/eng/docker-tools/templates/jobs/build-images.yml
+++ b/eng/docker-tools/templates/jobs/build-images.yml
@@ -4,7 +4,12 @@ parameters:
   matrix: {}
   dockerClientOS: null
   buildJobTimeout: 60
+  # Custom steps to set up ImageBuilder instead of pulling from MCR (e.g., bootstrap from source).
+  # Runs before ImageBuilder pull. If non-empty, skips the default ImageBuilder pull.
   customInitSteps: []
+  # Custom steps that run after ImageBuilder is set up but before the build starts.
+  # Use for build-specific initialization (e.g., setting variables, additional setup).
+  customBuildInitSteps: []
   publishConfig: null
   versionsRepoRef: ""
   noCache: false
@@ -36,6 +41,7 @@ jobs:
       versionsRepoRef: ${{ parameters.versionsRepoRef }}
       cleanupDocker: true
       customInitSteps: ${{ parameters.customInitSteps }}
+  - ${{ parameters.customBuildInitSteps }}
   - template: /eng/docker-tools/templates/steps/set-image-info-path-var.yml@self
     parameters:
       publicSourceBranch: $(publicSourceBranch)

--- a/eng/docker-tools/templates/jobs/copy-base-images-staging.yml
+++ b/eng/docker-tools/templates/jobs/copy-base-images-staging.yml
@@ -8,7 +8,13 @@ parameters:
 - name: publishConfig
   type: object
   default: null
+# Custom steps to set up ImageBuilder instead of pulling from MCR (e.g., bootstrap from source).
+# Runs before ImageBuilder pull. If non-empty, skips the default ImageBuilder pull.
 - name: customInitSteps
+  type: stepList
+  default: []
+# Custom steps that run after ImageBuilder is set up but before copy-base-images runs.
+- name: customCopyBaseImagesInitSteps
   type: stepList
   default: []
 - name: additionalOptions
@@ -28,6 +34,7 @@ jobs:
     pool: ${{ parameters.pool }}
     publishConfig: ${{ parameters.publishConfig }}
     customInitSteps: ${{ parameters.customInitSteps }}
+    customCopyBaseImagesInitSteps: ${{ parameters.customCopyBaseImagesInitSteps }}
     additionalOptions: ${{ parameters.additionalOptions }}
     acr: ${{ parameters.publishConfig.InternalMirrorRegistry }}
     versionsRepoRef: ${{ parameters.versionsRepoRef }}

--- a/eng/docker-tools/templates/jobs/copy-base-images.yml
+++ b/eng/docker-tools/templates/jobs/copy-base-images.yml
@@ -11,7 +11,13 @@ parameters:
 - name: acr
   type: object
   default: null
+# Custom steps to set up ImageBuilder instead of pulling from MCR (e.g., bootstrap from source).
+# Runs before ImageBuilder pull. If non-empty, skips the default ImageBuilder pull.
 - name: customInitSteps
+  type: stepList
+  default: []
+# Custom steps that run after ImageBuilder is set up but before copy-base-images runs.
+- name: customCopyBaseImagesInitSteps
   type: stepList
   default: []
 - name: additionalOptions
@@ -37,6 +43,7 @@ jobs:
       publishConfig: ${{ parameters.publishConfig }}
       customInitSteps: ${{ parameters.customInitSteps }}
       versionsRepoRef: ${{ parameters.versionsRepoRef }}
+  - ${{ parameters.customCopyBaseImagesInitSteps }}
   - template: /eng/docker-tools/templates/steps/copy-base-images.yml@self
     parameters:
       acr: ${{ parameters.acr }}

--- a/eng/docker-tools/templates/jobs/generate-matrix.yml
+++ b/eng/docker-tools/templates/jobs/generate-matrix.yml
@@ -7,7 +7,11 @@ parameters:
   internalProjectName: null
   noCache: false
   publishConfig: null
+  # Custom steps to set up ImageBuilder instead of pulling from MCR (e.g., bootstrap from source).
+  # Runs before ImageBuilder pull. If non-empty, skips the default ImageBuilder pull.
   customInitSteps: []
+  # Custom steps that run after ImageBuilder is set up but before matrix generation runs.
+  customGenerateMatrixInitSteps: []
   versionsRepoRef: ""
   sourceBuildPipelineRunId: ""
 
@@ -21,6 +25,7 @@ jobs:
       publishConfig: ${{ parameters.publishConfig }}
       versionsRepoRef: ${{ parameters.versionsRepoRef }}
       customInitSteps: ${{ parameters.customInitSteps }}
+  - ${{ parameters.customGenerateMatrixInitSteps }}
   - template: /eng/docker-tools/templates/steps/retain-build.yml@self
   - template: /eng/docker-tools/templates/steps/validate-branch.yml@self
     parameters:

--- a/eng/docker-tools/templates/stages/build-and-test.yml
+++ b/eng/docker-tools/templates/stages/build-and-test.yml
@@ -3,11 +3,17 @@ parameters:
   testMatrixType: platformVersionedOs
   buildMatrixCustomBuildLegGroupArgs: ""
   testMatrixCustomBuildLegGroupArgs: ""
+  # Custom steps to set up ImageBuilder instead of pulling from MCR (e.g., bootstrap from source).
+  # Runs before ImageBuilder pull. If non-empty, skips the default ImageBuilder pull.
+  customInitSteps: []
+  # Custom steps that run after ImageBuilder is set up but before copy-base-images runs.
   customCopyBaseImagesInitSteps: []
+  # Custom steps that run after ImageBuilder is set up but before matrix generation runs.
   customGenerateMatrixInitSteps: []
+  # Custom steps that run after ImageBuilder is set up but before the build starts.
+  # Use for build-specific initialization (e.g., setting variables, additional setup).
   customBuildInitSteps: []
   customTestInitSteps: []
-  customInitSteps: []
   sourceBuildPipelineRunId: ""
 
   linuxAmdBuildJobTimeout: 60
@@ -78,9 +84,8 @@ stages:
       publishConfig: ${{ parameters.publishConfig }}
       pool: ${{ parameters.linuxAmd64Pool }}
       additionalOptions: "--manifest '$(manifest)' $(imageBuilder.pathArgs) $(manifestVariables)"
-      customInitSteps:
-      - ${{ parameters.customInitSteps }}
-      - ${{ parameters.customCopyBaseImagesInitSteps }}
+      customInitSteps: ${{ parameters.customInitSteps }}
+      customCopyBaseImagesInitSteps: ${{ parameters.customCopyBaseImagesInitSteps }}
       versionsRepoRef: ${{ parameters.versionsRepoRef }}
 
   - template: /eng/docker-tools/templates/jobs/generate-matrix.yml@self
@@ -92,9 +97,8 @@ stages:
       internalProjectName: ${{ parameters.internalProjectName }}
       noCache: ${{ parameters.noCache }}
       publishConfig: ${{ parameters.publishConfig }}
-      customInitSteps:
-      - ${{ parameters.customInitSteps }}
-      - ${{ parameters.customGenerateMatrixInitSteps }}
+      customInitSteps: ${{ parameters.customInitSteps }}
+      customGenerateMatrixInitSteps: ${{ parameters.customGenerateMatrixInitSteps }}
       versionsRepoRef: ${{ parameters.versionsRepoRef }}
 
   - template: /eng/docker-tools/templates/jobs/build-images.yml@self
@@ -105,9 +109,8 @@ stages:
       dockerClientOS: linux
       buildJobTimeout: ${{ parameters.linuxAmdBuildJobTimeout }}
       versionsRepoRef: ${{ parameters.versionsRepoRef }}
-      customInitSteps:
-      - ${{ parameters.customInitSteps }}
-      - ${{ parameters.customBuildInitSteps }}
+      customInitSteps: ${{ parameters.customInitSteps }}
+      customBuildInitSteps: ${{ parameters.customBuildInitSteps }}
       noCache: ${{ parameters.noCache }}
       publishConfig: ${{ parameters.publishConfig }}
       internalProjectName: ${{ parameters.internalProjectName }}
@@ -121,9 +124,8 @@ stages:
       dockerClientOS: linux
       buildJobTimeout: ${{ parameters.linuxArmBuildJobTimeout }}
       versionsRepoRef: ${{ parameters.versionsRepoRef }}
-      customInitSteps:
-      - ${{ parameters.customInitSteps }}
-      - ${{ parameters.customBuildInitSteps }}
+      customInitSteps: ${{ parameters.customInitSteps }}
+      customBuildInitSteps: ${{ parameters.customBuildInitSteps }}
       noCache: ${{ parameters.noCache }}
       publishConfig: ${{ parameters.publishConfig }}
       internalProjectName: ${{ parameters.internalProjectName }}
@@ -137,9 +139,8 @@ stages:
       dockerClientOS: linux
       buildJobTimeout: ${{ parameters.linuxArmBuildJobTimeout }}
       versionsRepoRef: ${{ parameters.versionsRepoRef }}
-      customInitSteps:
-      - ${{ parameters.customInitSteps }}
-      - ${{ parameters.customBuildInitSteps }}
+      customInitSteps: ${{ parameters.customInitSteps }}
+      customBuildInitSteps: ${{ parameters.customBuildInitSteps }}
       noCache: ${{ parameters.noCache }}
       publishConfig: ${{ parameters.publishConfig }}
       internalProjectName: ${{ parameters.internalProjectName }}
@@ -153,9 +154,8 @@ stages:
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
       versionsRepoRef: ${{ parameters.versionsRepoRef }}
-      customInitSteps:
-      - ${{ parameters.customInitSteps }}
-      - ${{ parameters.customBuildInitSteps }}
+      customInitSteps: ${{ parameters.customInitSteps }}
+      customBuildInitSteps: ${{ parameters.customBuildInitSteps }}
       noCache: ${{ parameters.noCache }}
       publishConfig: ${{ parameters.publishConfig }}
       internalProjectName: ${{ parameters.internalProjectName }}
@@ -169,9 +169,8 @@ stages:
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
       versionsRepoRef: ${{ parameters.versionsRepoRef }}
-      customInitSteps:
-      - ${{ parameters.customInitSteps }}
-      - ${{ parameters.customBuildInitSteps }}
+      customInitSteps: ${{ parameters.customInitSteps }}
+      customBuildInitSteps: ${{ parameters.customBuildInitSteps }}
       noCache: ${{ parameters.noCache }}
       publishConfig: ${{ parameters.publishConfig }}
       internalProjectName: ${{ parameters.internalProjectName }}
@@ -185,9 +184,8 @@ stages:
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
       versionsRepoRef: ${{ parameters.versionsRepoRef }}
-      customInitSteps:
-      - ${{ parameters.customInitSteps }}
-      - ${{ parameters.customBuildInitSteps }}
+      customInitSteps: ${{ parameters.customInitSteps }}
+      customBuildInitSteps: ${{ parameters.customBuildInitSteps }}
       noCache: ${{ parameters.noCache }}
       publishConfig: ${{ parameters.publishConfig }}
       internalProjectName: ${{ parameters.internalProjectName }}
@@ -201,9 +199,8 @@ stages:
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
       versionsRepoRef: ${{ parameters.versionsRepoRef }}
-      customInitSteps:
-      - ${{ parameters.customInitSteps }}
-      - ${{ parameters.customBuildInitSteps }}
+      customInitSteps: ${{ parameters.customInitSteps }}
+      customBuildInitSteps: ${{ parameters.customBuildInitSteps }}
       noCache: ${{ parameters.noCache }}
       publishConfig: ${{ parameters.publishConfig }}
       internalProjectName: ${{ parameters.internalProjectName }}
@@ -251,9 +248,8 @@ stages:
         isTestStage: true
         internalProjectName: ${{ parameters.internalProjectName }}
         publicProjectName: ${{ parameters.publicProjectName }}
-        customInitSteps:
-        - ${{ parameters.customInitSteps }}
-        - ${{ parameters.customGenerateMatrixInitSteps }}
+        customInitSteps: ${{ parameters.customInitSteps }}
+        customGenerateMatrixInitSteps: ${{ parameters.customGenerateMatrixInitSteps }}
         sourceBuildPipelineRunId: ${{ parameters.sourceBuildPipelineRunId }}
         versionsRepoRef: ${{ parameters.versionsRepoRef }}
     - template: /eng/docker-tools/templates/jobs/test-images-linux-client.yml@self


### PR DESCRIPTION
## Summary

PR #1963 ("Update Image Builder tag reference") inadvertently reverted the fix from #1954 ("Separate custom init steps from job-specific init steps") due to a bad merge. This re-introduced the bug where Windows PR validation fails because `Microsoft.DotNet.ImageBuilder.exe` is never downloaded.

This is currently breaking the dotnet-docker nightly PR validation pipeline: [dotnet/dotnet-docker#7046](https://github.com/dotnet/dotnet-docker/pull/7046).

## Changes

Restores the separate parameter pattern from #1954:
- `customBuildInitSteps` in `build-images.yml` — injected after `init-common`
- `customGenerateMatrixInitSteps` in `generate-matrix.yml` — injected after `init-common`
- `customCopyBaseImagesInitSteps` in `copy-base-images.yml` / `copy-base-images-staging.yml` — injected after `init-common`

These steps run **after** ImageBuilder setup, not through `customInitSteps` which would bypass it.

## Related PRs

| PR | Repo | Description |
|----|------|-------------|
| [#1947](https://github.com/dotnet/docker-tools/pull/1947) | docker-tools | Original change that introduced the consolidation pattern |
| [#1954](https://github.com/dotnet/docker-tools/pull/1954) | docker-tools | Fix that separated custom init steps from job-specific steps |
| [#1963](https://github.com/dotnet/docker-tools/pull/1963) | docker-tools | Bad merge that reverted #1954 |
| [#7046](https://github.com/dotnet/dotnet-docker/pull/7046) | dotnet-docker | Downstream PR that pulled in the broken docker-tools update |