### PR TITLE
Add skills and helper scripts for triaging pipelines and pull requests

### DIFF
--- a/.github/skills/investigating-pipeline/SKILL.md
+++ b/.github/skills/investigating-pipeline/SKILL.md
@@ -6,22 +6,26 @@ description: >-
   or Azure DevOps build URL and wants to understand what failed and why.
 ---
 
-## Workflow
+# Investigating Azure Pipelines builds
 
-### Step 1: View the build timeline
+This document contains useful patterns for inspecting Azure Pipelines builds.
 
-```shell
-eng/docker-tools/skill-helpers/Show-BuildTimeline.ps1 <org> <project> <buildId>
-```
+## How to view the build timeline
 
-This prints a tree of stages, jobs, and tasks. By default only failing tasks are shown. Use `-ShowAllTasks` to see everything.
-
-Each node includes a log ID (e.g., `Task #42`). Note the log IDs of failing tasks for the next step.
-
-### Step 2: Read a failing task's log
+Use `Show-BuildTimeline.ps1` to view a build's timeline.
+This includes all stages, jobs, and tasks along with their results.
 
 ```shell
-eng/docker-tools/skill-helpers/Get-BuildLog.ps1 <org> <project> <buildId> <logId>
+pwsh ./eng/docker-tools/skill-helpers/Show-BuildTimeline.ps1 <org> <project> <buildId>
 ```
 
-This prints the full log for a specific task. Use this to understand the root cause of a failure.
+Each node includes a log ID (`Task #42` means log ID 42).
+
+## How to read pipeline logs
+
+First, get the log ID from the build timeline.
+Then, use `Get-BuildLog.ps1` to print the full log:
+
+```shell
+pwsh ./eng/docker-tools/skill-helpers/Get-BuildLog.ps1 -Organization dnceng -Project internal -BuildId $buildId -LogId $logId
+```

--- a/.github/skills/investigating-pull-request/SKILL.md
+++ b/.github/skills/investigating-pull-request/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: investigating-pull-request
+description: >-
+  Inspect GitHub pull request status, read review comments, and diagnose PR
+  validation failures. Use when the user wants to check the status of a pull
+  request or diagnose PR validation failures.
+---
+
+# Investigating GitHub pull requests
+
+This document contains useful patterns for inspecting a single GitHub pull request.
+
+## How to view pull request context
+
+Use `Show-PullRequestComments.ps1` to view all pull request comments, review
+decisions, issue comments, review submissions, and inline review comments.
+
+```shell
+pwsh ./eng/docker-tools/skill-helpers/Show-PullRequestComments.ps1 $prNumber [-Repo "$owner/$repo"]
+```
+
+## How to view pull request checks and logs
+
+Use `Show-PullRequestBuilds.ps1` to view the GitHub status check summary,
+including a detailed view of Azure Pipelines build checks.
+
+```shell
+pwsh ./eng/docker-tools/skill-helpers/Show-PullRequestBuilds.ps1 -PullRequest $prNumber [-Repo "$owner/$repo"]
+```
+
+## How to read Azure Pipelines logs
+
+First, get the log ID from the build timeline.
+Then, use `Get-BuildLog.ps1` to print the full log:
+
+```shell
+pwsh ./eng/docker-tools/skill-helpers/Get-BuildLog.ps1 -Organization dnceng-public -Project public -BuildId $buildId -LogId $logId
+```

--- a/.github/skills/triaging-pipelines/SKILL.md
+++ b/.github/skills/triaging-pipelines/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: triaging-pipelines
 description: Triage recent Azure Pipelines runs and failures.
-user-invocable: true
-disable-model-invocation: true
 ---
 
 ## Workflow

