### PR TITLE
Check base images using mirror registry instead of public DockerHub (+ pipeline changes)

### DIFF
--- a/eng/pipelines/check-base-image-updates.yml
+++ b/eng/pipelines/check-base-image-updates.yml
@@ -1,6 +1,15 @@
 trigger: none
 pr: none
 
+parameters:
+- name: bootstrapImageBuilder
+  displayName: >
+    Build ImageBuilder from source at the start of every job instead of pulling
+    the pre-built image from MCR. Use this option during development to
+    validate changes to ImageBuilder and pipeline templates at the same time.
+  type: boolean
+  default: false
+
 schedules:
 - cron: "0 0,4,8,12,16,20 * * *"
   displayName: Daily build
@@ -21,3 +30,5 @@ extends:
     - template: /eng/docker-tools/templates/stages/dotnet/publish-config-prod.yml@self
       parameters:
         stagesTemplate: /eng/pipelines/templates/stages/check-base-image-updates.yml@self
+        stagesTemplateParameters:
+          bootstrapImageBuilder: ${{ parameters.bootstrapImageBuilder }}

--- a/eng/pipelines/templates/jobs/check-base-image-updates.yml
+++ b/eng/pipelines/templates/jobs/check-base-image-updates.yml
@@ -46,7 +46,7 @@ jobs:
       additionalOptions: "--subscriptions-path '${{ parameters.subscriptionsPath }}'"
 
   - script: >
-      $(runImageBuilderCmd)
+      $(runAuthedImageBuilderCmd)
       getStaleImages
       $(dotnetDockerBot.userName)
       $(dotnetDockerBot.email)
@@ -60,6 +60,9 @@ jobs:
       $(dockerHubRegistryCreds)
     displayName: Get Stale Images
     name: GetStaleImages
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+      SYSTEM_OIDCREQUESTURI: $(System.OidcRequestUri)
 
   - script: >
       $(runImageBuilderCmd)

--- a/eng/pipelines/templates/jobs/check-base-image-updates.yml
+++ b/eng/pipelines/templates/jobs/check-base-image-updates.yml
@@ -20,10 +20,6 @@ parameters:
 # Schema is defined in src/ImageBuilder/Configuration/PublishConfiguration.cs.
 - name: publishConfig
   type: object
-# Additional arguments to pass to the getStaleImages command (optional).
-- name: customGetStaleImagesArgs
-  type: string
-  default: ""
 
 jobs:
 - job: ${{ parameters.jobName }}
@@ -56,7 +52,8 @@ jobs:
       $(dotnetDockerBot.email)
       --gh-token $(BotAccount-dotnet-docker-bot-PAT)
       staleImagePaths
-      ${{ parameters.customGetStaleImagesArgs }}
+      --base-override-regex '^(?!mcr\.microsoft\.com/|[^/]+\.azurecr\.io/)'
+      --base-override-sub '${{ parameters.publishConfig.InternalMirrorRegistry.server }}/${{ parameters.publishConfig.InternalMirrorRegistry.repoPrefix }}'
       --subscriptions-path ${{ parameters.subscriptionsPath }}
       --os-type '*'
       --architecture '*'

--- a/eng/pipelines/templates/jobs/check-base-image-updates.yml
+++ b/eng/pipelines/templates/jobs/check-base-image-updates.yml
@@ -52,8 +52,8 @@ jobs:
       $(dotnetDockerBot.email)
       --gh-token $(BotAccount-dotnet-docker-bot-PAT)
       staleImagePaths
-      --base-override-regex '^(?!mcr\.microsoft\.com/|[^/]+\.azurecr\.io/)'
-      --base-override-sub '${{ parameters.publishConfig.InternalMirrorRegistry.server }}/${{ parameters.publishConfig.InternalMirrorRegistry.repoPrefix }}'
+      --registry-override '${{ parameters.publishConfig.InternalMirrorRegistry.server }}'
+      --source-repo-prefix '${{ parameters.publishConfig.InternalMirrorRegistry.repoPrefix }}'
       --subscriptions-path ${{ parameters.subscriptionsPath }}
       --os-type '*'
       --architecture '*'

--- a/eng/pipelines/templates/jobs/check-base-image-updates.yml
+++ b/eng/pipelines/templates/jobs/check-base-image-updates.yml
@@ -20,6 +20,12 @@ parameters:
 # Schema is defined in src/ImageBuilder/Configuration/PublishConfiguration.cs.
 - name: publishConfig
   type: object
+# When true, build ImageBuilder from source instead of pulling from MCR. Used
+# during development to validate ImageBuilder and pipeline template changes
+# together before a new ImageBuilder image is published.
+- name: bootstrapImageBuilder
+  type: boolean
+  default: false
 
 jobs:
 - job: ${{ parameters.jobName }}
