### PR TITLE
Do not copy referrers in `CopyBaseImages`

### DIFF
--- a/src/ImageBuilder.Tests/BuildCommandTests.cs
+++ b/src/ImageBuilder.Tests/BuildCommandTests.cs
@@ -3704,6 +3704,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         destTagNames,
                         destRegistryName,
                         srcTagName,
+                        true,
                         srcRegistryName,
                         It.IsAny<ContainerRegistryImportSourceCredentials>(),
                         false));

--- a/src/ImageBuilder.Tests/CopyAcrImagesCommandTests.cs
+++ b/src/ImageBuilder.Tests/CopyAcrImagesCommandTests.cs
@@ -104,6 +104,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             new string[] { expectedTag },
                             manifest.Registry,
                             expectedTag,
+                            true,
                             SourceRegistry,
                             null,
                             false));
@@ -205,6 +206,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             new string[] { expectedTag },
                             manifest.Registry,
                             expectedTag,
+                            true,
                             SourceRegistry,
                             null,
                             false));
@@ -318,6 +320,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             new string[] { expectedTag },
                             manifest.Registry,
                             expectedTag,
+                            true,
                             SourceRegistry,
                             null,
                             false));
@@ -431,6 +434,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             new string[] { expectedTag },
                             manifest.Registry,
                             It.IsAny<string>(),
+                            true,
                             SourceRegistry,
                             null,
                             false));
@@ -516,6 +520,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     new string[] { $"test/runtime:tag1" },
                     DestinationRegistry,
                     "test/runtime:tag1",
+                    true,
                     SourceRegistry,
                     null,
                     false));
@@ -526,6 +531,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     new string[] { $"test/runtime:shared1" },
                     DestinationRegistry,
                     "test/runtime:shared1",
+                    true,
                     SourceRegistry,
                     null,
                     false));
@@ -535,6 +541,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     new string[] { $"test/runtime:shared2" },
                     DestinationRegistry,
                     "test/runtime:shared2",
+                    true,
                     SourceRegistry,
                     null,
                     false));
@@ -628,6 +635,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     new string[] { $"test/runtime:tag1" },
                     DestinationRegistry,
                     "test/runtime:tag1",
+                    true,
                     SourceRegistry,
                     null,
                     false));
@@ -638,6 +646,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     new string[] { $"test/runtime:shared1" },
                     DestinationRegistry,
                     "test/runtime:shared1",
+                    true,
                     SourceRegistry,
                     null,
                     false));
@@ -648,6 +657,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     new string[] { $"test/runtime2:syn-shared1" },
                     DestinationRegistry,
                     "test/runtime2:syn-shared1",
+                    true,
                     SourceRegistry,
                     null,
                     false));
@@ -721,6 +731,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     new string[] { $"test/runtime:tag1" },
                     DestinationRegistry,
                     It.IsAny<string>(),
+                    true,
                     SourceRegistry,
                     null,
                     false));

--- a/src/ImageBuilder.Tests/CopyBaseImagesCommandTests.cs
+++ b/src/ImageBuilder.Tests/CopyBaseImagesCommandTests.cs
@@ -93,6 +93,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             new string[] { expectedTagInfo.TargetTag },
                             manifest.Registry,
                             expectedTagInfo.SourceImage,
+                            false,
                             expectedTagInfo.Registry,
                             It.Is<ContainerRegistryImportSourceCredentials>(creds => creds.Username == expectedTagInfo.Username && creds.Password == expectedTagInfo.Password),
                             false));
@@ -167,6 +168,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             new string[] { expectedTagInfo.TargetTag },
                             manifest.Registry,
                             expectedTagInfo.SourceImage,
+                            false,
                             expectedTagInfo.Registry,
                             It.Is<ContainerRegistryImportSourceCredentials>(creds => (creds == null && expectedTagInfo.Username == null) || (creds.Username == expectedTagInfo.Username && creds.Password == expectedTagInfo.Password)),
                             false));

--- a/src/ImageBuilder.Tests/CopyImageServiceTests.cs
+++ b/src/ImageBuilder.Tests/CopyImageServiceTests.cs
@@ -46,7 +46,9 @@ public class CopyImageServiceTests
                 destAcrName: "myacr.azurecr.io",
                 srcTagName: "repo:tag",
                 srcRegistryName: "docker.io",