--- a/.github/skills/triaging-pipelines/SKILL.md
+++ b/.github/skills/triaging-pipelines/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: triaging-pipelines
+description: Triage recent Azure Pipelines runs and failures.
+user-invocable: true
+disable-model-invocation: true
+---
+
+## Workflow
+
+### Step 1: List recent builds
+
+```shell
+pwsh ./eng/docker-tools/skill-helpers/Get-RecentBuilds.ps1 -Organization dnceng -Project internal -Folder dotnet/docker-tools -Hours 24
+```
+
+Change the value of `-Hours` to list more or fewer builds.
+
+### Step 2: Investigate failures
+
+For any build whose state is `failed`, `partiallySucceeded`, or `canceled`, use the `investigating-pipeline` skill to view the build timeline and read failing task logs.
+
+### Step 3: Correlate failures with recent pull requests and issues
+
+To check recent issues, run `gh issue list --state all`.
+To check recent pull requests, run `gh pr list --state all`.
+Read the contents of issues and pull requests using the `gh` CLI if necessary.
+
+Look for:
+
+- A recent change that obviously caused the failure
+- An existing known issue tracking this failure
+- An open pull request that already addresses the failure

--- a/.github/skills/triaging-pull-requests/SKILL.md
+++ b/.github/skills/triaging-pull-requests/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: triaging-pull-requests
 description: Triage open pull requests into actionable categories.
-user-invocable: true
-disable-model-invocation: true
 ---
 
 ## Workflow

--- a/.github/skills/triaging-pull-requests/SKILL.md
+++ b/.github/skills/triaging-pull-requests/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: triaging-pull-requests
+description: Triage open pull requests into actionable categories.
+user-invocable: true
+disable-model-invocation: true
+---
+
+## Workflow
+
+### Step 1: List open pull requests
+
+List open pull requests by running `gh pr list`.
+
+### Step 2: Categorize pull requests
+
+Read the contents of pull requests using `gh pr view`.
+For any pull request that needs deeper status, review, comment, or CI context, use the `investigating-pull-request` skill.
+
+Categorize each pull request into one of the following buckets:
+
+- Ready to merge
+- Needs review
+- PR validation failing
+- Needs follow-up
+- Draft
+
+### Step 3: Investigate failures
+
+For failing pull requests, use the `investigating-pull-request` skill to gather their full context and check their CI status.
+
+For pull requests with CI failures, use the `investigating-pipeline` skill with the failing build ID to read task logs and identify root causes.
+
+### Step 4: Correlate failures with recent pull requests and issues
+
+To check recent issues, run `gh issue list --state all`.
+To check recently merged pull requests, run `gh pr list --state merged`.
+
+Look for:
+
+- A recent change that obviously caused the failure
+- An existing known issue tracking this failure
+- An open pull request that already addresses the failure
+
+### Step 5: Categorize and present results
+
+Using everything you've learned, place each pull request into **one** of these
+categories in this priority order:
+
+1. **Ready to Merge** — Approved, CI passing, no merge conflicts
+2. **Needs Review** — The current user is a requested reviewer
+3. **Needs Author Action** — Changes requested, CI failing, or merge conflicts
+4. **Stale** — No updates in 7+ days and not ready to merge
+
+Use your judgment when things are ambiguous. For example:
+
+- A pull request with only flaky-test failures might still be ready to merge
+- A draft pull request from the user that hasn't been touched in weeks is stale even if CI is green
+
+For "Needs Author Action" pull requests with CI failures, include the root cause diagnosis.
+
+End with a recommended next action.