@@ -33,6 +39,9 @@ jobs:
     parameters:
       dockerClientOS: linux
       publishConfig: ${{ parameters.publishConfig }}
+      ${{ if eq(parameters.bootstrapImageBuilder, true) }}:
+        customInitSteps:
+        - template: /eng/pipelines/templates/steps/bootstrap-imagebuilder.yml@self
 
   - template: /eng/docker-tools/templates/steps/reference-service-connections.yml@self
     parameters:

--- a/eng/pipelines/templates/stages/check-base-image-updates.yml
+++ b/eng/pipelines/templates/stages/check-base-image-updates.yml
@@ -31,7 +31,6 @@ stages:
     parameters:
       jobName: CheckBaseImages_BuildTools
       subscriptionsPath: eng/check-base-image-subscriptions-buildtools.json
-      customGetStaleImagesArgs: --base-override-regex '^((centos|debian|ubuntu):.+)' --base-override-sub '$(overrideRegistry)/$1'
       publicProjectName: ${{ parameters.publicProjectName }}
       internalProjectName: ${{ parameters.internalProjectName }}
       publishConfig: ${{ parameters.publishConfig }}

--- a/eng/pipelines/templates/stages/check-base-image-updates.yml
+++ b/eng/pipelines/templates/stages/check-base-image-updates.yml
@@ -12,6 +12,12 @@ parameters:
 # The name of the public Azure DevOps project (e.g., "public").
 - name: publicProjectName
   type: string
+# When true, build ImageBuilder from source instead of pulling from MCR. Used
+# during development to validate ImageBuilder and pipeline template changes
+# together before a new ImageBuilder image is published.
+- name: bootstrapImageBuilder
+  type: boolean
+  default: false
 
 stages:
 - stage: CheckBaseImages
@@ -26,6 +32,7 @@ stages:
       publicProjectName: ${{ parameters.publicProjectName }}
       internalProjectName: ${{ parameters.internalProjectName }}
       publishConfig: ${{ parameters.publishConfig }}
+      bootstrapImageBuilder: ${{ parameters.bootstrapImageBuilder }}
 
   - template: /eng/pipelines/templates/jobs/check-base-image-updates.yml@self
     parameters:
@@ -34,3 +41,4 @@ stages:
       publicProjectName: ${{ parameters.publicProjectName }}
       internalProjectName: ${{ parameters.internalProjectName }}
       publishConfig: ${{ parameters.publishConfig }}
+      bootstrapImageBuilder: ${{ parameters.bootstrapImageBuilder }}

--- a/src/ImageBuilder/Commands/GetStaleImagesCommand.cs
+++ b/src/ImageBuilder/Commands/GetStaleImagesCommand.cs
@@ -55,7 +55,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             IEnumerable<Task<SubscriptionImagePaths>> getPathResults =
                 SubscriptionHelper.GetSubscriptionManifests(
-                    Options.SubscriptionOptions.SubscriptionsPath, Options.FilterOptions, _gitService, _manifestJsonService)
+                    Options.SubscriptionOptions.SubscriptionsPath,
+                    Options.FilterOptions,
+                    _gitService,
+                    _manifestJsonService,
+                    manifestOptions => manifestOptions.RegistryOverride = Options.RegistryOverride)
                 .Select(async subscriptionManifest =>
                     new SubscriptionImagePaths
                     {
@@ -87,6 +91,12 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             ImageArtifactDetails imageArtifactDetails = await GetImageInfoForSubscriptionAsync(subscription, manifest);
 
+            ImageNameResolverForMatrix imageNameResolver = new(
+                Options.BaseImageOverrideOptions,
+                manifest,
+                repoPrefix: null,
+                sourceRepoPrefix: Options.SourceRepoPrefix);
+
             List<string> pathsToRebuild = new();
 
             foreach (RepoInfo repo in manifest.FilteredRepos)
@@ -97,7 +107,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
                 foreach (PlatformInfo platform in platforms)
                 {
-                    pathsToRebuild.AddRange(await GetPathsToRebuildAsync(manifest, platform, repo, imageArtifactDetails));
+                    pathsToRebuild.AddRange(
+                        await GetPathsToRebuildAsync(manifest, platform, repo, imageArtifactDetails, imageNameResolver));
                 }
             }
 
@@ -109,7 +120,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 .Prepend(platform);
 
         private async Task<List<string>> GetPathsToRebuildAsync(
-            ManifestInfo manifest, PlatformInfo platform, RepoInfo repo, ImageArtifactDetails imageArtifactDetails)
+            ManifestInfo manifest,
+            PlatformInfo platform,
+            RepoInfo repo,
+            ImageArtifactDetails imageArtifactDetails,
+            ImageNameResolverForMatrix imageNameResolver)
         {
             string? fromImage = platform.FinalStageFromImage;
             if (fromImage is null)
@@ -129,19 +144,26 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 return dependentPlatforms.Select(p => p.Model.Dockerfile).ToList();
             }
 
