### PR TITLE
Enable skipping pre-build validation tests separately from functional tests

### DIFF
--- a/eng/docker-tools/CHANGELOG.md
+++ b/eng/docker-tools/CHANGELOG.md
@@ -4,6 +4,16 @@ All breaking changes and new features in `eng/docker-tools` will be documented i
 
 ---
 
+## 2026-03-04: Pre-build validation gated by `preBuildTestScriptPath` variable
+
+The `PreBuildValidation` job condition now checks the new `preBuildTestScriptPath` variable instead of `testScriptPath`.
+This allows repos to independently control whether pre-build validation runs, without affecting functional tests.
+
+The new variable defaults to `$(testScriptPath)`, so existing repos that have pre-build tests are not affected.
+Repos that do not have pre-build tests can set `preBuildTestScriptPath` to `""` to skip the job entirely.
+
+---
+
 ## 2026-02-19: Separate Registry Endpoints from Authentication
 
 - Pull request: [#1945](https://github.com/dotnet/docker-tools/pull/1945)

--- a/eng/docker-tools/templates/jobs/test-images-linux-client.yml
+++ b/eng/docker-tools/templates/jobs/test-images-linux-client.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix: $[ ${{ parameters.matrix }} ]
   ${{ if eq(parameters.preBuildValidation, 'true') }}:
-    condition: and(succeeded(), ne(variables.testScriptPath, ''))
+    condition: and(succeeded(), ne(variables.preBuildTestScriptPath, ''))
   pool: ${{ parameters.pool }}
   timeoutInMinutes: ${{ parameters.testJobTimeout }}
   steps:

--- a/eng/docker-tools/templates/variables/common-paths.yml
+++ b/eng/docker-tools/templates/variables/common-paths.yml
@@ -3,3 +3,4 @@ variables:
   engDockerToolsPath: $(Build.Repository.LocalPath)/$(engDockerToolsRelativePath)
   engPath: $(Build.Repository.LocalPath)/eng
   testScriptPath: ""
+  preBuildTestScriptPath: $(testScriptPath)

--- a/eng/pipelines/templates/variables/image-builder.yml
+++ b/eng/pipelines/templates/variables/image-builder.yml
@@ -17,3 +17,5 @@ variables:
   value: ./src/run-tests.ps1
 - name: testResultsDirectory
   value: src/ImageBuilder.Tests/TestResults/
+- name: preBuildTestScriptPath
+  value: ""

--- a/src/run-tests.ps1
+++ b/src/run-tests.ps1
@@ -15,8 +15,7 @@ param(
     [switch]$DisableHttpVerification,
     [switch]$PullImages,
     [string]$ImageInfoPath,
-    [ValidateSet("functional", "pre-build")]
-    [string[]]$TestCategories = @("functional")
+    [string[]]$TestCategories = @()
 )
 
 Set-StrictMode -Version Latest
@@ -26,23 +25,17 @@ $dotnetInstallDir = "$PSScriptRoot/../.dotnet"
 
 Push-Location $PSScriptRoot
 
-if ($TestCategories.Contains("pre-build")) {
-    Write-Output "There are no pre-build tests"
+try {
+    & ../eng/docker-tools/Install-DotNetSdk.ps1 $dotnetInstallDir
+
+    $cmd = "$DotnetInstallDir/dotnet test $PSScriptRoot/ImageBuilder.Tests/Microsoft.DotNet.ImageBuilder.Tests.csproj --logger:trx"
+
+    Write-Output "Executing '$cmd'"
+    Invoke-Expression $cmd
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed: '$cmd'"
+    }
 }
-
-if ($TestCategories.Contains("functional")) {
-    try {
-        & ../eng/docker-tools/Install-DotNetSdk.ps1 $dotnetInstallDir
-
-        $cmd = "$DotnetInstallDir/dotnet test $PSScriptRoot/ImageBuilder.Tests/Microsoft.DotNet.ImageBuilder.Tests.csproj --logger:trx"
-
-        Write-Output "Executing '$cmd'"
-        Invoke-Expression $cmd
-        if ($LASTEXITCODE -ne 0) {
-            throw "Failed: '$cmd'"
-        }
-    }
-    finally {
-        Pop-Location
-    }
+finally {
+    Pop-Location
 }


### PR DESCRIPTION
Previously, this repo ran pre-build validation job even though it didn't have any, wasting up to 5 minutes of PR validation and CI machine time. Running pre-build validation was required even though this repo only had functional tests.

This PR separates `testScriptPath` and `preBuildTestScriptPath`. When `preBuildTestScriptPath` is not provided, then the pre-build validation job is skipped. It defaults to `$(testScriptPath)` so that the change is not breaking.