--- a/eng/docker-tools/skill-helpers/AzureDevOps.ps1
+++ b/eng/docker-tools/skill-helpers/AzureDevOps.ps1
@@ -41,6 +41,8 @@ function Invoke-AzDORestMethod {
         Request body as a hashtable. Automatically converted to JSON.
     .PARAMETER ApiVersion
         API version. Defaults to 7.1.
+    .PARAMETER QueryParams
+        Optional hashtable of additional query string parameters.
     #>
     [CmdletBinding()]
     param(
@@ -49,7 +51,8 @@ function Invoke-AzDORestMethod {
         [Parameter(Mandatory)][string] $Endpoint,
         [string] $Method = "GET",
         [hashtable] $Body,
-        [string] $ApiVersion = "7.1"
+        [string] $ApiVersion = "7.1",
+        [hashtable] $QueryParams
     )
 
     $token = Get-AzDOAccessToken
@@ -58,7 +61,15 @@ function Invoke-AzDORestMethod {
         "Content-Type" = "application/json"
     }
 
-    $uri = "https://dev.azure.com/$Organization/$Project/_apis/$($Endpoint)?api-version=$ApiVersion"
+    $query = "api-version=$ApiVersion"
+    if ($QueryParams) {
+        foreach ($key in $QueryParams.Keys) {
+            $value = [System.Uri]::EscapeDataString([string]$QueryParams[$key])
+            $query += "&$key=$value"
+        }
+    }
+
+    $uri = "https://dev.azure.com/$Organization/$Project/_apis/$($Endpoint)?$query"
 
     $params = @{
         Uri     = $uri

--- a/eng/docker-tools/skill-helpers/Get-FailingPipelines.ps1
+++ b/eng/docker-tools/skill-helpers/Get-FailingPipelines.ps1
@@ -1,0 +1,63 @@
+#!/usr/bin/env pwsh
+# Lists pipeline definitions in a folder whose most recent completed build did not succeed.
+# Usage:
+#   ./Get-FailingPipelines.ps1 -Organization dnceng -Project internal -Folder dotnet/docker-tools
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string] $Organization,
+    [Parameter(Mandatory)][string] $Project,
+    [Parameter(Mandatory)][string] $Folder,
+    [switch] $IncludeWarnings
+)
+
+$ErrorActionPreference = "Stop"
+
+. "$PSScriptRoot/AzureDevOps.ps1"
+
+# Normalize folder: accept "dotnet/docker-tools" or "\dotnet\docker-tools".
+$normalizedFolder = "\" + ($Folder.Trim('\', '/') -replace '/', '\')
+
+$failingResults = @("failed", "canceled")
+if ($IncludeWarnings) {
+    $failingResults += "partiallySucceeded"
+}
+
+$definitions = Invoke-AzDORestMethod `
+    -Organization $Organization `
+    -Project $Project `
+    -Endpoint "build/definitions" `
+    -QueryParams @{
+        path                = $normalizedFolder
+        includeLatestBuilds = "true"
+    }
+
+$failing = @()
+foreach ($def in $definitions.value) {
+    $latest = $def.latestCompletedBuild
+    if (-not $latest) { continue }
+    if ($failingResults -notcontains $latest.result) { continue }
+
+    $failing += [pscustomobject]@{
+        Definition  = $def.name
+        Result      = $latest.result
+        BuildId     = $latest.id
+        BuildNumber = $latest.buildNumber
+        Branch      = $latest.sourceBranch
+        FinishTime  = $latest.finishTime
+        Url         = "https://dev.azure.com/$Organization/$Project/_build/results?buildId=$($latest.id)"
+    }
+}
+
+Write-Host "# Failing pipelines in $normalizedFolder"
+Write-Host ""
+Write-Host "Found $($failing.Count) of $($definitions.value.Count) pipeline(s) with a failing latest run."
+Write-Host ""
+
+if ($failing.Count -gt 0) {
+    Write-Host "Pipeline | Result | Build | Branch | Finished | Link"
+    Write-Host "--- | --- | --- | --- | --- | ---"
+    foreach ($item in $failing | Sort-Object Definition) {
+        Write-Host "$($item.Definition) | $($item.Result) | $($item.BuildId) | $($item.Branch) | $($item.FinishTime) | $($item.Url)"
+    }
+}

--- a/eng/docker-tools/skill-helpers/Get-FailingPipelines.ps1
+++ b/eng/docker-tools/skill-helpers/Get-FailingPipelines.ps1
@@ -49,7 +49,7 @@ foreach ($def in $definitions.value) {
     }
 }
 
-Write-Host "# Failing pipelines in $normalizedFolder"
+Write-Host "## Failing pipelines in $normalizedFolder"
 Write-Host ""
 Write-Host "Found $($failing.Count) of $($definitions.value.Count) pipeline(s) with a failing latest run."
 Write-Host ""

--- a/eng/docker-tools/skill-helpers/Get-RecentBuilds.ps1
+++ b/eng/docker-tools/skill-helpers/Get-RecentBuilds.ps1
@@ -26,7 +26,7 @@ $definitions = Invoke-AzDORestMethod `
     -QueryParams @{ path = $normalizedFolder }
 
 if (-not $definitions.value -or $definitions.value.Count -eq 0) {
-    Write-Host "# No pipelines found in $normalizedFolder"
+    Write-Host "## No pipelines found in $normalizedFolder"
     return
 }
 
@@ -42,7 +42,7 @@ $builds = Invoke-AzDORestMethod `
         queryOrder  = "finishTimeDescending"
     }
 
