### PR TITLE
Check base images using mirror registry instead of public DockerHub

### DIFF
--- a/src/ImageBuilder/Commands/GetStaleImagesCommand.cs
+++ b/src/ImageBuilder/Commands/GetStaleImagesCommand.cs
@@ -55,7 +55,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             IEnumerable<Task<SubscriptionImagePaths>> getPathResults =
                 SubscriptionHelper.GetSubscriptionManifests(
-                    Options.SubscriptionOptions.SubscriptionsPath, Options.FilterOptions, _gitService, _manifestJsonService)
+                    Options.SubscriptionOptions.SubscriptionsPath,
+                    Options.FilterOptions,
+                    _gitService,
+                    _manifestJsonService,
+                    manifestOptions => manifestOptions.RegistryOverride = Options.RegistryOverride)
                 .Select(async subscriptionManifest =>
                     new SubscriptionImagePaths
                     {
@@ -87,6 +91,12 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             ImageArtifactDetails imageArtifactDetails = await GetImageInfoForSubscriptionAsync(subscription, manifest);
 
+            ImageNameResolverForMatrix imageNameResolver = new(
+                Options.BaseImageOverrideOptions,
+                manifest,
+                repoPrefix: null,
+                sourceRepoPrefix: Options.SourceRepoPrefix);
+
             List<string> pathsToRebuild = new();
 
             foreach (RepoInfo repo in manifest.FilteredRepos)
@@ -97,7 +107,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
                 foreach (PlatformInfo platform in platforms)
                 {
-                    pathsToRebuild.AddRange(await GetPathsToRebuildAsync(manifest, platform, repo, imageArtifactDetails));
+                    pathsToRebuild.AddRange(
+                        await GetPathsToRebuildAsync(manifest, platform, repo, imageArtifactDetails, imageNameResolver));
                 }
             }
 
@@ -109,7 +120,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 .Prepend(platform);
 
         private async Task<List<string>> GetPathsToRebuildAsync(
-            ManifestInfo manifest, PlatformInfo platform, RepoInfo repo, ImageArtifactDetails imageArtifactDetails)
+            ManifestInfo manifest,
+            PlatformInfo platform,
+            RepoInfo repo,
+            ImageArtifactDetails imageArtifactDetails,
+            ImageNameResolverForMatrix imageNameResolver)
         {
             string? fromImage = platform.FinalStageFromImage;
             if (fromImage is null)
@@ -129,19 +144,26 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 return dependentPlatforms.Select(p => p.Model.Dockerfile).ToList();
             }
 
-            fromImage = Options.BaseImageOverrideOptions.ApplyBaseImageOverride(fromImage);
+            // Resolve where to actually fetch the digest from. For external base images this
+            // points to the mirror location in the staging registry; for internal images it is
+            // the original FROM tag. The "public" form is the canonical reference matching what
+            // gets recorded in image-info.json and so is the right repo to use in the digest
+            // comparison string below.
+            string pullTag = imageNameResolver.GetFromImagePullTag(fromImage);
+            string publicTag = imageNameResolver.GetFromImagePublicTag(fromImage);
 
-            string currentDigest = await LockHelper.DoubleCheckedLockLookupAsync(_imageDigestsLock, _imageDigests, fromImage,
+            string currentDigest = await LockHelper.DoubleCheckedLockLookupAsync(_imageDigestsLock, _imageDigests, pullTag,
                 async () =>
                 {
-                    string digest = await _manifestService.Value.GetManifestDigestShaAsync(fromImage, Options.IsDryRun);
-                    return DockerHelper.GetDigestString(DockerHelper.GetRepo(fromImage), digest);
+                    string digest = await _manifestService.Value.GetManifestDigestShaAsync(pullTag, Options.IsDryRun);
+                    return DockerHelper.GetDigestString(DockerHelper.GetRepo(publicTag), digest);
                 });
 
             bool rebuildImage = matchingPlatform.Value.Platform.BaseImageDigest != currentDigest;
 
             _logger.LogInformation(
-                $"Checking base image '{fromImage}' from '{platform.DockerfilePath}'{Environment.NewLine}"
+                $"Checking base image '{publicTag}' from '{platform.DockerfilePath}'{Environment.NewLine}"
+                + $"\tPulled from:          {pullTag}{Environment.NewLine}"
                 + $"\tLast build digest:    {matchingPlatform.Value.Platform.BaseImageDigest}{Environment.NewLine}"
                 + $"\tCurrent digest:       {currentDigest}{Environment.NewLine}"
                 + $"\tImage is up-to-date:  {!rebuildImage}{Environment.NewLine}");

--- a/src/ImageBuilder/Commands/GetStaleImagesCommand.cs
+++ b/src/ImageBuilder/Commands/GetStaleImagesCommand.cs
@@ -130,16 +130,21 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             if (fromImage is null)
             {
                 _logger.LogInformation(
-                    $"There is no base image for '{platform.DockerfilePath}'. By default, it is considered up-to-date.");
+                    "Dockerfile {DockerfilePath} has no base image. It is automatically considered up-to-date.",
+                    platform.DockerfilePath);
+
                 return [];
             }
 
