### PR TITLE
In steps/clean-acr-images, use dryRunArg to fit pipeline usage

### DIFF
--- a/eng/docker-tools/templates/steps/clean-acr-images.yml
+++ b/eng/docker-tools/templates/steps/clean-acr-images.yml
@@ -3,7 +3,7 @@ parameters:
   acr: null
   action: null
   age: null
-  customArgs: "--dry-run"
+  customArgs: ''
   internalProjectName: null
 steps:
   - template: /eng/docker-tools/templates/steps/run-imagebuilder.yml@self
@@ -23,3 +23,4 @@ steps:
         --action ${{ parameters.action }}
         --age ${{ parameters.age }}
         ${{ parameters.customArgs }}
+        $(dryRunArg)


### PR DESCRIPTION
* Fixes https://github.com/dotnet/docker-tools/issues/2034

Seemed to work when temporarily applied onto the copied files for a Go cleanup pipeline. ([Run](https://dev.azure.com/dnceng/internal/internal%20Team/_build/results?buildId=2930045&view=logs&j=d914c6e3-666d-5b7e-797f-34f264e6df90&t=d7cb3594-03ee-5906-1ea4-eaf0f6fb42c1&l=77))