### PR TITLE
Fix PreBuildValidation to use preBuildTestScriptPath for execution

### DIFF
--- a/eng/docker-tools/CHANGELOG.md
+++ b/eng/docker-tools/CHANGELOG.md
@@ -6,10 +6,21 @@ All breaking changes and new features in `eng/docker-tools` will be documented i
 
 ## 2026-03-04: Pre-build validation gated by `preBuildTestScriptPath` variable
 
+- Pull request: [#1997](https://github.com/dotnet/docker-tools/pull/1997)
+
 The `PreBuildValidation` job condition now checks the new `preBuildTestScriptPath` variable instead of `testScriptPath`.
 This allows repos to independently control whether pre-build validation runs, without affecting functional tests.
 
 The new variable defaults to `$(testScriptPath)`, so existing repos that have pre-build tests are not affected.
+Repos that do not have pre-build tests can set `preBuildTestScriptPath` to `""` to skip the job entirely.
+
+### Update (2026-03-11): Use `preBuildTestScriptPath` for test execution
+
+- Pull request: [#2011](https://github.com/dotnet/docker-tools/pull/2011)
+
+The `PreBuildValidation` job now uses `preBuildTestScriptPath` for test execution instead of `testScriptPath`.
+Previously, the job condition was gated on `preBuildTestScriptPath` but the test execution step still used `testScriptPath`,
+which meant PreBuildValidation could not be enabled independently when `testScriptPath` was empty.
 Repos that do not have pre-build tests can set `preBuildTestScriptPath` to `""` to skip the job entirely.
 
 ---

--- a/eng/docker-tools/templates/steps/test-images-linux-client.yml
+++ b/eng/docker-tools/templates/steps/test-images-linux-client.yml
@@ -25,6 +25,12 @@ steps:
 - script: |
     echo "##vso[task.setvariable variable=testRunner.container]testrunner-$(Build.BuildId)-$(System.JobId)"
 
+    if [ "${{ parameters.preBuildValidation }}" == "true" ]; then
+      echo "##vso[task.setvariable variable=effectiveTestScriptPath]$(preBuildTestScriptPath)"
+    else
+      echo "##vso[task.setvariable variable=effectiveTestScriptPath]$(testScriptPath)"
+    fi
+
     additionalTestArgs="$ADDITIONALTESTARGS"
     if [ "${{ parameters.preBuildValidation }}" == "true" ]; then
       additionalTestArgs="$additionalTestArgs -TestCategories pre-build"
@@ -74,7 +80,7 @@ steps:
     $(testRunner.options)
     $(testRunner.container)
     pwsh
-    -Command "$(testScriptPath)
+    -Command "$(effectiveTestScriptPath)
     -Paths $(imageBuilderPathsArrayInitStr)
     -OSVersions $(osVersionsArrayInitStr)
     -Architecture '$(architecture)'


### PR DESCRIPTION
This PR is a follow up from https://github.com/dotnet/docker-tools/pull/1997.

https://github.com/dotnet/docker-tools/pull/1997 decoupled `preBuildTestScriptPath` from `testScriptPath` for the PreBuildValidation job condition, but the test execution step still always used `$(testScriptPath)`. This meant PreBuildValidation could not be enabled independently when `testScriptPath` was empty.

This PR ensures that correct test script variable is used for each test scenario (regular vs. pre-build tests).