### PR TITLE
Update Arcade and adopt V4 publishing

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <PublishingVersion>4</PublishingVersion>
+  </PropertyGroup>
+</Project>

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -6,7 +6,7 @@ This file should be imported by eng/Versions.props
 <Project>
   <PropertyGroup>
     <!-- dotnet-arcade dependencies -->
-    <MicrosoftDotNetArcadeSdkPackageVersion>11.0.0-beta.26181.7</MicrosoftDotNetArcadeSdkPackageVersion>
+    <MicrosoftDotNetArcadeSdkPackageVersion>11.0.0-beta.26204.2</MicrosoftDotNetArcadeSdkPackageVersion>
   </PropertyGroup>
   <!--Property group for alternate package version names-->
   <PropertyGroup>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -3,9 +3,9 @@
   <ProductDependencies>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26181.7">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26204.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>3294c57354d5d24eaa6aca9461635ab317163968</Sha>
+      <Sha>c1c7d910b2fb388d2e458282f5cde711115f99c1</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/common/core-templates/job/job.yml
+++ b/eng/common/core-templates/job/job.yml
@@ -26,6 +26,7 @@ parameters:
   enablePublishBuildArtifacts: false
   enablePublishBuildAssets: false
   enablePublishTestResults: false
+  enablePublishing: false
   enableBuildRetry: false
   mergeTestResults: false
   testRunTitle: ''

--- a/eng/common/core-templates/job/publish-build-assets.yml
+++ b/eng/common/core-templates/job/publish-build-assets.yml
@@ -173,6 +173,7 @@ jobs:
             artifactName: AssetManifests
             displayName: 'Publish Merged Manifest'
             retryCountOnTaskFailure: 10 # for any files being locked
+            isProduction: false # just metadata for publishing
 
     - template: /eng/common/core-templates/steps/publish-pipeline-artifacts.yml
       parameters:
@@ -182,6 +183,7 @@ jobs:
           targetPath: '$(Build.StagingDirectory)/ReleaseConfigs'
           artifactName: ReleaseConfigs
           retryCountOnTaskFailure: 10 # for any files being locked
+          isProduction: false # just metadata for publishing
 
     - ${{ if or(eq(parameters.publishAssetsImmediately, 'true'), eq(parameters.isAssetlessBuild, 'true')) }}:
       - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml

