### PR TITLE
Move ImageBuilder tests to pre-build validation

### DIFF
--- a/eng/pipelines/templates/variables/image-builder.yml
+++ b/eng/pipelines/templates/variables/image-builder.yml
@@ -14,8 +14,8 @@ variables:
 - name: imageInfoVariant
   value: "-imagebuilder"
 - name: testScriptPath
-  value: ./src/run-tests.ps1
+  value: ""
 - name: testResultsDirectory
   value: src/ImageBuilder.Tests/TestResults/
 - name: preBuildTestScriptPath
-  value: ""
+  value: ./src/run-tests.ps1


### PR DESCRIPTION
ImageBuilder only has unit tests -- it does not have any tests that inspect or run the ImageBuilder container image produced by the build pipeline. The test script simply runs `dotnet test` and does not do anything platform specific. Therefore, we are wasting pipeline time by running these tests in parallel on multiple build agents.

This PR moves ImageBuilder's tests from distributed Test jobs to the PreBuildValidation job, so that the tests run only once, and before spinning up extra build agents to build the ImageBuilder container images. The entire test stage will also be skipped, including Test matrix generation and spinning up build agents for 4 multiple platforms.

This reduces CPU/Machine time spent in the ImageBuilder build pipeline by **22%**, from 1h31m to 1h11m (comparing build#2924511 and build#2925370 (This PR)). Wall clock time is difficult to compare directly due to build agent queue times, but the pipeline will now only use **11** separate jobs instead of **16** jobs, which means the pipeline will be less affected by build agent wait times.

Related:
- #1250
- https://github.com/dotnet/docker-tools/pull/2011
- https://github.com/dotnet/docker-tools/pull/1997