### PR TITLE
Revert "Remove unnecessary Docker login from CleanAcrImagesCommand"

### DIFF
--- a/src/ImageBuilder.Tests/CleanAcrImagesCommandTest.cs
+++ b/src/ImageBuilder.Tests/CleanAcrImagesCommandTest.cs
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             IAcrClientFactory acrClientFactory = CreateAcrClientFactory(AcrName, acrClientMock.Object);
 
             CleanAcrImagesCommand command = new(
-                acrClientFactory, Mock.Of<IAcrContentClientFactory>(), Mock.Of<ILogger<CleanAcrImagesCommand>>(), Mock.Of<ILifecycleMetadataService>(), Microsoft.Extensions.Options.Options.Create(new PublishConfiguration()));
+                acrClientFactory, Mock.Of<IAcrContentClientFactory>(), Mock.Of<ILogger<CleanAcrImagesCommand>>(), Mock.Of<ILifecycleMetadataService>(), Mock.Of<IRegistryCredentialsProvider>(), Microsoft.Extensions.Options.Options.Create(new PublishConfiguration()));
             command.Options.RegistryName = AcrName;
             command.Options.RepoName = "build-staging/*";
             command.Options.Action = CleanAcrImagesAction.Delete;
@@ -121,7 +121,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 AcrName, [repo1ContentClient, repo2ContentClient, repo3ContentClient, repo4ContentClient]);
 
             CleanAcrImagesCommand command = new(
-                acrClientFactory, acrContentClientFactory, Mock.Of<ILogger<CleanAcrImagesCommand>>(), Mock.Of<ILifecycleMetadataService>(), Microsoft.Extensions.Options.Options.Create(new PublishConfiguration()));
+                acrClientFactory, acrContentClientFactory, Mock.Of<ILogger<CleanAcrImagesCommand>>(), Mock.Of<ILifecycleMetadataService>(), Mock.Of<IRegistryCredentialsProvider>(), Microsoft.Extensions.Options.Options.Create(new PublishConfiguration()));
             command.Options.RegistryName = AcrName;
             command.Options.RepoName = "public/dotnet/*nightly/*";
             command.Options.Action = CleanAcrImagesAction.PruneDangling;
@@ -166,7 +166,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             IAcrClientFactory acrClientFactory = CreateAcrClientFactory(AcrName, acrClientMock.Object);
 
             CleanAcrImagesCommand command = new(
-                acrClientFactory, Mock.Of<IAcrContentClientFactory>(), Mock.Of<ILogger<CleanAcrImagesCommand>>(), Mock.Of<ILifecycleMetadataService>(), Microsoft.Extensions.Options.Options.Create(new PublishConfiguration()));
+                acrClientFactory, Mock.Of<IAcrContentClientFactory>(), Mock.Of<ILogger<CleanAcrImagesCommand>>(), Mock.Of<ILifecycleMetadataService>(), Mock.Of<IRegistryCredentialsProvider>(), Microsoft.Extensions.Options.Options.Create(new PublishConfiguration()));
             command.Options.RegistryName = AcrName;
             command.Options.RepoName = "test/*";
             command.Options.Action = CleanAcrImagesAction.PruneAll;
@@ -205,7 +205,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             IAcrClientFactory acrClientFactory = CreateAcrClientFactory(AcrName, acrClientMock.Object);
 
             CleanAcrImagesCommand command = new CleanAcrImagesCommand(
-                acrClientFactory, Mock.Of<IAcrContentClientFactory>(), Mock.Of<ILogger<CleanAcrImagesCommand>>(), Mock.Of<ILifecycleMetadataService>(), Microsoft.Extensions.Options.Options.Create(new PublishConfiguration()));
+                acrClientFactory, Mock.Of<IAcrContentClientFactory>(), Mock.Of<ILogger<CleanAcrImagesCommand>>(), Mock.Of<ILifecycleMetadataService>(), Mock.Of<IRegistryCredentialsProvider>(), Microsoft.Extensions.Options.Options.Create(new PublishConfiguration()));
             command.Options.RegistryName = AcrName;
             command.Options.RepoName = "test/*";
             command.Options.Action = CleanAcrImagesAction.PruneAll;
@@ -254,7 +254,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             IAcrContentClientFactory acrContentClientFactory = CreateAcrContentClientFactory(AcrName, [repo1ContentClientMock, repo2ContentClientMock]);
 
             CleanAcrImagesCommand command = new CleanAcrImagesCommand(
-                acrClientFactory, acrContentClientFactory, Mock.Of<ILogger<CleanAcrImagesCommand>>(), Mock.Of<ILifecycleMetadataService>(), Microsoft.Extensions.Options.Options.Create(new PublishConfiguration()));
+                acrClientFactory, acrContentClientFactory, Mock.Of<ILogger<CleanAcrImagesCommand>>(), Mock.Of<ILifecycleMetadataService>(), Mock.Of<IRegistryCredentialsProvider>(), Microsoft.Extensions.Options.Options.Create(new PublishConfiguration()));
             command.Options.RegistryName = AcrName;
             command.Options.RepoName = "test/*";
             command.Options.Action = CleanAcrImagesAction.PruneAll;
