### PR TITLE
Log unhandled exceptions thrown from command actions

### DIFF
--- a/src/ImageBuilder/Commands/Command.TOptions.cs
+++ b/src/ImageBuilder/Commands/Command.TOptions.cs
@@ -4,8 +4,6 @@
 
 using System;
 using System.CommandLine;
-using System.CommandLine.Parsing;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
@@ -47,12 +45,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 }
                 catch (Exception ex)
                 {
-                    // System.CommandLine's DefaultExceptionHandler silently swallows
-                    // OperationCanceledException (and AggregateException wrapping one),
-                    // producing exit code 1 with no diagnostic output. Write the
-                    // exception details to stderr ourselves before rethrowing so
-                    // failures are always observable in pipeline logs.
-                    // See: https://github.com/dotnet/command-line-api/issues/430
+                    // System.CommandLine silently swallows OperationCanceledException and TaskCanceledException, so
+                    // log all unhandled exceptions to stderr here and re-throw. This makes sure failures are always
+                    // observable in pipeline logs.
+                    // For more details, see https://github.com/dotnet/command-line-api/issues/2808.
                     Console.Error.WriteLine($"Unhandled exception in command '{this.GetCommandName()}':");
                     Console.Error.WriteLine(ex.ToString());
                     Console.Error.Flush();

--- a/src/ImageBuilder/Commands/Command.TOptions.cs
+++ b/src/ImageBuilder/Commands/Command.TOptions.cs
@@ -33,15 +33,31 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             cmd.SetAction(async (parseResult, cancellationToken) =>
             {
-                options.Bind(parseResult);
-
-                if (!options.NoVersionLogging)
+                try
                 {
-                    LogDockerVersions();
-                }
+                    options.Bind(parseResult);
 
-                Initialize(options);
-                await ExecuteAsync();
+                    if (!options.NoVersionLogging)
+                    {
+                        LogDockerVersions();
+                    }
+
+                    Initialize(options);
+                    await ExecuteAsync();
+                }
+                catch (Exception ex)
+                {
+                    // System.CommandLine's DefaultExceptionHandler silently swallows
+                    // OperationCanceledException (and AggregateException wrapping one),
+                    // producing exit code 1 with no diagnostic output. Write the
+                    // exception details to stderr ourselves before rethrowing so
+                    // failures are always observable in pipeline logs.
+                    // See: https://github.com/dotnet/command-line-api/issues/430
+                    Console.Error.WriteLine($"Unhandled exception in command '{this.GetCommandName()}':");
+                    Console.Error.WriteLine(ex.ToString());
+                    Console.Error.Flush();
+                    throw;
+                }
             });
 
             return cmd;


### PR DESCRIPTION
This PR adds explicit stderr logging for any exception thrown out of an ImageBuilder command's action handler.

The root cause is that `System.CommandLine`'s default exception handler silently swallows `OperationCanceledException` (and `TaskCanceledException`, which derives from it), returning exit code 1 with zero diagnostic output. This makes any failure that surfaces as a cancellation invisible in pipeline logs (e.g. `HttpClient` timeout). The `check-base-image-updates` pipeline has been failing this way: after `READING MANIFEST`, the process exits 1 with no stack trace.

This PR wraps the action body in `Command.TOptions.cs` with a try/catch that writes the full exception to `Console.Error`.

Upstream issue: https://github.com/dotnet/command-line-api/issues/2808