### PR TITLE
Add service connection reference to generate-matrix job

### DIFF
--- a/eng/docker-tools/templates/jobs/generate-matrix.yml
+++ b/eng/docker-tools/templates/jobs/generate-matrix.yml
@@ -25,6 +25,13 @@ jobs:
       publishConfig: ${{ parameters.publishConfig }}
       versionsRepoRef: ${{ parameters.versionsRepoRef }}
       customInitSteps: ${{ parameters.customInitSteps }}
+  # When --trim-cached-images is active, ImageBuilder checks base image digests
+  # in the ACR mirror registry, which requires OIDC auth via this service connection.
+  - template: /eng/docker-tools/templates/steps/reference-service-connections.yml@self
+    parameters:
+      publishConfig: ${{ parameters.publishConfig }}
+      usesRegistries:
+        - ${{ parameters.publishConfig.BuildRegistry.server }}
   - ${{ parameters.customGenerateMatrixInitSteps }}
   - template: /eng/docker-tools/templates/steps/retain-build.yml@self
   - template: /eng/docker-tools/templates/steps/validate-branch.yml@self


### PR DESCRIPTION
The generate-matrix.yml job template was missed in PR #2013 when reference-service-connections.yml was added to other job templates. This causes OIDC auth failures when --trim-cached-images checks base image digests in the ACR mirror registry.

This fixes the build error seen in dotnet-buildtools-prereqs-docker build#2925830.