-Write-Host "# Builds in $normalizedFolder (last $Hours hours)"
+Write-Host "## Builds in $normalizedFolder (last $Hours hours)"
 Write-Host ""
 Write-Host "Found $($builds.value.Count) build(s) across $($definitions.value.Count) pipeline(s)."
 Write-Host ""

--- a/eng/docker-tools/skill-helpers/Get-RecentBuilds.ps1
+++ b/eng/docker-tools/skill-helpers/Get-RecentBuilds.ps1
@@ -1,0 +1,58 @@
+#!/usr/bin/env pwsh
+# Lists all build runs in the last N hours for pipelines under a given folder.
+# Usage:
+#   ./Get-RecentBuilds.ps1 -Organization dnceng -Project internal -Folder dotnet/docker-tools
+#   ./Get-RecentBuilds.ps1 -Organization dnceng -Project internal -Folder dotnet/docker-tools -Hours 48
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string] $Organization,
+    [Parameter(Mandatory)][string] $Project,
+    [Parameter(Mandatory)][string] $Folder,
+    [int] $Hours = 24
+)
+
+$ErrorActionPreference = "Stop"
+
+. "$PSScriptRoot/AzureDevOps.ps1"
+
+$normalizedFolder = "\" + ($Folder.Trim('\', '/') -replace '/', '\')
+$minTime = [DateTime]::UtcNow.AddHours(-$Hours).ToString("o")
+
+$definitions = Invoke-AzDORestMethod `
+    -Organization $Organization `
+    -Project $Project `
+    -Endpoint "build/definitions" `
+    -QueryParams @{ path = $normalizedFolder }
+
+if (-not $definitions.value -or $definitions.value.Count -eq 0) {
+    Write-Host "# No pipelines found in $normalizedFolder"
+    return
+}
+
+$definitionIds = ($definitions.value | ForEach-Object { $_.id }) -join ","
+
+$builds = Invoke-AzDORestMethod `
+    -Organization $Organization `
+    -Project $Project `
+    -Endpoint "build/builds" `
+    -QueryParams @{
+        definitions = $definitionIds
+        minTime     = $minTime
+        queryOrder  = "finishTimeDescending"
+    }
+
+Write-Host "# Builds in $normalizedFolder (last $Hours hours)"
+Write-Host ""
+Write-Host "Found $($builds.value.Count) build(s) across $($definitions.value.Count) pipeline(s)."
+Write-Host ""
+
+if ($builds.value.Count -gt 0) {
+    Write-Host "Pipeline | State | Build | Branch | Finished | Link"
+    Write-Host "--- | --- | --- | --- | --- | ---"
+    foreach ($build in $builds.value) {
+        $state = if ($build.status -eq "completed") { $build.result } else { $build.status }
+        $url = "https://dev.azure.com/$Organization/$Project/_build/results?buildId=$($build.id)"
+        Write-Host "$($build.definition.name) | $state | $($build.id) | $($build.sourceBranch) | $($build.finishTime) | $url"
+    }
+}

--- a/eng/docker-tools/skill-helpers/Show-BuildTimeline.ps1
+++ b/eng/docker-tools/skill-helpers/Show-BuildTimeline.ps1
@@ -21,7 +21,7 @@ $build = Invoke-AzDORestMethod `
     -Project $Project `
     -Endpoint "build/builds/$BuildId"
 
-Write-Host "# Build $BuildId - $($build.definition.name)"
+Write-Host "## Build $BuildId - $($build.definition.name)"
 Write-Host ""
 Write-Host "- Status:  $($build.status) $(if ($build.result) { "($($build.result))" })"
 Write-Host "- Branch:  $($build.sourceBranch)"
@@ -71,7 +71,7 @@ function Write-TimelineNode([string] $nodeId, [int] $depth) {
     }
 }
 
-Write-Host "## Build Timeline"
+Write-Host "### Build Timeline"
 Write-Host ""
 Write-TimelineNode "" 0
 Write-Host ""

