### PR TITLE
Use correct Image Builder executable name inside Dockerfile

### DIFF
--- a/src/Dockerfile.linux
+++ b/src/Dockerfile.linux
@@ -50,4 +50,4 @@ COPY ["notation-trust/policies/", "/notation-trust/policies/"]
 WORKDIR /image-builder
 COPY --from=build-env /image-builder/out ./
 
-ENTRYPOINT ["/image-builder/imagebuilder"]
+ENTRYPOINT ["/image-builder/Microsoft.DotNet.ImageBuilder"]

--- a/src/Dockerfile.windows
+++ b/src/Dockerfile.windows
@@ -26,4 +26,4 @@ FROM mcr.microsoft.com/windows/$WINDOWS_BASE
 WORKDIR /image-builder
 COPY --from=build-env /image-builder/out ./
 
-ENTRYPOINT ["/image-builder/imagebuilder"]
+ENTRYPOINT ["/image-builder/Microsoft.DotNet.ImageBuilder"]


### PR DESCRIPTION
#2007 started packing Image Builder as a .NET tool. There was an oversight in that PR: The tool name is `imagebuilder` but the assembly/executable name didn't change. This PR fixes the Dockerfile to reference the correct executable name.