### PR TITLE
Fix timeout catch in HTTP LoggingHandler and add tests to verify

### DIFF
--- a/src/ImageBuilder.Tests/LoggingHandlerTests.cs
+++ b/src/ImageBuilder.Tests/LoggingHandlerTests.cs
@@ -63,6 +63,10 @@ public class LoggingHandlerTests
         mockLogger.VerifyLog(LogLevel.Warning, "HTTP timeout", Times.Never());
     }
 
+    /// <summary>
+    /// Creates a mock ILogger with all log levels enabled so that LogDebug/LogWarning
+    /// extension methods don't short-circuit before calling <see cref="ILogger.Log"/>.
+    /// </summary>
     private static Mock<ILogger> CreateMockLogger()
     {
         Mock<ILogger> mock = new();
@@ -70,6 +74,11 @@ public class LoggingHandlerTests
         return mock;
     }
 
+    /// <summary>
+    /// Creates a mock HttpMessageHandler whose SendAsync (protected) throws the given exception.
+    /// This replaces the real HTTP stack so LoggingHandler's catch clauses can be exercised
+    /// without making any network calls.
+    /// </summary>
     private static HttpMessageHandler CreateThrowingHandler(Exception exception)
     {
         Mock<HttpMessageHandler> mock = new();

--- a/src/ImageBuilder.Tests/LoggingHandlerTests.cs
+++ b/src/ImageBuilder.Tests/LoggingHandlerTests.cs
@@ -1,0 +1,102 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Moq.Protected;
+using Shouldly;
+using Xunit;
+
+namespace Microsoft.DotNet.ImageBuilder.Tests;
+
+public class LoggingHandlerTests
+{
+    /// <summary>
+    /// Validates that when an HTTP timeout occurs (OperationCanceledException with TimeoutException inner),
+    /// LoggingHandler logs a warning containing "HTTP timeout" and re-throws.
+    /// </summary>
+    [Fact]
+    public async Task SendAsync_Timeout_LogsWarningAndThrows()
+    {
+        Mock<ILogger> mockLogger = CreateMockLogger();
+        HttpMessageHandler stubInner = CreateThrowingHandler(
+            new TaskCanceledException(
+                "The request was canceled due to the configured HttpClient.Timeout of 100 seconds elapsing.",
+                new TimeoutException("A task was canceled.")));
+
+        using LoggingHandler handler = new(mockLogger.Object) { InnerHandler = stubInner };
+        using HttpMessageInvoker invoker = new(handler);
+
+        HttpRequestMessage request = new(HttpMethod.Get, "https://example.com/v2/test/manifests/latest");
+
+        await Should.ThrowAsync<TaskCanceledException>(
+            () => invoker.SendAsync(request, CancellationToken.None));
+
+        mockLogger.VerifyLog(LogLevel.Warning, "HTTP timeout", Times.Once());
+    }
+
+    /// <summary>
+    /// Validates that when a caller-driven cancellation occurs (OperationCanceledException without
+    /// TimeoutException inner), LoggingHandler logs "HTTP canceled" rather than "HTTP timeout".
+    /// </summary>
+    [Fact]
+    public async Task SendAsync_CallerCancellation_LogsCanceledAndThrows()
+    {
+        Mock<ILogger> mockLogger = CreateMockLogger();
+        HttpMessageHandler stubInner = CreateThrowingHandler(
+            new OperationCanceledException("The operation was canceled."));
+
+        using LoggingHandler handler = new(mockLogger.Object) { InnerHandler = stubInner };
+        using HttpMessageInvoker invoker = new(handler);
+
+        HttpRequestMessage request = new(HttpMethod.Get, "https://example.com/v2/test/manifests/latest");
+
+        await Should.ThrowAsync<OperationCanceledException>(
+            () => invoker.SendAsync(request, CancellationToken.None));
+
+        mockLogger.VerifyLog(LogLevel.Warning, "HTTP canceled", Times.Once());
+        mockLogger.VerifyLog(LogLevel.Warning, "HTTP timeout", Times.Never());
+    }
+
+    private static Mock<ILogger> CreateMockLogger()
+    {
+        Mock<ILogger> mock = new();
+        mock.Setup(l => l.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
+        return mock;
+    }
+
+    private static HttpMessageHandler CreateThrowingHandler(Exception exception)
+    {
+        Mock<HttpMessageHandler> mock = new();
+        mock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(exception);
+        return mock.Object;
+    }
+}
+
+internal static class MockLoggerExtensions
+{
+    /// <summary>
+    /// Verifies that the logger was called at the specified level with a message containing the expected substring.
+    /// </summary>
+    public static void VerifyLog(this Mock<ILogger> mockLogger, LogLevel level, string messageSubstring, Times times)
+    {
+        mockLogger.Verify(
+            l => l.Log(
+                level,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains(messageSubstring)),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            times);
+    }
+}

--- a/src/ImageBuilder/HttpClientProvider.cs
+++ b/src/ImageBuilder/HttpClientProvider.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.ImageBuilder
     /// Failures (timeouts, cancellations, transport errors) are logged at Warning level
     /// with elapsed time to aid diagnosis of hanging requests.
     /// </summary>
-    public class LoggingHandler : DelegatingHandler
+    public sealed class LoggingHandler : DelegatingHandler
     {
         private readonly ILogger _logger;
 

--- a/src/ImageBuilder/HttpClientProvider.cs
+++ b/src/ImageBuilder/HttpClientProvider.cs
@@ -32,54 +32,60 @@ namespace Microsoft.DotNet.ImageBuilder
 
         public RegistryHttpClient GetRegistryClient() => _registryHttpClient.Value;
 
-        /// <summary>
-        /// Logs HTTP request/response activity. Successful responses are logged at Debug level.
-        /// Failures (timeouts, cancellations, transport errors) are logged at Warning level
-        /// with elapsed time to aid diagnosis of hanging requests.
-        /// </summary>
-        private class LoggingHandler : DelegatingHandler
+    }
+
+    /// <summary>
+    /// Logs HTTP request/response activity. Successful responses are logged at Debug level.
+    /// Failures (timeouts, cancellations, transport errors) are logged at Warning level
+    /// with elapsed time to aid diagnosis of hanging requests.
+    /// </summary>
+    public class LoggingHandler : DelegatingHandler
+    {
+        private readonly ILogger _logger;
+
+        public LoggingHandler(ILoggerFactory loggerFactory)
+            : this(loggerFactory.CreateLogger<LoggingHandler>())
         {
-            private readonly ILogger<LoggingHandler> _logger;
+            InnerHandler = new HttpClientHandler();
+        }
 
-            public LoggingHandler(ILoggerFactory loggerFactory)
+        public LoggingHandler(ILogger logger)
+        {
+            ArgumentNullException.ThrowIfNull(logger);
+            _logger = logger;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            long startTime = Stopwatch.GetTimestamp();
+            _logger.LogDebug("HTTP {Method} {RequestUri} sending", request.Method, request.RequestUri);
+
+            try
             {
-                ArgumentNullException.ThrowIfNull(loggerFactory);
-                _logger = loggerFactory.CreateLogger<LoggingHandler>();
-                InnerHandler = new HttpClientHandler();
+                HttpResponseMessage response = await base.SendAsync(request, cancellationToken);
+                _logger.LogDebug("HTTP {StatusCode} {Method} {RequestUri} in {Elapsed}",
+                    (int)response.StatusCode, request.Method, request.RequestUri, Stopwatch.GetElapsedTime(startTime));
+                return response;
             }
-
-            protected override async Task<HttpResponseMessage> SendAsync(
-                HttpRequestMessage request,
-                CancellationToken cancellationToken)
+            catch (OperationCanceledException ex) when (ex.InnerException is TimeoutException)
             {
-                long startTime = Stopwatch.GetTimestamp();
-                _logger.LogDebug("HTTP {Method} {RequestUri} sending", request.Method, request.RequestUri);
-
-                try
-                {
-                    HttpResponseMessage response = await base.SendAsync(request, cancellationToken);
-                    _logger.LogDebug("HTTP {StatusCode} {Method} {RequestUri} in {Elapsed}",
-                        (int)response.StatusCode, request.Method, request.RequestUri, Stopwatch.GetElapsedTime(startTime));
-                    return response;
-                }
-                catch (OperationCanceledException ex) when (ex.InnerException is TimeoutException)
-                {
-                    _logger.LogWarning(ex, "HTTP timeout {Method} {RequestUri} after {Elapsed}",
-                        request.Method, request.RequestUri, Stopwatch.GetElapsedTime(startTime));
-                    throw;
-                }
-                catch (OperationCanceledException ex)
-                {
-                    _logger.LogWarning(ex, "HTTP canceled {Method} {RequestUri} after {Elapsed}",
-                        request.Method, request.RequestUri, Stopwatch.GetElapsedTime(startTime));
-                    throw;
-                }
-                catch (HttpRequestException ex)
-                {
-                    _logger.LogWarning(ex, "HTTP failure {Method} {RequestUri} after {Elapsed}",
-                        request.Method, request.RequestUri, Stopwatch.GetElapsedTime(startTime));
-                    throw;
-                }
+                _logger.LogWarning(ex, "HTTP timeout {Method} {RequestUri} after {Elapsed}",
+                    request.Method, request.RequestUri, Stopwatch.GetElapsedTime(startTime));
+                throw;
+            }
+            catch (OperationCanceledException ex)
+            {
+                _logger.LogWarning(ex, "HTTP canceled {Method} {RequestUri} after {Elapsed}",
+                    request.Method, request.RequestUri, Stopwatch.GetElapsedTime(startTime));
+                throw;
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.LogWarning(ex, "HTTP failure {Method} {RequestUri} after {Elapsed}",
+                    request.Method, request.RequestUri, Stopwatch.GetElapsedTime(startTime));
+                throw;
             }
         }
     }

--- a/src/ImageBuilder/HttpClientProvider.cs
+++ b/src/ImageBuilder/HttpClientProvider.cs
@@ -53,6 +53,7 @@ namespace Microsoft.DotNet.ImageBuilder
                 CancellationToken cancellationToken)
             {
                 long startTime = Stopwatch.GetTimestamp();
+                _logger.LogDebug("HTTP {Method} {RequestUri} sending", request.Method, request.RequestUri);
 
                 try
                 {
@@ -61,9 +62,15 @@ namespace Microsoft.DotNet.ImageBuilder
                         (int)response.StatusCode, request.Method, request.RequestUri, Stopwatch.GetElapsedTime(startTime));
                     return response;
                 }
-                catch (TaskCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+                catch (OperationCanceledException ex) when (ex.InnerException is TimeoutException)
                 {
                     _logger.LogWarning(ex, "HTTP timeout {Method} {RequestUri} after {Elapsed}",
+                        request.Method, request.RequestUri, Stopwatch.GetElapsedTime(startTime));
+                    throw;
+                }
+                catch (OperationCanceledException ex)
+                {
+                    _logger.LogWarning(ex, "HTTP canceled {Method} {RequestUri} after {Elapsed}",
                         request.Method, request.RequestUri, Stopwatch.GetElapsedTime(startTime));
                     throw;
                 }

--- a/src/ImageBuilder/Oras/OrasDotNetService.cs
+++ b/src/ImageBuilder/Oras/OrasDotNetService.cs
@@ -121,16 +121,8 @@ public class OrasDotNetService(
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(reference);
 
-        IReadOnlyList<ReferrerInfo> referrers;
-        if (isDryRun)
-        {
-            referrers = [];
-        }
-        else
-        {
-            _logger.LogDebug("Fetching referrers for {Reference}", reference);
-            referrers = await GetReferrersImplAsync(reference, cancellationToken);
-        }
+        IReadOnlyList<ReferrerInfo> referrers = isDryRun ? []
+            : await GetReferrersImplAsync(reference, cancellationToken);
 
         _logger.LogInformation(
             "{Reference} has {Count} referrer(s) (DryRun={DryRun})",

--- a/src/ImageBuilder/Oras/OrasDotNetService.cs
+++ b/src/ImageBuilder/Oras/OrasDotNetService.cs
@@ -120,8 +120,17 @@ public class OrasDotNetService(
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(reference);
-        IReadOnlyList<ReferrerInfo> referrers = isDryRun ? []
-            : await GetReferrersImplAsync(reference, cancellationToken);
+
+        IReadOnlyList<ReferrerInfo> referrers;
+        if (isDryRun)
+        {
+            referrers = [];
+        }
+        else
+        {
+            _logger.LogDebug("Fetching referrers for {Reference}", reference);
+            referrers = await GetReferrersImplAsync(reference, cancellationToken);
+        }
 
         _logger.LogInformation(
             "{Reference} has {Count} referrer(s) (DryRun={DryRun})",


### PR DESCRIPTION
This PR is a follow up from https://github.com/dotnet/docker-tools/pull/2071.

The `LoggingHandler` timeout catch clause never fired because HttpClient passes a linked CancellationToken (user token + timeout token) to `DelegatingHandler.SendAsync`. When a timeout occurs, the linked token is already cancelled, so the `when (!cancellationToken.IsCancellationRequested)` guard evaluated to false and the catch was skipped entirely.