-            fromImage = Options.BaseImageOverrideOptions.ApplyBaseImageOverride(fromImage);
+            // Resolve where to actually fetch the digest from. For external base images this
+            // points to the mirror location in the staging registry; for internal images it is
+            // the original FROM tag. The "public" form is the canonical reference matching what
+            // gets recorded in image-info.json and so is the right repo to use in the digest
+            // comparison string below.
+            string pullTag = imageNameResolver.GetFromImagePullTag(fromImage);
+            string publicTag = imageNameResolver.GetFromImagePublicTag(fromImage);
 
-            string currentDigest = await LockHelper.DoubleCheckedLockLookupAsync(_imageDigestsLock, _imageDigests, fromImage,
+            string currentDigest = await LockHelper.DoubleCheckedLockLookupAsync(_imageDigestsLock, _imageDigests, pullTag,
                 async () =>
                 {
-                    string digest = await _manifestService.Value.GetManifestDigestShaAsync(fromImage, Options.IsDryRun);
-                    return DockerHelper.GetDigestString(DockerHelper.GetRepo(fromImage), digest);
+                    string digest = await _manifestService.Value.GetManifestDigestShaAsync(pullTag, Options.IsDryRun);
+                    return DockerHelper.GetDigestString(DockerHelper.GetRepo(publicTag), digest);
                 });
 
             bool rebuildImage = matchingPlatform.Value.Platform.BaseImageDigest != currentDigest;
 
             _logger.LogInformation(
-                $"Checking base image '{fromImage}' from '{platform.DockerfilePath}'{Environment.NewLine}"
+                $"Checking base image '{publicTag}' from '{platform.DockerfilePath}'{Environment.NewLine}"
+                + $"\tPulled from:          {pullTag}{Environment.NewLine}"
                 + $"\tLast build digest:    {matchingPlatform.Value.Platform.BaseImageDigest}{Environment.NewLine}"
                 + $"\tCurrent digest:       {currentDigest}{Environment.NewLine}"
                 + $"\tImage is up-to-date:  {!rebuildImage}{Environment.NewLine}");

--- a/src/ImageBuilder/Commands/GetStaleImagesCommand.cs
+++ b/src/ImageBuilder/Commands/GetStaleImagesCommand.cs
@@ -130,16 +130,21 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             if (fromImage is null)
             {
                 _logger.LogInformation(
-                    $"There is no base image for '{platform.DockerfilePath}'. By default, it is considered up-to-date.");
+                    "Dockerfile {DockerfilePath} has no base image. It is automatically considered up-to-date.",
+                    platform.DockerfilePath);
+
                 return [];
             }
 
-            (PlatformData Platform, ImageData Image)? matchingPlatform = ImageInfoHelper.GetMatchingPlatformData(platform, repo, imageArtifactDetails);
+            (PlatformData Platform, ImageData Image)? matchingPlatform =
+                ImageInfoHelper.GetMatchingPlatformData(platform, repo, imageArtifactDetails);
 
             if (matchingPlatform is null)
             {
-                _logger.LogInformation(
-                    $"WARNING: Image info not found for '{platform.DockerfilePath}'. Adding path to build to be queued anyway.");
+                _logger.LogWarning(
+                    "Image info not found for '{DockerfilePath}'. It will be queued for rebuild.",
+                    platform.DockerfilePath);
+
                 IEnumerable<PlatformInfo> dependentPlatforms = GetDescendants(platform, manifest);
                 return dependentPlatforms.Select(p => p.Model.Dockerfile).ToList();
             }
