### PR TITLE
Remove unused DotNet releases dependency

### DIFF
--- a/src/ImageBuilder/Microsoft.DotNet.ImageBuilder.csproj
+++ b/src/ImageBuilder/Microsoft.DotNet.ImageBuilder.csproj
@@ -35,7 +35,6 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.15" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.15" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.15" />
-    <PackageReference Include="Microsoft.Deployment.DotNet.Releases" Version="1.0.1" />
     <PackageReference Include="Microsoft.DotNet.VersionTools" Version="9.0.0-beta.25255.5" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="20.256.2" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />


### PR DESCRIPTION
Removes the leftover `Microsoft.Deployment.DotNet.Releases` package reference from ImageBuilder.

This dependency was originally added in #1358 for EOL annotation data generation, then bumped in #1577. The product-version EOL handling and `DotNetReleasesService` usage were removed in #1590, leaving the package reference unused.