--- a/eng/docker-tools/skill-helpers/Show-PullRequestBuilds.ps1
+++ b/eng/docker-tools/skill-helpers/Show-PullRequestBuilds.ps1
@@ -1,0 +1,99 @@
+#!/usr/bin/env pwsh
+# Shows all PR checks as a summary table, then expands AzDO build timelines for any
+# checks that point at Azure Pipelines (https://dev.azure.com/...).
+# Requires `gh` CLI authenticated against the target repo.
+#
+# Usage:
+#   ./Show-PullRequestBuilds.ps1 -PullRequest 2100
+#   ./Show-PullRequestBuilds.ps1 -PullRequest 2100 -Repo dotnet/docker-tools
+#   ./Show-PullRequestBuilds.ps1 -PullRequest 2100 -ShowAllTasks
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][int]    $PullRequest,
+    [string] $Repo,
+    [switch] $ShowAllTasks
+)
+
+$ErrorActionPreference = "Stop"
+
+$ghArgs = @("pr", "view", $PullRequest, "--json", "statusCheckRollup")
+if ($Repo) { $ghArgs += @("--repo", $Repo) }
+
+$checksJson = & gh @ghArgs 2>&1
+if ($LASTEXITCODE -ne 0) {
+    throw "gh pr view failed: $checksJson"
+}
+
+$checks = ($checksJson | ConvertFrom-Json).statusCheckRollup
+
+# statusCheckRollup mixes two shapes:
+#   CheckRun:      { name, status, conclusion, detailsUrl, workflowName }
+#   StatusContext: { context, state, targetUrl, description }
+# Normalize them.
+$normalized = foreach ($check in $checks) {
+    if ($check.PSObject.Properties.Name -contains "context") {
+        [pscustomobject]@{
+            Name  = $check.context
+            State = $check.state
+            Url   = $check.targetUrl
+        }
+    }
+    else {
+        $state = if ($check.conclusion) { $check.conclusion } else { $check.status }
+        [pscustomobject]@{
+            Name  = $check.name
+            State = $state
+            Url   = $check.detailsUrl
+        }
+    }
+}
+
+# AzDO build results URLs look like:
+#   https://dev.azure.com/<org>/<project>/_build/results?buildId=<id>...
+$pattern = '^https?://dev\.azure\.com/(?<org>[^/]+)/(?<project>[^/]+)/_build/results\?.*buildId=(?<buildId>\d+)'
+
+$builds = @()
+foreach ($check in $normalized) {
+    if (-not $check.Url) { continue }
+    $match = [regex]::Match($check.Url, $pattern)
+    if (-not $match.Success) { continue }
+
+    $builds += [pscustomobject]@{
+        Org     = $match.Groups["org"].Value
+        Project = $match.Groups["project"].Value
+        BuildId = [int]$match.Groups["buildId"].Value
+    }
+}
+
+# Deduplicate by buildId (a single build can produce multiple check-run rows).
+$builds = $builds | Sort-Object BuildId -Unique
+
+$title = if ($Repo) { "$Repo#$PullRequest" } else { "PR #$PullRequest" }
+Write-Host "# Checks for $title"
+Write-Host ""
+Write-Host "$($normalized.Count) check(s); $($builds.Count) Azure Pipelines build(s)."
+Write-Host ""
+
+if ($normalized.Count -gt 0) {
+    Write-Host "Check | State | URL"
+    Write-Host "--- | --- | ---"
+    foreach ($check in $normalized | Sort-Object Name) {
+        Write-Host "$($check.Name) | $($check.State) | $($check.Url)"
+    }
+    Write-Host ""
+}
+
+if ($builds.Count -eq 0) { return }
+
+$timelineScript = "$PSScriptRoot/Show-BuildTimeline.ps1"
+
+foreach ($build in $builds) {
+    Write-Host "---"
+    Write-Host ""
+    & $timelineScript `
+        -Organization $build.Org `
+        -Project $build.Project `
+        -BuildId $build.BuildId `
+        -ShowAllTasks:$ShowAllTasks
+}