@@ -179,11 +184,15 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             bool shouldRebuildImage = matchingPlatform.Value.Platform.BaseImageDigest != currentBaseImageDigestReference;
 
             _logger.LogInformation(
-                $"Checking base image '{baseImagePublicReference}' from '{platform.DockerfilePath}'{Environment.NewLine}"
-                + $"\tPulled from:          {baseImagePullReference}{Environment.NewLine}"
-                + $"\tLast build digest:    {matchingPlatform.Value.Platform.BaseImageDigest}{Environment.NewLine}"
-                + $"\tCurrent digest:       {currentBaseImageDigestReference}{Environment.NewLine}"
-                + $"\tImage is up-to-date:  {!shouldRebuildImage}{Environment.NewLine}");
+                "Dockerfile {DockerfilePath} was last built with base image {BaseImagePublicReference} at digest"
+                    + " {LastBuildBaseImageDigestReference}. Image {BaseImagePullReference} has current digest"
+                    + " {CurrentBaseImageDigestReference}. Up to date: {IsUpToDate}.",
+                platform.DockerfilePath,
+                baseImagePublicReference,
+                matchingPlatform.Value.Platform.BaseImageDigest,
+                baseImagePullReference,
+                currentBaseImageDigestReference,
+                !shouldRebuildImage);
 
             if (shouldRebuildImage)
             {

--- a/src/ImageBuilder/Commands/GetStaleImagesCommand.cs
+++ b/src/ImageBuilder/Commands/GetStaleImagesCommand.cs
@@ -152,12 +152,14 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             string pullTag = imageNameResolver.GetFromImagePullTag(fromImage);
             string publicTag = imageNameResolver.GetFromImagePublicTag(fromImage);
 
-            string currentDigest = await LockHelper.DoubleCheckedLockLookupAsync(_imageDigestsLock, _imageDigests, pullTag,
-                async () =>
-                {
-                    string digest = await _manifestService.Value.GetManifestDigestShaAsync(pullTag, Options.IsDryRun);
-                    return DockerHelper.GetDigestString(DockerHelper.GetRepo(publicTag), digest);
-                });
+            // Cache only the raw SHA by pull location. Two different FROM spellings
+            // can normalize to the same pull tag (e.g. 'almalinux:8' and 'library/almalinux:8')
+            // but produce different public tags; the digest comparison string must always
+            // be built from the current platform's own public tag.
+            string sha = await LockHelper.DoubleCheckedLockLookupAsync(_imageDigestsLock, _imageDigests, pullTag,
+                () => _manifestService.Value.GetManifestDigestShaAsync(pullTag, Options.IsDryRun));
+
+            string currentDigest = DockerHelper.GetDigestString(DockerHelper.GetRepo(publicTag), sha);
 
             bool rebuildImage = matchingPlatform.Value.Platform.BaseImageDigest != currentDigest;
 

--- a/src/ImageBuilder/Commands/GetStaleImagesCommand.cs
+++ b/src/ImageBuilder/Commands/GetStaleImagesCommand.cs
@@ -145,32 +145,47 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             }
 
             // Resolve where to actually fetch the digest from. For external base images this
-            // points to the mirror location in the staging registry; for internal images it is
-            // the original FROM tag. The "public" form is the canonical reference matching what
-            // gets recorded in image-info.json and so is the right repo to use in the digest
-            // comparison string below.
-            string pullTag = imageNameResolver.GetFromImagePullTag(fromImage);
-            string publicTag = imageNameResolver.GetFromImagePublicTag(fromImage);
+            // points to the mirror location in the staging registry; for internal images it is the
+            // original FROM tag. The "public" form is the canonical reference matching what gets
+            // recorded in image-info.json and so is the right repo to use in the digest comparison
+            // string below.
+            string baseImagePullReference = imageNameResolver.GetFromImagePullTag(fromImage);
+            string baseImagePublicReference = imageNameResolver.GetFromImagePublicTag(fromImage);
 
-            // Cache only the raw SHA by pull location. Two different FROM spellings
-            // can normalize to the same pull tag (e.g. 'almalinux:8' and 'library/almalinux:8')
-            // but produce different public tags; the digest comparison string must always
-            // be built from the current platform's own public tag.
-            string sha = await LockHelper.DoubleCheckedLockLookupAsync(_imageDigestsLock, _imageDigests, pullTag,
-                () => _manifestService.Value.GetManifestDigestShaAsync(pullTag, Options.IsDryRun));
+            // Cache the manifest digest by pull reference. The digest is a function of where we
+            // actually pull bytes from, so the pull reference is the correct cache key.
+            string baseImageManifestDigest =
+                await LockHelper.DoubleCheckedLockLookupAsync(
+                    semaphore: _imageDigestsLock,
+                    dictionary: _imageDigests,
+                    key: baseImagePullReference,
+                    getValue: () =>
+                        // This reaches out to the registry to fetch the digest from the pull
+                        // reference. For external images, this fetches from the mirror.
+                        _manifestService.Value.GetManifestDigestShaAsync(baseImagePullReference, Options.IsDryRun));
 