-            (PlatformData Platform, ImageData Image)? matchingPlatform = ImageInfoHelper.GetMatchingPlatformData(platform, repo, imageArtifactDetails);
+            (PlatformData Platform, ImageData Image)? matchingPlatform =
+                ImageInfoHelper.GetMatchingPlatformData(platform, repo, imageArtifactDetails);
 
             if (matchingPlatform is null)
             {
-                _logger.LogInformation(
-                    $"WARNING: Image info not found for '{platform.DockerfilePath}'. Adding path to build to be queued anyway.");
+                _logger.LogWarning(
+                    "Image info not found for '{DockerfilePath}'. It will be queued for rebuild.",
+                    platform.DockerfilePath);
+
                 IEnumerable<PlatformInfo> dependentPlatforms = GetDescendants(platform, manifest);
                 return dependentPlatforms.Select(p => p.Model.Dockerfile).ToList();
             }
@@ -179,11 +184,15 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             bool shouldRebuildImage = matchingPlatform.Value.Platform.BaseImageDigest != currentBaseImageDigestReference;
 
             _logger.LogInformation(
-                $"Checking base image '{baseImagePublicReference}' from '{platform.DockerfilePath}'{Environment.NewLine}"
-                + $"\tPulled from:          {baseImagePullReference}{Environment.NewLine}"
-                + $"\tLast build digest:    {matchingPlatform.Value.Platform.BaseImageDigest}{Environment.NewLine}"
-                + $"\tCurrent digest:       {currentBaseImageDigestReference}{Environment.NewLine}"
-                + $"\tImage is up-to-date:  {!shouldRebuildImage}{Environment.NewLine}");
+                "Dockerfile {DockerfilePath} was last built with base image {BaseImagePublicReference} at digest"
+                    + " {LastBuildBaseImageDigestReference}. Image {BaseImagePullReference} has current digest"
+                    + " {CurrentBaseImageDigestReference}. Up to date: {IsUpToDate}.",
+                platform.DockerfilePath,
+                baseImagePublicReference,
+                matchingPlatform.Value.Platform.BaseImageDigest,
+                baseImagePullReference,
+                currentBaseImageDigestReference,
+                !shouldRebuildImage);
 
             if (shouldRebuildImage)
             {

--- a/src/ImageBuilder/Commands/GetStaleImagesCommand.cs
+++ b/src/ImageBuilder/Commands/GetStaleImagesCommand.cs
@@ -152,12 +152,14 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             string pullTag = imageNameResolver.GetFromImagePullTag(fromImage);
             string publicTag = imageNameResolver.GetFromImagePublicTag(fromImage);
 
-            string currentDigest = await LockHelper.DoubleCheckedLockLookupAsync(_imageDigestsLock, _imageDigests, pullTag,
-                async () =>
-                {
-                    string digest = await _manifestService.Value.GetManifestDigestShaAsync(pullTag, Options.IsDryRun);
-                    return DockerHelper.GetDigestString(DockerHelper.GetRepo(publicTag), digest);
-                });
+            // Cache only the raw SHA by pull location. Two different FROM spellings
+            // can normalize to the same pull tag (e.g. 'almalinux:8' and 'library/almalinux:8')
+            // but produce different public tags; the digest comparison string must always
+            // be built from the current platform's own public tag.
+            string sha = await LockHelper.DoubleCheckedLockLookupAsync(_imageDigestsLock, _imageDigests, pullTag,
+                () => _manifestService.Value.GetManifestDigestShaAsync(pullTag, Options.IsDryRun));
+
+            string currentDigest = DockerHelper.GetDigestString(DockerHelper.GetRepo(publicTag), sha);
 
             bool rebuildImage = matchingPlatform.Value.Platform.BaseImageDigest != currentDigest;
 

--- a/src/ImageBuilder/Commands/GetStaleImagesCommand.cs
+++ b/src/ImageBuilder/Commands/GetStaleImagesCommand.cs
@@ -145,32 +145,47 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             }
 
             // Resolve where to actually fetch the digest from. For external base images this
