### PR TITLE
Guard against empty service connection names in `reference-service-connections.yml`

### DIFF
--- a/eng/docker-tools/templates/jobs/build-images.yml
+++ b/eng/docker-tools/templates/jobs/build-images.yml
@@ -48,7 +48,9 @@ jobs:
       dockerClientOS: ${{ parameters.dockerClientOS }}
       usesRegistries:
         - ${{ parameters.publishConfig.BuildRegistry.server }}
-      ${{ if parameters.storageAccountServiceConnection }}:
+      # Check .name instead of the whole object - null parameters can become
+      # empty objects through template layers, making ${{ if }} truthy.
+      ${{ if parameters.storageAccountServiceConnection.name }}:
         serviceConnections:
         - name: ${{ parameters.storageAccountServiceConnection.name }}
   - template: /eng/docker-tools/templates/steps/set-image-info-path-var.yml@self

--- a/eng/docker-tools/templates/steps/reference-service-connections.yml
+++ b/eng/docker-tools/templates/steps/reference-service-connections.yml
@@ -43,19 +43,23 @@ parameters:
 
 steps:
 - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
+  # Guard on .name: null parameters passed through template layers can become
+  # empty objects that are truthy, so check the concrete property instead.
   - ${{ each serviceConnection in parameters.serviceConnections }}:
-    - task: AzureCLI@2
-      displayName: Reference ${{ serviceConnection.name }}
-      inputs:
-        azureSubscription: ${{ serviceConnection.name }}
-        ${{ if eq(parameters.dockerClientOS, 'windows') }}:
-          scriptType: ps
-        ${{ else }}:
-          scriptType: pscore
-        scriptLocation: inlineScript
-        inlineScript: Write-Host "Service connection referenced for OIDC"
+    - ${{ if serviceConnection.name }}:
+      - task: AzureCLI@2
+        displayName: Reference ${{ serviceConnection.name }}
+        inputs:
+          azureSubscription: ${{ serviceConnection.name }}
+          ${{ if eq(parameters.dockerClientOS, 'windows') }}:
+            scriptType: ps
+          ${{ else }}:
+            scriptType: pscore
+          scriptLocation: inlineScript
+          inlineScript: Write-Host "Service connection referenced for OIDC"
   - ${{ each auth in parameters.publishConfig.RegistryAuthentication }}:
-    - ${{ if containsValue(parameters.usesRegistries, auth.server) }}:
+    # Also guard on .name here for the same reason as the serviceConnections loop above.
+    - ${{ if and(containsValue(parameters.usesRegistries, auth.server), auth.serviceConnection.name) }}:
       - task: AzureCLI@2
         displayName: Reference ${{ auth.serviceConnection.name }}
         inputs:


### PR DESCRIPTION
This PR aims to fix the failing eng-validation pipeline (example: build#2925057). The symptom is an error message like `##[error]Script failed with error: Error: Input required: connectedServiceNameARM` in the reference service connections step.

Azure Pipelines can pass null parameters as empty objects through template layers, causing `${{ if parameters.storageAccountServiceConnection }}` to evaluate as true even when the value is null/empty. This produced `AzureCLI@2` tasks with empty `azureSubscription` inputs, failing with 'Input required: connectedServiceNameARM'.

Fixes:
- Add name guards in reference-service-connections.yml loops to skip entries with empty names
- Change build-images.yml to check .name property instead of the whole object