--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -66,20 +66,7 @@ try {
 
   if( $msbuildEngine -eq "vs") {
     # Ensure desktop MSBuild is available for sdk tasks.
-    if( -not ($GlobalJson.tools.PSObject.Properties.Name -contains "vs" )) {
-      $GlobalJson.tools | Add-Member -Name "vs" -Value (ConvertFrom-Json "{ `"version`": `"16.5`" }") -MemberType NoteProperty
-    }
-    if( -not ($GlobalJson.tools.PSObject.Properties.Name -match "xcopy-msbuild" )) {
-      $GlobalJson.tools | Add-Member -Name "xcopy-msbuild" -Value "18.0.0" -MemberType NoteProperty
-    }
-    if ($GlobalJson.tools."xcopy-msbuild".Trim() -ine "none") {
-        $xcopyMSBuildToolsFolder = InitializeXCopyMSBuild $GlobalJson.tools."xcopy-msbuild" -install $true
-    }
-    if ($xcopyMSBuildToolsFolder -eq $null) {
-      throw 'Unable to get xcopy downloadable version of msbuild'
-    }
-
-    $global:_MSBuildExe = "$($xcopyMSBuildToolsFolder)\MSBuild\Current\Bin\MSBuild.exe"
+    $global:_MSBuildExe = InitializeVisualStudioMSBuild
   }
 
   $taskProject = GetSdkTaskProject $task

--- a/eng/common/templates-official/job/job.yml
+++ b/eng/common/templates-official/job/job.yml
@@ -63,7 +63,8 @@ jobs:
       # V4 publishing: automatically publish staged artifacts as a pipeline artifact.
       # The artifact name matches the SDK's FutureArtifactName ($(System.PhaseName)_Artifacts),
       # which is encoded in the asset manifest for downstream publishing to discover.
-      - ${{ if eq(parameters.publishingVersion, 4) }}:
+      # Jobs can opt in by setting enablePublishing: true.
+      - ${{ if and(eq(parameters.publishingVersion, 4), eq(parameters.enablePublishing, 'true')) }}:
         - output: pipelineArtifact
           displayName: 'Publish V4 pipeline artifacts'
           targetPath: '$(Build.ArtifactStagingDirectory)/artifacts'

--- a/eng/common/templates-official/steps/publish-pipeline-artifacts.yml
+++ b/eng/common/templates-official/steps/publish-pipeline-artifacts.yml
@@ -24,7 +24,7 @@ steps:
       artifactName: ${{ parameters.args.artifactName }}
     ${{ if parameters.args.properties }}:
       properties: ${{ parameters.args.properties }}
-    ${{ if parameters.args.sbomEnabled }}:
+    ${{ if ne(parameters.args.sbomEnabled, '') }}:
       sbomEnabled: ${{ parameters.args.sbomEnabled }}
-    ${{ if parameters.args.isProduction }}:
+    ${{ if ne(parameters.args.isProduction, '') }}:
       isProduction: ${{ parameters.args.isProduction }}

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -375,12 +375,11 @@ function InstallDotNet([string] $dotnetRoot,
 #
 #   1. MSBuild from an active VS command prompt
 #   2. MSBuild from a compatible VS installation
-#   3. MSBuild from the xcopy tool package
 #
 # Returns full path to msbuild.exe.
 # Throws on failure.
 #
-function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements = $null) {
+function InitializeVisualStudioMSBuild([object]$vsRequirements = $null) {
   if (-not (IsWindowsPlatform)) {
     throw "Cannot initialize Visual Studio on non-Windows"
   }
@@ -390,13 +389,7 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
   }
 
   # Minimum VS version to require.
-  $vsMinVersionReqdStr = '17.7'
-  $vsMinVersionReqd = [Version]::new($vsMinVersionReqdStr)
-
-  # If the version of msbuild is going to be xcopied,
-  # use this version. Version matches a package here:
-  # https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-eng/NuGet/Microsoft.DotNet.Arcade.MSBuild.Xcopy/versions/18.0.0
-  $defaultXCopyMSBuildVersion = '18.0.0'
+  $vsMinVersionReqdStr = '18.0'
 
   if (!$vsRequirements) {
     if (Get-Member -InputObject $GlobalJson.tools -Name 'vs') {
@@ -426,46 +419,16 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
     }
   }
 
-  # Locate Visual Studio installation or download x-copy msbuild.
+  # Locate Visual Studio installation.
   $vsInfo = LocateVisualStudio $vsRequirements
-  if ($vsInfo -ne $null -and $env:ForceUseXCopyMSBuild -eq $null) {
+  if ($vsInfo -ne $null) {
     # Ensure vsInstallDir has a trailing slash
     $vsInstallDir = Join-Path $vsInfo.installationPath "\"
     $vsMajorVersion = $vsInfo.installationVersion.Split('.')[0]
 
     InitializeVisualStudioEnvironmentVariables $vsInstallDir $vsMajorVersion
   } else {
-    if (Get-Member -InputObject $GlobalJson.tools -Name 'xcopy-msbuild') {
-      $xcopyMSBuildVersion = $GlobalJson.tools.'xcopy-msbuild'
-      $vsMajorVersion = $xcopyMSBuildVersion.Split('.')[0]
-    } else {
-      #if vs version provided in global.json is incompatible (too low) then use the default version for xcopy msbuild download
-      if($vsMinVersion -lt $vsMinVersionReqd){
-        Write-Host "Using xcopy-msbuild version of $defaultXCopyMSBuildVersion since VS version $vsMinVersionStr provided in global.json is not compatible"
-        $xcopyMSBuildVersion = $defaultXCopyMSBuildVersion
-        $vsMajorVersion = $xcopyMSBuildVersion.Split('.')[0]
-      }
-      else{
-        # If the VS version IS compatible, look for an xcopy msbuild package
-        # with a version matching VS.
-        # Note: If this version does not exist, then an explicit version of xcopy msbuild
-        # can be specified in global.json. This will be required for pre-release versions of msbuild.
-        $vsMajorVersion = $vsMinVersion.Major
-        $vsMinorVersion = $vsMinVersion.Minor
-        $xcopyMSBuildVersion = "$vsMajorVersion.$vsMinorVersion.0"
-      }
-    }
-
-    $vsInstallDir = $null
-    if ($xcopyMSBuildVersion.Trim() -ine "none") {
-        $vsInstallDir = InitializeXCopyMSBuild $xcopyMSBuildVersion $install
-        if ($vsInstallDir -eq $null) {
-            throw "Could not xcopy msbuild. Please check that package 'Microsoft.DotNet.Arcade.MSBuild.Xcopy @ $xcopyMSBuildVersion' exists on feed 'dotnet-eng'."
-        }
-    }
-    if ($vsInstallDir -eq $null) {
-      throw 'Unable to find Visual Studio that has required version and components installed'
-    }
+    throw 'Unable to find Visual Studio that has required version and components installed'
   }
 
   $msbuildVersionDir = if ([int]$vsMajorVersion -lt 16) { "$vsMajorVersion.0" } else { "Current" }
@@ -490,38 +453,6 @@ function InitializeVisualStudioEnvironmentVariables([string] $vsInstallDir, [str
     Set-Item "env:VSSDK$($vsMajorVersion)0Install" $vsSdkInstallDir
     $env:VSSDKInstall = $vsSdkInstallDir
   }
-}
-
-function InstallXCopyMSBuild([string]$packageVersion) {
-  return InitializeXCopyMSBuild $packageVersion -install $true
-}
-
-function InitializeXCopyMSBuild([string]$packageVersion, [bool]$install) {
-  $packageName = 'Microsoft.DotNet.Arcade.MSBuild.Xcopy'
-  $packageDir = Join-Path $ToolsDir "msbuild\$packageVersion"
-  $packagePath = Join-Path $packageDir "$packageName.$packageVersion.nupkg"
-
-  if (!(Test-Path $packageDir)) {
-    if (!$install) {
-      return $null
-    }
-
-    Create-Directory $packageDir
-
-    Write-Host "Downloading $packageName $packageVersion"
-    $ProgressPreference = 'SilentlyContinue' # Don't display the console progress UI - it's a huge perf hit
-    Retry({
-      Invoke-WebRequest "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/flat2/$packageName/$packageVersion/$packageName.$packageVersion.nupkg" -UseBasicParsing -OutFile $packagePath
-    })
-
-    if (!(Test-Path $packagePath)) {
-      Write-PipelineTelemetryError -Category 'InitializeToolset' -Message "See https://dev.azure.com/dnceng/internal/_wiki/wikis/DNCEng%20Services%20Wiki/1074/Updating-Microsoft.DotNet.Arcade.MSBuild.Xcopy-WAS-RoslynTools.MSBuild-(xcopy-msbuild)-generation?anchor=troubleshooting for help troubleshooting issues with XCopy MSBuild"
-      throw
-    }
-    Unzip $packagePath $packageDir
-  }
-
-  return Join-Path $packageDir 'tools'
 }
 
 #
@@ -633,7 +564,7 @@ function InitializeBuildTool() {
     $buildTool = @{ Path = $dotnetPath; Command = 'msbuild'; Tool = 'dotnet'; Framework = 'net' }
   } elseif ($msbuildEngine -eq "vs") {
     try {
-      $msbuildPath = InitializeVisualStudioMSBuild -install:$restore
+      $msbuildPath = InitializeVisualStudioMSBuild
     } catch {
       Write-PipelineTelemetryError -Category 'InitializeToolset' -Message $_
       ExitWithExitCode 1

--- a/eng/pipelines/templates/jobs/build-and-publish-packages.yml
+++ b/eng/pipelines/templates/jobs/build-and-publish-packages.yml
@@ -26,6 +26,7 @@ jobs:
     enableMicrobuild: false
     enablePublishBuildArtifacts: ${{ parameters.enablePublish }}
     enablePublishBuildAssets: ${{ parameters.enablePublish }}
+    # Keep this in sync with PublishingVersion in eng/Publishing.props
     publishingVersion: 4
     enableTelemetry: true
 

--- a/eng/pipelines/templates/jobs/build-and-publish-packages.yml
+++ b/eng/pipelines/templates/jobs/build-and-publish-packages.yml
@@ -26,10 +26,12 @@ jobs:
     enableMicrobuild: false
     enablePublishBuildArtifacts: ${{ parameters.enablePublish }}
     enablePublishBuildAssets: ${{ parameters.enablePublish }}
+    publishingVersion: 4
     enableTelemetry: true
 
     jobs:
     - job: Linux
+      enablePublishing: ${{ parameters.enablePublish }}
       container: LinuxContainer
       pool:
         name: $(PoolProvider)
@@ -49,8 +51,6 @@ jobs:
           --prepareMachine
           -p:OfficialBuildId=$(Build.BuildNumber)
           -p:DotNetSignType=$(_SignType)
-          -p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
-          -p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
         displayName: Unix Build / Publish
       - task: ComponentGovernanceComponentDetection@0
         displayName: Component Governance scan

--- a/global.json
+++ b/global.json
@@ -14,6 +14,6 @@
     }
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26181.7"
+    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26204.2"
   }
 }


### PR DESCRIPTION
## Summary
- update the Arcade SDK to `11.0.0-beta.26204.2`
- add repo-owned `PublishingVersion` 4 configuration
- switch the package-build job template to V4 `publishingVersion` / `enablePublishing`
- remove the obsolete symbol-server token plumbing from the repo-owned build arguments

## Validation
- parsed the updated Azure Pipelines YAML with PyYAML

Related to dotnet/arcade#16697.