-                isDryRun: true));
+                sourceCredentials: null,
+                isDryRun: true,
+                copyReferrers: true));
     }
 
     /// <summary>
@@ -94,7 +96,9 @@ public class CopyImageServiceTests
             destAcrName: "myacr.azurecr.io",
             srcTagName: "repo:tag",
             srcRegistryName: "docker.io",
-            isDryRun: false);
+            sourceCredentials: null,
+            isDryRun: false,
+            copyReferrers: true);
 
         // Verify the importer was called, proving execution reached the import step
         // (past the external registry lookup that previously threw)
@@ -137,7 +141,9 @@ public class CopyImageServiceTests
             destAcrName: "myacr.azurecr.io",
             srcTagName: "repo:tag",
             srcRegistryName: "myacr.azurecr.io",
-            isDryRun: false);
+            sourceCredentials: null,
+            isDryRun: false,
+            copyReferrers: true);
 
         // Main image import with TargetTags
         mockImporter.Verify(
@@ -203,8 +209,51 @@ public class CopyImageServiceTests
             destAcrName: "myacr.azurecr.io",
             srcTagName: "repo:tag",
             srcRegistryName: "myacr.azurecr.io",
-            isDryRun: false);
+            sourceCredentials: null,
+            isDryRun: false,
+            copyReferrers: true);
 
+        mockImporter.Verify(
+            x => x.ImportImageAsync(
+                It.IsAny<string>(),
+                It.IsAny<ResourceIdentifier>(),
+                It.IsAny<ContainerRegistryImportImageContent>()),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// When copyReferrers is false, referrer discovery and referrer imports are
+    /// both skipped. Only the main image is imported.
+    /// </summary>
+    [Fact]
+    public async Task ImportImageAsync_CopyReferrersFalse_SkipsReferrerDiscoveryAndImport()
+    {
+        PublishConfiguration publishConfig = CreateAcrPublishConfig("myacr.azurecr.io");
+
+        var mockImporter = new Mock<IAcrImageImporter>();
+        var mockOras = new Mock<IOrasService>();
+
+        var service = new CopyImageService(
+            Mock.Of<ILogger<CopyImageService>>(),
+            mockImporter.Object,
+            mockOras.Object,
+            ConfigurationHelper.CreateOptionsMock(publishConfig));
+
+        await service.ImportImageAsync(
+            destTagNames: ["mirror/repo:tag"],
+            destAcrName: "myacr.azurecr.io",
+            srcTagName: "repo:tag",
+            srcRegistryName: "myacr.azurecr.io",
+            sourceCredentials: null,
+            isDryRun: false,
+            copyReferrers: false);
+
+        // GetReferrersAsync should never be called when copyReferrers is false
+        mockOras.Verify(
+            o => o.GetReferrersAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        // Only the main image should be imported (no referrers)
         mockImporter.Verify(
             x => x.ImportImageAsync(
                 It.IsAny<string>(),
@@ -239,7 +288,9 @@ public class CopyImageServiceTests
             destAcrName: "myacr.azurecr.io",
             srcTagName: "repo:tag",
             srcRegistryName: "myacr.azurecr.io",
-            isDryRun: true);
+            sourceCredentials: null,
+            isDryRun: true,
+            copyReferrers: true);
 
         mockOras.Verify(
             o => o.GetReferrersAsync(It.IsAny<string>(), true, It.IsAny<CancellationToken>()),

--- a/src/ImageBuilder/Commands/BuildCommand.cs
+++ b/src/ImageBuilder/Commands/BuildCommand.cs
@@ -624,6 +624,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 destTagNames: destTags,
                 destAcrName: Manifest.Registry,
                 srcTagName: DockerHelper.TrimRegistry(sourceDigest, srcRegistry),
+                copyReferrers: true,
                 srcRegistryName: srcRegistry);
 
             // Redefine the source digest to be from the destination of the copy, not the source. The canonical scenario

--- a/src/ImageBuilder/Commands/CopyAcrImagesCommand.cs
+++ b/src/ImageBuilder/Commands/CopyAcrImagesCommand.cs
@@ -59,6 +59,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                                 DockerHelper.TrimRegistry(tagInfo.DestinationTag, Manifest.Registry),
                                 Manifest.Registry,
                                 DockerHelper.TrimRegistry(tagInfo.SourceTag, Options.SourceRegistry),
+                                copyReferrers: true,
                                 srcRegistryName: Options.SourceRegistry)))
                 .SelectMany(tasks => tasks);
 
