### PR TITLE
Improve CopyBaseImages and HttpClient logging

### DIFF
--- a/src/ImageBuilder.Tests/CopyImageServiceTests.cs
+++ b/src/ImageBuilder.Tests/CopyImageServiceTests.cs
@@ -31,7 +31,7 @@ public class CopyImageServiceTests
         var emptyConfig = new PublishConfiguration();
         var mockOras = new Mock<IOrasService>();
         mockOras
-            .Setup(o => o.GetReferrersAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(o => o.GetReferrersAsync(It.IsAny<string>(), true, It.IsAny<CancellationToken>()))
             .ReturnsAsync([]);
 
         var service = new CopyImageService(
@@ -80,7 +80,7 @@ public class CopyImageServiceTests
         var mockImporter = new Mock<IAcrImageImporter>();
         var mockOras = new Mock<IOrasService>();
         mockOras
-            .Setup(o => o.GetReferrersAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(o => o.GetReferrersAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<ReferrerInfo>());
 
         var service = new CopyImageService(
@@ -119,7 +119,7 @@ public class CopyImageServiceTests
         var mockImporter = new Mock<IAcrImageImporter>();
         var mockOras = new Mock<IOrasService>();
         mockOras
-            .Setup(o => o.GetReferrersAsync("myacr.azurecr.io/repo:tag", It.IsAny<CancellationToken>()))
+            .Setup(o => o.GetReferrersAsync("myacr.azurecr.io/repo:tag", It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<ReferrerInfo>
             {
                 new("myacr.azurecr.io/repo@sha256:ref1", "application/vnd.cncf.notary.signature"),
@@ -189,7 +189,7 @@ public class CopyImageServiceTests
         var mockImporter = new Mock<IAcrImageImporter>();
         var mockOras = new Mock<IOrasService>();
         mockOras
-            .Setup(o => o.GetReferrersAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(o => o.GetReferrersAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<ReferrerInfo>());
 
         var service = new CopyImageService(
@@ -214,19 +214,17 @@ public class CopyImageServiceTests
     }
 
     /// <summary>
-    /// In dry-run mode, referrer discovery still runs (it is read-only) but the actual
-    /// ACR import of referrers is skipped.
+    /// In dry-run mode, referrer discovery and ACR imports are both skipped.
+    /// The ORAS service receives the dry-run flag and returns an empty list
+    /// to avoid rate limiting on unauthenticated registries.
     /// </summary>
     [Fact]
-    public async Task ImportImageAsync_DryRun_DiscoversReferrersButSkipsImport()
+    public async Task ImportImageAsync_DryRun_SkipsReferrerDiscoveryAndImport()
     {
         var mockOras = new Mock<IOrasService>();
         mockOras
-            .Setup(o => o.GetReferrersAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(
-            [
-                new ReferrerInfo("myacr.azurecr.io/repo@sha256:abc123", "application/vnd.oci.image.manifest.v1+json")
-            ]);
+            .Setup(o => o.GetReferrersAsync(It.IsAny<string>(), true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
 
         var mockImporter = new Mock<IAcrImageImporter>();
 
@@ -244,7 +242,7 @@ public class CopyImageServiceTests
             isDryRun: true);
 
         mockOras.Verify(
-            o => o.GetReferrersAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            o => o.GetReferrersAsync(It.IsAny<string>(), true, It.IsAny<CancellationToken>()),
             Times.Once);
 
         mockImporter.Verify(

--- a/src/ImageBuilder.Tests/CopyImageServiceTests.cs
+++ b/src/ImageBuilder.Tests/CopyImageServiceTests.cs
@@ -209,17 +209,25 @@ public class CopyImageServiceTests
     }
 
     /// <summary>
-    /// In dry-run mode, referrer discovery should be skipped entirely since it
-    /// requires registry connectivity.
+    /// In dry-run mode, referrer discovery still runs (it is read-only) but the actual
+    /// ACR import of referrers is skipped.
     /// </summary>
     [Fact]
-    public async Task ImportImageAsync_DryRun_SkipsReferrerDiscovery()
+    public async Task ImportImageAsync_DryRun_DiscoversReferrersButSkipsImport()
     {
         var mockOras = new Mock<IOrasService>();
+        mockOras
+            .Setup(o => o.GetReferrersAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+            [
+                new ReferrerInfo("myacr.azurecr.io/repo@sha256:abc123", "application/vnd.oci.image.manifest.v1+json")
+            ]);
+
+        var mockImporter = new Mock<IAcrImageImporter>();
 
         var service = new CopyImageService(
             Mock.Of<ILogger<CopyImageService>>(),
-            Mock.Of<IAcrImageImporter>(),
+            mockImporter.Object,
             mockOras.Object,
             ConfigurationHelper.CreateOptionsMock(new PublishConfiguration()));
 
@@ -232,6 +240,13 @@ public class CopyImageServiceTests
 
         mockOras.Verify(
             o => o.GetReferrersAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        mockImporter.Verify(
+            o => o.ImportImageAsync(
+                It.IsAny<string>(),
+                It.IsAny<ResourceIdentifier>(),
+                It.IsAny<ContainerRegistryImportImageContent>()),
             Times.Never);
     }
 

--- a/src/ImageBuilder.Tests/CopyImageServiceTests.cs
+++ b/src/ImageBuilder.Tests/CopyImageServiceTests.cs
@@ -29,10 +29,15 @@ public class CopyImageServiceTests
     public async Task ImportImageAsync_DryRun_DoesNotRequirePublishConfiguration()
     {
         var emptyConfig = new PublishConfiguration();
+        var mockOras = new Mock<IOrasService>();
+        mockOras
+            .Setup(o => o.GetReferrersAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
         var service = new CopyImageService(
             Mock.Of<ILogger<CopyImageService>>(),
             Mock.Of<IAcrImageImporter>(),
-            Mock.Of<IOrasService>(),
+            mockOras.Object,
             ConfigurationHelper.CreateOptionsMock(emptyConfig));
 
         await Should.NotThrowAsync(() =>

--- a/src/ImageBuilder.Tests/Signing/ImageSigningServiceTests.cs
+++ b/src/ImageBuilder.Tests/Signing/ImageSigningServiceTests.cs
@@ -218,7 +218,7 @@ public class ImageSigningServiceTests
             });
         mockOras
             .Setup(s => s.GetReferrersAsync(
-                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<ReferrerInfo>());
 
         var fileSystem = new InMemoryFileSystem();
@@ -306,7 +306,7 @@ public class ImageSigningServiceTests
                 $"sha256:sig-{p.ImageName}");
         mock
             .Setup(s => s.GetReferrersAsync(
-                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<ReferrerInfo>());
         return mock;
     }
@@ -370,7 +370,7 @@ public class ImageSigningServiceTests
         // Both digests already have signature referrers
         mockOras
             .Setup(s => s.GetReferrersAsync(
-                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<ReferrerInfo>
             {
                 new("registry/repo@sha256:existingsig", "application/vnd.cncf.notary.signature")
@@ -407,10 +407,10 @@ public class ImageSigningServiceTests
 
         // Referrers should be checked for each digest
         mockOras.Verify(
-            s => s.GetReferrersAsync("sha256:abc123", It.IsAny<CancellationToken>()),
+            s => s.GetReferrersAsync("sha256:abc123", It.IsAny<bool>(), It.IsAny<CancellationToken>()),
             Times.Once);
         mockOras.Verify(
-            s => s.GetReferrersAsync("sha256:def456", It.IsAny<CancellationToken>()),
+            s => s.GetReferrersAsync("sha256:def456", It.IsAny<bool>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         // ESRP should never be called
@@ -429,14 +429,14 @@ public class ImageSigningServiceTests
         // First digest already has a signature, second does not
         mockOras
             .Setup(s => s.GetReferrersAsync(
-                "sha256:already-signed", It.IsAny<CancellationToken>()))
+                "sha256:already-signed", It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<ReferrerInfo>
             {
                 new("registry/repo@sha256:existingsig", "application/vnd.cncf.notary.signature")
             });
         mockOras
             .Setup(s => s.GetReferrersAsync(
-                "sha256:not-yet-signed", It.IsAny<CancellationToken>()))
+                "sha256:not-yet-signed", It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<ReferrerInfo>());
 
         var service = CreateService(mockOras, mockEsrp: mockEsrp, fileSystem: fileSystem);
@@ -488,7 +488,7 @@ public class ImageSigningServiceTests
         // Referrer exists but is NOT a Notary signature (e.g., an SBOM)
         mockOras
             .Setup(s => s.GetReferrersAsync(
-                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<ReferrerInfo>
             {
                 new("registry/repo@sha256:sbom123", "application/spdx+json")

--- a/src/ImageBuilder/CopyImageService.cs
+++ b/src/ImageBuilder/CopyImageService.cs
@@ -54,58 +54,61 @@ public class CopyImageService : ICopyImageService
     {
         Acr destAcr = Acr.Parse(destAcrName);
 
-        string action = isDryRun ? "(Dry run) Would have imported" : "Importing";
         string sourceImageName = DockerHelper.GetImageName(srcRegistryName, srcTagName);
         var destinationImageNames = destTagNames
-            .Select(tag => $"'{DockerHelper.GetImageName(destAcr.Name, tag)}'")
+            .Select(tag => $"'{DockerHelper.GetImageName(destAcr.Server, tag)}'")
             .ToList();
         string formattedDestinationImages = string.Join(", ", destinationImageNames);
-        _logger.LogInformation("{Action} {DestinationImages} from '{SourceImage}'",
-            action, formattedDestinationImages, sourceImageName);
+        _logger.LogInformation("Importing {DestinationImages} from '{SourceImage}' (DryRun={DryRun})",
+            formattedDestinationImages, sourceImageName, isDryRun);
 
-        if (isDryRun)
+        ResourceIdentifier? destResourceId = null;
+        ResourceIdentifier? srcResourceId = null;
+
+        if (!isDryRun)
         {
-            _logger.LogInformation("Importing skipped due to dry run.");
-            return;
+            destResourceId = _publishConfig.GetAcrResource(destAcrName);
+
+            // Only look up the source resource ID for registries in the publish config (i.e. ACRs).
+            // External registries like docker.io use RegistryAddress + Credentials instead.
+            srcResourceId =
+                // TODO: In the future, ACR credentials (user/pw) could be passed via PublishConfiguration
+                // as well, and resolved here.
+                srcRegistryName is not null && _publishConfig.FindRegistryAuthentication(srcRegistryName) is not null
+                    ? _publishConfig.GetAcrResource(srcRegistryName)
+                    : null;
+
+            ContainerRegistryImportSource importSrc = new(srcTagName)
+            {
+                ResourceId = srcResourceId,
+                RegistryAddress = srcResourceId is null ? srcRegistryName : null,
+                Credentials = sourceCredentials
+            };
+
+            ContainerRegistryImportImageContent importImageContent = new(importSrc)
+            {
+                Mode = ContainerRegistryImportMode.Force
+            };
+
+            importImageContent.TargetTags.AddRange(destTagNames);
+
+            await _acrRegistryImporter.ImportImageAsync(destAcrName, destResourceId, importImageContent);
         }
 
-        var destResourceId = _publishConfig.GetAcrResource(destAcrName);
-
-        // Only look up the source resource ID for registries in the publish config (i.e. ACRs).
-        // External registries like docker.io use RegistryAddress + Credentials instead.
-        ResourceIdentifier? srcResourceId =
-            // TODO: In the future, ACR credentials (user/pw) could be passed via PublishConfiguration
-            // as well, and resolved here.
-            srcRegistryName is not null && _publishConfig.FindRegistryAuthentication(srcRegistryName) is not null
-                ? _publishConfig.GetAcrResource(srcRegistryName)
-                : null;
-
-        // Azure ACR import only supports one source identifier. Use ResourceId for ACR-to-ACR
-        // imports (same tenant), or RegistryAddress for external registries.
-        ContainerRegistryImportSource importSrc = new(srcTagName)
-        {
-            ResourceId = srcResourceId,
-            RegistryAddress = srcResourceId is null ? srcRegistryName : null,
-            Credentials = sourceCredentials
-        };
-
-        ContainerRegistryImportImageContent importImageContent = new(importSrc)
-        {
-            Mode = ContainerRegistryImportMode.Force
-        };
-
-        importImageContent.TargetTags.AddRange(destTagNames);
-
-        await _acrRegistryImporter.ImportImageAsync(destAcrName, destResourceId, importImageContent);
-
-        // Discover and import all OCI referrers (signatures, SBOMs, etc.) for the source image.
+        // Discover referrers (signatures, SBOMs, etc.) for the source image.
+        // This is a read-only operation against the source registry, so it runs even in dry-run mode.
         string sourceImageReference = DockerHelper.GetImageName(srcRegistryName, srcTagName);
         IReadOnlyList<ReferrerInfo> referrers = await _orasService.GetReferrersAsync(sourceImageReference);
 
         string destRepo = destTagNames.First().Split(':')[0].Split('@')[0];
         foreach (ReferrerInfo referrer in referrers)
         {
-            _logger.LogInformation("Importing referrer '{Referrer}' to '{DestAcr}/{DestRepo}'", referrer.Digest, destAcrName, destRepo);
+            _logger.LogInformation("Importing referrer '{Referrer}' to '{DestAcr}/{DestRepo}' (DryRun={DryRun})", referrer.Digest, destAcrName, destRepo, isDryRun);
+
+            if (isDryRun)
+            {
+                continue;
+            }
 
             string referrerDigestReference = DockerHelper.TrimRegistry(referrer.Digest, srcRegistryName);
             ContainerRegistryImportSource referrerImportSrc = new(referrerDigestReference)
@@ -121,7 +124,7 @@ public class CopyImageService : ICopyImageService
             };
             referrerImportContent.UntaggedTargetRepositories.Add(destRepo);
 
-            await _acrRegistryImporter.ImportImageAsync(destAcrName, destResourceId, referrerImportContent);
+            await _acrRegistryImporter.ImportImageAsync(destAcrName, destResourceId!, referrerImportContent);
         }
     }
 }

--- a/src/ImageBuilder/CopyImageService.cs
+++ b/src/ImageBuilder/CopyImageService.cs
@@ -58,14 +58,15 @@ public class CopyImageService : ICopyImageService
         string destRepo = destTagNames.First().Split(':')[0].Split('@')[0];
 
         // Discover referrers (signatures, SBOMs, etc.) for the source image.
-        // This is a read-only operation against the source registry, so it runs even in dry-run mode.
-        IReadOnlyList<ReferrerInfo> referrers = await _orasService.GetReferrersAsync(sourceImageName);
+        IReadOnlyList<ReferrerInfo> referrers =
+            await _orasService.GetReferrersAsync(reference: sourceImageName, isDryRun: isDryRun);
 
-        var destinationImageNames = destTagNames
-            .Select(tag => $"'{DockerHelper.GetImageName(destAcr.Server, tag)}'")
-            .ToList();
+        var destinationImageNames =
+            destTagNames.Select(tag => $"'{DockerHelper.GetImageName(destAcr.Server, tag)}'").ToList();
         string formattedDestinationImages = string.Join(", ", destinationImageNames);
-        _logger.LogInformation("Importing {DestinationImages} and {ReferrerCount} referrer(s) from '{SourceImage}' (DryRun={DryRun})",
+
+        _logger.LogInformation(
+            "Importing {DestinationImages} and {ReferrerCount} referrer(s) from '{SourceImage}' (DryRun={DryRun})",
             formattedDestinationImages, referrers.Count, sourceImageName, isDryRun);
 
         if (isDryRun)

--- a/src/ImageBuilder/CopyImageService.cs
+++ b/src/ImageBuilder/CopyImageService.cs
@@ -55,61 +55,53 @@ public class CopyImageService : ICopyImageService
         Acr destAcr = Acr.Parse(destAcrName);
 
         string sourceImageName = DockerHelper.GetImageName(srcRegistryName, srcTagName);
+        string destRepo = destTagNames.First().Split(':')[0].Split('@')[0];
+
+        // Discover referrers (signatures, SBOMs, etc.) for the source image.
+        // This is a read-only operation against the source registry, so it runs even in dry-run mode.
+        IReadOnlyList<ReferrerInfo> referrers = await _orasService.GetReferrersAsync(sourceImageName);
+
         var destinationImageNames = destTagNames
             .Select(tag => $"'{DockerHelper.GetImageName(destAcr.Server, tag)}'")
             .ToList();
         string formattedDestinationImages = string.Join(", ", destinationImageNames);
-        _logger.LogInformation("Importing {DestinationImages} from '{SourceImage}' (DryRun={DryRun})",
-            formattedDestinationImages, sourceImageName, isDryRun);
+        _logger.LogInformation("Importing {DestinationImages} and {ReferrerCount} referrer(s) from '{SourceImage}' (DryRun={DryRun})",
+            formattedDestinationImages, referrers.Count, sourceImageName, isDryRun);
 
-        ResourceIdentifier? destResourceId = null;
-        ResourceIdentifier? srcResourceId = null;
-
-        if (!isDryRun)
+        if (isDryRun)
         {
-            destResourceId = _publishConfig.GetAcrResource(destAcrName);
-
-            // Only look up the source resource ID for registries in the publish config (i.e. ACRs).
-            // External registries like docker.io use RegistryAddress + Credentials instead.
-            srcResourceId =
-                // TODO: In the future, ACR credentials (user/pw) could be passed via PublishConfiguration
-                // as well, and resolved here.
-                srcRegistryName is not null && _publishConfig.FindRegistryAuthentication(srcRegistryName) is not null
-                    ? _publishConfig.GetAcrResource(srcRegistryName)
-                    : null;
-
-            ContainerRegistryImportSource importSrc = new(srcTagName)
-            {
-                ResourceId = srcResourceId,
-                RegistryAddress = srcResourceId is null ? srcRegistryName : null,
-                Credentials = sourceCredentials
-            };
-
-            ContainerRegistryImportImageContent importImageContent = new(importSrc)
-            {
-                Mode = ContainerRegistryImportMode.Force
-            };
-
-            importImageContent.TargetTags.AddRange(destTagNames);
-
-            await _acrRegistryImporter.ImportImageAsync(destAcrName, destResourceId, importImageContent);
+            return;
         }
 
-        // Discover referrers (signatures, SBOMs, etc.) for the source image.
-        // This is a read-only operation against the source registry, so it runs even in dry-run mode.
-        string sourceImageReference = DockerHelper.GetImageName(srcRegistryName, srcTagName);
-        IReadOnlyList<ReferrerInfo> referrers = await _orasService.GetReferrersAsync(sourceImageReference);
+        ResourceIdentifier destResourceId = _publishConfig.GetAcrResource(destAcrName);
 
-        string destRepo = destTagNames.First().Split(':')[0].Split('@')[0];
+        // Only look up the source resource ID for registries in the publish config (i.e. ACRs).
+        // External registries like docker.io use RegistryAddress + Credentials instead.
+        ResourceIdentifier? srcResourceId =
+            // TODO: In the future, ACR credentials (user/pw) could be passed via PublishConfiguration
+            // as well, and resolved here.
+            srcRegistryName is not null && _publishConfig.FindRegistryAuthentication(srcRegistryName) is not null
+                ? _publishConfig.GetAcrResource(srcRegistryName)
+                : null;
+
+        ContainerRegistryImportSource importSrc = new(srcTagName)
+        {
+            ResourceId = srcResourceId,
+            RegistryAddress = srcResourceId is null ? srcRegistryName : null,
+            Credentials = sourceCredentials
+        };
+
+        ContainerRegistryImportImageContent importImageContent = new(importSrc)
+        {
+            Mode = ContainerRegistryImportMode.Force
+        };
+
+        importImageContent.TargetTags.AddRange(destTagNames);
+
+        await _acrRegistryImporter.ImportImageAsync(destAcrName, destResourceId, importImageContent);
+
         foreach (ReferrerInfo referrer in referrers)
         {
-            _logger.LogInformation("Importing referrer '{Referrer}' to '{DestAcr}/{DestRepo}' (DryRun={DryRun})", referrer.Digest, destAcrName, destRepo, isDryRun);
-
-            if (isDryRun)
-            {
-                continue;
-            }
-
             string referrerDigestReference = DockerHelper.TrimRegistry(referrer.Digest, srcRegistryName);
             ContainerRegistryImportSource referrerImportSrc = new(referrerDigestReference)
             {
@@ -124,7 +116,7 @@ public class CopyImageService : ICopyImageService
             };
             referrerImportContent.UntaggedTargetRepositories.Add(destRepo);
 
-            await _acrRegistryImporter.ImportImageAsync(destAcrName, destResourceId!, referrerImportContent);
+            await _acrRegistryImporter.ImportImageAsync(destAcrName, destResourceId, referrerImportContent);
         }
     }
 }

--- a/src/ImageBuilder/HttpClientProvider.cs
+++ b/src/ImageBuilder/HttpClientProvider.cs
@@ -3,8 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
 using System.Net.Http;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.ImageBuilder
 {
@@ -30,7 +32,12 @@ namespace Microsoft.DotNet.ImageBuilder
 
         public RegistryHttpClient GetRegistryClient() => _registryHttpClient.Value;
 
-        private class LoggingHandler : MessageProcessingHandler
+        /// <summary>
+        /// Logs HTTP request/response activity. Successful responses are logged at Debug level.
+        /// Failures (timeouts, cancellations, transport errors) are logged at Warning level
+        /// with elapsed time to aid diagnosis of hanging requests.
+        /// </summary>
+        private class LoggingHandler : DelegatingHandler
         {
             private readonly ILogger<LoggingHandler> _logger;
 
@@ -41,15 +48,31 @@ namespace Microsoft.DotNet.ImageBuilder
                 InnerHandler = new HttpClientHandler();
             }
 
-            protected override HttpRequestMessage ProcessRequest(HttpRequestMessage request, CancellationToken cancellationToken)
+            protected override async Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request,
+                CancellationToken cancellationToken)
             {
-                _logger.LogInformation($"Sending HTTP request: {request.RequestUri}");
-                return request;
-            }
+                long startTime = Stopwatch.GetTimestamp();
 
-            protected override HttpResponseMessage ProcessResponse(HttpResponseMessage response, CancellationToken cancellationToken)
-            {
-                return response;
+                try
+                {
+                    HttpResponseMessage response = await base.SendAsync(request, cancellationToken);
+                    _logger.LogDebug("HTTP {StatusCode} {Method} {RequestUri} in {Elapsed}",
+                        (int)response.StatusCode, request.Method, request.RequestUri, Stopwatch.GetElapsedTime(startTime));
+                    return response;
+                }
+                catch (TaskCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+                {
+                    _logger.LogWarning(ex, "HTTP timeout {Method} {RequestUri} after {Elapsed}",
+                        request.Method, request.RequestUri, Stopwatch.GetElapsedTime(startTime));
+                    throw;
+                }
+                catch (HttpRequestException ex)
+                {
+                    _logger.LogWarning(ex, "HTTP failure {Method} {RequestUri} after {Elapsed}",
+                        request.Method, request.RequestUri, Stopwatch.GetElapsedTime(startTime));
+                    throw;
+                }
             }
         }
     }

--- a/src/ImageBuilder/ImageBuilder.cs
+++ b/src/ImageBuilder/ImageBuilder.cs
@@ -11,6 +11,7 @@ using Microsoft.DotNet.ImageBuilder.Services;
 using Microsoft.DotNet.ImageBuilder.Signing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using ICommand = Microsoft.DotNet.ImageBuilder.Commands.ICommand;
 
 namespace Microsoft.DotNet.ImageBuilder;
@@ -29,6 +30,7 @@ public static class ImageBuilder
             builder.AddBuildConfiguration();
 
             // Logging
+            builder.Logging.SetMinimumLevel(LogLevel.Debug);
             builder.Logging.AddSimpleConsole(options =>
             {
                 options.IncludeScopes = true;

--- a/src/ImageBuilder/LifecycleMetadataService.cs
+++ b/src/ImageBuilder/LifecycleMetadataService.cs
@@ -33,7 +33,8 @@ public class LifecycleMetadataService : ILifecycleMetadataService
 
         try
         {
-            IReadOnlyList<ReferrerInfo> referrers = await _orasService.GetReferrersAsync(digest, cancellationToken);
+            IReadOnlyList<ReferrerInfo> referrers =
+                await _orasService.GetReferrersAsync(digest, isDryRun: false, cancellationToken);
 
             ReferrerInfo? lifecycleReferrer = referrers.FirstOrDefault(
                 r => r.ArtifactType == OciArtifactType.Lifecycle);

--- a/src/ImageBuilder/Oras/IOrasService.cs
+++ b/src/ImageBuilder/Oras/IOrasService.cs
@@ -39,6 +39,7 @@ public interface IOrasService
     /// Returns the OCI referrers for the given image.
     /// </summary>
     /// <param name="reference">Full registry reference (e.g., "registry.io/repo:tag" or "registry.io/repo@sha256:...").</param>
+    /// <param name="isDryRun">When true, skips registry calls and returns an empty list.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>
     /// A list of <see cref="ReferrerInfo"/> containing the digest reference and artifact type
@@ -46,6 +47,7 @@ public interface IOrasService
     /// </returns>
     Task<IReadOnlyList<ReferrerInfo>> GetReferrersAsync(
         string reference,
+        bool isDryRun = false,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/ImageBuilder/Oras/OrasDotNetService.cs
+++ b/src/ImageBuilder/Oras/OrasDotNetService.cs
@@ -116,11 +116,24 @@ public class OrasDotNetService(
     /// <inheritdoc/>
     public async Task<IReadOnlyList<ReferrerInfo>> GetReferrersAsync(
         string reference,
+        bool isDryRun = false,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(reference);
+        IReadOnlyList<ReferrerInfo> referrers = isDryRun ? []
+            : await GetReferrersImplAsync(reference, cancellationToken);
 
-        long startTime = Stopwatch.GetTimestamp();
+        _logger.LogInformation(
+            "{Reference} has {Count} referrer(s) (DryRun={DryRun})",
+            reference, referrers.Count, isDryRun);
+
+        return referrers;
+    }
+
+    private async Task<IReadOnlyList<ReferrerInfo>> GetReferrersImplAsync(
+        string reference,
+        CancellationToken cancellationToken)
+    {
         Repository repository = CreateRepository(reference);
         Descriptor subjectDescriptor = await repository.ResolveAsync(reference, cancellationToken);
 
@@ -137,9 +150,6 @@ public class OrasDotNetService(
             });
             _logger.LogDebug("Found referrer: {Referrer} (artifactType={ArtifactType})", referrerReference, referrer.ArtifactType);
         }
-
-        TimeSpan elapsed = Stopwatch.GetElapsedTime(startTime);
-        _logger.LogInformation("{Reference} has {Count} referrer(s) ({Elapsed})", reference, referrers.Count, elapsed);
 
         return referrers;
     }

--- a/src/ImageBuilder/Oras/OrasDotNetService.cs
+++ b/src/ImageBuilder/Oras/OrasDotNetService.cs
@@ -43,7 +43,7 @@ public class OrasDotNetService(
     private const string CertificateChainAnnotation = "io.cncf.notary.x509chain.thumbprint#S256";
 
     private readonly IHttpClientProvider _httpClientProvider = httpClientProvider;
-    private readonly IMemoryCache _cache = cache;
+    private readonly Cache _orasCache = new(cache);
     private readonly IFileSystem _fileSystem = fileSystem;
     private readonly ILogger<OrasDotNetService> _logger = logger;
     private readonly OrasCredentialProviderAdapter _credentialProvider = new(credentialsProvider, credentialsHost);
@@ -194,8 +194,7 @@ public class OrasDotNetService(
             parsedRef.Registry, parsedRef.Repository, parsedRef.ContentReference);
 
         HttpClient httpClient = _httpClientProvider.GetClient();
-        Cache cache = new(_cache);
-        Client authClient = new(httpClient, _credentialProvider, cache);
+        Client authClient = new(httpClient, _credentialProvider, _orasCache);
 
         RepositoryOptions repositoryOptions = new()
         {

--- a/src/ImageBuilder/Oras/OrasDotNetService.cs
+++ b/src/ImageBuilder/Oras/OrasDotNetService.cs
@@ -120,8 +120,6 @@ public class OrasDotNetService(
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(reference);
 
-        _logger.LogDebug("Fetching referrers for reference: {Reference}", reference);
-
         long startTime = Stopwatch.GetTimestamp();
         Repository repository = CreateRepository(reference);
         Descriptor subjectDescriptor = await repository.ResolveAsync(reference, cancellationToken);
@@ -141,7 +139,7 @@ public class OrasDotNetService(
         }
 
         TimeSpan elapsed = Stopwatch.GetElapsedTime(startTime);
-        _logger.LogDebug("Found {Count} referrer(s) for {Reference} in {Elapsed}", referrers.Count, reference, elapsed);
+        _logger.LogInformation("{Reference} has {Count} referrer(s) ({Elapsed})", reference, referrers.Count, elapsed);
 
         return referrers;
     }

--- a/src/ImageBuilder/Signing/ImageSigningService.cs
+++ b/src/ImageBuilder/Signing/ImageSigningService.cs
@@ -32,11 +32,6 @@ public class ImageSigningService(
 {
     private const string SigningPayloadsSubdirectory = "signing-payloads";
 
-    /// <summary>
-    /// OCI artifact type for Notary v2 signatures, used to detect already-signed digests.
-    /// </summary>
-    private const string NotarySignatureArtifactType = OciArtifactType.NotarySignatureV2;
-
     private readonly IOrasService _orasService = orasService;
     private readonly IEsrpSigningService _esrpSigningService = esrpSigningService;
     private readonly ILogger<ImageSigningService> _logger = logger;
@@ -70,7 +65,7 @@ public class ImageSigningService(
             IReadOnlyList<ReferrerInfo> referrers =
                 await _orasService.GetReferrersAsync(imageDigest, isDryRun: false, ct);
 
-            bool alreadySigned = referrers.Any(r => r.ArtifactType == NotarySignatureArtifactType);
+            bool alreadySigned = referrers.Any(r => r.ArtifactType == OciArtifactType.NotarySignatureV2);
             if (alreadySigned)
             {
                 _logger.LogInformation("Skipping already-signed digest {Digest}.", imageDigest);

--- a/src/ImageBuilder/Signing/ImageSigningService.cs
+++ b/src/ImageBuilder/Signing/ImageSigningService.cs
@@ -67,9 +67,10 @@ public class ImageSigningService(
         ConcurrentBag<string> unsignedDigests = [];
         await Parallel.ForEachAsync(imageDigests, cancellationToken, async (imageDigest, ct) =>
         {
-            IReadOnlyList<ReferrerInfo> referrers = await _orasService.GetReferrersAsync(imageDigest, ct);
-            bool alreadySigned = referrers.Any(r => r.ArtifactType == NotarySignatureArtifactType);
+            IReadOnlyList<ReferrerInfo> referrers =
+                await _orasService.GetReferrersAsync(imageDigest, isDryRun: false, ct);
 
+            bool alreadySigned = referrers.Any(r => r.ArtifactType == NotarySignatureArtifactType);
             if (alreadySigned)
             {
                 _logger.LogInformation("Skipping already-signed digest {Digest}.", imageDigest);


### PR DESCRIPTION
The `CopyBaseImages` job failed in build#2946397 with a timeout error. Don't really know why. This PR improves logging in `CopyBaseImages`, the HTTP `LoggingHandler`, and `OrasService.GetReferrersAsync` in an attempt to figure out why.

Changes in this PR:
- **Fix OrasDotnetService auth cache concurrency bug**: Share a single `Cache` instance across concurrent `GetReferrersAsync` calls instead of creating one per call, prevents `InvalidOperationException` from concurrent `Dictionary` mutations (I hit this locally).
- **Imporve HTTP logging**: `LoggingHandler` is now a `DelegatingHandler` instead of a `MessageProcessingHandler` which allows it to capture and log elapsed time and transport errors (including timeouts).
- **Change HTTP logging to Debug level** and also set the default log level to Debug.
- **Fix destination image name formatting** in CopyBaseImages logging.
- CopyBaseImages now does more things in dry-run mode.
- **Add `isDryRun` to `IOrasService.GetReferrersAsync`**: Skips registry calls in dry-run mode to avoid rate limiting on unauthenticated registries.
- **Consolidate import logging**: Single log message per image showing destination, referrer count, source, and dry-run status

CopyBaseImages dry run log now looks like this:

<details>

```
19:13:48 info: Microsoft.DotNet.ImageBuilder.ManifestJsonService[0] READING MANIFEST
19:13:50 info: Microsoft.DotNet.ImageBuilder.Commands.CopyBaseImagesCommand[0] COPYING IMAGES
19:13:50 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/amd64/debian:bookworm-slim has 0 referrer(s) (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/amd64/debian:bookworm-slim' and 0 referrer(s) from 'docker.io/amd64/debian:bookworm-slim' (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/arm32v7/debian:bookworm-slim has 0 referrer(s) (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/arm32v7/debian:bookworm-slim' and 0 referrer(s) from 'docker.io/arm32v7/debian:bookworm-slim' (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/arm64v8/debian:bookworm-slim has 0 referrer(s) (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/arm64v8/debian:bookworm-slim' and 0 referrer(s) from 'docker.io/arm64v8/debian:bookworm-slim' (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/amd64/alpine:3.23 has 0 referrer(s) (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/amd64/alpine:3.23' and 0 referrer(s) from 'docker.io/amd64/alpine:3.23' (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/arm32v7/alpine:3.23 has 0 referrer(s) (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/arm32v7/alpine:3.23' and 0 referrer(s) from 'docker.io/arm32v7/alpine:3.23' (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/arm64v8/alpine:3.23 has 0 referrer(s) (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/arm64v8/alpine:3.23' and 0 referrer(s) from 'docker.io/arm64v8/alpine:3.23' (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] ubuntu.azurecr.io/ubuntu:noble has 0 referrer(s) (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/ubuntu.azurecr.io/ubuntu:noble' and 0 referrer(s) from 'ubuntu.azurecr.io/ubuntu:noble' (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/amd64/buildpack-deps:noble-curl has 0 referrer(s) (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/amd64/buildpack-deps:noble-curl' and 0 referrer(s) from 'docker.io/amd64/buildpack-deps:noble-curl' (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/arm64v8/buildpack-deps:noble-curl has 0 referrer(s) (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/arm64v8/buildpack-deps:noble-curl' and 0 referrer(s) from 'docker.io/arm64v8/buildpack-deps:noble-curl' (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] ubuntu.azurecr.io/ubuntu:jammy has 0 referrer(s) (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/ubuntu.azurecr.io/ubuntu:jammy' and 0 referrer(s) from 'ubuntu.azurecr.io/ubuntu:jammy' (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/amd64/buildpack-deps:jammy-curl has 0 referrer(s) (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/amd64/buildpack-deps:jammy-curl' and 0 referrer(s) from 'docker.io/amd64/buildpack-deps:jammy-curl' (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/arm64v8/buildpack-deps:jammy-curl has 0 referrer(s) (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/arm64v8/buildpack-deps:jammy-curl' and 0 referrer(s) from 'docker.io/arm64v8/buildpack-deps:jammy-curl' (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/arm32v7/buildpack-deps:jammy-curl has 0 referrer(s) (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/arm32v7/buildpack-deps:jammy-curl' and 0 referrer(s) from 'docker.io/arm32v7/buildpack-deps:jammy-curl' (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/arm32v7/buildpack-deps:noble-curl has 0 referrer(s) (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/arm32v7/buildpack-deps:noble-curl' and 0 referrer(s) from 'docker.io/arm32v7/buildpack-deps:noble-curl' (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] ubuntu.azurecr.io/ubuntu:resolute has 0 referrer(s) (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/ubuntu.azurecr.io/ubuntu:resolute' and 0 referrer(s) from 'ubuntu.azurecr.io/ubuntu:resolute' (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/amd64/buildpack-deps:resolute-curl has 0 referrer(s) (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/amd64/buildpack-deps:resolute-curl' and 0 referrer(s) from 'docker.io/amd64/buildpack-deps:resolute-curl' (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/arm64v8/buildpack-deps:resolute-curl has 0 referrer(s) (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/arm64v8/buildpack-deps:resolute-curl' and 0 referrer(s) from 'docker.io/arm64v8/buildpack-deps:resolute-curl' (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/arm32v7/buildpack-deps:resolute-curl has 0 referrer(s) (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/arm32v7/buildpack-deps:resolute-curl' and 0 referrer(s) from 'docker.io/arm32v7/buildpack-deps:resolute-curl' (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/amd64/buildpack-deps:bookworm-curl has 0 referrer(s) (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/amd64/buildpack-deps:bookworm-curl' and 0 referrer(s) from 'docker.io/amd64/buildpack-deps:bookworm-curl' (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/arm32v7/buildpack-deps:bookworm-curl has 0 referrer(s) (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/arm32v7/buildpack-deps:bookworm-curl' and 0 referrer(s) from 'docker.io/arm32v7/buildpack-deps:bookworm-curl' (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/arm64v8/buildpack-deps:bookworm-curl has 0 referrer(s) (DryRun=True)
19:13:50 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/arm64v8/buildpack-deps:bookworm-curl' and 0 referrer(s) from 'docker.io/arm64v8/buildpack-deps:bookworm-curl' (DryRun=True)
```

</details>

If you modify the code so that the OCI referrer lookup runs in dry run mode it looks like this:

<details>

```
18:01:50 info: Microsoft.DotNet.ImageBuilder.ManifestJsonService[0] READING MANIFEST
18:01:50 info: Microsoft.DotNet.ImageBuilder.Commands.CopyBaseImagesCommand[0] COPYING IMAGES
18:01:50 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 HEAD https://ubuntu.azurecr.io/v2/ubuntu/manifests/noble in 00:00:00.3005499
18:01:50 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 HEAD https://ubuntu.azurecr.io/v2/ubuntu/manifests/jammy in 00:00:00.3146257
18:01:50 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 HEAD https://ubuntu.azurecr.io/v2/ubuntu/manifests/resolute in 00:00:00.3179327
18:01:50 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 HEAD https://registry-1.docker.io/v2/arm64v8/debian/manifests/bookworm-slim in 00:00:00.3250952
18:01:50 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 HEAD https://registry-1.docker.io/v2/amd64/debian/manifests/bookworm-slim in 00:00:00.3388503
18:01:50 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 HEAD https://registry-1.docker.io/v2/amd64/buildpack-deps/manifests/noble-curl in 00:00:00.3322192
18:01:50 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 HEAD https://registry-1.docker.io/v2/amd64/alpine/manifests/3.23 in 00:00:00.3400287
18:01:50 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 HEAD https://registry-1.docker.io/v2/arm64v8/alpine/manifests/3.23 in 00:00:00.3550078
18:01:50 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 HEAD https://registry-1.docker.io/v2/amd64/buildpack-deps/manifests/resolute-curl in 00:00:00.3547405
18:01:50 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 HEAD https://registry-1.docker.io/v2/arm32v7/buildpack-deps/manifests/resolute-curl in 00:00:00.3553147
18:01:50 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 HEAD https://registry-1.docker.io/v2/arm32v7/buildpack-deps/manifests/noble-curl in 00:00:00.3554622
18:01:50 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 HEAD https://registry-1.docker.io/v2/arm32v7/buildpack-deps/manifests/bookworm-curl in 00:00:00.3573198
18:01:50 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 HEAD https://registry-1.docker.io/v2/arm64v8/buildpack-deps/manifests/bookworm-curl in 00:00:00.3573386
18:01:50 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 HEAD https://registry-1.docker.io/v2/amd64/buildpack-deps/manifests/bookworm-curl in 00:00:00.3573833
18:01:50 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 HEAD https://registry-1.docker.io/v2/arm32v7/debian/manifests/bookworm-slim in 00:00:00.3609042
18:01:50 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 HEAD https://registry-1.docker.io/v2/arm32v7/alpine/manifests/3.23 in 00:00:00.3606243
18:01:50 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 HEAD https://registry-1.docker.io/v2/arm64v8/buildpack-deps/manifests/resolute-curl in 00:00:00.3603186
18:01:50 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 HEAD https://registry-1.docker.io/v2/arm64v8/buildpack-deps/manifests/noble-curl in 00:00:00.3606121
18:01:50 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 HEAD https://registry-1.docker.io/v2/arm64v8/buildpack-deps/manifests/jammy-curl in 00:00:00.3605551
18:01:50 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 HEAD https://registry-1.docker.io/v2/arm32v7/buildpack-deps/manifests/jammy-curl in 00:00:00.3605411
18:01:50 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 HEAD https://registry-1.docker.io/v2/amd64/buildpack-deps/manifests/jammy-curl in 00:00:00.3637359
18:01:50 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://ubuntu.azurecr.io/oauth2/token?service=ubuntu.azurecr.io&scope=repository%3Aubuntu%3Apull in 00:00:00.0623255
18:01:50 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://ubuntu.azurecr.io/oauth2/token?service=ubuntu.azurecr.io&scope=repository%3Aubuntu%3Apull in 00:00:00.0638855
18:01:50 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://ubuntu.azurecr.io/oauth2/token?service=ubuntu.azurecr.io&scope=repository%3Aubuntu%3Apull in 00:00:00.0698071
18:01:50 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 HEAD https://ubuntu.azurecr.io/v2/ubuntu/manifests/jammy in 00:00:00.1051171
18:01:50 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 HEAD https://ubuntu.azurecr.io/v2/ubuntu/manifests/noble in 00:00:00.1089188
18:01:50 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://auth.docker.io/token?service=registry.docker.io&scope=repository%3Aamd64%2Fbuildpack-deps%3Apull in 00:00:00.1638174
18:01:50 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 HEAD https://ubuntu.azurecr.io/v2/ubuntu/manifests/resolute in 00:00:00.1096148
18:01:50 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://auth.docker.io/token?service=registry.docker.io&scope=repository%3Aamd64%2Fdebian%3Apull in 00:00:00.1749372
18:01:50 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://auth.docker.io/token?service=registry.docker.io&scope=repository%3Aarm64v8%2Fdebian%3Apull in 00:00:00.1874288
18:01:50 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://auth.docker.io/token?service=registry.docker.io&scope=repository%3Aamd64%2Fbuildpack-deps%3Apull in 00:00:00.1842548
18:01:50 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://auth.docker.io/token?service=registry.docker.io&scope=repository%3Aarm32v7%2Fbuildpack-deps%3Apull in 00:00:00.1898716
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://auth.docker.io/token?service=registry.docker.io&scope=repository%3Aamd64%2Falpine%3Apull in 00:00:00.2095304
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://auth.docker.io/token?service=registry.docker.io&scope=repository%3Aarm64v8%2Falpine%3Apull in 00:00:00.1947812
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://auth.docker.io/token?service=registry.docker.io&scope=repository%3Aarm32v7%2Fbuildpack-deps%3Apull in 00:00:00.1939848
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://auth.docker.io/token?service=registry.docker.io&scope=repository%3Aamd64%2Fbuildpack-deps%3Apull in 00:00:00.1970007
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://auth.docker.io/token?service=registry.docker.io&scope=repository%3Aarm32v7%2Fbuildpack-deps%3Apull in 00:00:00.2006996
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://auth.docker.io/token?service=registry.docker.io&scope=repository%3Aarm32v7%2Fbuildpack-deps%3Apull in 00:00:00.2017782
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://auth.docker.io/token?service=registry.docker.io&scope=repository%3Aarm64v8%2Fbuildpack-deps%3Apull in 00:00:00.2044717
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://auth.docker.io/token?service=registry.docker.io&scope=repository%3Aamd64%2Fbuildpack-deps%3Apull in 00:00:00.2012402
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://auth.docker.io/token?service=registry.docker.io&scope=repository%3Aarm32v7%2Falpine%3Apull in 00:00:00.2046367
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://auth.docker.io/token?service=registry.docker.io&scope=repository%3Aarm32v7%2Fdebian%3Apull in 00:00:00.2208057
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://auth.docker.io/token?service=registry.docker.io&scope=repository%3Aarm64v8%2Fbuildpack-deps%3Apull in 00:00:00.2294110
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://auth.docker.io/token?service=registry.docker.io&scope=repository%3Aarm64v8%2Fbuildpack-deps%3Apull in 00:00:00.2266858
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://auth.docker.io/token?service=registry.docker.io&scope=repository%3Aarm64v8%2Fbuildpack-deps%3Apull in 00:00:00.2505945
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 HEAD https://registry-1.docker.io/v2/amd64/buildpack-deps/manifests/noble-curl in 00:00:00.1224319
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 HEAD https://registry-1.docker.io/v2/amd64/debian/manifests/bookworm-slim in 00:00:00.1329883
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 HEAD https://registry-1.docker.io/v2/arm64v8/debian/manifests/bookworm-slim in 00:00:00.1235392
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 HEAD https://registry-1.docker.io/v2/amd64/buildpack-deps/manifests/resolute-curl in 00:00:00.1312610
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 HEAD https://registry-1.docker.io/v2/arm64v8/alpine/manifests/3.23 in 00:00:00.1270026
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 HEAD https://registry-1.docker.io/v2/arm32v7/buildpack-deps/manifests/resolute-curl in 00:00:00.1369695
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 HEAD https://registry-1.docker.io/v2/amd64/alpine/manifests/3.23 in 00:00:00.1331314
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 GET https://registry-1.docker.io/v2/amd64/buildpack-deps/referrers/sha256:444a772704c94decfa2369436b592c7f7e272dcf2ca106e98853136c3b797774 in 00:00:00.0706987
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 HEAD https://registry-1.docker.io/v2/arm32v7/buildpack-deps/manifests/bookworm-curl in 00:00:00.1253584
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 HEAD https://registry-1.docker.io/v2/arm32v7/buildpack-deps/manifests/noble-curl in 00:00:00.1277611
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 HEAD https://registry-1.docker.io/v2/amd64/buildpack-deps/manifests/bookworm-curl in 00:00:00.1396001
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 GET https://registry-1.docker.io/v2/arm64v8/debian/referrers/sha256:003eb522097769dfa78f72917421c5709f33261812ce8b764a5a3eeab1203076 in 00:00:00.0679354
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 GET https://registry-1.docker.io/v2/amd64/debian/referrers/sha256:06e64e210bc80fe9b5725b9575cc20e4bc7c09124de8842b96d23ca3b136463b in 00:00:00.0688166
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 HEAD https://registry-1.docker.io/v2/arm32v7/buildpack-deps/manifests/jammy-curl in 00:00:00.1467317
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 HEAD https://registry-1.docker.io/v2/amd64/buildpack-deps/manifests/jammy-curl in 00:00:00.1340480
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 HEAD https://registry-1.docker.io/v2/arm64v8/buildpack-deps/manifests/bookworm-curl in 00:00:00.1232762
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 HEAD https://registry-1.docker.io/v2/arm64v8/buildpack-deps/manifests/noble-curl in 00:00:00.1410145
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 HEAD https://registry-1.docker.io/v2/arm32v7/alpine/manifests/3.23 in 00:00:00.1409525
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 HEAD https://registry-1.docker.io/v2/arm32v7/debian/manifests/bookworm-slim in 00:00:00.1382296
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 HEAD https://registry-1.docker.io/v2/arm64v8/buildpack-deps/manifests/jammy-curl in 00:00:00.1404515
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 GET https://registry-1.docker.io/v2/amd64/buildpack-deps/referrers/sha256:a82236ee4801edb93d54bfe6d8d2b45c1447f8bd2bfced65b46f91f5ef314ba5 in 00:00:00.0702097
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 HEAD https://registry-1.docker.io/v2/arm64v8/buildpack-deps/manifests/resolute-curl in 00:00:00.1317902
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 GET https://registry-1.docker.io/v2/arm64v8/alpine/referrers/sha256:b44095febd0478ce6af640e50a9c66a37c9dcee639bfb64a0441f74a8fe464fc in 00:00:00.0726057
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 GET https://registry-1.docker.io/v2/arm32v7/buildpack-deps/referrers/sha256:fadad4334dfdfed01fa1630c2726877e8b05024d40c20d0a345b34f4c9128d94 in 00:00:00.0729160
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 GET https://registry-1.docker.io/v2/amd64/alpine/referrers/sha256:da143300ea1b5cd2cf20cccafd3b4135047d232645974d28efa6a2314c9b1a11 in 00:00:00.0729215
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 GET https://registry-1.docker.io/v2/arm32v7/buildpack-deps/referrers/sha256:b921d95fd1a646ced860880461eb32356d93038715d6d295c56b97d260668e6c in 00:00:00.0681988
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 GET https://registry-1.docker.io/v2/arm32v7/buildpack-deps/referrers/sha256:3d7af4aa52ce92fc7c77e664f965fa76995f66a0f30d6b130714e3207f57b296 in 00:00:00.0691713
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 GET https://registry-1.docker.io/v2/amd64/buildpack-deps/referrers/sha256:4960a04ff1aed212036d5f26fdc6eb32c0d16fe749cb4786b3950e8c3ebcd719 in 00:00:00.0704765
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 GET https://registry-1.docker.io/v2/arm32v7/buildpack-deps/referrers/sha256:7f22fb10fba5d88b2437cbe806964902817efa38e1e0301b4b94ec1f2f8b1526 in 00:00:00.0697022
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 GET https://registry-1.docker.io/v2/amd64/buildpack-deps/referrers/sha256:7cf22600bb2b79c6ed6c5d504bcb9df96eaead036680d0e2e5dad6eee04f14d7 in 00:00:00.0701619
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 GET https://registry-1.docker.io/v2/arm64v8/buildpack-deps/referrers/sha256:8bd47d050b10495a241a767bb76a6e839b724091c183dd6063531588797dad65 in 00:00:00.0688891
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 GET https://registry-1.docker.io/v2/arm64v8/buildpack-deps/referrers/sha256:71ed006785a1f38cd09a590969da349fffe1573461365e4d47b50633de55e835 in 00:00:00.0724159
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 GET https://registry-1.docker.io/v2/arm32v7/alpine/referrers/sha256:2825fce7e7974c9ea3fdc32c4976a080a408913f0c35b5d90fe04078b59c4ffb in 00:00:00.0723666
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 GET https://registry-1.docker.io/v2/arm32v7/debian/referrers/sha256:07f5899dc53fb11deac5f95f509afea5e5f4ff36d2c13cd0af8f0735bdcfa237 in 00:00:00.0703206
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://registry-1.docker.io/v2/arm64v8/debian/referrers/sha256:003eb522097769dfa78f72917421c5709f33261812ce8b764a5a3eeab1203076 in 00:00:00.0951733
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 GET https://registry-1.docker.io/v2/arm64v8/buildpack-deps/referrers/sha256:26e4b15930c578a27824fbf6050140058677b2e4a7396b488bd35b4b1209325a in 00:00:00.0689345
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://registry-1.docker.io/v2/amd64/debian/referrers/sha256:06e64e210bc80fe9b5725b9575cc20e4bc7c09124de8842b96d23ca3b136463b in 00:00:00.1009678
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://registry-1.docker.io/v2/amd64/buildpack-deps/referrers/sha256:444a772704c94decfa2369436b592c7f7e272dcf2ca106e98853136c3b797774 in 00:00:00.1196251
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 401 GET https://registry-1.docker.io/v2/arm64v8/buildpack-deps/referrers/sha256:50fd83e17411cf02773cf1a312f2b68da0aba025ea59495c29c5121cc75830ff in 00:00:00.0719277
18:01:51 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/arm64v8/debian:bookworm-slim has 0 referrer(s) (00:00:00.8167858)
18:01:51 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/amd64/debian:bookworm-slim has 0 referrer(s) (00:00:00.8550414)
18:01:51 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/amd64/buildpack-deps:noble-curl has 0 referrer(s) (00:00:00.8165777)
18:01:51 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/amd64/buildpack-deps:noble-curl' and 0 referrer(s) from 'docker.io/amd64/buildpack-deps:noble-curl' (DryRun=True)
18:01:51 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/arm64v8/debian:bookworm-slim' and 0 referrer(s) from 'docker.io/arm64v8/debian:bookworm-slim' (DryRun=True)
18:01:51 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/amd64/debian:bookworm-slim' and 0 referrer(s) from 'docker.io/amd64/debian:bookworm-slim' (DryRun=True)
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://registry-1.docker.io/v2/amd64/buildpack-deps/referrers/sha256:a82236ee4801edb93d54bfe6d8d2b45c1447f8bd2bfced65b46f91f5ef314ba5 in 00:00:00.1000027
18:01:51 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/amd64/buildpack-deps:resolute-curl has 0 referrer(s) (00:00:00.8409430)
18:01:51 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/amd64/buildpack-deps:resolute-curl' and 0 referrer(s) from 'docker.io/amd64/buildpack-deps:resolute-curl' (DryRun=True)
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://registry-1.docker.io/v2/arm32v7/buildpack-deps/referrers/sha256:fadad4334dfdfed01fa1630c2726877e8b05024d40c20d0a345b34f4c9128d94 in 00:00:00.0959294
18:01:51 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/arm32v7/buildpack-deps:resolute-curl has 0 referrer(s) (00:00:00.8515305)
18:01:51 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/arm32v7/buildpack-deps:resolute-curl' and 0 referrer(s) from 'docker.io/arm32v7/buildpack-deps:resolute-curl' (DryRun=True)
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://registry-1.docker.io/v2/arm32v7/buildpack-deps/referrers/sha256:b921d95fd1a646ced860880461eb32356d93038715d6d295c56b97d260668e6c in 00:00:00.1013826
18:01:51 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/arm32v7/buildpack-deps:bookworm-curl has 0 referrer(s) (00:00:00.8591775)
18:01:51 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/arm32v7/buildpack-deps:bookworm-curl' and 0 referrer(s) from 'docker.io/arm32v7/buildpack-deps:bookworm-curl' (DryRun=True)
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://registry-1.docker.io/v2/amd64/alpine/referrers/sha256:da143300ea1b5cd2cf20cccafd3b4135047d232645974d28efa6a2314c9b1a11 in 00:00:00.1080230
18:01:51 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/amd64/alpine:3.23 has 0 referrer(s) (00:00:00.8640017)
18:01:51 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/amd64/alpine:3.23' and 0 referrer(s) from 'docker.io/amd64/alpine:3.23' (DryRun=True)
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://registry-1.docker.io/v2/amd64/buildpack-deps/referrers/sha256:4960a04ff1aed212036d5f26fdc6eb32c0d16fe749cb4786b3950e8c3ebcd719 in 00:00:00.0970514
18:01:51 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/amd64/buildpack-deps:bookworm-curl has 0 referrer(s) (00:00:00.8665075)
18:01:51 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/amd64/buildpack-deps:bookworm-curl' and 0 referrer(s) from 'docker.io/amd64/buildpack-deps:bookworm-curl' (DryRun=True)
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://registry-1.docker.io/v2/arm64v8/alpine/referrers/sha256:b44095febd0478ce6af640e50a9c66a37c9dcee639bfb64a0441f74a8fe464fc in 00:00:00.1211145
18:01:51 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/arm64v8/alpine:3.23 has 0 referrer(s) (00:00:00.8728603)
18:01:51 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/arm64v8/alpine:3.23' and 0 referrer(s) from 'docker.io/arm64v8/alpine:3.23' (DryRun=True)
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://registry-1.docker.io/v2/arm32v7/buildpack-deps/referrers/sha256:3d7af4aa52ce92fc7c77e664f965fa76995f66a0f30d6b130714e3207f57b296 in 00:00:00.1085072
18:01:51 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/arm32v7/buildpack-deps:noble-curl has 0 referrer(s) (00:00:00.8752578)
18:01:51 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/arm32v7/buildpack-deps:noble-curl' and 0 referrer(s) from 'docker.io/arm32v7/buildpack-deps:noble-curl' (DryRun=True)
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://registry-1.docker.io/v2/arm32v7/alpine/referrers/sha256:2825fce7e7974c9ea3fdc32c4976a080a408913f0c35b5d90fe04078b59c4ffb in 00:00:00.0962742
18:01:51 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/arm32v7/alpine:3.23 has 0 referrer(s) (00:00:00.8839988)
18:01:51 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/arm32v7/alpine:3.23' and 0 referrer(s) from 'docker.io/arm32v7/alpine:3.23' (DryRun=True)
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://registry-1.docker.io/v2/amd64/buildpack-deps/referrers/sha256:7cf22600bb2b79c6ed6c5d504bcb9df96eaead036680d0e2e5dad6eee04f14d7 in 00:00:00.1098375
18:01:51 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/amd64/buildpack-deps:jammy-curl has 0 referrer(s) (00:00:00.8881441)
18:01:51 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/amd64/buildpack-deps:jammy-curl' and 0 referrer(s) from 'docker.io/amd64/buildpack-deps:jammy-curl' (DryRun=True)
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://registry-1.docker.io/v2/arm64v8/buildpack-deps/referrers/sha256:8bd47d050b10495a241a767bb76a6e839b724091c183dd6063531588797dad65 in 00:00:00.1125125
18:01:51 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/arm64v8/buildpack-deps:bookworm-curl has 0 referrer(s) (00:00:00.8933367)
18:01:51 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/arm64v8/buildpack-deps:bookworm-curl' and 0 referrer(s) from 'docker.io/arm64v8/buildpack-deps:bookworm-curl' (DryRun=True)
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://registry-1.docker.io/v2/arm32v7/debian/referrers/sha256:07f5899dc53fb11deac5f95f509afea5e5f4ff36d2c13cd0af8f0735bdcfa237 in 00:00:00.1048807
18:01:51 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/arm32v7/debian:bookworm-slim has 0 referrer(s) (00:00:00.8955604)
18:01:51 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/arm32v7/debian:bookworm-slim' and 0 referrer(s) from 'docker.io/arm32v7/debian:bookworm-slim' (DryRun=True)
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://registry-1.docker.io/v2/arm32v7/buildpack-deps/referrers/sha256:7f22fb10fba5d88b2437cbe806964902817efa38e1e0301b4b94ec1f2f8b1526 in 00:00:00.1236496
18:01:51 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/arm32v7/buildpack-deps:jammy-curl has 0 referrer(s) (00:00:00.8996689)
18:01:51 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/arm32v7/buildpack-deps:jammy-curl' and 0 referrer(s) from 'docker.io/arm32v7/buildpack-deps:jammy-curl' (DryRun=True)
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://registry-1.docker.io/v2/arm64v8/buildpack-deps/referrers/sha256:71ed006785a1f38cd09a590969da349fffe1573461365e4d47b50633de55e835 in 00:00:00.1153257
18:01:51 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/arm64v8/buildpack-deps:noble-curl has 0 referrer(s) (00:00:00.9028450)
18:01:51 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/arm64v8/buildpack-deps:noble-curl' and 0 referrer(s) from 'docker.io/arm64v8/buildpack-deps:noble-curl' (DryRun=True)
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://registry-1.docker.io/v2/arm64v8/buildpack-deps/referrers/sha256:26e4b15930c578a27824fbf6050140058677b2e4a7396b488bd35b4b1209325a in 00:00:00.1146535
18:01:51 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/arm64v8/buildpack-deps:jammy-curl has 0 referrer(s) (00:00:00.9140050)
18:01:51 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/arm64v8/buildpack-deps:jammy-curl' and 0 referrer(s) from 'docker.io/arm64v8/buildpack-deps:jammy-curl' (DryRun=True)
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://registry-1.docker.io/v2/arm64v8/buildpack-deps/referrers/sha256:50fd83e17411cf02773cf1a312f2b68da0aba025ea59495c29c5121cc75830ff in 00:00:00.0999244
18:01:51 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] docker.io/arm64v8/buildpack-deps:resolute-curl has 0 referrer(s) (00:00:00.9148180)
18:01:51 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/arm64v8/buildpack-deps:resolute-curl' and 0 referrer(s) from 'docker.io/arm64v8/buildpack-deps:resolute-curl' (DryRun=True)
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://ubuntu.azurecr.io/v2/ubuntu/referrers/sha256:2942ff52ece39b70afadf29eea924810b485fede02729b3579aec79f3ed060d1 in 00:00:00.6349282
18:01:51 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] ubuntu.azurecr.io/ubuntu:jammy has 0 referrer(s) (00:00:01.1294688)
18:01:51 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/ubuntu.azurecr.io/ubuntu:jammy' and 0 referrer(s) from 'ubuntu.azurecr.io/ubuntu:jammy' (DryRun=True)
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://ubuntu.azurecr.io/v2/ubuntu/referrers/sha256:f2a22c549032a731b81666e8fd9adbb7bacb1522b0871b14636aadb3380dede5 in 00:00:00.6348021
18:01:51 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] ubuntu.azurecr.io/ubuntu:resolute has 0 referrer(s) (00:00:01.1328048)
18:01:51 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/ubuntu.azurecr.io/ubuntu:resolute' and 0 referrer(s) from 'ubuntu.azurecr.io/ubuntu:resolute' (DryRun=True)
18:01:51 dbug: Microsoft.DotNet.ImageBuilder.HttpClientProvider.LoggingHandler[0] HTTP 200 GET https://ubuntu.azurecr.io/v2/ubuntu/referrers/sha256:3fe0158dab8918f3deb1adfd37ad44e493986d5b8dcf68995d6eac75c5a8dc2c in 00:00:00.7057142
18:01:51 info: Microsoft.DotNet.ImageBuilder.Oras.OrasDotNetService[0] ubuntu.azurecr.io/ubuntu:noble has 0 referrer(s) (00:00:01.2001596)
18:01:51 info: Microsoft.DotNet.ImageBuilder.CopyImageService[0] Importing 'fake.azurecr.io/ubuntu.azurecr.io/ubuntu:noble' and 0 referrer(s) from 'ubuntu.azurecr.io/ubuntu:noble' (DryRun=True)
```

</details>

Verbose, yes, but hopefully helpful.