--- a/eng/docker-tools/skill-helpers/Show-PullRequestBuilds.ps1
+++ b/eng/docker-tools/skill-helpers/Show-PullRequestBuilds.ps1
@@ -70,7 +70,7 @@ foreach ($check in $normalized) {
 $builds = $builds | Sort-Object BuildId -Unique
 
 $title = if ($Repo) { "$Repo#$PullRequest" } else { "PR #$PullRequest" }
-Write-Host "# Checks for $title"
+Write-Host "## Checks for $title"
 Write-Host ""
 Write-Host "$($normalized.Count) check(s); $($builds.Count) Azure Pipelines build(s)."
 Write-Host ""

--- a/eng/docker-tools/skill-helpers/Show-PullRequestComments.ps1
+++ b/eng/docker-tools/skill-helpers/Show-PullRequestComments.ps1
@@ -1,0 +1,107 @@
+#!/usr/bin/env pwsh
+# Shows a focused summary of a pull request: metadata, reviews, issue-level comments,
+# and inline review comments (which `gh pr view --json` does not expose).
+# Requires `gh` CLI authenticated against the target repo.
+#
+# Usage:
+#   ./Show-PullRequestComments.ps1 2100
+#   ./Show-PullRequestComments.ps1 2100 -Repo dotnet/docker-tools
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][int] $PullRequest,
+    [string] $Repo
+)
+
+$ErrorActionPreference = "Stop"
+$PSNativeCommandUseErrorActionPreference = $true
+
+function Write-BlockComment {
+    param([string] $Text)
+    if (-not $Text) { return }
+    $Text.TrimEnd() -split "`n" | ForEach-Object { Write-Host "> $_" }
+    Write-Host ""
+}
+
+# Fetch PR overview.
+$viewArgs = @(
+    "pr", "view", $PullRequest,
+    "--json", "number,title,state,author,baseRefName,headRefName,isDraft,url,additions,deletions,changedFiles,reviewDecision,labels,reviews,comments"
+)
+if ($Repo) { $viewArgs += @("--repo", $Repo) }
+
+$prJson = & gh @viewArgs
+$pr = $prJson | ConvertFrom-Json
+
+# Fetch inline review comments via REST API. `gh pr view --json` exposes review bodies
+# but drops the inline diff comments attached to specific files/lines.
+$apiPath = if ($Repo) {
+    "repos/$Repo/pulls/$PullRequest/comments"
+} else {
+    "repos/{owner}/{repo}/pulls/$PullRequest/comments"
+}
+
+$inlineJson = & gh api --paginate $apiPath
+$inline = $inlineJson | ConvertFrom-Json
+
+# Render.
+$title = if ($Repo) { "$Repo#$PullRequest" } else { "PR #$PullRequest" }
+Write-Host "## $title - $($pr.title)"
+Write-Host ""
+Write-Host "- State: $($pr.state)$(if ($pr.isDraft) { ' (draft)' })"
+Write-Host "- Author: $($pr.author.login)"
+Write-Host "- Branch: $($pr.headRefName) -> $($pr.baseRefName)"
+Write-Host "- Changes: +$($pr.additions)/-$($pr.deletions) ($($pr.changedFiles) files)"
+Write-Host "- Review decision: $($pr.reviewDecision)"
+if ($pr.labels) {
+    Write-Host "- Labels: $(($pr.labels | ForEach-Object { $_.name }) -join ', ')"
+}
+Write-Host "- URL: $($pr.url)"
+Write-Host ""
+
+# Reviews (the Approve / Request changes / Comment submissions themselves).
+Write-Host "### Reviews ($($pr.reviews.Count))"
+Write-Host ""
+if ($pr.reviews.Count -eq 0) {
+    Write-Host "_None_"
+} else {
+    foreach ($review in $pr.reviews) {
+        Write-Host "**$($review.author.login)** $($review.state) at $($review.submittedAt)"
+        Write-BlockComment $review.body
+    }
+}
+Write-Host ""
+
+# Top-level (issue) comments on the PR conversation.
+Write-Host "### Conversation comments ($($pr.comments.Count))"
+Write-Host ""
+if ($pr.comments.Count -eq 0) {
+    Write-Host "_None_"
+} else {
+    foreach ($comment in $pr.comments) {
+        Write-Host "**$($comment.author.login)** commented at $($comment.createdAt):"
+        Write-BlockComment $comment.body
+    }
+}
+Write-Host ""
+
+# Inline review comments grouped by file and line.
+Write-Host "### Inline review comments ($($inline.Count))"
+Write-Host ""
+if ($inline.Count -eq 0) {
+    Write-Host "_None_"
+} else {
+    $grouped = $inline |
+        Group-Object -Property { "$($_.path):$(if ($_.line) { $_.line } else { $_.original_line })" } |
+        Sort-Object Name
+    foreach ($group in $grouped) {
+        $first = $group.Group[0]
+        $line = if ($first.line) { $first.line } else { $first.original_line }
+        Write-Host "#### $($first.path) (line $line)"
+        Write-Host ""
+        foreach ($comment in $group.Group | Sort-Object created_at) {
+            Write-Host "**$($comment.user.login)** commented at $($comment.created_at):"
+            Write-BlockComment $comment.body
+        }
+    }
+}

