### PR TITLE
Add retry logic to issue comment and close in NotificationService

### DIFF
--- a/src/ImageBuilder/NotificationService.cs
+++ b/src/ImageBuilder/NotificationService.cs
@@ -49,8 +49,9 @@ namespace Microsoft.DotNet.ImageBuilder
                 {
                     foreach (string comment in comments)
                     {
-                        IssueComment postedComment =
-                            await github.Issue.Comment.Create(repoOwner, repoName, issue.Number, comment);
+                        await RetryHelper.GetWaitAndRetryPolicy<ApiException>(_logger)
+                            .ExecuteAsync(() =>
+                                github.Issue.Comment.Create(repoOwner, repoName, issue.Number, comment));
                     }
                 }
             }
@@ -80,11 +81,15 @@ namespace Microsoft.DotNet.ImageBuilder
                 return;
             }
 
-            // Immediately close issues which aren't failures, since open issues should represent actionable items
+            // Immediately close issues which aren't failures, since open issues should represent actionable items.
+            // Retry with backoff to handle GitHub's eventual consistency - the issue may not be fully
+            // propagated across GitHub's backend services immediately after creation.
             if (!labels.Where(l => l.Contains(Commands.NotificationLabels.Failure)).Any())
             {
                 _logger.LogInformation("No failure label found in the notification labels.");
-                await github.Issue.Update(repoOwner, repoName, issue.Number, new IssueUpdate { State = ItemState.Closed });
+                await RetryHelper.GetWaitAndRetryPolicy<ApiException>(_logger)
+                    .ExecuteAsync(() =>
+                        github.Issue.Update(repoOwner, repoName, issue.Number, new IssueUpdate { State = ItemState.Closed }));
             }
         }
     }


### PR DESCRIPTION
The GitHub API has eventual consistency - a newly created issue may not be fully propagated across GitHub's backend services when the first comment or close request arrives. This was observed as an ApiValidationException ("could not resolve to a node") on the comment step in build#2925294.

Wrap both the comment creation and issue close calls with the existing RetryHelper policy (5 retries, jittered exponential backoff) to handle these transient failures.

Related: https://github.com/dotnet/dotnet-docker-internal/issues/10232