-            // points to the mirror location in the staging registry; for internal images it is
-            // the original FROM tag. The "public" form is the canonical reference matching what
-            // gets recorded in image-info.json and so is the right repo to use in the digest
-            // comparison string below.
-            string pullTag = imageNameResolver.GetFromImagePullTag(fromImage);
-            string publicTag = imageNameResolver.GetFromImagePublicTag(fromImage);
+            // points to the mirror location in the staging registry; for internal images it is the
+            // original FROM tag. The "public" form is the canonical reference matching what gets
+            // recorded in image-info.json and so is the right repo to use in the digest comparison
+            // string below.
+            string baseImagePullReference = imageNameResolver.GetFromImagePullTag(fromImage);
+            string baseImagePublicReference = imageNameResolver.GetFromImagePublicTag(fromImage);
 
-            // Cache only the raw SHA by pull location. Two different FROM spellings
-            // can normalize to the same pull tag (e.g. 'almalinux:8' and 'library/almalinux:8')
-            // but produce different public tags; the digest comparison string must always
-            // be built from the current platform's own public tag.
-            string sha = await LockHelper.DoubleCheckedLockLookupAsync(_imageDigestsLock, _imageDigests, pullTag,
-                () => _manifestService.Value.GetManifestDigestShaAsync(pullTag, Options.IsDryRun));
+            // Cache the manifest digest by pull reference. The digest is a function of where we
+            // actually pull bytes from, so the pull reference is the correct cache key.
+            string baseImageManifestDigest =
+                await LockHelper.DoubleCheckedLockLookupAsync(
+                    semaphore: _imageDigestsLock,
+                    dictionary: _imageDigests,
+                    key: baseImagePullReference,
+                    getValue: () =>
+                        // This reaches out to the registry to fetch the digest from the pull
+                        // reference. For external images, this fetches from the mirror.
+                        _manifestService.Value.GetManifestDigestShaAsync(baseImagePullReference, Options.IsDryRun));
 
-            string currentDigest = DockerHelper.GetDigestString(DockerHelper.GetRepo(publicTag), sha);
+            // Build a digest-pinned reference of the form '<public-repo>@sha256:<hex>' (e.g.
+            // 'mcr.microsoft.com/dotnet/runtime@sha256:abc123...'). This must be built per-call
+            // from this platform's own public reference — two FROM spellings (e.g. 'almalinux:8'
+            // vs 'library/almalinux:8') can share a pull reference but resolve to different
+            // public references, so the formed string cannot be cached or shared across platforms.
+            // The shape matches what's stored in Platform.BaseImageDigest so the equality check
+            // below is meaningful.
+            string currentBaseImageDigestReference =
+                DockerHelper.GetDigestString(
+                    repo: DockerHelper.GetRepo(baseImagePublicReference),
+                    sha: baseImageManifestDigest);
 
