### PR TITLE
Enable signing for ImageBuilder container image

### DIFF
--- a/eng/pipelines/dotnet-buildtools-image-builder-official.yml
+++ b/eng/pipelines/dotnet-buildtools-image-builder-official.yml
@@ -44,6 +44,7 @@ extends:
     stages:
     - template: /eng/docker-tools/templates/stages/dotnet/publish-config-prod.yml@self
       parameters:
+        enableSigning: true
         sourceBuildPipelineRunId: ${{ parameters.sourceBuildPipelineRunId }}
         stagesTemplate: /eng/pipelines/templates/stages/build-test-publish.yml@self
         stagesTemplateParameters:


### PR DESCRIPTION
Follow-up to #1376 

This PR enables real signing for the ImageBuilder container image.