### PR TITLE
Properly implement eng-validation-unofficial pipeline

### DIFF
--- a/eng/pipelines/dotnet-docker-tools-eng-validation-unofficial.yml
+++ b/eng/pipelines/dotnet-docker-tools-eng-validation-unofficial.yml
@@ -20,8 +20,11 @@ variables:
 - template: /eng/pipelines/templates/variables/eng-validation.yml@self
 # Uses DockerHub registry creds to avoid rate limiting during CopyBaseImages job
 - template: /eng/docker-tools/templates/variables/dotnet/secrets-unofficial.yml@self
-# Unofficial secrets group has no GitHub token for publishing image info or notifications
+# Unofficial secrets group has no GitHub token for publishing image info, readmes, or notifications
 - name: "publishImageInfo"
+  value: false
+  readonly: true
+- name: "publishReadme"
   value: false
   readonly: true
 - name: "publishNotificationsEnabled"


### PR DESCRIPTION
The docker-tools-imagebuilder unofficial pipeline was frequently used to test changes to the pipeline infrastructure in this repo. Since #2016, the ImageBuilder pipeline is now more optimized, with the tradeoff that it doesn't exercise all of the stages anymore, namely the Test stage.

This PR brings the eng-validaiton-unofficial pipeline up to parity with the docker-tools-imagebuilder unofficial pipeline, so that it can be used in its place.