@@ -68,6 +69,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         DockerHelper.TrimRegistry(tagInfo.DestinationTag, Manifest.Registry),
                         Manifest.Registry,
                         DockerHelper.TrimRegistry(tagInfo.SourceTag, Options.SourceRegistry),
+                        copyReferrers: true,
                         srcRegistryName: Options.SourceRegistry));
 
             await Task.WhenAll(platformImportTasks.Concat(manifestListImportTasks));

--- a/src/ImageBuilder/Commands/CopyBaseImagesCommand.cs
+++ b/src/ImageBuilder/Commands/CopyBaseImagesCommand.cs
@@ -96,7 +96,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             }
 
             return ImportImageAsync($"{Options.RepoPrefix}{fromImage}", destinationRegistryName, srcImage,
-                srcRegistryName: registry, sourceCredentials: importSourceCreds);
+                srcRegistryName: registry, sourceCredentials: importSourceCreds, copyReferrers: false);
         }
     }
 }

--- a/src/ImageBuilder/Commands/CopyBaseImagesCommand.cs
+++ b/src/ImageBuilder/Commands/CopyBaseImagesCommand.cs
@@ -95,8 +95,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 };
             }
 
-            return ImportImageAsync($"{Options.RepoPrefix}{fromImage}", destinationRegistryName, srcImage,
-                srcRegistryName: registry, sourceCredentials: importSourceCreds, copyReferrers: false);
+            return ImportImageAsync(
+                destTagName: $"{Options.RepoPrefix}{fromImage}",
+                destRegistryName: destinationRegistryName,
+                srcTagName: srcImage,
+                srcRegistryName: registry,
+                sourceCredentials: importSourceCreds,
+                copyReferrers: false);
         }
     }
 }

--- a/src/ImageBuilder/Commands/CopyImagesCommand.cs
+++ b/src/ImageBuilder/Commands/CopyImagesCommand.cs
@@ -22,6 +22,7 @@ public abstract class CopyImagesCommand<TOptions, TOptionsBuilder>(
         string destTagName,
         string destRegistryName,
         string srcTagName,
+        bool copyReferrers,
         string? srcRegistryName = null,
         ContainerRegistryImportSourceCredentials? sourceCredentials = null) =>
             _copyImageService.ImportImageAsync(
@@ -30,5 +31,6 @@ public abstract class CopyImagesCommand<TOptions, TOptionsBuilder>(
                 srcTagName: srcTagName,
                 srcRegistryName: srcRegistryName,
                 sourceCredentials: sourceCredentials,
-                isDryRun: Options.IsDryRun);
+                isDryRun: Options.IsDryRun,
+                copyReferrers: copyReferrers);
 }

--- a/src/ImageBuilder/CopyImageService.cs
+++ b/src/ImageBuilder/CopyImageService.cs
@@ -20,6 +20,7 @@ public interface ICopyImageService
         string[] destTagNames,
         string destAcrName,
         string srcTagName,
+        bool copyReferrers,
         string? srcRegistryName = null,
         ContainerRegistryImportSourceCredentials? sourceCredentials = null,
         bool isDryRun = false);
@@ -48,6 +49,7 @@ public class CopyImageService : ICopyImageService
         string[] destTagNames,
         string destAcrName,
         string srcTagName,
+        bool copyReferrers,
         string? srcRegistryName = null,
         ContainerRegistryImportSourceCredentials? sourceCredentials = null,
         bool isDryRun = false)
@@ -57,9 +59,17 @@ public class CopyImageService : ICopyImageService
         string sourceImageName = DockerHelper.GetImageName(srcRegistryName, srcTagName);
         string destRepo = destTagNames.First().Split(':')[0].Split('@')[0];
 