@@ -311,7 +311,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Mock<ILifecycleMetadataService> lifecycleMetadataServiceMock = CreateLifecycleMetadataServiceMock(age, repo1Name);
 
             CleanAcrImagesCommand command = new CleanAcrImagesCommand(
-                acrClientFactory, acrContentClientFactory, Mock.Of<ILogger<CleanAcrImagesCommand>>(), lifecycleMetadataServiceMock.Object, Microsoft.Extensions.Options.Options.Create(new PublishConfiguration()));
+                acrClientFactory, acrContentClientFactory, Mock.Of<ILogger<CleanAcrImagesCommand>>(), lifecycleMetadataServiceMock.Object, Mock.Of<IRegistryCredentialsProvider>(), Microsoft.Extensions.Options.Options.Create(new PublishConfiguration()));
             command.Options.RegistryName = AcrName;
             command.Options.RepoName = "test/*";
             command.Options.Action = CleanAcrImagesAction.PruneEol;
@@ -361,7 +361,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 AcrName, [repo1ContentClient, repo2ContentClient]);
 
             CleanAcrImagesCommand command = new(
-                acrClientFactory, acrContentClientFactory, Mock.Of<ILogger<CleanAcrImagesCommand>>(), Mock.Of<ILifecycleMetadataService>(), Microsoft.Extensions.Options.Options.Create(new PublishConfiguration()));
+                acrClientFactory, acrContentClientFactory, Mock.Of<ILogger<CleanAcrImagesCommand>>(), Mock.Of<ILifecycleMetadataService>(), Mock.Of<IRegistryCredentialsProvider>(), Microsoft.Extensions.Options.Options.Create(new PublishConfiguration()));
             command.Options.RegistryName = AcrName;
             command.Options.RepoName = "public/dotnet/nightly/*";
             command.Options.Action = CleanAcrImagesAction.PruneAll;

--- a/src/ImageBuilder/Commands/CleanAcrImagesCommand.cs
+++ b/src/ImageBuilder/Commands/CleanAcrImagesCommand.cs
@@ -25,6 +25,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private readonly IAcrContentClientFactory _acrContentClientFactory;
         private readonly ILogger<CleanAcrImagesCommand> _logger;
         private readonly ILifecycleMetadataService _lifecycleMetadataService;
+        private readonly IRegistryCredentialsProvider _registryCredentialsProvider;
         private readonly PublishConfiguration _publishConfig;
 
         private const int MaxConcurrentDeleteRequestsPerRepo = 5;
@@ -34,12 +35,14 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             IAcrContentClientFactory acrContentClientFactory,
             ILogger<CleanAcrImagesCommand> logger,
             ILifecycleMetadataService lifecycleMetadataService,
+            IRegistryCredentialsProvider registryCredentialsProvider,
             IOptions<PublishConfiguration> publishConfigOptions)
         {
             _acrClientFactory = acrClientFactory ?? throw new ArgumentNullException(nameof(acrClientFactory));
             _acrContentClientFactory = acrContentClientFactory;
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _lifecycleMetadataService = lifecycleMetadataService ?? throw new ArgumentNullException(nameof(lifecycleMetadataService));
+            _registryCredentialsProvider = registryCredentialsProvider ?? throw new ArgumentNullException(nameof(registryCredentialsProvider));
             _publishConfig = publishConfigOptions.Value;
         }
 
@@ -67,18 +70,25 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             List<string> deletedRepos = new List<string>();
             List<string> deletedImages = new List<string>();
 
-            IEnumerable<Task> cleanupTasks = await repositoryNames
-                .Where(repoName => repoNameFilterRegex.IsMatch(repoName))
-                .Select(repoName => acrClient.GetRepository(repoName))
-                .Select(repo =>
+            await _registryCredentialsProvider.ExecuteWithCredentialsAsync(
+                isDryRun: false,
+                async () =>
                 {
-                    Acr acr = Acr.Parse(Options.RegistryName);
-                    IAcrContentClient acrContentClient = CreateAcrContentClient(acr, repo.Name);
-                    return ProcessRepoAsync(acrClient, acrContentClient, repo, deletedRepos, deletedImages);
-                })
-                .ToArrayAsync();
+                    IEnumerable<Task> cleanupTasks = await repositoryNames
+                        .Where(repoName => repoNameFilterRegex.IsMatch(repoName))
+                        .Select(repoName => acrClient.GetRepository(repoName))
+                        .Select(repo =>
+                        {
+                            Acr acr = Acr.Parse(Options.RegistryName);
+                            IAcrContentClient acrContentClient = CreateAcrContentClient(acr, repo.Name);
+                            return ProcessRepoAsync(acrClient, acrContentClient, repo, deletedRepos, deletedImages);
+                        })
+                        .ToArrayAsync();
 
-            await Task.WhenAll(cleanupTasks);
+                    await Task.WhenAll(cleanupTasks);
+                },
+                Options.CredentialsOptions,
+                registryName: Options.RegistryName);
 
             await LogSummaryAsync(acrClient, deletedRepos, deletedImages);
         }


### PR DESCRIPTION
Reverts dotnet/docker-tools#2044. The login was necessary for the ORAS CLI to function. Part of #2051.