--- a/eng/docker-tools/skill-helpers/Show-PullRequestComments.ps1
+++ b/eng/docker-tools/skill-helpers/Show-PullRequestComments.ps1
@@ -59,34 +59,44 @@ if ($pr.labels) {
 Write-Host "- URL: $($pr.url)"
 Write-Host ""
 
-# Reviews (the Approve / Request changes / Comment submissions themselves).
-Write-Host "### Reviews ($($pr.reviews.Count))"
-Write-Host ""
-if ($pr.reviews.Count -eq 0) {
-    Write-Host "_None_"
-} else {
-    foreach ($review in $pr.reviews) {
-        Write-Host "**$($review.author.login)** $($review.state) at $($review.submittedAt)"
-        Write-BlockComment $review.body
+# Conversation: top-level issue comments and review submissions, merged in
+# chronological order.
+$conversation = @()
+foreach ($comment in $pr.comments) {
+    $conversation += [pscustomobject]@{
+        Timestamp = [datetime]$comment.createdAt
+        Header    = "**$($comment.author.login)** commented at $($comment.createdAt):"
+        Body      = $comment.body
     }
 }
-Write-Host ""
+foreach ($review in $pr.reviews) {
+    $header = if ($review.state -eq "COMMENTED") {
+        "**$($review.author.login)** left a comment at $($review.submittedAt):"
+    } else {
+        "**$($review.author.login)** reviewed ($($review.state)) at $($review.submittedAt):"
+    }
+    $conversation += [pscustomobject]@{
+        Timestamp = [datetime]$review.submittedAt
+        Header    = $header
+        Body      = $review.body
+    }
+}
+$conversation = $conversation | Sort-Object Timestamp
 
-# Top-level (issue) comments on the PR conversation.
-Write-Host "### Conversation comments ($($pr.comments.Count))"
+Write-Host "### Conversation ($($conversation.Count))"
 Write-Host ""
-if ($pr.comments.Count -eq 0) {
+if ($conversation.Count -eq 0) {
     Write-Host "_None_"
 } else {
-    foreach ($comment in $pr.comments) {
-        Write-Host "**$($comment.author.login)** commented at $($comment.createdAt):"
-        Write-BlockComment $comment.body
+    foreach ($entry in $conversation) {
+        Write-Host $entry.Header
+        Write-BlockComment $entry.Body
     }
 }
 Write-Host ""
 
 # Inline review comments grouped by file and line.
-Write-Host "### Inline review comments ($($inline.Count))"
+Write-Host "### Code review comments ($($inline.Count))"
 Write-Host ""
 if ($inline.Count -eq 0) {
     Write-Host "_None_"


### PR DESCRIPTION
This PR adds three new skills and refactors the existing one. The total set of skills is now:

| area | multiple targets | single target |
| ---- | ---------------- | ------------- |
| pull requests | triaging-pull-requests | investigating-pull-request |
| pipelines | triaging-pipelines | investigating-pipeline |

New scripts that are referenced from these skills:

- eng/docker-tools/skill-helpers/
  - Get-FailingPipelines.ps1 - shows pipelines in a folder whose most recent build is failing. This isn't referenced by a skill, I might remove it.
  - Get-RecentBuilds.ps1 - shows all pipeline runs in a folder in a given period of time.
  - Show-PullRequestBuilds.ps1 - shows Azure Pipelines build timelines associated with GitHub pull requests.
  - Show-PullRequestComments.ps1 - shows all PR review comments, since `gh` CLI does not support showing review comments natively (you have to drop to the API).

All these scripts fill in a gap that isn't handled natively by the GitHub CLI or the Azure CLI.

If you were wondering why the skills use gerund form for names, that's [recommended in Claude's documentation](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices#naming-conventions).