-        // Discover referrers (signatures, SBOMs, etc.) for the source image.
-        IReadOnlyList<ReferrerInfo> referrers =
-            await _orasService.GetReferrersAsync(reference: sourceImageName, isDryRun: isDryRun);
+        IReadOnlyList<ReferrerInfo> referrers;
+        if (copyReferrers)
+        {
+            // Discover referrers (signatures, SBOMs, etc.) for the source image.
+            referrers = await _orasService.GetReferrersAsync(reference: sourceImageName, isDryRun: isDryRun);
+        }
+        else
+        {
+            referrers = [];
+            _logger.LogInformation("Skipping referrer discovery for '{SourceImage}' (copyReferrers=false)", sourceImageName);
+        }
 
         var destinationImageNames =
             destTagNames.Select(tag => $"'{DockerHelper.GetImageName(destAcr.Server, tag)}'").ToList();

--- a/src/ImageBuilder/CopyImageService.cs
+++ b/src/ImageBuilder/CopyImageService.cs
@@ -59,25 +59,17 @@ public class CopyImageService : ICopyImageService
         string sourceImageName = DockerHelper.GetImageName(srcRegistryName, srcTagName);
         string destRepo = destTagNames.First().Split(':')[0].Split('@')[0];
 
-        IReadOnlyList<ReferrerInfo> referrers;
-        if (copyReferrers)
-        {
-            // Discover referrers (signatures, SBOMs, etc.) for the source image.
-            referrers = await _orasService.GetReferrersAsync(reference: sourceImageName, isDryRun: isDryRun);
-        }
-        else
-        {
-            referrers = [];
-            _logger.LogInformation("Skipping referrer discovery for '{SourceImage}' (copyReferrers=false)", sourceImageName);
-        }
+        IReadOnlyList<ReferrerInfo> referrers = copyReferrers
+            ? await _orasService.GetReferrersAsync(reference: sourceImageName, isDryRun: isDryRun)
+            : [];
 
         var destinationImageNames =
             destTagNames.Select(tag => $"'{DockerHelper.GetImageName(destAcr.Server, tag)}'").ToList();
         string formattedDestinationImages = string.Join(", ", destinationImageNames);
 
         _logger.LogInformation(
-            "Importing {DestinationImages} and {ReferrerCount} referrer(s) from '{SourceImage}' (DryRun={DryRun})",
-            formattedDestinationImages, referrers.Count, sourceImageName, isDryRun);
+            "Importing {DestinationImages} and {ReferrerCount} referrer(s) from '{SourceImage}' (DryRun={DryRun}, CopyReferrers={CopyReferrers})",
+            formattedDestinationImages, referrers.Count, sourceImageName, isDryRun, copyReferrers);
 
         if (isDryRun)
         {


### PR DESCRIPTION
**Hypothesis**: `CopyBaseImages` is timing out due to network isolation restrictions when reaching out to DockerHub. Even though #2071 failed to provide the improved logging that I want (#2072 is follow-up for that), I still believe that network isolation is the cause, because https://github.com/dotnet/dotnet-docker/pull/7141 has the same timeout symptom when reaching out to DH, in a completely different scenario (a Dockerfile build).

Even though I do not have concrete logs showing that the network isolation is the cause, I am submitting this PR now in order to unblock servicing/staging images asap.

This PR adds a required `bool copyReferrers` parameter to `ICopyImageService.ImportImageAsync` so callers must explicitly opt in or out of referrer copying. It disables the referrer lookup and copy in `CopyBaseImages`. At the moment we do not use referrer artifacts from base images for any reason, so there is no downside.

<details>

<summary>AI generated change summary</summary>

- **`ICopyImageService` / `CopyImageService`** — Added required `copyReferrers` parameter. When `false`, skips both `GetReferrersAsync` and the referrer import loop.
- **`CopyBaseImagesCommand`** — Passes `copyReferrers: false`.
- **`CopyAcrImagesCommand`** / **`BuildCommand`** — Pass `copyReferrers: true` (preserving existing behavior).
- **Tests** — Added `ImportImageAsync_CopyReferrersFalse_SkipsReferrerDiscoveryAndImport`; updated all existing mock verifications to pass the new parameter explicitly.

</details>