### PR TITLE
Write build matrix variables directly to stdout

### DIFF
--- a/src/ImageBuilder/Commands/GenerateBuildMatrixCommand.cs
+++ b/src/ImageBuilder/Commands/GenerateBuildMatrixCommand.cs
@@ -369,8 +369,12 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         return $" \"{leg.Name}\": {{{variables} }}";
                     })
                     .Aggregate((working, next) => $"{working},{next}");
-                _logger.LogInformation(PipelineHelper.FormatOutputVariable(matrix.Name, $"{{{legs}}}"));
+                Console.Out.WriteLine(PipelineHelper.FormatOutputVariable(matrix.Name, $"{{{legs}}}"));
             }
+
+            // Workaround for https://github.com/dotnet/docker-tools/issues/2124. Prevents dropping variables if
+            // logger output is not finished flushing when ImageBuilder exits.
+            Console.Out.Flush();
         }
 
         /// <summary>


### PR DESCRIPTION
This PR prevents `generateBuildMatrix` Azure Pipelines output variables from being dropped by writing `task.setvariable` directives directly to `Console.Out` and flushing after emission.

This is a workaround for https://github.com/dotnet/docker-tools/issues/2124 while `ImageBuilder` does not start and stop the generic application host, which can leave logger output unfinished when the process exits.
