### PR TITLE
Fix slow tests by adding `IAcrImageImporter` abstraction

### DIFF
--- a/src/ImageBuilder.Tests/CopyImageServiceTests.cs
+++ b/src/ImageBuilder.Tests/CopyImageServiceTests.cs
@@ -28,7 +28,7 @@ public class CopyImageServiceTests
         var emptyConfig = new PublishConfiguration();
         var service = new CopyImageService(
             Mock.Of<ILogger<CopyImageService>>(),
-            Mock.Of<IAcrRegistryImporter>(),
+            Mock.Of<IAcrImageImporter>(),
             ConfigurationHelper.CreateOptionsMock(emptyConfig));
 
         await Should.NotThrowAsync(() =>
@@ -68,7 +68,7 @@ public class CopyImageServiceTests
             ]
         };
 
-        var mockImporter = new Mock<IAcrRegistryImporter>();
+        var mockImporter = new Mock<IAcrImageImporter>();
 
         var service = new CopyImageService(
             Mock.Of<ILogger<CopyImageService>>(),

--- a/src/ImageBuilder/AcrImageImporter.cs
+++ b/src/ImageBuilder/AcrImageImporter.cs
@@ -16,15 +16,15 @@ using Microsoft.Extensions.Options;
 namespace Microsoft.DotNet.ImageBuilder;
 
 /// <inheritdoc />
-internal class AcrRegistryImporter : IAcrRegistryImporter
+internal class AcrImageImporter : IAcrImageImporter
 {
-    private readonly ILogger<AcrRegistryImporter> _logger;
+    private readonly ILogger<AcrImageImporter> _logger;
     private readonly IAzureTokenCredentialProvider _tokenCredentialProvider;
     private readonly PublishConfiguration _publishConfig;
     private readonly ConcurrentDictionary<string, ArmClient> _armClientCache = new();
 
-    public AcrRegistryImporter(
-        ILogger<AcrRegistryImporter> logger,
+    public AcrImageImporter(
+        ILogger<AcrImageImporter> logger,
         IAzureTokenCredentialProvider tokenCredentialProvider,
         IOptions<PublishConfiguration> publishConfigOptions)
     {

--- a/src/ImageBuilder/CopyImageService.cs
+++ b/src/ImageBuilder/CopyImageService.cs
@@ -26,12 +26,12 @@ public interface ICopyImageService
 public class CopyImageService : ICopyImageService
 {
     private readonly ILogger<CopyImageService> _logger;
-    private readonly IAcrRegistryImporter _acrRegistryImporter;
+    private readonly IAcrImageImporter _acrRegistryImporter;
     private readonly PublishConfiguration _publishConfig;
 
     public CopyImageService(
         ILogger<CopyImageService> logger,
-        IAcrRegistryImporter acrRegistryImporter,
+        IAcrImageImporter acrRegistryImporter,
         IOptions<PublishConfiguration> publishConfigOptions)
     {
         _logger = logger;

--- a/src/ImageBuilder/IAcrImageImporter.cs
+++ b/src/ImageBuilder/IAcrImageImporter.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.ImageBuilder;
 /// Abstracts ACR image import operations via the Azure Resource Manager SDK,
 /// allowing tests to mock the ARM interaction.
 /// </summary>
-public interface IAcrRegistryImporter
+public interface IAcrImageImporter
 {
     /// <summary>
     /// Imports an image into an Azure Container Registry using the ARM SDK.

--- a/src/ImageBuilder/ImageBuilder.cs
+++ b/src/ImageBuilder/ImageBuilder.cs
@@ -44,7 +44,7 @@ public static class ImageBuilder
             builder.Services.AddSingleton<IAzureTokenCredentialProvider, AzureTokenCredentialProvider>();
             builder.Services.AddSingleton<IAcrClientFactory, AcrClientFactory>();
             builder.Services.AddSingleton<IAcrContentClientFactory, AcrContentClientFactory>();
-            builder.Services.AddSingleton<IAcrRegistryImporter, AcrRegistryImporter>();
+            builder.Services.AddSingleton<IAcrImageImporter, AcrImageImporter>();
             builder.Services.AddSingleton<ICopyImageService, CopyImageService>();
             builder.Services.AddSingleton<IDateTimeService, DateTimeService>();
             builder.Services.AddSingleton<IDockerService, DockerService>();


### PR DESCRIPTION
`git bisect` found that #1975 caused ImageBuilder's test to slow down dramatically, increasing from ~3 seconds to 100+ seconds.

The test `ImportImageAsync_ExternalSourceRegistry_DoesNotRequireSourceRegistryInPublishConfig` calls `CopyImageService.ImportImageAsync` with `isDryRun: false`, which hits real ARM SDK methods through a mocked `TokenCredential`. Each call fails and `RetryHelper` retries 5 times with backoff as well, causing that single test to take over one minute.

This PR adds an abstraction for the ARM client which `CopyImageService` resolves via DI so that the test can mock it. All 424 tests now pass in ~5 seconds.