-            string currentDigest = DockerHelper.GetDigestString(DockerHelper.GetRepo(publicTag), sha);
+            // Build a digest-pinned reference of the form '<public-repo>@sha256:<hex>' (e.g.
+            // 'mcr.microsoft.com/dotnet/runtime@sha256:abc123...'). This must be built per-call
+            // from this platform's own public reference — two FROM spellings (e.g. 'almalinux:8'
+            // vs 'library/almalinux:8') can share a pull reference but resolve to different
+            // public references, so the formed string cannot be cached or shared across platforms.
+            // The shape matches what's stored in Platform.BaseImageDigest so the equality check
+            // below is meaningful.
+            string currentBaseImageDigestReference =
+                DockerHelper.GetDigestString(
+                    repo: DockerHelper.GetRepo(baseImagePublicReference),
+                    sha: baseImageManifestDigest);
 
-            bool rebuildImage = matchingPlatform.Value.Platform.BaseImageDigest != currentDigest;
+            bool shouldRebuildImage = matchingPlatform.Value.Platform.BaseImageDigest != currentBaseImageDigestReference;
 
             _logger.LogInformation(
-                $"Checking base image '{publicTag}' from '{platform.DockerfilePath}'{Environment.NewLine}"
-                + $"\tPulled from:          {pullTag}{Environment.NewLine}"
+                $"Checking base image '{baseImagePublicReference}' from '{platform.DockerfilePath}'{Environment.NewLine}"
+                + $"\tPulled from:          {baseImagePullReference}{Environment.NewLine}"
                 + $"\tLast build digest:    {matchingPlatform.Value.Platform.BaseImageDigest}{Environment.NewLine}"
-                + $"\tCurrent digest:       {currentDigest}{Environment.NewLine}"
-                + $"\tImage is up-to-date:  {!rebuildImage}{Environment.NewLine}");
+                + $"\tCurrent digest:       {currentBaseImageDigestReference}{Environment.NewLine}"
+                + $"\tImage is up-to-date:  {!shouldRebuildImage}{Environment.NewLine}");
 
-            if (rebuildImage)
+            if (shouldRebuildImage)
             {
                 IEnumerable<PlatformInfo> dependentPlatforms = GetDescendants(platform, manifest);
                 return dependentPlatforms.Select(p => p.Model.Dockerfile).ToList();

--- a/src/ImageBuilder/Commands/GetStaleImagesOptions.cs
+++ b/src/ImageBuilder/Commands/GetStaleImagesOptions.cs
@@ -23,11 +23,28 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         public BaseImageOverrideOptions BaseImageOverrideOptions { get; set; } = new();
 
+        public string? RegistryOverride { get; set; }
+
+        public string? SourceRepoPrefix { get; set; }
+
         private static readonly GitOptionsBuilder GitBuilder = GitOptionsBuilder.BuildForRepositoryOperations();
 
         private static readonly Argument<string> VariableNameArgument = new(nameof(VariableName))
         {
             Description = "The Azure Pipeline variable name to assign the image paths to"
+        };
+
+        private static readonly Option<string?> RegistryOverrideOption = new($"--{ManifestOptions.RegistryOverrideName}")
+        {
+            Description = "Alternative registry that overrides the registry defined in each subscription's manifest. " +
+                "Used together with --source-repo-prefix to redirect external base image lookups to a mirror location."
+        };
+
+        private static readonly Option<string?> SourceRepoPrefixOption = new("--source-repo-prefix")
+        {
+            Description = "Repo prefix used to locate mirrored external base images in the overridden registry " +
+                "(e.g. 'mirror/'). Combined with --registry-override, external FROM tags are resolved against " +
+                "'<registry-override>/<source-repo-prefix><original-repo>:<tag>' instead of their public source."
         };
 
         public override IEnumerable<Option> GetCliOptions() =>
@@ -38,6 +55,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             ..GitBuilder.GetCliOptions(),
             ..CredentialsOptions.GetCliOptions(),
             ..BaseImageOverrideOptions.GetCliOptions(),
+            RegistryOverrideOption,
+            SourceRepoPrefixOption,
         ];
 
         public override IEnumerable<Argument> GetCliArguments() =>
@@ -64,6 +83,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             GitBuilder.Bind(result, GitOptions);
             CredentialsOptions.Bind(result);
             BaseImageOverrideOptions.Bind(result);
+            RegistryOverride = result.GetValue(RegistryOverrideOption);
+            SourceRepoPrefix = result.GetValue(SourceRepoPrefixOption);
             VariableName = result.GetValue(VariableNameArgument) ?? string.Empty;
         }
     }


### PR DESCRIPTION
This PR is based on https://github.com/dotnet/docker-tools/pull/2119 and also includes the necessary pipeline changes that should be applied after the ImageBuilder reference is updated.