### PR TITLE
Allow publishing images without (re-)running Sign stage

### DIFF
--- a/eng/docker-tools/DEV-GUIDE.md
+++ b/eng/docker-tools/DEV-GUIDE.md
@@ -427,6 +427,8 @@ When you queue a new run, you can override these as runtime parameters:
 
 This avoids the multi-hour rebuild cycle when you just need to retry a failed operation.
 
+When signing is enabled, use `"publish"` by itself only if the images from `sourceBuildPipelineRunId` were already signed and the current run is not building new images. Use `"sign,publish"` when the current run still needs to sign them before publishing.
+
 ---
 
 ## Troubleshooting

--- a/eng/docker-tools/templates/stages/publish.yml
+++ b/eng/docker-tools/templates/stages/publish.yml
@@ -47,7 +47,7 @@ stages:
   # Run when all of the following are true:
   # 1. The pipeline has not been canceled.
   # 2. The stages variable includes 'publish'.
-  # 3. Either signing is not enabled, or the Sign stage succeeded.
+  # 3. Either signing is not enabled, this run is reusing previously signed images, or the Sign stage succeeded.
   # 4. Either the stages variable does not include 'build', or Post_Build succeeded.
   # 5. Either the stages variable does not include 'test', or Test succeeded/was skipped.
   condition: "
@@ -56,6 +56,10 @@ stages:
       contains(variables['stages'], 'publish'),
       or(
         ne(lower('${{ parameters.publishConfig.Signing.Enabled }}'), 'true'),
+        and(
+          not(contains(variables['stages'], 'build')),
+          not(contains(variables['stages'], 'sign'))
+        ),
         in(dependencies.Sign.result, 'Succeeded', 'SucceededWithIssues')
       ),
       or(


### PR DESCRIPTION
## Background

Publishing from a previous signed build currently requires rerunning the `Sign` stage whenever signing is enabled. That blocks recovery scenarios where tests are broken but the images were already signed in the source build.

## Changes

This PR changes the following:
- Allows `stages=publish` to run without a current-run `Sign` stage when the run is not building new images.
- Keeps signing required for `build,publish` runs when signing is enabled.
- Documents when to use `publish` versus `sign,publish` for recovery runs.