### PR TITLE
Fix ImageBuilder test toolset resolution

### DIFF
--- a/src/run-tests.ps1
+++ b/src/run-tests.ps1
@@ -38,8 +38,23 @@ try {
     $globalJson = Get-Content (Join-Path $repoRoot 'global.json') | ConvertFrom-Json
     $arcadeSdkVersion = $globalJson.'msbuild-sdks'.'Microsoft.DotNet.Arcade.Sdk'
     # Need to use nested Join-Path calls to support Windows PowerShell, which doesn't support multiple paths in a single Join-Path call
-    $toolsetLocationFile = Join-Path (Join-Path (Join-Path $repoRoot 'artifacts') 'toolset') "$arcadeSdkVersion.txt"
-    $buildProj = Get-Content $toolsetLocationFile -TotalCount 1
+    $toolsetDir = Join-Path (Join-Path (Join-Path $repoRoot 'artifacts') 'toolset') $arcadeSdkVersion
+    $toolsetBuildProj = Join-Path $toolsetDir 'Build.proj'
+    $buildProj = $toolsetBuildProj
+
+    if (-not (Test-Path $buildProj)) {
+        $toolsetLocationFile = Join-Path (Join-Path (Join-Path $repoRoot 'artifacts') 'toolset') "$arcadeSdkVersion.txt"
+        if (Test-Path $toolsetLocationFile) {
+            $legacyBuildProj = Get-Content $toolsetLocationFile -TotalCount 1
+            if (-not [string]::IsNullOrWhiteSpace($legacyBuildProj)) {
+                $buildProj = $legacyBuildProj
+            }
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($buildProj) -or -not (Test-Path $buildProj)) {
+        throw "Failed to locate Arcade toolset Build.proj. Expected '$toolsetBuildProj'."
+    }
 
     $dotnet = Join-Path $dotnetInstallDir 'dotnet'
     & $dotnet msbuild $buildProj /p:Restore=true /p:Build=false /p:RepoRoot="$repoRoot/" /clp:NoSummary


### PR DESCRIPTION
This PR fixes `docker-tools-imagebuilder-official` failing in `Test Images` after the Arcade update in dotnet/docker-tools#2099.

The root cause is that Arcade stopped writing `artifacts/toolset/<version>.txt` and now restores the SDK toolset to `artifacts/toolset/<version>/Build.proj`.

Relevant Arcade history:
- dotnet/arcade#16726 originally introduced the `InitializeToolset` layout change.
- dotnet/arcade#16744 reverted that source update.
- dotnet/arcade#16753 reintroduced the layout change; this is the change present in the Arcade build consumed by dotnet/docker-tools#2099.

This PR updates `src/run-tests.ps1` to resolve the new `Build.proj` location first while retaining a legacy marker-file fallback for older Arcade layouts.

Validation:
- `git clean -ffxd`
- `pwsh -NoLogo -NoProfile -NonInteractive -File ./src/run-tests.ps1` (478 tests passed)

Fixes #2104