-            bool rebuildImage = matchingPlatform.Value.Platform.BaseImageDigest != currentDigest;
+            bool shouldRebuildImage = matchingPlatform.Value.Platform.BaseImageDigest != currentBaseImageDigestReference;
 
             _logger.LogInformation(
-                $"Checking base image '{publicTag}' from '{platform.DockerfilePath}'{Environment.NewLine}"
-                + $"\tPulled from:          {pullTag}{Environment.NewLine}"
+                $"Checking base image '{baseImagePublicReference}' from '{platform.DockerfilePath}'{Environment.NewLine}"
+                + $"\tPulled from:          {baseImagePullReference}{Environment.NewLine}"
                 + $"\tLast build digest:    {matchingPlatform.Value.Platform.BaseImageDigest}{Environment.NewLine}"
-                + $"\tCurrent digest:       {currentDigest}{Environment.NewLine}"
-                + $"\tImage is up-to-date:  {!rebuildImage}{Environment.NewLine}");
+                + $"\tCurrent digest:       {currentBaseImageDigestReference}{Environment.NewLine}"
+                + $"\tImage is up-to-date:  {!shouldRebuildImage}{Environment.NewLine}");
 
-            if (rebuildImage)
+            if (shouldRebuildImage)
             {
                 IEnumerable<PlatformInfo> dependentPlatforms = GetDescendants(platform, manifest);
                 return dependentPlatforms.Select(p => p.Model.Dockerfile).ToList();

--- a/src/ImageBuilder/Commands/GetStaleImagesOptions.cs
+++ b/src/ImageBuilder/Commands/GetStaleImagesOptions.cs
@@ -23,11 +23,28 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         public BaseImageOverrideOptions BaseImageOverrideOptions { get; set; } = new();
 
+        public string? RegistryOverride { get; set; }
+
+        public string? SourceRepoPrefix { get; set; }
+
         private static readonly GitOptionsBuilder GitBuilder = GitOptionsBuilder.BuildForRepositoryOperations();
 
         private static readonly Argument<string> VariableNameArgument = new(nameof(VariableName))
         {
             Description = "The Azure Pipeline variable name to assign the image paths to"
+        };
+
+        private static readonly Option<string?> RegistryOverrideOption = new($"--{ManifestOptions.RegistryOverrideName}")
+        {
+            Description = "Alternative registry that overrides the registry defined in each subscription's manifest. " +
+                "Used together with --source-repo-prefix to redirect external base image lookups to a mirror location."
+        };
+
+        private static readonly Option<string?> SourceRepoPrefixOption = new("--source-repo-prefix")
+        {
+            Description = "Repo prefix used to locate mirrored external base images in the overridden registry " +
+                "(e.g. 'mirror/'). Combined with --registry-override, external FROM tags are resolved against " +
+                "'<registry-override>/<source-repo-prefix><original-repo>:<tag>' instead of their public source."
         };
 
         public override IEnumerable<Option> GetCliOptions() =>
@@ -38,6 +55,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             ..GitBuilder.GetCliOptions(),
             ..CredentialsOptions.GetCliOptions(),
             ..BaseImageOverrideOptions.GetCliOptions(),
+            RegistryOverrideOption,
+            SourceRepoPrefixOption,
         ];
 
         public override IEnumerable<Argument> GetCliArguments() =>
@@ -64,6 +83,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             GitBuilder.Bind(result, GitOptions);
             CredentialsOptions.Bind(result);
             BaseImageOverrideOptions.Bind(result);
+            RegistryOverride = result.GetValue(RegistryOverrideOption);
+            SourceRepoPrefix = result.GetValue(SourceRepoPrefixOption);
             VariableName = result.GetValue(VariableNameArgument) ?? string.Empty;
         }
     }


### PR DESCRIPTION
This PR responds to new network isolation requirements that broke the check base images pipeline. Outbound connections to DockerHub are blocked by 1ES Network Isolation policies ("CFSClean") in internal Azure Pipelines runs.

Previously the pipeline worked like this:
1. **Copy Base Images** - imports new/updated external images to the internal mirror registry. Since this process runs in Azure, it isn't subject to the same Network Isolation policies as 1ES Pipelines.
2. **Get Stale Images** - compares base image digests from two sources:
    - From dotnet/versions / image-info.json files.
    - From the upstream/DockerHub registry.
3. **Queue a build** for all images that have mis-matched digests.

Obviously, comparing base image digests from DockerHub is a problem if the network blocks the connection.

This PR updates the `getStaleImages` command to use the mirrored images that we had already just copied anyways. For simplicity/consistency's sake, I also updated `getStaleImages` to use the exact same mirror/override arguments as `copyBaseImages`, that way we know we're referencing the images the exact same way.
