### PR TITLE
Fix pruneEol not deleting expired images due to oras output format change

### DIFF
--- a/src/ImageBuilder/LifecycleMetadataService.cs
+++ b/src/ImageBuilder/LifecycleMetadataService.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.DotNet.ImageBuilder.Models.Oci;
@@ -88,9 +89,10 @@ public class LifecycleMetadataService : ILifecycleMetadataService
         try
         {
             OrasDiscoverData? orasDiscoverData = JsonConvert.DeserializeObject<OrasDiscoverData>(json);
-            if (orasDiscoverData?.Manifests != null)
+            List<Manifest>? manifests = orasDiscoverData?.Manifests ?? orasDiscoverData?.Referrers;
+            if (manifests != null)
             {
-                lifecycleArtifactManifest = orasDiscoverData.Manifests.FirstOrDefault(m => m.ArtifactType == LifecycleArtifactType);
+                lifecycleArtifactManifest = manifests.FirstOrDefault(m => m.ArtifactType == LifecycleArtifactType);
                 return lifecycleArtifactManifest is not null;
             }
         }

--- a/src/ImageBuilder/Models/Oras/OrasDiscoverData.cs
+++ b/src/ImageBuilder/Models/Oras/OrasDiscoverData.cs
@@ -9,4 +9,6 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Oras;
 public class OrasDiscoverData
 {
     public List<Oci.Manifest>? Manifests { get; set; }
+
+    public List<Oci.Manifest>? Referrers { get; set; }
 }


### PR DESCRIPTION
fixes #2045 

Newer versions of oras changed the `discover --format json` output to use a `referrers` property instead of `manifests`. OrasDiscoverData only had a `Manifests` property, so deserialization always produced null and HasExpiredEol returned false for every image.

Add a `Referrers` property to OrasDiscoverData and fall back to it when `Manifests` is null, supporting both old and new oras output formats.

This breaking change was made in https://github.com/oras-project/oras/releases/tag/v1.3.0:

<img width="675" height="108" alt="Screenshot 2026-03-24 at 10 00 43" src="https://github.com/user-attachments/assets/af38d093-11bc-49ce-9b31-ca368018a47e" />
