### PR TITLE
Convert ImageBuilder tests from xUnit to MSTest

### DIFF
--- a/src/ImageBuilder.Tests/AnnotateEolDigestsCommandTests.cs
+++ b/src/ImageBuilder.Tests/AnnotateEolDigestsCommandTests.cs
@@ -14,14 +14,13 @@ using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
 using System.Threading;
 using Moq;
 using Newtonsoft.Json;
-using Xunit.Abstractions;
-using Xunit;
+using Shouldly;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
+    [TestClass]
     public class AnnotateEolDigestsCommandTests
     {
-        private readonly ITestOutputHelper _outputHelper;
         private readonly DateOnly _globalDate = new DateOnly(2024, 6, 10);
         private readonly DateOnly _specificDigestDate = new DateOnly(2022, 1, 1);
         private const string RepoPrefix = "public/";
@@ -30,12 +29,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         private const string AnnotationDigest1 = "annotationdigest1";
         private const string AnnotationDigest2 = "annotationdigest2";
 
-        public AnnotateEolDigestsCommandTests(ITestOutputHelper outputHelper)
-        {
-            _outputHelper = outputHelper;
-        }
-
-        [Fact]
+        [TestMethod]
         public async Task AnnotateEolDigestsCommand_AnnotationSuccess()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -61,10 +55,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     $"{AcrName}/{RepoPrefix}@{AnnotationDigest2}"
                 ];
             string[] annotationDigests = File.ReadAllLines(Path.Combine(tempFolderContext.Path, AnnotationsOutputPath));
-            Assert.Equal(expectedAnnotationDigests, annotationDigests);
+            annotationDigests.ShouldBe(expectedAnnotationDigests);
         }
 
-        [Fact]
+        [TestMethod]
         public async Task AnnotateEolDigestsCommand_AnnotationFailures()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -78,13 +72,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     digestAlreadyAnnotated: false,
                     digestAnnotationIsSuccessful: false);
 
-            InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(() => command.ExecuteAsync());
-            Assert.Contains(
-                $"(failed: 2, skipped: 0)",
-                ex.Message);
+            InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(() => command.ExecuteAsync());
+            ex.Message.ShouldContain($"(failed: 2, skipped: 0)");
         }
 
-        [Fact]
+        [TestMethod]
         public async Task AnnotateEolDigestsCommand_CheckAnnotations_AlreadyAnnotated_NonMatchingEolDate()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -99,17 +91,15 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     digestAnnotationIsSuccessful: true,
                     useNonMatchingDate: true);
 
-            InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(() => command.ExecuteAsync());
-            Assert.Contains(
-                $"(failed: 0, skipped: 2)",
-                ex.Message);
+            InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(() => command.ExecuteAsync());
+            ex.Message.ShouldContain($"(failed: 0, skipped: 2)");
 
             lifecycleMetadataServiceMock.Verify(
                 o => o.AnnotateEolDigestAsync(It.IsAny<string>(), It.IsAny<DateOnly>(), It.IsAny<CancellationToken>()),
                 Times.Never());
         }
 
-        [Fact]
+        [TestMethod]
         public async Task AnnotateEolDigestsCommand_CheckAnnotations_AlreadyAnnotated_MatchingEolDate()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();

--- a/src/ImageBuilder.Tests/BuildCommandTests.cs
+++ b/src/ImageBuilder.Tests/BuildCommandTests.cs
@@ -1232,7 +1232,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             bool isRuntimeDepsCached,
             bool isRuntimeCached)
         {
-            TestContext.WriteLine("{0}", $"Running scenario '{scenario}'");
+            TestContext.WriteLine($"Running scenario '{scenario}'");
 
             const string registry = "mcr.microsoft.com";
             const string registryOverride = "new-registry.azurecr.io";

--- a/src/ImageBuilder.Tests/BuildCommandTests.cs
+++ b/src/ImageBuilder.Tests/BuildCommandTests.cs
@@ -20,8 +20,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using Newtonsoft.Json;
-using Xunit.Abstractions;
-using Xunit;
+using Shouldly;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ConfigurationHelper;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ImageInfoHelper;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
@@ -29,19 +28,15 @@ using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestServiceHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
+    [TestClass]
     public class BuildCommandTests
     {
-        private readonly ITestOutputHelper _outputHelper;
-
-        public BuildCommandTests(ITestOutputHelper outputHelper)
-        {
-            _outputHelper = outputHelper;
-        }
+        public TestContext TestContext { get; set; }
 
         /// <summary>
         /// Verifies the command outputs an image info correctly for a basic scenario.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task BuildCommand_ImageInfoOutput_Basic()
         {
             const string getInstalledPackagesScriptPath = "get-pkgs.sh";
@@ -315,7 +310,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 string expectedOutput = JsonHelper.SerializeObject(imageArtifactDetails);
                 string actualOutput = File.ReadAllText(command.Options.ImageInfoOutputPath);
 
-                Assert.Equal(expectedOutput, actualOutput);
+                actualOutput.ShouldBe(expectedOutput);
             }
         }
 
@@ -323,7 +318,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// Verifies the command outputs an image info correctly for a scenario where a platform has been duplicated in order
         /// for it to be contained in two different images.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task BuildCommand_ImageInfoOutput_DuplicatedPlatform()
         {
             const string runtimeRepo = "runtime";
@@ -459,13 +454,13 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             string expectedOutput = JsonHelper.SerializeObject(imageArtifactDetails);
             string actualOutput = File.ReadAllText(command.Options.ImageInfoOutputPath);
 
-            Assert.Equal(expectedOutput, actualOutput);
+            actualOutput.ShouldBe(expectedOutput);
         }
 
         /// <summary>
         /// Verifies the tags that get built and published.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task BuildCommand_Publish()
         {
             const string repoName = "runtime";
@@ -545,7 +540,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Verifies that the manifest's platform architecture settings match the architecture of the base image.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task BuildCommand_VerifyOnBaseImageArchMismatch()
         {
             const string repoName = "runtime";
@@ -584,21 +579,19 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             command.LoadManifest();
 
-            InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(() => command.ExecuteAsync());
-            Assert.StartsWith(
-                $"Platform '{PathHelper.NormalizePath(dockerfileRelativePath)}' is configured with an architecture that is not compatible with the base image '{baseImageTag}'",
-                ex.Message);
+            InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(() => command.ExecuteAsync());
+            ex.Message.ShouldStartWith($"Platform '{PathHelper.NormalizePath(dockerfileRelativePath)}' is configured with an architecture that is not compatible with the base image '{baseImageTag}'");
         }
 
         /// <summary>
         /// Verifies that arm/v7 is compatible with arm/ (empty variant) since containerd
         /// treats them as equivalent, similar to arm64/v8 and arm64/.
         /// </summary>
-        [Theory]
-        [InlineData("v7", null)]
-        [InlineData(null, "v7")]
-        [InlineData(null, null)]
-        [InlineData("v7", "v7")]
+        [TestMethod]
+        [DataRow("v7", null)]
+        [DataRow(null, "v7")]
+        [DataRow(null, null)]
+        [DataRow("v7", "v7")]
         public async Task BuildCommand_ArmVariantCompatibility(string manifestVariant, string baseImageVariant)
         {
             const string repoName = "runtime";
@@ -647,7 +640,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Verifies that manifest-defined and globally-defined build args can be used.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task BuildCommand_BuildArgs()
         {
             const string repoName = "runtime";
@@ -705,7 +698,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Verifies that Docker build options can be passed through to the Docker build command.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task BuildCommand_DockerBuildOptions()
         {
             const string repoName = "runtime";
@@ -759,7 +752,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Verifies that an image with no base image will get built.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task BuildCommand_NoBaseImage_Build()
         {
             const string repoName = "runtime";
@@ -828,7 +821,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Verifies that an image with no base image will be considered up-to-date.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task BuildCommand_NoBaseImage_Cached()
         {
             const string runtimeDepsRepo = "runtime-deps";
@@ -993,7 +986,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             string expectedOutput = JsonHelper.SerializeObject(expectedOutputImageArtifactDetails);
             string actualOutput = File.ReadAllText(command.Options.ImageInfoOutputPath);
 
-            Assert.Equal(expectedOutput, actualOutput);
+            actualOutput.ShouldBe(expectedOutput);
 
             manifestServiceMock.Verify(o => o.GetImageLayersAsync($"{runtimeDepsRepo}:{tag}", false), Times.Once);
             manifestServiceMock.Verify(o => o.GetImageLayersAsync($"{runtimeDepsRepo}:{newTag}", false), Times.Once);
@@ -1024,7 +1017,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Verifies the command outputs an image info correctly when the manifest references a custom named Dockerfile.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task BuildCommand_ImageInfoOutput_CustomDockerfile()
         {
             using (TempFolderContext tempFolderContext = TestHelper.UseTempFolder())
@@ -1071,18 +1064,16 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
                 ImageArtifactDetails imageArtifactDetails = JsonConvert.DeserializeObject<ImageArtifactDetails>(
                     File.ReadAllText(command.Options.ImageInfoOutputPath));
-                Assert.Equal(
-                    PathHelper.NormalizePath(dockerfileRelativePath),
-                    imageArtifactDetails.Repos[0].Images.First().Platforms.First().Dockerfile);
+                imageArtifactDetails.Repos[0].Images.First().Platforms.First().Dockerfile.ShouldBe(PathHelper.NormalizePath(dockerfileRelativePath));
             }
         }
 
         /// <summary>
         /// Verifies an exception is thrown if the build output contains pull information.
         /// </summary>
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public async Task BuildCommand_ThrowsIfImageIsPulled(bool isSkipPullingEnabled)
         {
             Mock<IDockerService> dockerServiceMock = CreateDockerServiceMock("Pulling from");
@@ -1127,15 +1118,15 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             }
             else
             {
-                await Assert.ThrowsAsync<InvalidOperationException>(command.ExecuteAsync);
+                await Should.ThrowAsync<InvalidOperationException>(command.ExecuteAsync);
             }
         }
 
         /// <summary>
         /// Verifies the image caching logic.
         /// </summary>
-        [Theory]
-        [InlineData(
+        [TestMethod]
+        [DataRow(
             "All images cached",
             "sha256:baseImageSha-1", "sha256:baseImageSha-1",
             "sha256:runtimeDepsImageSha-1", "sha256:runtimeDepsImageSha-1",
@@ -1144,7 +1135,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             new string[] {},
             false,
             true, true)]
-        [InlineData(
+        [DataRow(
             "All previously published, diffs for all image digests and commit SHAs",
             "sha256:baseImageSha-1", "sha256:baseImageSha-2",
             "sha256:runtimeDepsImageSha-1", "sha256:runtimeDepsImageSha-2",
@@ -1153,7 +1144,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             new string[] {},
             false,
             false, false)]
-        [InlineData(
+        [DataRow(
             "All previously published, diff for runtimeDeps image digest",
             "sha256:baseImageSha-1", "sha256:baseImageSha-1",
             "sha256:runtimeDepsImageSha-1", "sha256:runtimeDepsImageSha-2",
@@ -1162,7 +1153,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             new string[] {},
             false,
             true, false)]
-        [InlineData(
+        [DataRow(
             "All previously published, diff for runtime commit SHA",
             "sha256:baseImageSha-1", "sha256:baseImageSha-1",
             "sha256:runtimeDepsImageSha-1", "sha256:runtimeDepsImageSha-1",
@@ -1171,7 +1162,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             new string[] {},
             false,
             true, false)]
-        [InlineData(
+        [DataRow(
             "All previously published, diff for base image digest",
             "sha256:baseImageSha-1", "sha256:baseImageSha-2",
             "sha256:runtimeDepsImageSha-1", "sha256:runtimeDepsImageSha-2",
@@ -1180,7 +1171,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             new string[] {},
             false,
             false, false)]
-        [InlineData(
+        [DataRow(
             "Runtime not previously published",
             "sha256:baseImageSha-1", "sha256:baseImageSha-1",
             "sha256:runtimeDepsImageSha-1", "sha256:runtimeDepsImageSha-1",
@@ -1189,7 +1180,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             new string[] {},
             false,
             true, false)]
-        [InlineData(
+        [DataRow(
             "No images previously published",
             "sha256:baseImageSha-1", "sha256:baseImageSha-1",
             null, "sha256:runtimeDepsImageSha-1",
@@ -1198,7 +1189,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             new string[] {},
             false,
             false, false)]
-        [InlineData(
+        [DataRow(
             "All previously published, commit diff for runtime-deps",
             "sha256:baseImageSha", "sha256:baseImageSha",
             "sha256:runtimeDepsImageSha-1", "sha256:runtimeDepsImageSha-1",
@@ -1207,7 +1198,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             new string[] {},
             false,
             false, false)]
-        [InlineData(
+        [DataRow(
             "All unchanged, noCache set to true",
             "sha256:baseImageSha", "sha256:baseImageSha",
             "sha256:runtimeDepsImageSha", "sha256:runtimeDepsImageSha",
@@ -1217,7 +1208,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             true,
             false, false)]
         // Test failing due to https://github.com/dotnet/docker-tools/issues/1185
-        // [InlineData(
+        // [DataRow(
         //     "All unchanged, noCache set to true, path filter set to runtime",
         //     "sha256:baseImageSha", "sha256:baseImageSha",
         //     "sha256:runtimeDepsImageSha", "sha256:runtimeDepsImageSha",
@@ -1241,7 +1232,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             bool isRuntimeDepsCached,
             bool isRuntimeCached)
         {
-            _outputHelper.WriteLine($"Running scenario '{scenario}'");
+            TestContext.WriteLine("{0}", $"Running scenario '{scenario}'");
 
             const string registry = "mcr.microsoft.com";
             const string registryOverride = "new-registry.azurecr.io";
@@ -1450,7 +1441,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// has an entry defined in the source image info file. It's configured so the first platform should be a cache hit and
         /// and the second platform should also be a cache hit even though it doesn't have an entry in the source image info file.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task BuildCommand_Caching_SharedDockerfile_MissingSourceImageInfoEntry()
         {
             string runtimeDepsRepo = $"runtime-deps";
@@ -1716,7 +1707,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             string expectedOutput = JsonHelper.SerializeObject(expectedOutputImageArtifactDetails);
             string actualOutput = File.ReadAllText(command.Options.ImageInfoOutputPath);
 
-            Assert.Equal(expectedOutput, actualOutput);
+            actualOutput.ShouldBe(expectedOutput);
 
             manifestServiceMock.Verify(o => o.GetLocalImageDigestAsync(linuxBaseImageTag, false), Times.Once);
             manifestServiceMock.Verify(o => o.GetLocalImageDigestAsync(windowsBaseImageTag, false), Times.Once);
@@ -1769,7 +1760,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// it too should be a cache hit. The last platform again has no entry in the image info file and shares the same Dockerfile
         /// but it uses different build args so it should be a cache miss.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task BuildCommand_Caching_SharedDockerfile_MissingSourceImageInfoEntry_DiffBuildArgs()
         {
             const string runtimeDepsRepo = "runtime-deps";
@@ -2026,7 +2017,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             string expectedOutput = JsonHelper.SerializeObject(expectedOutputImageArtifactDetails);
             string actualOutput = File.ReadAllText(command.Options.ImageInfoOutputPath);
 
-            Assert.Equal(expectedOutput, actualOutput);
+            actualOutput.ShouldBe(expectedOutput);
 
             manifestServiceMock.Verify(o => o.GetImageLayersAsync($"{runtimeDepsRepo}:{tag}", false), Times.Once);
             manifestServiceMock.Verify(o => o.GetImageLayersAsync($"{runtimeDeps2Repo}:{tag}", false), Times.Once);
@@ -2072,7 +2063,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// Tests a caching scenario where two platforms are defined that share the same Dockerfile and neither of them
         /// have a entry in the source image info file.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task BuildCommand_Caching_SharedDockerfile_NoExistingImageInfoEntries()
         {
             const string runtimeDepsRepo = "runtime-deps";
@@ -2229,7 +2220,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             string expectedOutput = JsonHelper.SerializeObject(expectedOutputImageArtifactDetails);
             string actualOutput = File.ReadAllText(command.Options.ImageInfoOutputPath);
 
-            Assert.Equal(expectedOutput, actualOutput);
+            actualOutput.ShouldBe(expectedOutput);
 
             dockerServiceMock.Verify(o => o.PushImage($"{runtimeDepsRepo}:{tag}", false));
             dockerServiceMock.Verify(o => o.PushImage($"{runtimeDeps2Repo}:{tag}", false));
@@ -2280,7 +2271,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// This scenario has caching allowed with a source image info but a build should occur for both platforms
         /// due to a base image digest diff.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task BuildCommand_SharedDockerfile()
         {
             const string runtimeDepsRepo = "runtime-deps";
@@ -2473,7 +2464,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             string expectedOutput = JsonHelper.SerializeObject(expectedOutputImageArtifactDetails);
             string actualOutput = File.ReadAllText(command.Options.ImageInfoOutputPath);
 
-            Assert.Equal(expectedOutput, actualOutput);
+            actualOutput.ShouldBe(expectedOutput);
 
             dockerServiceMock.Verify(o => o.PushImage($"{runtimeDepsRepo}:{tag}", false));
             dockerServiceMock.Verify(o => o.PushImage($"{runtimeDeps2Repo}:{tag}", false));
@@ -2522,7 +2513,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// tag has been introduced that isn't set in the source image info. The platform should not be marked as cached
         /// in that case.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task BuildCommand_Caching_TagUpdate()
         {
             const string runtimeDepsRepo = "runtime-deps";
@@ -2697,7 +2688,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             string expectedOutput = JsonHelper.SerializeObject(expectedOutputImageArtifactDetails);
             string actualOutput = File.ReadAllText(command.Options.ImageInfoOutputPath);
 
-            Assert.Equal(expectedOutput, actualOutput);
+            actualOutput.ShouldBe(expectedOutput);
 
             manifestServiceMock.Verify(o => o.GetLocalImageDigestAsync(baseImageTag, false), Times.Once);
             manifestServiceMock.Verify(o => o.GetImageLayersAsync($"{runtimeDepsRepo}:{tag}", false), Times.Once);
@@ -2733,7 +2724,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// Tests a caching scenario where two platforms are defined that share the same Dockerfile. One of the platforms introduces
         /// a new tag that didn't exist in the source image info file. It should not be marked as cached.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task BuildCommand_Caching_SharedDockerfile_TagUpdate()
         {
             const string runtimeDepsRepo = "runtime-deps";
@@ -2956,7 +2947,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             string expectedOutput = JsonHelper.SerializeObject(expectedOutputImageArtifactDetails);
             string actualOutput = File.ReadAllText(command.Options.ImageInfoOutputPath);
 
-            Assert.Equal(expectedOutput, actualOutput);
+            actualOutput.ShouldBe(expectedOutput);
 
             manifestServiceMock.Verify(o => o.GetImageLayersAsync($"{overridePrefix}{runtimeDepsRepo}:{tag}", false), Times.Once);
             manifestServiceMock.Verify(o => o.GetImageLayersAsync($"{overridePrefix}{runtimeDeps2Repo}:{tag}", false), Times.Once);
@@ -2994,11 +2985,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Verifies the command pulls base images from a mirror location.
         /// </summary>
-        [Theory]
-        [InlineData(false, "library/baserepo", "baserepo")]
-        [InlineData(false, "library/baserepo", "library/baserepo")]
-        [InlineData(true, "library/baserepo", "baserepo")]
-        [InlineData(true, "library/baserepo", "library/baserepo")]
+        [TestMethod]
+        [DataRow(false, "library/baserepo", "baserepo")]
+        [DataRow(false, "library/baserepo", "library/baserepo")]
+        [DataRow(true, "library/baserepo", "baserepo")]
+        [DataRow(true, "library/baserepo", "library/baserepo")]
         public async Task BuildCommand_MirroredImages(bool hasCachedImage, string srcBaseImageRepo, string referencedBaseImageRepo)
         {
             const string Registry = "mcr.microsoft.com";
@@ -3320,7 +3311,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             string expectedOutput = JsonHelper.SerializeObject(expectedOutputImageArtifactDetails);
             string actualOutput = File.ReadAllText(command.Options.ImageInfoOutputPath);
 
-            Assert.Equal(expectedOutput, actualOutput);
+            actualOutput.ShouldBe(expectedOutput);
 
             dockerServiceMock.Verify(o => o.PullImage(mirrorBaseTag, "linux/amd64", false));
             dockerServiceMock.Verify(o => o.CreateTag(mirrorBaseTag, referencedBaseImageTag, false));
@@ -3400,9 +3391,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Tests the logic of image mirroring when the base image is considered to be external from a graph perspective.
         /// </summary>
-        [Theory]
-        [InlineData("mcr.microsoft.com", "mcr.microsoft.com")]
-        [InlineData("other-registry.com", "mcr.microsoft.com")]
+        [TestMethod]
+        [DataRow("mcr.microsoft.com", "mcr.microsoft.com")]
+        [DataRow("other-registry.com", "mcr.microsoft.com")]
         public async Task BuildCommand_MirroredImages_External(string baseImageRegistry, string manifestRegistry)
         {
             const string RegistryOverride = "dotnetdocker.azurecr.io";
@@ -3504,7 +3495,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Tests the logic of image mirroring when the base image tag is configured to be overriden.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task BuildCommand_MirroredImages_BaseImageTagOverride()
         {
             const string RegistryOverride = "dotnetdocker.azurecr.io";
@@ -3611,7 +3602,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             string expectedOutput = JsonHelper.SerializeObject(imageArtifactDetails);
             string actualOutput = File.ReadAllText(command.Options.ImageInfoOutputPath);
 
-            Assert.Equal(expectedOutput, actualOutput);
+            actualOutput.ShouldBe(expectedOutput);
 
             dockerServiceMock.Verify(
                 o => o.BuildImage(

--- a/src/ImageBuilder.Tests/BuildCommandTests.cs
+++ b/src/ImageBuilder.Tests/BuildCommandTests.cs
@@ -29,9 +29,8 @@ using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestServiceHelper;
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
     [TestClass]
-    public class BuildCommandTests
+    public class BuildCommandTests(TestContext testContext)
     {
-        public TestContext TestContext { get; set; }
 
         /// <summary>
         /// Verifies the command outputs an image info correctly for a basic scenario.
@@ -1232,7 +1231,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             bool isRuntimeDepsCached,
             bool isRuntimeCached)
         {
-            TestContext.WriteLine($"Running scenario '{scenario}'");
+            testContext.WriteLine($"Running scenario '{scenario}'");
 
             const string registry = "mcr.microsoft.com";
             const string registryOverride = "new-registry.azurecr.io";

--- a/src/ImageBuilder.Tests/CleanAcrImagesCommandTest.cs
+++ b/src/ImageBuilder.Tests/CleanAcrImagesCommandTest.cs
@@ -15,16 +15,16 @@ using Microsoft.DotNet.ImageBuilder.Models.Oci;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
-using Xunit;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ContainerRegistryHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
+    [TestClass]
     public class CleanAcrImagesCommandTest
     {
         private const string AcrName = "myacr.azurecr.io";
 
-        [Fact]
+        [TestMethod]
         public async Task StagingRepos()
         {
             const string stagingRepo1Name = "build-staging/repo1";
@@ -66,7 +66,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             acrClientMock.Verify(o => o.DeleteRepositoryAsync(stagingRepo2Name));
         }
 
-        [Fact]
+        [TestMethod]
         public async Task PublicNightlyRepos()
         {
             const string publicRepo1Name = "public/dotnet/core-nightly/repo1";
@@ -141,7 +141,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Validates that an empty test repo will be deleted.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task DeleteEmptyTestRepo()
         {
             const string repo1Name = "test/repo1";
@@ -181,7 +181,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Validates that a test repo consisting of only expired images will result in the entire repo being deleted.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task DeleteAllExpiredImagesTestRepo()
         {
             const string repo1Name = "test/repo1";
@@ -216,7 +216,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             acrClientMock.Verify(o => o.DeleteRepositoryAsync(repo1Name));
         }
 
-        [Fact]
+        [TestMethod]
         public async Task TestRepos()
         {
             const string repo1Name = "test/repo1";
@@ -271,7 +271,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Validates that images with EOL date older than specified age are deleted.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task DeleteEolImages()
         {
             const string repo1Name = "test/repo1";
@@ -325,7 +325,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             repo1ContentClientMock.Verify(o => o.DeleteManifestAsync(annotationdigest), Times.Never);
         }
 
-        [Fact]
+        [TestMethod]
         public async Task ExcludedImages()
         {
             const string publicRepo1Name = "public/dotnet/nightly/repo1";

--- a/src/ImageBuilder.Tests/CommandLine/BuildOptionsBindingTests.cs
+++ b/src/ImageBuilder.Tests/CommandLine/BuildOptionsBindingTests.cs
@@ -4,14 +4,14 @@
 
 using Microsoft.DotNet.ImageBuilder.Commands;
 using Shouldly;
-using Xunit;
 using static Microsoft.DotNet.ImageBuilder.Tests.CommandLine.OptionsBindingTestHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests.CommandLine;
 
+[TestClass]
 public class BuildOptionsBindingTests
 {
-    [Fact]
+    [TestMethod]
     public void RegistryCredentials_SingleCredential()
     {
         BuildOptions options = ParseAndBind<BuildOptions>(["--registry-creds", "mcr.microsoft.com=myuser;mypass"]);
@@ -20,7 +20,7 @@ public class BuildOptionsBindingTests
         options.CredentialsOptions.Credentials["mcr.microsoft.com"].Password.ShouldBe("mypass");
     }
 
-    [Fact]
+    [TestMethod]
     public void RegistryCredentials_MultipleCredentials()
     {
         string[] args =
@@ -36,7 +36,7 @@ public class BuildOptionsBindingTests
         options.CredentialsOptions.Credentials["reg2.io"].Password.ShouldBe("pass2");
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildArgs_ParsesDictionaryValues()
     {
         string[] args =
@@ -51,7 +51,7 @@ public class BuildOptionsBindingTests
         options.BuildArgs.ShouldContainKeyAndValue("RUNTIME", "aspnet");
     }
 
-    [Fact]
+    [TestMethod]
     public void Variables_ParsesDictionaryValues()
     {
         BuildOptions options = ParseAndBind<BuildOptions>(["--var", "branch=main", "--var", "version=8.0"]);
@@ -59,7 +59,7 @@ public class BuildOptionsBindingTests
         options.Variables.ShouldContainKeyAndValue("version", "8.0");
     }
 
-    [Fact]
+    [TestMethod]
     public void BooleanFlags_DefaultToFalse()
     {
         BuildOptions options = ParseAndBind<BuildOptions>([]);
@@ -70,7 +70,7 @@ public class BuildOptionsBindingTests
         options.IsDryRun.ShouldBeFalse();
     }
 
-    [Fact]
+    [TestMethod]
     public void BooleanFlags_SetWhenPresent()
     {
         BuildOptions options = ParseAndBind<BuildOptions>(["--push", "--no-cache", "--retry"]);
@@ -79,14 +79,14 @@ public class BuildOptionsBindingTests
         options.IsRetryEnabled.ShouldBeTrue();
     }
 
-    [Fact]
+    [TestMethod]
     public void ManifestOption_DefaultsToManifestJson()
     {
         BuildOptions options = ParseAndBind<BuildOptions>([]);
         options.Manifest.ShouldBe("manifest.json");
     }
 
-    [Fact]
+    [TestMethod]
     public void ManifestOption_OverriddenWhenSpecified()
     {
         BuildOptions options = ParseAndBind<BuildOptions>(["--manifest", "custom-manifest.json"]);

--- a/src/ImageBuilder.Tests/CommandLine/GitOptionsBindingTests.cs
+++ b/src/ImageBuilder.Tests/CommandLine/GitOptionsBindingTests.cs
@@ -8,14 +8,14 @@ using System.CommandLine;
 using System.CommandLine.Parsing;
 using Microsoft.DotNet.ImageBuilder.Commands;
 using Shouldly;
-using Xunit;
 using static Microsoft.DotNet.ImageBuilder.Tests.CommandLine.OptionsBindingTestHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests.CommandLine;
 
+[TestClass]
 public class GitOptionsBindingTests
 {
-    [Fact]
+    [TestMethod]
     public void GitHubToken_BoundFromCliArgs()
     {
         string[] args = ["--gh-token", "my-pat"];
@@ -29,7 +29,7 @@ public class GitOptionsBindingTests
         options.GitOptions.GitHubAuthOptions.IsGitHubAppAuth.ShouldBeFalse();
     }
 
-    [Fact]
+    [TestMethod]
     public void GitHubAppAuth_BoundFromCliArgs()
     {
         string[] args =
@@ -49,7 +49,7 @@ public class GitOptionsBindingTests
         options.GitOptions.GitHubAuthOptions.IsGitHubAppAuth.ShouldBeTrue();
     }
 
-    [Fact]
+    [TestMethod]
     public void GitRepositoryValues_BoundFromCliArgs()
     {
         string[] args =
@@ -68,7 +68,7 @@ public class GitOptionsBindingTests
         options.GitOptions.Path.ShouldBe("eng/docker-tools");
     }
 
-    [Fact]
+    [TestMethod]
     public void GitUserValues_BoundFromCliArgs()
     {
         string[] args = ["--git-username", "bot", "--git-email", "bot@example.com"];
@@ -78,7 +78,7 @@ public class GitOptionsBindingTests
         options.GitOptions.Email.ShouldBe("bot@example.com");
     }
 
-    [Fact]
+    [TestMethod]
     public void GitHubAuth_DefaultsWhenNotSpecified()
     {
         TestGitOptions options = ParseAndBind<TestGitOptions>([]);
@@ -91,7 +91,7 @@ public class GitOptionsBindingTests
         options.GitOptions.GitHubAuthOptions.IsGitHubAppAuth.ShouldBeFalse();
     }
 
-    [Fact]
+    [TestMethod]
     public void RequiredGitHubAuth_ProducesParseErrorWhenNoAuthProvided()
     {
         TestGitOptionsWithRequiredAuth options = new();
@@ -101,7 +101,7 @@ public class GitOptionsBindingTests
             "Expected a parse error when no GitHub auth is provided but auth is required");
     }
 
-    [Fact]
+    [TestMethod]
     public void RequiredGitHubToken_BoundFromCliArgs()
     {
         string[] args = ["--gh-token", "my-pat"];
@@ -111,7 +111,7 @@ public class GitOptionsBindingTests
         options.GitOptions.GitHubAuthOptions.HasCredentials.ShouldBeTrue();
     }
 
-    [Fact]
+    [TestMethod]
     public void RequiredGitHubAppAuth_BoundFromCliArgs()
     {
         string[] args = ["--gh-private-key", "base64key", "--gh-app-client-id", "my-client-id"];

--- a/src/ImageBuilder.Tests/CommandLine/ServiceConnectionOptionsBindingTests.cs
+++ b/src/ImageBuilder.Tests/CommandLine/ServiceConnectionOptionsBindingTests.cs
@@ -5,14 +5,14 @@
 using System.CommandLine;
 using Microsoft.DotNet.ImageBuilder.Commands;
 using Shouldly;
-using Xunit;
 using static Microsoft.DotNet.ImageBuilder.Tests.CommandLine.OptionsBindingTestHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests.CommandLine;
 
+[TestClass]
 public class ServiceConnectionOptionsBindingTests
 {
-    [Fact]
+    [TestMethod]
     public void ValidFormat_ParsesCorrectly()
     {
         string[] args = ["--storage-service-connection", "my-tenant:my-client:my-connection-id"];
@@ -24,10 +24,10 @@ public class ServiceConnectionOptionsBindingTests
         options.StorageServiceConnection.Id.ShouldBe("my-connection-id");
     }
 
-    [Theory]
-    [InlineData("invalid")]
-    [InlineData("only:two")]
-    [InlineData("a:b:c:d")]
+    [TestMethod]
+    [DataRow("invalid")]
+    [DataRow("only:two")]
+    [DataRow("a:b:c:d")]
     public void InvalidFormat_ProducesParseError(string invalidValue)
     {
         string[] args = ["--storage-service-connection", invalidValue];

--- a/src/ImageBuilder.Tests/CommandLine/SignImagesOptionsBindingTests.cs
+++ b/src/ImageBuilder.Tests/CommandLine/SignImagesOptionsBindingTests.cs
@@ -5,13 +5,13 @@
 using Microsoft.DotNet.ImageBuilder.Commands.Signing;
 using static Microsoft.DotNet.ImageBuilder.Tests.CommandLine.OptionsBindingTestHelper;
 using Shouldly;
-using Xunit;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests.CommandLine;
 
+[TestClass]
 public class SignImagesOptionsBindingTests
 {
-    [Fact]
+    [TestMethod]
     public void RegistryOverride_BoundFromCliArgs()
     {
         string[] args = ["image-info.json", "--registry-override", "myregistry.azurecr.io"];
@@ -19,7 +19,7 @@ public class SignImagesOptionsBindingTests
         options.RegistryOverride.Registry.ShouldBe("myregistry.azurecr.io");
     }
 
-    [Fact]
+    [TestMethod]
     public void RepoPrefix_BoundFromCliArgs()
     {
         string[] args = ["image-info.json", "--repo-prefix", "public/"];

--- a/src/ImageBuilder.Tests/CommandLine/VerifySignaturesOptionsBindingTests.cs
+++ b/src/ImageBuilder.Tests/CommandLine/VerifySignaturesOptionsBindingTests.cs
@@ -5,13 +5,13 @@
 using Microsoft.DotNet.ImageBuilder.Commands.Signing;
 using static Microsoft.DotNet.ImageBuilder.Tests.CommandLine.OptionsBindingTestHelper;
 using Shouldly;
-using Xunit;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests.CommandLine;
 
+[TestClass]
 public class VerifySignaturesOptionsBindingTests
 {
-    [Fact]
+    [TestMethod]
     public void RegistryOverride_BoundFromCliArgs()
     {
         string[] args = ["image-info.json", "--registry-override", "myregistry.azurecr.io"];
@@ -19,7 +19,7 @@ public class VerifySignaturesOptionsBindingTests
         options.RegistryOverride.Registry.ShouldBe("myregistry.azurecr.io");
     }
 
-    [Fact]
+    [TestMethod]
     public void RepoPrefix_BoundFromCliArgs()
     {
         string[] args = ["image-info.json", "--repo-prefix", "public/"];

--- a/src/ImageBuilder.Tests/CopyAcrImagesCommandTests.cs
+++ b/src/ImageBuilder.Tests/CopyAcrImagesCommandTests.cs
@@ -13,12 +13,12 @@ using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Newtonsoft.Json;
-using Xunit;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ImageInfoHelper;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
+    [TestClass]
     public class CopyAcrImagesCommandTests
     {
         private const string SourceRegistry = "my.custom.registry";
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Verifies that image tags associated with a custom Dockerfile will by copied to ACR correctly.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task CopyAcrImagesCommand_CustomDockerfileName()
         {
             using (TempFolderContext tempFolderContext = TestHelper.UseTempFolder())
@@ -117,7 +117,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Verifies that image tags associated with a Dockerfile that is shared by more than one platform are copied.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task CopyAcrImagesCommand_SharedDockerfile()
         {
             using (TempFolderContext tempFolderContext = TestHelper.UseTempFolder())
@@ -219,7 +219,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Verifies that image tags associated with a runtime-deps Dockerfiles that is shared by multiple versions.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task CopyAcrImagesCommand_RuntimeDepsSharing()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -332,7 +332,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Verifies that image tags can be syndicated to another repo.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task SyndicatedTags()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -446,7 +446,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Verifies that manifest list shared tags are copied alongside platform tags.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task CopyAcrImagesCommand_CopiesManifestListTags()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -552,7 +552,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Verifies that syndicated manifest list shared tags are copied to the syndicated repo.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task CopyAcrImagesCommand_CopiesSyndicatedManifestListTags()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -668,7 +668,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Verifies that images without ManifestData do not produce manifest list tag copies.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task CopyAcrImagesCommand_SkipsManifestListsWithNoManifestData()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();

--- a/src/ImageBuilder.Tests/CopyBaseImagesCommandTests.cs
+++ b/src/ImageBuilder.Tests/CopyBaseImagesCommandTests.cs
@@ -13,20 +13,20 @@ using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Newtonsoft.Json;
-using Xunit;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ConfigurationHelper;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.DockerfileHelper;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
+    [TestClass]
     public class CopyBaseImagesCommandTests
     {
         private const string SubscriptionId = "my subscription";
         private const string ResourceGroup = "my resource group";
         private const string DestinationRegistry = "mcr.microsoft.com";
 
-        [Fact]
+        [TestMethod]
         public async Task MultipleBaseTags()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -113,7 +113,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// So it's configured to be overriden to use contoso.azurecr.io/os:tag as the source tag. This ends up getting copied
         /// to mcr.microsoft.com/custom-repo/contoso.azurecr.io/os:tag.
         /// </remarks>
-        [Fact]
+        [TestMethod]
         public async Task OverridenBaseTag()
         {
             const string CustomRegistry = "contoso.azurecr.io";

--- a/src/ImageBuilder.Tests/CopyImageServiceTests.cs
+++ b/src/ImageBuilder.Tests/CopyImageServiceTests.cs
@@ -14,10 +14,10 @@ using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Shouldly;
-using Xunit;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests;
 
+[TestClass]
 public class CopyImageServiceTests
 {
     /// <summary>
@@ -25,7 +25,7 @@ public class CopyImageServiceTests
     /// ImportImageAsync should succeed without throwing. This scenario occurs in PR validation
     /// pipelines where appsettings.json is not generated.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ImportImageAsync_DryRun_DoesNotRequirePublishConfiguration()
     {
         var emptyConfig = new PublishConfiguration();
@@ -56,7 +56,7 @@ public class CopyImageServiceTests
     /// ImportImageAsync should proceed past the registry lookup without throwing. External registries
     /// use RegistryAddress + Credentials for ACR import, not ResourceId.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ImportImageAsync_ExternalSourceRegistry_DoesNotRequireSourceRegistryInPublishConfig()
     {
         var publishConfig = new PublishConfiguration
@@ -115,7 +115,7 @@ public class CopyImageServiceTests
     /// When referrers exist for the source image, ImportImageAsync should import each referrer
     /// as an untagged artifact in addition to the main image.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ImportImageAsync_CopiesReferrersAlongWithSourceImage()
     {
         PublishConfiguration publishConfig = CreateAcrPublishConfig("myacr.azurecr.io");
@@ -187,7 +187,7 @@ public class CopyImageServiceTests
     /// <summary>
     /// When no referrers exist, ImportImageAsync should import only the main image.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ImportImageAsync_NoReferrers_ImportsOnlySourceImage()
     {
         PublishConfiguration publishConfig = CreateAcrPublishConfig("myacr.azurecr.io");
@@ -225,7 +225,7 @@ public class CopyImageServiceTests
     /// When copyReferrers is false, referrer discovery and referrer imports are
     /// both skipped. Only the main image is imported.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ImportImageAsync_CopyReferrersFalse_SkipsReferrerDiscoveryAndImport()
     {
         PublishConfiguration publishConfig = CreateAcrPublishConfig("myacr.azurecr.io");
@@ -267,7 +267,7 @@ public class CopyImageServiceTests
     /// The ORAS service receives the dry-run flag and returns an empty list
     /// to avoid rate limiting on unauthenticated registries.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ImportImageAsync_DryRun_SkipsReferrerDiscoveryAndImport()
     {
         var mockOras = new Mock<IOrasService>();

--- a/src/ImageBuilder.Tests/CreateManifestListCommandTests.cs
+++ b/src/ImageBuilder.Tests/CreateManifestListCommandTests.cs
@@ -19,7 +19,6 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using Newtonsoft.Json;
 using Shouldly;
-using Xunit;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.DockerfileHelper;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ImageInfoHelper;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
@@ -27,13 +26,14 @@ using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestServiceHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests;
 
+[TestClass]
 public class CreateManifestListCommandTests
 {
     /// <summary>
     /// Verifies that manifest lists are created, pushed, and digests are
     /// recorded in image-info.json.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ExecuteAsync_CreatesAndPushesManifestLists()
     {
         Mock<IManifestService> manifestServiceMock = CreateManifestServiceMock();
@@ -84,7 +84,7 @@ public class CreateManifestListCommandTests
     /// <summary>
     /// Verifies that ManifestData.Digest is populated from the registry after pushing.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ExecuteAsync_RecordsDigestsInImageInfo()
     {
         Mock<IManifestService> manifestServiceMock = new() { CallBase = true };
@@ -131,7 +131,7 @@ public class CreateManifestListCommandTests
     /// <summary>
     /// Verifies that syndicated digests are recorded in ManifestData.SyndicatedDigests.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ExecuteAsync_RecordsSyndicatedDigests()
     {
         Mock<IManifestService> manifestServiceMock = new() { CallBase = true };
@@ -215,7 +215,7 @@ public class CreateManifestListCommandTests
     /// <summary>
     /// Verifies that when image-info file doesn't exist, command logs a warning and returns.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ExecuteAsync_MissingImageInfoFile_LogsWarningAndReturns()
     {
         CreateManifestListCommand command = CreateCommand(
@@ -249,7 +249,7 @@ public class CreateManifestListCommandTests
     /// the missing sibling platforms are ported in from the source registry so the
     /// shared-tag manifest list still references all declared platforms.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ExecuteAsync_PortsMissingPlatforms_IntoManifestList()
     {
         Mock<IManifestService> manifestServiceMock = CreateManifestServiceMock();
@@ -314,7 +314,7 @@ public class CreateManifestListCommandTests
     /// publishing the partial list back to prod would silently regress the previously
     /// complete multi-platform shared tags (see issue #2107).
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ExecuteAsync_PortsMissingPlatformsAndPublishesCompleteSharedTagManifestList()
     {
         const string PreviousLinuxDigestSha = "sha256:previous-linux";
@@ -432,7 +432,7 @@ public class CreateManifestListCommandTests
         portedPlatform.IsUnchanged.ShouldBeTrue();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ExecuteAsync_DoesNotPortImagesThatAreAbsentFromImageInfo()
     {
         const string SourceRegistry = "source.example.com";
@@ -503,7 +503,7 @@ public class CreateManifestListCommandTests
     /// or an MCR mirror lag window), the command fails loudly rather than silently
     /// producing a degraded shared-tag manifest list.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ExecuteAsync_Throws_WhenSourceTagDoesNotExist()
     {
         const string SourceRegistry = "source.example.com";
@@ -562,8 +562,8 @@ public class CreateManifestListCommandTests
         SetupCommand(command, manifest, imageArtifactDetails, tempFolderContext);
 
         HttpRequestException thrown =
-            await Assert.ThrowsAsync<HttpRequestException>(() => command.ExecuteAsync());
-        Assert.Equal(System.Net.HttpStatusCode.NotFound, thrown.StatusCode);
+            await Should.ThrowAsync<HttpRequestException>(() => command.ExecuteAsync());
+        thrown.StatusCode.ShouldBe(System.Net.HttpStatusCode.NotFound);
 
         // The 404 fails the command before any imports or manifest-list creation occur.
         copyImageServiceMock.Verify(o => o.ImportImageAsync(
@@ -582,7 +582,7 @@ public class CreateManifestListCommandTests
     /// build, not a path-filtered one), the porting service is a no-op and no
     /// imports are performed.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ExecuteAsync_DoesNotPort_WhenAllPlatformsArePresent()
     {
         Mock<IManifestService> manifestServiceMock = CreateManifestServiceMock();

--- a/src/ImageBuilder.Tests/DependencyInjectionTests.cs
+++ b/src/ImageBuilder.Tests/DependencyInjectionTests.cs
@@ -3,17 +3,18 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Linq;
-using Xunit;
+using Shouldly;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests;
 
+[TestClass]
 public class DependencyInjectionTests
 {
-    [Fact]
+    [TestMethod]
     public void DependencyResolution()
     {
         var commands = ImageBuilder.Commands.ToArray();
-        Assert.NotNull(commands);
-        Assert.NotEmpty(commands);
+        commands.ShouldNotBeNull();
+        commands.ShouldNotBeEmpty();
     }
 }

--- a/src/ImageBuilder.Tests/GenerateBuildMatrixCommandTests.cs
+++ b/src/ImageBuilder.Tests/GenerateBuildMatrixCommandTests.cs
@@ -16,12 +16,13 @@ using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Newtonsoft.Json;
-using Xunit;
+using Shouldly;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.DockerfileHelper;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
+    [TestClass]
     public class GenerateBuildMatrixCommandTests
     {
         /// <summary>
@@ -30,10 +31,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <remarks>
         /// https://github.com/dotnet/docker-tools/issues/243
         /// </remarks>
-        [Theory]
-        [InlineData(null, "--path 2.1.1/runtime-deps/os --path 2.2/runtime/os", "2.1.1")]
-        [InlineData("--path 2.2/runtime/os", "--path 2.2/runtime/os", "2.2")]
-        [InlineData("--path 2.1.1/runtime-deps/os", "--path 2.1.1/runtime-deps/os", "2.1.1")]
+        [TestMethod]
+        [DataRow(null, "--path 2.1.1/runtime-deps/os --path 2.2/runtime/os", "2.1.1")]
+        [DataRow("--path 2.2/runtime/os", "--path 2.2/runtime/os", "2.2")]
+        [DataRow("--path 2.1.1/runtime-deps/os", "--path 2.1.1/runtime-deps/os", "2.1.1")]
         public async Task GenerateBuildMatrixCommand_PlatformVersionedOs(string filterPaths, string expectedPaths, string verificationLegName)
         {
             using (TempFolderContext tempFolderContext = TestHelper.UseTempFolder())
@@ -80,13 +81,13 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
                 command.LoadManifest();
                 IEnumerable<BuildMatrixInfo> matrixInfos = await command.GenerateMatrixInfoAsync();
-                Assert.Single(matrixInfos);
+                matrixInfos.ShouldHaveSingleItem();
 
                 BuildMatrixInfo matrixInfo = matrixInfos.First();
                 BuildLegInfo leg = matrixInfo.Legs.First(leg => leg.Name.StartsWith(verificationLegName));
                 string imageBuilderPaths = leg.Variables.First(variable => variable.Name == "imageBuilderPaths").Value;
 
-                Assert.Equal(expectedPaths, imageBuilderPaths);
+                imageBuilderPaths.ShouldBe(expectedPaths);
             }
         }
 
@@ -96,12 +97,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <remarks>
         /// Test uses a dependency graph of runtimedeps <- sdk <- sample
         /// </remarks>
-        [Theory]
-        [InlineData(null, "--path 1.0/runtimedeps/os/amd64 --path 1.0/sdk/os/amd64 --path 1.0/sample/os/amd64")]
-        [InlineData("--path 1.0/runtimedeps/os/amd64", "--path 1.0/runtimedeps/os/amd64")]
-        [InlineData("--path 1.0/runtimedeps/os/amd64 --path 1.0/sdk/os/amd64", "--path 1.0/runtimedeps/os/amd64 --path 1.0/sdk/os/amd64")]
-        [InlineData("--path 1.0/sdk/os/amd64", "--path 1.0/sdk/os/amd64")]
-        [InlineData("--path 1.0/sdk/os/amd64 --path 1.0/sample/os/amd64", "--path 1.0/sdk/os/amd64 --path 1.0/sample/os/amd64")]
+        [TestMethod]
+        [DataRow(null, "--path 1.0/runtimedeps/os/amd64 --path 1.0/sdk/os/amd64 --path 1.0/sample/os/amd64")]
+        [DataRow("--path 1.0/runtimedeps/os/amd64", "--path 1.0/runtimedeps/os/amd64")]
+        [DataRow("--path 1.0/runtimedeps/os/amd64 --path 1.0/sdk/os/amd64", "--path 1.0/runtimedeps/os/amd64 --path 1.0/sdk/os/amd64")]
+        [DataRow("--path 1.0/sdk/os/amd64", "--path 1.0/sdk/os/amd64")]
+        [DataRow("--path 1.0/sdk/os/amd64 --path 1.0/sample/os/amd64", "--path 1.0/sdk/os/amd64 --path 1.0/sample/os/amd64")]
         public async Task GenerateBuildMatrixCommand_PlatformDependencyGraph(string filterPaths, string expectedPaths)
         {
             using (TempFolderContext tempFolderContext = TestHelper.UseTempFolder())
@@ -148,13 +149,13 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
                 command.LoadManifest();
                 IEnumerable<BuildMatrixInfo> matrixInfos = await command.GenerateMatrixInfoAsync();
-                Assert.Single(matrixInfos);
+                matrixInfos.ShouldHaveSingleItem();
 
                 BuildMatrixInfo matrixInfo = matrixInfos.First();
                 BuildLegInfo leg = matrixInfo.Legs.First();
                 string imageBuilderPaths = leg.Variables.First(variable => variable.Name == "imageBuilderPaths").Value;
 
-                Assert.Equal(expectedPaths, imageBuilderPaths);
+                imageBuilderPaths.ShouldBe(expectedPaths);
             }
         }
 
@@ -172,33 +173,33 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 .ReturnsAsync(new ImageCacheResult(cacheState, false, null));
         }
 
-        [Theory]
-        [InlineData(
+        [TestMethod]
+        [DataRow(
             ImageCacheState.NotCached,
             ImageCacheState.NotCached,
             "--path 1.0/runtime/os/amd64/Dockerfile --path 1.0/sdk/os/amd64/Dockerfile",
             "--path 2.0/runtime/os/amd64/Dockerfile --path 2.0/sdk/os/amd64/Dockerfile")]
-        [InlineData(
+        [DataRow(
             ImageCacheState.Cached,
             ImageCacheState.Cached,
             "--path 2.0/runtime/os/amd64/Dockerfile --path 2.0/sdk/os/amd64/Dockerfile")]
-        [InlineData(
+        [DataRow(
             ImageCacheState.Cached,
             ImageCacheState.Cached,
             "--path 1.0/standalone/os/amd64/Dockerfile",
             "--path 2.0/standalone/os/amd64/Dockerfile",
             null,
             "*standalone*")]
-        [InlineData(
+        [DataRow(
             ImageCacheState.CachedWithMissingTags,
             ImageCacheState.Cached,
             "--path 2.0/runtime/os/amd64/Dockerfile --path 2.0/sdk/os/amd64/Dockerfile")]
-        [InlineData(
+        [DataRow(
             ImageCacheState.Cached,
             ImageCacheState.NotCached,
             "--path 1.0/runtime/os/amd64/Dockerfile --path 1.0/sdk/os/amd64/Dockerfile",
             "--path 2.0/runtime/os/amd64/Dockerfile --path 2.0/sdk/os/amd64/Dockerfile")]
-        [InlineData(
+        [DataRow(
             ImageCacheState.NotCached,
             ImageCacheState.NotCached,
             "--path 1.0/runtime/os/amd64/Dockerfile --path 1.0/sdk/os/amd64/Dockerfile",
@@ -340,32 +341,32 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             command.LoadManifest();
             IEnumerable<BuildMatrixInfo> matrixInfos = await command.GenerateMatrixInfoAsync();
-            Assert.Single(matrixInfos);
+            matrixInfos.ShouldHaveSingleItem();
 
             BuildMatrixInfo matrixInfo = matrixInfos.First();
             BuildLegInfo leg = matrixInfo.Legs.First();
             string imageBuilderPaths = leg.Variables.First(variable => variable.Name == "imageBuilderPaths").Value;
-            Assert.Equal(leg1ExpectedPaths, imageBuilderPaths);
+            imageBuilderPaths.ShouldBe(leg1ExpectedPaths);
 
             if (leg2ExpectedPaths is not null)
             {
                 leg = matrixInfo.Legs.Skip(1).First();
                 imageBuilderPaths = leg.Variables.First(variable => variable.Name == "imageBuilderPaths").Value;
-                Assert.Equal(leg2ExpectedPaths, imageBuilderPaths);
+                imageBuilderPaths.ShouldBe(leg2ExpectedPaths);
             }
 
             if (leg3ExpectedPaths is not null)
             {
                 leg = matrixInfo.Legs.Skip(2).First();
                 imageBuilderPaths = leg.Variables.First(variable => variable.Name == "imageBuilderPaths").Value;
-                Assert.Equal(leg3ExpectedPaths, imageBuilderPaths);
+                imageBuilderPaths.ShouldBe(leg3ExpectedPaths);
             }
         }
 
         /// <summary>
         /// Verifies that the correct matrix is generated when the DistinctMatrixOsVersion option is set.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task GenerateBuildMatrixCommand_CustomMatrixOsVersion()
         {
             const string CustomMatrixOsVersion = "custom";
@@ -405,21 +406,17 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             command.LoadManifest();
             IEnumerable<BuildMatrixInfo> matrixInfos = await command.GenerateMatrixInfoAsync();
-            Assert.Equal(2, matrixInfos.Count());
+            matrixInfos.Count().ShouldBe(2);
 
             BuildMatrixInfo matrixInfo = matrixInfos.ElementAt(0);
-            Assert.Equal($"{CustomMatrixOsVersion}Amd64", matrixInfo.Name);
-            Assert.Single(matrixInfo.Legs);
-            Assert.Equal(
-                "--path 1.0/aspnet/os2/amd64/Dockerfile --path 1.0/sdk/os2/amd64/Dockerfile",
-                matrixInfo.Legs.First().Variables.First(variable => variable.Name == "imageBuilderPaths").Value);
+            matrixInfo.Name.ShouldBe($"{CustomMatrixOsVersion}Amd64");
+            matrixInfo.Legs.ShouldHaveSingleItem();
+            (matrixInfo.Legs.First().Variables.First(variable => variable.Name == "imageBuilderPaths").Value).ShouldBe("--path 1.0/aspnet/os2/amd64/Dockerfile --path 1.0/sdk/os2/amd64/Dockerfile");
 
             matrixInfo = matrixInfos.ElementAt(1);
-            Assert.Equal($"linuxAmd64", matrixInfo.Name);
-            Assert.Single(matrixInfo.Legs);
-            Assert.Equal(
-                "--path 1.0/aspnet/os/amd64/Dockerfile --path 1.0/sdk/os/amd64/Dockerfile",
-                matrixInfo.Legs.First().Variables.First(variable => variable.Name == "imageBuilderPaths").Value);
+            matrixInfo.Name.ShouldBe($"linuxAmd64");
+            matrixInfo.Legs.ShouldHaveSingleItem();
+            (matrixInfo.Legs.First().Variables.First(variable => variable.Name == "imageBuilderPaths").Value).ShouldBe("--path 1.0/aspnet/os/amd64/Dockerfile --path 1.0/sdk/os/amd64/Dockerfile");
         }
 
         /// <summary>
@@ -429,9 +426,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <remarks>
         /// https://github.com/dotnet/docker-tools/issues/243
         /// </remarks>
-        [Theory]
-        [InlineData(CustomBuildLegDependencyType.Integral)]
-        [InlineData(CustomBuildLegDependencyType.Supplemental)]
+        [TestMethod]
+        [DataRow(CustomBuildLegDependencyType.Integral)]
+        [DataRow(CustomBuildLegDependencyType.Supplemental)]
         public async Task GenerateBuildMatrixCommand_CustomBuildLegGroupingParentGraph(CustomBuildLegDependencyType dependencyType)
         {
             using (TempFolderContext tempFolderContext = TestHelper.UseTempFolder())
@@ -496,15 +493,15 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
                 command.LoadManifest();
                 IEnumerable<BuildMatrixInfo> matrixInfos = await command.GenerateMatrixInfoAsync();
-                Assert.Single(matrixInfos);
+                matrixInfos.ShouldHaveSingleItem();
 
                 BuildMatrixInfo matrixInfo = matrixInfos.First();
-                Assert.Single(matrixInfo.Legs);
+                matrixInfo.Legs.ShouldHaveSingleItem();
                 BuildLegInfo leg_1_0 = matrixInfo.Legs.First();
                 string imageBuilderPaths = leg_1_0.Variables.First(variable => variable.Name == "imageBuilderPaths").Value;
-                Assert.Equal("--path 1.0/runtime-deps/os/Dockerfile --path 1.0/runtime/os/Dockerfile --path 2.0/sdk/os2/Dockerfile --path 2.0/runtime/os2/Dockerfile", imageBuilderPaths);
+                imageBuilderPaths.ShouldBe("--path 1.0/runtime-deps/os/Dockerfile --path 1.0/runtime/os/Dockerfile --path 2.0/sdk/os2/Dockerfile --path 2.0/runtime/os2/Dockerfile");
                 string osVersions = leg_1_0.Variables.First(variable => variable.Name == "osVersions").Value;
-                Assert.Equal("--os-version noble --os-version trixie --os-version trixie-slim", osVersions);
+                osVersions.ShouldBe("--os-version noble --os-version trixie --os-version trixie-slim");
             }
         }
 
@@ -514,7 +511,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// dependency. The scenario for this is that, for a given matching version between Server Core and Nano Server,
         /// those Dockerfiles should be built in the same job.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task GenerateBuildMatrixCommand_ServerCoreAndNanoServerDependency()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -586,25 +583,21 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             command.LoadManifest();
             IEnumerable<BuildMatrixInfo> matrixInfos = await command.GenerateMatrixInfoAsync();
-            Assert.Single(matrixInfos);
+            matrixInfos.ShouldHaveSingleItem();
 
             BuildMatrixInfo matrixInfo = matrixInfos.First();
             BuildLegInfo leg = matrixInfo.Legs.First();
             string imageBuilderPaths = leg.Variables.First(variable => variable.Name == "imageBuilderPaths").Value;
-            Assert.Equal(
-                "--path 1.0/runtime/nanoserver-1909/Dockerfile --path 1.0/aspnet/nanoserver-1909/Dockerfile --path 1.0/runtime/windowsservercore-1909/Dockerfile --path 1.0/aspnet/windowsservercore-1909/Dockerfile",
-                imageBuilderPaths);
+            imageBuilderPaths.ShouldBe("--path 1.0/runtime/nanoserver-1909/Dockerfile --path 1.0/aspnet/nanoserver-1909/Dockerfile --path 1.0/runtime/windowsservercore-1909/Dockerfile --path 1.0/aspnet/windowsservercore-1909/Dockerfile");
             string osVersions = leg.Variables.First(variable => variable.Name == "osVersions").Value;
-            Assert.Equal(
-                "--os-version nanoserver-1909 --os-version windowsservercore-1909",
-                osVersions);
+            osVersions.ShouldBe("--os-version nanoserver-1909 --os-version windowsservercore-1909");
         }
 
         /// <summary>
         /// Verifies the platformVersionedOs matrix type is generated correctly when there's a dependency on a
         /// tag that's outside the platform group.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task GenerateBuildMatrixCommand_ParentGraphOutsidePlatformGroup()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -656,24 +649,24 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             command.LoadManifest();
             IEnumerable<BuildMatrixInfo> matrixInfos = await command.GenerateMatrixInfoAsync();
-            Assert.Single(matrixInfos);
+            matrixInfos.ShouldHaveSingleItem();
 
             BuildMatrixInfo matrixInfo = matrixInfos.First();
-            Assert.Equal(2, matrixInfo.Legs.Count);
+            matrixInfo.Legs.Count.ShouldBe(2);
             BuildLegInfo leg_1_0 = matrixInfo.Legs.First();
             string imageBuilderPaths = leg_1_0.Variables.First(variable => variable.Name == "imageBuilderPaths").Value;
-            Assert.Equal("--path 1.0/runtime/os/Dockerfile", imageBuilderPaths);
+            imageBuilderPaths.ShouldBe("--path 1.0/runtime/os/Dockerfile");
 
             BuildLegInfo leg_2_0 = matrixInfo.Legs.ElementAt(1);
             imageBuilderPaths = leg_2_0.Variables.First(variable => variable.Name == "imageBuilderPaths").Value;
-            Assert.Equal("--path 1.0/runtime2/os/Dockerfile --path 1.0/sdk3/os2/Dockerfile --path 1.0/runtime3/os2/Dockerfile", imageBuilderPaths);
+            imageBuilderPaths.ShouldBe("--path 1.0/runtime2/os/Dockerfile --path 1.0/sdk3/os2/Dockerfile --path 1.0/runtime3/os2/Dockerfile");
         }
 
         /// <summary>
         /// Verifies that a <see cref="MatrixType.PlatformVersionedOs"/> build matrix can be generated correctly
         /// when there are multiple custom build leg groups defined.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task GenerateBuildMatrixCommand_MultiBuildLegGroups()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -756,32 +749,28 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             command.LoadManifest();
             IEnumerable<BuildMatrixInfo> matrixInfos = await command.GenerateMatrixInfoAsync();
-            Assert.Single(matrixInfos);
+            matrixInfos.ShouldHaveSingleItem();
 
             BuildMatrixInfo matrixInfo = matrixInfos.First();
-            Assert.Equal(2, matrixInfo.Legs.Count());
+            matrixInfo.Legs.Count().ShouldBe(2);
             BuildLegInfo leg = matrixInfo.Legs.ElementAt(0);
             string imageBuilderPaths = leg.Variables.First(variable => variable.Name == "imageBuilderPaths").Value;
-            Assert.Equal(
-                "--path 1.0/repo1/os/Dockerfile --path 1.0/repo2/os/Dockerfile",
-                imageBuilderPaths);
+            imageBuilderPaths.ShouldBe("--path 1.0/repo1/os/Dockerfile --path 1.0/repo2/os/Dockerfile");
 
             leg = matrixInfo.Legs.ElementAt(1);
             imageBuilderPaths = leg.Variables.First(variable => variable.Name == "imageBuilderPaths").Value;
-            Assert.Equal(
-                "--path 1.0/repo3/os/Dockerfile --path 1.0/repo4/os/Dockerfile",
-                imageBuilderPaths);
+            imageBuilderPaths.ShouldBe("--path 1.0/repo3/os/Dockerfile --path 1.0/repo4/os/Dockerfile");
         }
 
         /// <summary>
         /// Verifies the matrix produced by the platformVersionedOs matrix type for a scenario
         /// where the platforms in the image info are a result of cached images.
         /// </summary>
-        [Theory]
-        [InlineData(false, false, false, "--path 1.0/runtime/os/Dockerfile --path 1.0/aspnet/os/Dockerfile --path 1.0/sdk/os/Dockerfile")]
-        [InlineData(true, false, false, "--path 1.0/aspnet/os/Dockerfile --path 1.0/sdk/os/Dockerfile")]
-        [InlineData(true, true, false, "--path 1.0/sdk/os/Dockerfile")]
-        [InlineData(true, true, true, null)]
+        [TestMethod]
+        [DataRow(false, false, false, "--path 1.0/runtime/os/Dockerfile --path 1.0/aspnet/os/Dockerfile --path 1.0/sdk/os/Dockerfile")]
+        [DataRow(true, false, false, "--path 1.0/aspnet/os/Dockerfile --path 1.0/sdk/os/Dockerfile")]
+        [DataRow(true, true, false, "--path 1.0/sdk/os/Dockerfile")]
+        [DataRow(true, true, true, null)]
         public async Task PlatformVersionedOs_Cached(bool isRuntimeCached, bool isAspnetCached, bool isSdkCached, string expectedPaths)
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -884,17 +873,17 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             if (isRuntimeCached && isAspnetCached && isSdkCached)
             {
-                Assert.Empty(matrixInfos);
+                matrixInfos.ShouldBeEmpty();
             }
             else
             {
-                Assert.Single(matrixInfos);
-                Assert.Single(matrixInfos.First().Legs);
+                matrixInfos.ShouldHaveSingleItem();
+                matrixInfos.First().Legs.ShouldHaveSingleItem();
 
                 BuildLegInfo buildLeg = matrixInfos.First().Legs.First();
                 string imageBuilderPaths = buildLeg.Variables.First(variable => variable.Name == "imageBuilderPaths").Value;
 
-                Assert.Equal(expectedPaths, imageBuilderPaths);
+                imageBuilderPaths.ShouldBe(expectedPaths);
             }
         }
 
@@ -905,10 +894,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <remarks>
         /// https://github.com/dotnet/docker-tools/issues/1141
         /// </remarks>
-        [Theory]
-        [InlineData(false, false, "--path 1.0/runtime/os/Dockerfile --path 1.0/aspnet/os-composite/Dockerfile --path 1.0/aspnet/os/Dockerfile --path 1.0/sdk/os/Dockerfile")]
-        [InlineData(true, false, "--path 1.0/aspnet/os/Dockerfile --path 1.0/aspnet/os-composite/Dockerfile --path 1.0/sdk/os/Dockerfile")]
-        [InlineData(true, true, "--path 1.0/aspnet/os-composite/Dockerfile --path 1.0/sdk/os/Dockerfile")]
+        [TestMethod]
+        [DataRow(false, false, "--path 1.0/runtime/os/Dockerfile --path 1.0/aspnet/os-composite/Dockerfile --path 1.0/aspnet/os/Dockerfile --path 1.0/sdk/os/Dockerfile")]
+        [DataRow(true, false, "--path 1.0/aspnet/os/Dockerfile --path 1.0/aspnet/os-composite/Dockerfile --path 1.0/sdk/os/Dockerfile")]
+        [DataRow(true, true, "--path 1.0/aspnet/os-composite/Dockerfile --path 1.0/sdk/os/Dockerfile")]
         public async Task PlatformVersionedOs_CachedParent(bool isRuntimeCached, bool isAspnetCached, string expectedPaths)
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -1062,15 +1051,15 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             command.LoadManifest();
             IEnumerable<BuildMatrixInfo> matrixInfos = await command.GenerateMatrixInfoAsync();
 
-            Assert.Single(matrixInfos);
-            Assert.Single(matrixInfos.First().Legs);
+            matrixInfos.ShouldHaveSingleItem();
+            matrixInfos.First().Legs.ShouldHaveSingleItem();
 
             BuildLegInfo buildLeg = matrixInfos.First().Legs.First();
             string imageBuilderPaths = buildLeg.Variables.First(variable => variable.Name == "imageBuilderPaths").Value;
-            Assert.Equal(expectedPaths, imageBuilderPaths);
+            imageBuilderPaths.ShouldBe(expectedPaths);
         }
 
-        [Fact]
+        [TestMethod]
         public async Task PlatformDependencyGraph_CrossReferencedDockerfileFromMultipleRepos_SingleDockerfile()
         {
             TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -1113,19 +1102,19 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             command.LoadManifest();
             IEnumerable<BuildMatrixInfo> matrixInfos = await command.GenerateMatrixInfoAsync();
-            Assert.Single(matrixInfos);
+            matrixInfos.ShouldHaveSingleItem();
 
             BuildMatrixInfo matrixInfo = matrixInfos.First();
-            Assert.Single(matrixInfo.Legs);
+            matrixInfo.Legs.ShouldHaveSingleItem();
 
-            Assert.Equal("3.1-runtime-deps-os", matrixInfo.Legs[0].Name);
+            matrixInfo.Legs[0].Name.ShouldBe("3.1-runtime-deps-os");
             string imageBuilderPaths = matrixInfo.Legs[0].Variables.First(variable => variable.Name == "imageBuilderPaths").Value;
-            Assert.Equal($"--path {runtimeDepsRelativeDir}", imageBuilderPaths);
+            imageBuilderPaths.ShouldBe($"--path {runtimeDepsRelativeDir}");
         }
 
-        [Theory]
-        [InlineData(MatrixType.PlatformVersionedOs)]
-        [InlineData(MatrixType.PlatformDependencyGraph)]
+        [TestMethod]
+        [DataRow(MatrixType.PlatformVersionedOs)]
+        [DataRow(MatrixType.PlatformDependencyGraph)]
         public async Task CrossReferencedDockerfileFromMultipleRepos_ImageGraph(MatrixType matrixType)
         {
             TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -1177,34 +1166,34 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             command.LoadManifest();
             IEnumerable<BuildMatrixInfo> matrixInfos = await command.GenerateMatrixInfoAsync();
-            Assert.Single(matrixInfos);
+            matrixInfos.ShouldHaveSingleItem();
             BuildMatrixInfo matrixInfo = matrixInfos.First();
 
             if (matrixType == MatrixType.PlatformDependencyGraph)
             {
-                Assert.Single(matrixInfo.Legs);
+                matrixInfo.Legs.ShouldHaveSingleItem();
 
-                Assert.Equal("3.1-runtime-deps-os-Dockerfile-graph", matrixInfo.Legs[0].Name);
+                matrixInfo.Legs[0].Name.ShouldBe("3.1-runtime-deps-os-Dockerfile-graph");
                 string imageBuilderPaths = matrixInfo.Legs[0].Variables.First(variable => variable.Name == "imageBuilderPaths").Value;
-                Assert.Equal($"--path 3.1/runtime-deps/os/Dockerfile --path 3.1/runtime/os/Dockerfile --path 5.0/runtime/os/Dockerfile", imageBuilderPaths);
+                imageBuilderPaths.ShouldBe($"--path 3.1/runtime-deps/os/Dockerfile --path 3.1/runtime/os/Dockerfile --path 5.0/runtime/os/Dockerfile");
             }
             else
             {
-                Assert.Equal(2, matrixInfo.Legs.Count);
+                matrixInfo.Legs.Count.ShouldBe(2);
 
-                Assert.Equal("3.1-noble-core-runtime-deps", matrixInfo.Legs[0].Name);
+                matrixInfo.Legs[0].Name.ShouldBe("3.1-noble-core-runtime-deps");
                 string imageBuilderPaths = matrixInfo.Legs[0].Variables.First(variable => variable.Name == "imageBuilderPaths").Value;
-                Assert.Equal($"--path 3.1/runtime-deps/os/Dockerfile --path 3.1/runtime/os/Dockerfile", imageBuilderPaths);
+                imageBuilderPaths.ShouldBe($"--path 3.1/runtime-deps/os/Dockerfile --path 3.1/runtime/os/Dockerfile");
 
-                Assert.Equal("5.0-noble-runtime-deps", matrixInfo.Legs[1].Name);
+                matrixInfo.Legs[1].Name.ShouldBe("5.0-noble-runtime-deps");
                 imageBuilderPaths = matrixInfo.Legs[1].Variables.First(variable => variable.Name == "imageBuilderPaths").Value;
-                Assert.Equal($"--path 3.1/runtime-deps/os/Dockerfile --path 5.0/runtime/os/Dockerfile", imageBuilderPaths);
+                imageBuilderPaths.ShouldBe($"--path 3.1/runtime-deps/os/Dockerfile --path 5.0/runtime/os/Dockerfile");
             }
         }
 
-        [Theory]
-        [InlineData(MatrixType.PlatformVersionedOs)]
-        [InlineData(MatrixType.PlatformDependencyGraph)]
+        [TestMethod]
+        [DataRow(MatrixType.PlatformVersionedOs)]
+        [DataRow(MatrixType.PlatformDependencyGraph)]
         public async Task NonDependentReposWithSameProductVersion(MatrixType matrixType)
         {
             TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -1238,22 +1227,22 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             command.LoadManifest();
             IEnumerable<BuildMatrixInfo> matrixInfos = await command.GenerateMatrixInfoAsync();
-            Assert.Single(matrixInfos);
+            matrixInfos.ShouldHaveSingleItem();
             BuildMatrixInfo matrixInfo = matrixInfos.First();
 
-            Assert.Equal(2, matrixInfo.Legs.Count);
-            Assert.Equal(matrixType == MatrixType.PlatformDependencyGraph ? "1.0-repo1-os-Dockerfile" : "1.0-noble-repo1", matrixInfo.Legs[0].Name);
+            matrixInfo.Legs.Count.ShouldBe(2);
+            matrixInfo.Legs[0].Name.ShouldBe(matrixType == MatrixType.PlatformDependencyGraph ? "1.0-repo1-os-Dockerfile" : "1.0-noble-repo1");
             string imageBuilderPaths = matrixInfo.Legs[0].Variables.First(variable => variable.Name == "imageBuilderPaths").Value;
-            Assert.Equal($"--path 1.0/repo1/os/Dockerfile", imageBuilderPaths);
+            imageBuilderPaths.ShouldBe($"--path 1.0/repo1/os/Dockerfile");
 
-            Assert.Equal(matrixType == MatrixType.PlatformDependencyGraph ? "1.0-repo2-os-Dockerfile" : "1.0-noble-repo2", matrixInfo.Legs[1].Name);
+            matrixInfo.Legs[1].Name.ShouldBe(matrixType == MatrixType.PlatformDependencyGraph ? "1.0-repo2-os-Dockerfile" : "1.0-noble-repo2");
             imageBuilderPaths = matrixInfo.Legs[1].Variables.First(variable => variable.Name == "imageBuilderPaths").Value;
-            Assert.Equal($"--path 1.0/repo2/os/Dockerfile", imageBuilderPaths);
+            imageBuilderPaths.ShouldBe($"--path 1.0/repo2/os/Dockerfile");
         }
 
-        [Theory]
-        [InlineData(MatrixType.PlatformVersionedOs)]
-        [InlineData(MatrixType.PlatformDependencyGraph)]
+        [TestMethod]
+        [DataRow(MatrixType.PlatformVersionedOs)]
+        [DataRow(MatrixType.PlatformDependencyGraph)]
         public async Task DuplicatedPlatforms(MatrixType matrixType)
         {
             TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -1285,11 +1274,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             command.LoadManifest();
             IEnumerable<BuildMatrixInfo> matrixInfos = await command.GenerateMatrixInfoAsync();
-            Assert.Single(matrixInfos);
+            matrixInfos.ShouldHaveSingleItem();
 
             BuildMatrixInfo matrixInfo = matrixInfos.First();
 
-            Assert.Single(matrixInfo.Legs);
+            matrixInfo.Legs.ShouldHaveSingleItem();
 
             string expectedLegName;
             if (matrixType == MatrixType.PlatformDependencyGraph)
@@ -1301,17 +1290,17 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 expectedLegName = "3.1-noble-runtime";
             }
 
-            Assert.Equal(expectedLegName, matrixInfo.Legs[0].Name);
+            matrixInfo.Legs[0].Name.ShouldBe(expectedLegName);
 
             string imageBuilderPaths = matrixInfo.Legs[0].Variables.First(variable => variable.Name == "imageBuilderPaths").Value;
-            Assert.Equal($"--path 3.1/runtime/os/Dockerfile", imageBuilderPaths);
+            imageBuilderPaths.ShouldBe($"--path 3.1/runtime/os/Dockerfile");
         }
 
         /// <summary>
         /// Scenario where a non-root Dockerfile has a duplicated platform that gets consolidated with another graph due
         /// to a shared root Dockerfile.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task DuplicatedPlatforms_SubgraphConsolidation()
         {
             TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -1351,22 +1340,20 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             command.LoadManifest();
             IEnumerable<BuildMatrixInfo> matrixInfos = await command.GenerateMatrixInfoAsync();
-            Assert.Single(matrixInfos);
+            matrixInfos.ShouldHaveSingleItem();
 
             BuildMatrixInfo matrixInfo = matrixInfos.First();
 
-            Assert.Single(matrixInfo.Legs);
+            matrixInfo.Legs.ShouldHaveSingleItem();
 
             string imageBuilderPaths = matrixInfo.Legs[0].Variables.First(variable => variable.Name == "imageBuilderPaths").Value;
-            Assert.Equal(
-                $"--path 3.1/runtime-deps/os/Dockerfile --path 3.1/runtime/os/Dockerfile --path 6.0/runtime/os/Dockerfile",
-                imageBuilderPaths);
+            imageBuilderPaths.ShouldBe($"--path 3.1/runtime-deps/os/Dockerfile --path 3.1/runtime/os/Dockerfile --path 6.0/runtime/os/Dockerfile");
         }
 
         /// <summary>
         /// Verifies that legs that have common Dockerfiles are consolidated together.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task PlatformVersionedOs_ConsolidateCommonDockerfiles()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -1401,15 +1388,15 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             command.LoadManifest();
             IEnumerable<BuildMatrixInfo> matrixInfos = await command.GenerateMatrixInfoAsync();
-            Assert.Single(matrixInfos);
+            matrixInfos.ShouldHaveSingleItem();
 
             BuildMatrixInfo matrixInfo = matrixInfos.First();
-            Assert.Single(matrixInfo.Legs);
+            matrixInfo.Legs.ShouldHaveSingleItem();
             BuildLegInfo leg = matrixInfo.Legs.First();
-            Assert.Equal("os-repo", leg.Name);
+            leg.Name.ShouldBe("os-repo");
             string imageBuilderPaths = leg.Variables.First(variable => variable.Name == "imageBuilderPaths").Value;
 
-            Assert.Equal("--path 1.0/repo/os/amd64/Dockerfile --path 1.0/repo/os-variant/amd64/Dockerfile", imageBuilderPaths);
+            imageBuilderPaths.ShouldBe("--path 1.0/repo/os/amd64/Dockerfile --path 1.0/repo/os-variant/amd64/Dockerfile");
         }
 
         /// <summary>
@@ -1421,7 +1408,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// It was incorrectly separating out the 2.0 version from 1.0 but including the 1.0/runtime-deps/mariner-distroless/amd64
         /// in the 2.0 job. So both 1.0 and 2.0 had the same Dockerfile which leads to a conflict when publishing.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task PlatformDependencyGraph_MultiVersionSharedDockerfileGraphWithDockerfileThatHasMultiOsVersionDependencies()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -1524,15 +1511,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             command.LoadManifest();
             IEnumerable<BuildMatrixInfo> matrixInfos = await command.GenerateMatrixInfoAsync();
-            Assert.Single(matrixInfos);
+            matrixInfos.ShouldHaveSingleItem();
 
             BuildMatrixInfo matrix = matrixInfos.First();
-            Assert.Single(matrix.Legs);
+            matrix.Legs.ShouldHaveSingleItem();
 
             BuildLegInfo leg = matrix.Legs.First();
             string imageBuilderPaths = leg.Variables.First(variable => variable.Name == "imageBuilderPaths").Value;
-            Assert.Equal("--path 1.0/runtime-deps/mariner/amd64/Dockerfile --path 1.0/runtime/mariner/amd64/Dockerfile --path 1.0/aspnet/mariner/amd64/Dockerfile --path 1.0/sdk/mariner/amd64/Dockerfile --path 1.0/monitor/mariner-distroless/amd64/Dockerfile --path 1.0/aspnet/mariner-distroless/amd64/Dockerfile --path 1.0/runtime/mariner-distroless/amd64/Dockerfile --path 1.0/runtime-deps/mariner-distroless/amd64/Dockerfile --path 2.0/runtime-deps/mariner/amd64/Dockerfile --path 2.0/runtime/mariner/amd64/Dockerfile --path 2.0/aspnet/mariner/amd64/Dockerfile --path 2.0/sdk/mariner/amd64/Dockerfile --path 2.0/monitor/mariner-distroless/amd64/Dockerfile --path 2.0/aspnet/mariner-distroless/amd64/Dockerfile --path 2.0/runtime/mariner-distroless/amd64/Dockerfile",
-                imageBuilderPaths);
+            imageBuilderPaths.ShouldBe("--path 1.0/runtime-deps/mariner/amd64/Dockerfile --path 1.0/runtime/mariner/amd64/Dockerfile --path 1.0/aspnet/mariner/amd64/Dockerfile --path 1.0/sdk/mariner/amd64/Dockerfile --path 1.0/monitor/mariner-distroless/amd64/Dockerfile --path 1.0/aspnet/mariner-distroless/amd64/Dockerfile --path 1.0/runtime/mariner-distroless/amd64/Dockerfile --path 1.0/runtime-deps/mariner-distroless/amd64/Dockerfile --path 2.0/runtime-deps/mariner/amd64/Dockerfile --path 2.0/runtime/mariner/amd64/Dockerfile --path 2.0/aspnet/mariner/amd64/Dockerfile --path 2.0/sdk/mariner/amd64/Dockerfile --path 2.0/monitor/mariner-distroless/amd64/Dockerfile --path 2.0/aspnet/mariner-distroless/amd64/Dockerfile --path 2.0/runtime/mariner-distroless/amd64/Dockerfile");
         }
 
         private static PlatformData CreateSimplePlatformData(string dockerfilePath, bool isCached = false)
@@ -1552,7 +1538,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// failure due to missing RegistryAuthentication config), the exception propagates rather than
         /// being silently swallowed. This is the fix for https://github.com/dotnet/docker-tools/issues/1964.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task TrimCachedImages_DigestQueryAuthFailure_Throws()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -1565,7 +1551,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             // The digest query throws a generic exception (simulating auth failure).
             // This should propagate instead of being silently swallowed.
-            await Assert.ThrowsAsync<Exception>(command.GenerateMatrixInfoAsync);
+            await Should.ThrowAsync<Exception>(command.GenerateMatrixInfoAsync);
         }
 
         /// <summary>
@@ -1573,7 +1559,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// a cache miss and the platform is included in the matrix. This handles the case where a new
         /// image hasn't been published yet.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task TrimCachedImages_DigestQueryReturnsNotFound_CacheMiss()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -1591,8 +1577,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             IEnumerable<BuildMatrixInfo> matrixInfos = await command.GenerateMatrixInfoAsync();
 
             // Image not found → cache miss → platform should be included in the matrix
-            Assert.Single(matrixInfos);
-            Assert.Single(matrixInfos.First().Legs);
+            matrixInfos.ShouldHaveSingleItem();
+            matrixInfos.First().Legs.ShouldHaveSingleItem();
         }
 
         /// <summary>
@@ -1600,7 +1586,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// and the Dockerfile commit also matches, the platform is correctly cached and trimmed from
         /// the matrix.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task TrimCachedImages_DigestAndCommitMatch_PlatformIsCached()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -1621,7 +1607,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             IEnumerable<BuildMatrixInfo> matrixInfos = await command.GenerateMatrixInfoAsync();
 
             // Digest matches and Dockerfile unchanged → platform is cached → trimmed from matrix
-            Assert.Empty(matrixInfos);
+            matrixInfos.ShouldBeEmpty();
         }
 
         /// <summary>

--- a/src/ImageBuilder.Tests/GenerateDockerfilesCommandTests.cs
+++ b/src/ImageBuilder.Tests/GenerateDockerfilesCommandTests.cs
@@ -14,11 +14,12 @@ using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Newtonsoft.Json;
-using Xunit;
+using Shouldly;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
+    [TestClass]
     public class GenerateDockerfilesCommandTests
     {
         private const string DockerfilePath = "1.0/sdk/os/Dockerfile";
@@ -40,7 +41,7 @@ ENV TEST2 Value1";
         {
         }
 
-        [Fact]
+        [TestMethod]
         public async Task GenerateDockerfilesCommand_Canonical()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -49,35 +50,35 @@ ENV TEST2 Value1";
             await command.ExecuteAsync();
 
             string generatedDockerfile = File.ReadAllText(Path.Combine(tempFolderContext.Path, DockerfilePath));
-            Assert.Equal(ExpectedDockerfile.NormalizeLineEndings(generatedDockerfile), generatedDockerfile);
+            generatedDockerfile.ShouldBe(ExpectedDockerfile.NormalizeLineEndings(generatedDockerfile));
         }
 
-        [Fact]
+        [TestMethod]
         public async Task GenerateDockerfilesCommand_InvalidTemplate()
         {
             string template = "FROM $REPO:2.1-{{if:}}";
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
             GenerateDockerfilesCommand command = InitializeCommand(tempFolderContext, template);
 
-            Exception actualException = await Assert.ThrowsAsync<Exception>(command.ExecuteAsync);
+            Exception actualException = await Should.ThrowAsync<Exception>(command.ExecuteAsync);
 
-            Assert.Same(_exitException, actualException);
+            actualException.ShouldBeSameAs(_exitException);
             _environmentServiceMock.Verify(o => o.Exit(It.IsAny<int>()), Times.Once);
         }
 
-        [Fact]
+        [TestMethod]
         public async Task GenerateDockerfilesCommand_MissingTemplate()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
             GenerateDockerfilesCommand command = InitializeCommand(tempFolderContext, null, allowOptionalTemplates: false);
 
-            await Assert.ThrowsAsync<InvalidOperationException>(command.ExecuteAsync);
+            await Should.ThrowAsync<InvalidOperationException>(command.ExecuteAsync);
         }
 
         /// <summary>
         /// Validates an exception is thrown if more than one unique template file is associated with a generated Dockerfile.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task GenerateDockerfilesCommand_MismatchedTemplates()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -119,11 +120,11 @@ ENV TEST2 Value1";
             command.Options.Manifest = manifestPath;
             command.LoadManifest();
 
-            InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(() => command.ExecuteAsync());
-            Assert.StartsWith("Multiple unique template files are associated with the generated artifact path", exception.Message);
+            InvalidOperationException exception = await Should.ThrowAsync<InvalidOperationException>(() => command.ExecuteAsync());
+            exception.Message.ShouldStartWith("Multiple unique template files are associated with the generated artifact path");
         }
 
-        [Fact]
+        [TestMethod]
         public async Task GenerateDockerfilesCommand_Validate_UpToDate()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -134,48 +135,48 @@ ENV TEST2 Value1";
             _environmentServiceMock.Verify(o => o.Exit(It.IsAny<int>()), Times.Never);
         }
 
-        [Fact]
+        [TestMethod]
         public async Task GenerateDockerfilesCommand_Validate_OutOfSync()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
             GenerateDockerfilesCommand command = InitializeCommand(tempFolderContext, validate: true);
 
-            Exception actualException = await Assert.ThrowsAsync<Exception>(command.ExecuteAsync);
+            Exception actualException = await Should.ThrowAsync<Exception>(command.ExecuteAsync);
 
-            Assert.Same(_exitException, actualException);
+            actualException.ShouldBeSameAs(_exitException);
             _environmentServiceMock.Verify(o => o.Exit(It.IsAny<int>()), Times.Once);
             // Validate Dockerfile remains unmodified
-            Assert.Equal(DefaultDockerfile, File.ReadAllText(Path.Combine(tempFolderContext.Path, DockerfilePath)));
+            File.ReadAllText(Path.Combine(tempFolderContext.Path, DockerfilePath)).ShouldBe(DefaultDockerfile);
         }
 
-        [Theory]
-        [InlineData("repo1:tag1", "ARCH_SHORT", "arm")]
-        [InlineData("repo1:tag1", "ARCH_NUPKG", "arm32")]
-        [InlineData("repo1:tag1", "ARCH_VERSIONED", "arm32v7")]
-        [InlineData("repo1:tag2", "ARCH_VERSIONED", "amd64")]
-        [InlineData("repo1:tag3", "ARCH_VERSIONED", "amd64")]
-        [InlineData("repo1:tag1", "ARCH_TAG_SUFFIX", "-arm32v7")]
-        [InlineData("repo1:tag2", "ARCH_TAG_SUFFIX", "-amd64")]
-        [InlineData("repo1:tag3", "ARCH_TAG_SUFFIX", "-amd64")]
-        [InlineData("repo1:tag1", "PRODUCT_VERSION", "1.2.3")]
-        [InlineData("repo1:tag1", "OS_VERSION", "trixie-slim")]
-        [InlineData("repo1:tag2", "OS_VERSION", "nanoserver-1903")]
-        [InlineData("repo1:tag3", "OS_VERSION", "windowsservercore-1903")]
-        [InlineData("repo1:tag4", "OS_VERSION", "windowsservercore-ltsc2019")]
-        [InlineData("repo1:tag1", "OS_VERSION_BASE", "trixie")]
-        [InlineData("repo1:tag1", "OS_VERSION_NUMBER", "")]
-        [InlineData("repo1:tag2", "OS_VERSION_NUMBER", "1903")]
-        [InlineData("repo1:tag3", "OS_VERSION_NUMBER", "1903")]
-        [InlineData("repo1:tag4", "OS_VERSION_NUMBER", "ltsc2019")]
-        [InlineData("repo1:tag5", "OS_VERSION_NUMBER", "3.12")]
-        [InlineData("repo1:tag6", "OS_VERSION_NUMBER", "1.0")]
-        [InlineData("repo1:tag1", "OS_ARCH_HYPHENATED", "Debian-13-arm32")]
-        [InlineData("repo1:tag2", "OS_ARCH_HYPHENATED", "NanoServer-1903")]
-        [InlineData("repo1:tag3", "OS_ARCH_HYPHENATED", "WindowsServerCore-1903")]
-        [InlineData("repo1:tag4", "OS_ARCH_HYPHENATED", "WindowsServerCore-ltsc2019")]
-        [InlineData("repo1:tag5", "OS_ARCH_HYPHENATED", "Alpine-3.12")]
-        [InlineData("repo1:tag6", "OS_ARCH_HYPHENATED", "CBL-Mariner-1.0")]
-        [InlineData("repo1:tag1", "Variable1", "Value1", true)]
+        [TestMethod]
+        [DataRow("repo1:tag1", "ARCH_SHORT", "arm")]
+        [DataRow("repo1:tag1", "ARCH_NUPKG", "arm32")]
+        [DataRow("repo1:tag1", "ARCH_VERSIONED", "arm32v7")]
+        [DataRow("repo1:tag2", "ARCH_VERSIONED", "amd64")]
+        [DataRow("repo1:tag3", "ARCH_VERSIONED", "amd64")]
+        [DataRow("repo1:tag1", "ARCH_TAG_SUFFIX", "-arm32v7")]
+        [DataRow("repo1:tag2", "ARCH_TAG_SUFFIX", "-amd64")]
+        [DataRow("repo1:tag3", "ARCH_TAG_SUFFIX", "-amd64")]
+        [DataRow("repo1:tag1", "PRODUCT_VERSION", "1.2.3")]
+        [DataRow("repo1:tag1", "OS_VERSION", "trixie-slim")]
+        [DataRow("repo1:tag2", "OS_VERSION", "nanoserver-1903")]
+        [DataRow("repo1:tag3", "OS_VERSION", "windowsservercore-1903")]
+        [DataRow("repo1:tag4", "OS_VERSION", "windowsservercore-ltsc2019")]
+        [DataRow("repo1:tag1", "OS_VERSION_BASE", "trixie")]
+        [DataRow("repo1:tag1", "OS_VERSION_NUMBER", "")]
+        [DataRow("repo1:tag2", "OS_VERSION_NUMBER", "1903")]
+        [DataRow("repo1:tag3", "OS_VERSION_NUMBER", "1903")]
+        [DataRow("repo1:tag4", "OS_VERSION_NUMBER", "ltsc2019")]
+        [DataRow("repo1:tag5", "OS_VERSION_NUMBER", "3.12")]
+        [DataRow("repo1:tag6", "OS_VERSION_NUMBER", "1.0")]
+        [DataRow("repo1:tag1", "OS_ARCH_HYPHENATED", "Debian-13-arm32")]
+        [DataRow("repo1:tag2", "OS_ARCH_HYPHENATED", "NanoServer-1903")]
+        [DataRow("repo1:tag3", "OS_ARCH_HYPHENATED", "WindowsServerCore-1903")]
+        [DataRow("repo1:tag4", "OS_ARCH_HYPHENATED", "WindowsServerCore-ltsc2019")]
+        [DataRow("repo1:tag5", "OS_ARCH_HYPHENATED", "Alpine-3.12")]
+        [DataRow("repo1:tag6", "OS_ARCH_HYPHENATED", "CBL-Mariner-1.0")]
+        [DataRow("repo1:tag1", "Variable1", "Value1", true)]
         public void GenerateDockerfilesCommand_SupportedSymbols(string tag, string symbol, string expectedValue, bool isVariable = false)
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -194,7 +195,7 @@ ENV TEST2 Value1";
                 variableValue = symbols[symbol];
             }
 
-            Assert.Equal(expectedValue, variableValue);
+            variableValue.ShouldBe(expectedValue);
         }
 
         private GenerateDockerfilesCommand InitializeCommand(

--- a/src/ImageBuilder.Tests/GenerateEolAnnotationDataForPublishCommandTests.cs
+++ b/src/ImageBuilder.Tests/GenerateEolAnnotationDataForPublishCommandTests.cs
@@ -18,11 +18,12 @@ using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Newtonsoft.Json;
-using Xunit;
+using Shouldly;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ContainerRegistryHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
+    [TestClass]
     public class GenerateEolAnnotationDataForPublishTests
     {
         private const string DefaultRepoPrefix = "public/";
@@ -34,7 +35,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         // *  exclusion of digests which are already annotated
         // *
 
-        [Fact]
+        [TestMethod]
         public async Task GenerateEolAnnotationData_RepoRemoved()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -197,10 +198,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             string expectedEolAnnotationsJson = JsonConvert.SerializeObject(expectedEolAnnotations, Formatting.Indented, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
             string actualEolDigestsJson = File.ReadAllText(newEolDigestsListPath);
 
-            Assert.Equal(expectedEolAnnotationsJson, actualEolDigestsJson);
+            actualEolDigestsJson.ShouldBe(expectedEolAnnotationsJson);
         }
 
-        [Fact]
+        [TestMethod]
         public async Task GenerateEolAnnotationData_ImageRemoved()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -331,10 +332,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             string expectedEolAnnotationsJson = JsonConvert.SerializeObject(expectedEolAnnotations, Formatting.Indented, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
             string actualEolDigestsJson = File.ReadAllText(newEolDigestsListPath);
 
-            Assert.Equal(expectedEolAnnotationsJson, actualEolDigestsJson);
+            actualEolDigestsJson.ShouldBe(expectedEolAnnotationsJson);
         }
 
-        [Fact]
+        [TestMethod]
         public async Task GenerateEolAnnotationData_ExcludeDigestsThatAreAlreadyAnnotated()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -474,10 +475,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             string expectedEolAnnotationsJson = JsonConvert.SerializeObject(expectedEolAnnotations, Formatting.Indented, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
             string actualEolDigestsJson = File.ReadAllText(newEolDigestsListPath);
 
-            Assert.Equal(expectedEolAnnotationsJson, actualEolDigestsJson);
+            actualEolDigestsJson.ShouldBe(expectedEolAnnotationsJson);
         }
 
-        [Fact]
+        [TestMethod]
         public async Task GenerateEolAnnotationData_DockerfileInSeveralImages_OnlyOneUpdated()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -602,10 +603,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             string expectedEolAnnotationsJson = JsonConvert.SerializeObject(expectedEolAnnotations, Formatting.Indented, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
             string actualEolDigestsJson = File.ReadAllText(newEolDigestsListPath);
 
-            Assert.Equal(expectedEolAnnotationsJson, actualEolDigestsJson);
+            actualEolDigestsJson.ShouldBe(expectedEolAnnotationsJson);
         }
 
-        [Fact]
+        [TestMethod]
         public async Task GenerateEolAnnotationData_ImageAndPlatformUpdated()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -705,10 +706,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             string expectedEolAnnotationsJson = JsonConvert.SerializeObject(expectedEolAnnotations, Formatting.Indented, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
             string actualEolDigestsJson = File.ReadAllText(newEolDigestsListPath);
 
-            Assert.Equal(expectedEolAnnotationsJson, actualEolDigestsJson);
+            actualEolDigestsJson.ShouldBe(expectedEolAnnotationsJson);
         }
 
-        [Fact]
+        [TestMethod]
         public async Task GenerateEolAnnotationData_JustOnePlatformUpdated()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -813,10 +814,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             string expectedEolAnnotationsJson = JsonConvert.SerializeObject(expectedEolAnnotations, Formatting.Indented, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
             string actualEolDigestsJson = File.ReadAllText(newEolDigestsListPath);
 
-            Assert.Equal(expectedEolAnnotationsJson, actualEolDigestsJson);
+            actualEolDigestsJson.ShouldBe(expectedEolAnnotationsJson);
         }
 
-        [Fact]
+        [TestMethod]
         public async Task GenerateEolAnnotationData_DoNotReturnAnnotationDigest()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -924,10 +925,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             string expectedEolAnnotationsJson = JsonConvert.SerializeObject(expectedEolAnnotations, Formatting.Indented, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
             string actualEolDigestsJson = File.ReadAllText(newEolDigestsListPath);
 
-            Assert.Equal(expectedEolAnnotationsJson, actualEolDigestsJson);
+            actualEolDigestsJson.ShouldBe(expectedEolAnnotationsJson);
         }
 
-        [Fact]
+        [TestMethod]
         public async Task GenerateEolAnnotationData_PlatformRemoved()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -1030,10 +1031,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             string expectedEolAnnotationsJson = JsonConvert.SerializeObject(expectedEolAnnotations, Formatting.Indented, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
             string actualEolDigestsJson = File.ReadAllText(newEolDigestsListPath);
 
-            Assert.Equal(expectedEolAnnotationsJson, actualEolDigestsJson);
+            actualEolDigestsJson.ShouldBe(expectedEolAnnotationsJson);
         }
 
-        [Fact]
+        [TestMethod]
         public async Task GenerateEolAnnotationData_ManifestDeletedDuringEnumeration_Skipped()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -1128,7 +1129,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             string expectedEolAnnotationsJson = JsonConvert.SerializeObject(expectedEolAnnotations, Formatting.Indented, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
             string actualEolDigestsJson = File.ReadAllText(newEolDigestsListPath);
 
-            Assert.Equal(expectedEolAnnotationsJson, actualEolDigestsJson);
+            actualEolDigestsJson.ShouldBe(expectedEolAnnotationsJson);
         }
 
         private static GenerateEolAnnotationDataForPublishCommand InitializeCommand(

--- a/src/ImageBuilder.Tests/GenerateReadmesCommandTests.cs
+++ b/src/ImageBuilder.Tests/GenerateReadmesCommandTests.cs
@@ -15,11 +15,11 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using Newtonsoft.Json;
 using Shouldly;
-using Xunit;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
+    [TestClass]
     public class GenerateReadmesCommandTests
     {
         private const string ProductFamilyReadmePath = "ProductFamilyReadme.md";
@@ -46,7 +46,7 @@ Referenced Template Content";
         {
         }
 
-        [Fact]
+        [TestMethod]
         public async Task GenerateReadmesCommand_Canonical()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -55,13 +55,13 @@ Referenced Template Content";
             await command.ExecuteAsync();
 
             string generatedReadme = File.ReadAllText(Path.Combine(tempFolderContext.Path, ProductFamilyReadmePath));
-            Assert.Equal(ExpectedProductFamilyReadme.NormalizeLineEndings(generatedReadme), generatedReadme);
+            generatedReadme.ShouldBe(ExpectedProductFamilyReadme.NormalizeLineEndings(generatedReadme));
 
             generatedReadme = File.ReadAllText(Path.Combine(tempFolderContext.Path, RepoReadmePath));
-            Assert.Equal(ExpectedRepoReadme.NormalizeLineEndings(generatedReadme), generatedReadme);
+            generatedReadme.ShouldBe(ExpectedRepoReadme.NormalizeLineEndings(generatedReadme));
         }
 
-        [Fact]
+        [TestMethod]
         public async Task GenerateReadmesCommand_StringReplace()
         {
             const string Template = """
@@ -78,7 +78,7 @@ Referenced Template Content";
             generatedReadme.ShouldBe(Expected);
         }
 
-        [Fact]
+        [TestMethod]
         public async Task GenerateReadmesCommand_TemplateArgs()
         {
             const string readmeTemplate =
@@ -98,32 +98,32 @@ Referenced Template Content";
             string expectedReadme =
 @"Hello World
 ABC-123";
-            Assert.Equal(expectedReadme, generatedReadme);
+            generatedReadme.ShouldBe(expectedReadme);
         }
 
-        [Fact]
+        [TestMethod]
         public async Task GenerateReadmesCommand_InvalidTemplate()
         {
             string template = "about{{if:}}";
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
             GenerateReadmesCommand command = InitializeCommand(tempFolderContext, template);
 
-            Exception actualException = await Assert.ThrowsAsync<Exception>(command.ExecuteAsync);
+            Exception actualException = await Should.ThrowAsync<Exception>(command.ExecuteAsync);
 
-            Assert.Same(_exitException, actualException);
+            actualException.ShouldBeSameAs(_exitException);
             _environmentServiceMock.Verify(o => o.Exit(It.IsAny<int>()), Times.Once);
         }
 
-        [Fact]
+        [TestMethod]
         public async Task GenerateReadmesCommand_MissingTemplate()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
             GenerateReadmesCommand command = InitializeCommand(tempFolderContext, null, allowOptionalTemplates: false);
 
-            await Assert.ThrowsAsync<InvalidOperationException>(command.ExecuteAsync);
+            await Should.ThrowAsync<InvalidOperationException>(command.ExecuteAsync);
         }
 
-        [Fact]
+        [TestMethod]
         public async Task GenerateReadmesCommand_Validate_UpToDate()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -135,28 +135,28 @@ ABC-123";
             _environmentServiceMock.Verify(o => o.Exit(It.IsAny<int>()), Times.Never);
         }
 
-        [Fact]
+        [TestMethod]
         public async Task GenerateReadmesCommand_Validate_OutOfSync()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
             GenerateReadmesCommand command = InitializeCommand(tempFolderContext, validate: true);
 
-            Exception actualException = await Assert.ThrowsAsync<Exception>(command.ExecuteAsync);
+            Exception actualException = await Should.ThrowAsync<Exception>(command.ExecuteAsync);
 
-            Assert.Same(_exitException, actualException);
+            actualException.ShouldBeSameAs(_exitException);
             _environmentServiceMock.Verify(o => o.Exit(It.IsAny<int>()), Times.Once);
             // Validate readmes remain unmodified
-            Assert.Equal(DefaultReadme, File.ReadAllText(Path.Combine(tempFolderContext.Path, ProductFamilyReadmePath)));
-            Assert.Equal(DefaultReadme, File.ReadAllText(Path.Combine(tempFolderContext.Path, RepoReadmePath)));
+            File.ReadAllText(Path.Combine(tempFolderContext.Path, ProductFamilyReadmePath)).ShouldBe(DefaultReadme);
+            File.ReadAllText(Path.Combine(tempFolderContext.Path, RepoReadmePath)).ShouldBe(DefaultReadme);
         }
 
-        [Theory]
-        [InlineData("IS_PRODUCT_FAMILY", "true", true)]
-        [InlineData("IS_PRODUCT_FAMILY", "false")]
-        [InlineData("FULL_REPO", "mcr.microsoft.com/dotnet/repo")]
-        [InlineData("REPO", "dotnet/repo")]
-        [InlineData("PARENT_REPO", "dotnet")]
-        [InlineData("SHORT_REPO", "repo")]
+        [TestMethod]
+        [DataRow("IS_PRODUCT_FAMILY", "true", true)]
+        [DataRow("IS_PRODUCT_FAMILY", "false")]
+        [DataRow("FULL_REPO", "mcr.microsoft.com/dotnet/repo")]
+        [DataRow("REPO", "dotnet/repo")]
+        [DataRow("PARENT_REPO", "dotnet")]
+        [DataRow("SHORT_REPO", "repo")]
         public void GenerateReadmesCommand_SupportedSymbols(string symbol, string expectedValue, bool isManifest = false)
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -183,7 +183,7 @@ ABC-123";
                 expectedSymbolValue = Value.FromString(expectedValue);
             }
 
-            Assert.Equal(expectedSymbolValue, actualSymbolValue);
+            actualSymbolValue.ShouldBe(expectedSymbolValue);
         }
 
         private GenerateReadmesCommand InitializeCommand(

--- a/src/ImageBuilder.Tests/GetStaleImagesCommandTests.cs
+++ b/src/ImageBuilder.Tests/GetStaleImagesCommandTests.cs
@@ -102,9 +102,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            using (TestContext context = new TestContext(subscriptionInfos, dockerfileInfos))
+            using (TestFixture fixture = new TestFixture(subscriptionInfos, dockerfileInfos))
             {
-                await context.ExecuteCommandAsync();
+                await fixture.ExecuteCommandAsync();
 
                 // Only one of the images has a changed digest
                 Dictionary<Subscription, IList<string>> expectedPathsBySubscription =
@@ -119,7 +119,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     }
                 };
 
-                context.Verify(expectedPathsBySubscription);
+                fixture.Verify(expectedPathsBySubscription);
             }
         }
 
@@ -193,10 +193,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            using (TestContext context =
-                new TestContext(subscriptionInfos, dockerfileInfos))
+            using (TestFixture fixture =
+                new TestFixture(subscriptionInfos, dockerfileInfos))
             {
-                await context.ExecuteCommandAsync();
+                await fixture.ExecuteCommandAsync();
 
                 // The base image of the final stage has changed for only one of the images.
                 Dictionary<Subscription, IList<string>> expectedPathsBySubscription =
@@ -211,7 +211,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     }
                 };
 
-                context.Verify(expectedPathsBySubscription);
+                fixture.Verify(expectedPathsBySubscription);
             }
         }
 
@@ -259,10 +259,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             // This should cause the subscription to be processed.
             const string commandOsType = "windows";
 
-            using (TestContext context =
-                new TestContext(subscriptionInfos, dockerfileInfos, commandOsType))
+            using (TestFixture fixture =
+                new TestFixture(subscriptionInfos, dockerfileInfos, commandOsType))
             {
-                await context.ExecuteCommandAsync();
+                await fixture.ExecuteCommandAsync();
 
                 Dictionary<Subscription, IList<string>> expectedPathsBySubscription =
                     new Dictionary<Subscription, IList<string>>
@@ -277,7 +277,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     }
                 };
 
-                context.Verify(expectedPathsBySubscription);
+                fixture.Verify(expectedPathsBySubscription);
             }
         }
 
@@ -325,17 +325,17 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             // This should cause the subscription to be ignored.
             const string commandOsType = "linux";
 
-            using (TestContext context =
-                new TestContext(subscriptionInfos, dockerfileInfos, commandOsType))
+            using (TestFixture fixture =
+                new TestFixture(subscriptionInfos, dockerfileInfos, commandOsType))
             {
-                await context.ExecuteCommandAsync();
+                await fixture.ExecuteCommandAsync();
 
                 Dictionary<Subscription, IList<string>> expectedPathsBySubscription =
                     new Dictionary<Subscription, IList<string>>
                 {
                 };
 
-                context.Verify(expectedPathsBySubscription);
+                fixture.Verify(expectedPathsBySubscription);
             }
         }
 
@@ -377,10 +377,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            using (TestContext context =
-                new TestContext(subscriptionInfos, dockerfileInfos))
+            using (TestFixture fixture =
+                new TestFixture(subscriptionInfos, dockerfileInfos))
             {
-                await context.ExecuteCommandAsync();
+                await fixture.ExecuteCommandAsync();
 
                 // Since neither of the images existed in the image info data, both should be queued.
                 Dictionary<Subscription, IList<string>> expectedPathsBySubscription =
@@ -396,7 +396,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     }
                 };
 
-                context.Verify(expectedPathsBySubscription);
+                fixture.Verify(expectedPathsBySubscription);
             }
         }
 
@@ -554,10 +554,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            using (TestContext context =
-                new TestContext(subscriptionInfos, dockerfileInfos))
+            using (TestFixture fixture =
+                new TestFixture(subscriptionInfos, dockerfileInfos))
             {
-                await context.ExecuteCommandAsync();
+                await fixture.ExecuteCommandAsync();
 
                 Dictionary<Subscription, IList<string>> expectedPathsBySubscription =
                     new Dictionary<Subscription, IList<string>>
@@ -578,7 +578,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     }
                 };
 
-                context.Verify(expectedPathsBySubscription);
+                fixture.Verify(expectedPathsBySubscription);
             }
         }
 
@@ -648,10 +648,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            using (TestContext context =
-                new TestContext(subscriptionInfos, dockerfileInfos))
+            using (TestFixture fixture =
+                new TestFixture(subscriptionInfos, dockerfileInfos))
             {
-                await context.ExecuteCommandAsync();
+                await fixture.ExecuteCommandAsync();
 
                 // Both of the images has a changed digest
                 Dictionary<Subscription, IList<string>> expectedPathsBySubscription =
@@ -667,9 +667,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     }
                 };
 
-                context.Verify(expectedPathsBySubscription);
+                fixture.Verify(expectedPathsBySubscription);
 
-                context.ManifestServiceMock
+                fixture.ManifestServiceMock
                     .Verify(o => o.GetManifestAsync(baseImage, false), Times.Once);
             }
         }
@@ -732,16 +732,16 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            using (TestContext context =
-                new TestContext(subscriptionInfos, dockerfileInfos))
+            using (TestFixture fixture =
+                new TestFixture(subscriptionInfos, dockerfileInfos))
             {
-                await context.ExecuteCommandAsync();
+                await fixture.ExecuteCommandAsync();
 
                 // No paths are expected
                 Dictionary<Subscription, IList<string>> expectedPathsBySubscription =
                     new Dictionary<Subscription, IList<string>>();
 
-                context.Verify(expectedPathsBySubscription);
+                fixture.Verify(expectedPathsBySubscription);
             }
         }
 
@@ -800,14 +800,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            using (TestContext context = new(subscriptionInfos, dockerfileInfos))
+            using (TestFixture fixture = new(subscriptionInfos, dockerfileInfos))
             {
-                await context.ExecuteCommandAsync();
+                await fixture.ExecuteCommandAsync();
 
                 // No paths are expected
                 Dictionary<Subscription, IList<string>> expectedPathsBySubscription = new();
 
-                context.Verify(expectedPathsBySubscription);
+                fixture.Verify(expectedPathsBySubscription);
             }
         }
 
@@ -931,10 +931,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            using (TestContext context =
-                new TestContext(subscriptionInfos, dockerfileInfos))
+            using (TestFixture fixture =
+                new TestFixture(subscriptionInfos, dockerfileInfos))
             {
-                await context.ExecuteCommandAsync();
+                await fixture.ExecuteCommandAsync();
 
                 Dictionary<Subscription, IList<string>> expectedPathsBySubscription =
                     new Dictionary<Subscription, IList<string>>
@@ -951,7 +951,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     }
                 };
 
-                context.Verify(expectedPathsBySubscription);
+                fixture.Verify(expectedPathsBySubscription);
             }
         }
 
@@ -1079,10 +1079,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            using (TestContext context =
+            using (TestFixture fixture =
                 new(subscriptionInfos, dockerfileInfos))
             {
-                await context.ExecuteCommandAsync();
+                await fixture.ExecuteCommandAsync();
 
                 Dictionary<Subscription, IList<string>> expectedPathsBySubscription =
                     new()
@@ -1103,7 +1103,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     }
                 };
 
-                context.Verify(expectedPathsBySubscription);
+                fixture.Verify(expectedPathsBySubscription);
             }
         }
 
@@ -1177,10 +1177,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            using (TestContext context =
-                new TestContext(subscriptionInfos, dockerfileInfos))
+            using (TestFixture fixture =
+                new TestFixture(subscriptionInfos, dockerfileInfos))
             {
-                await context.ExecuteCommandAsync();
+                await fixture.ExecuteCommandAsync();
 
                 Dictionary<Subscription, IList<string>> expectedPathsBySubscription =
                     new Dictionary<Subscription, IList<string>>
@@ -1198,7 +1198,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     }
                 };
 
-                context.Verify(expectedPathsBySubscription);
+                fixture.Verify(expectedPathsBySubscription);
             }
         }
 
@@ -1266,10 +1266,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            using (TestContext context =
-                new TestContext(subscriptionInfos, dockerfileInfos))
+            using (TestFixture fixture =
+                new TestFixture(subscriptionInfos, dockerfileInfos))
             {
-                await context.ExecuteCommandAsync();
+                await fixture.ExecuteCommandAsync();
 
                 // Only one of the images has a changed digest
                 Dictionary<Subscription, IList<string>> expectedPathsBySubscription =
@@ -1284,7 +1284,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     }
                 };
 
-                context.Verify(expectedPathsBySubscription);
+                fixture.Verify(expectedPathsBySubscription);
             }
         }
 
@@ -1343,10 +1343,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            using (TestContext context =
-                new TestContext(subscriptionInfos, dockerfileInfos))
+            using (TestFixture fixture =
+                new TestFixture(subscriptionInfos, dockerfileInfos))
             {
-                await context.ExecuteCommandAsync();
+                await fixture.ExecuteCommandAsync();
 
                 Dictionary<Subscription, IList<string>> expectedPathsBySubscription =
                     new Dictionary<Subscription, IList<string>>
@@ -1360,7 +1360,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     }
                 };
 
-                context.Verify(expectedPathsBySubscription);
+                fixture.Verify(expectedPathsBySubscription);
             }
         }
 
@@ -1425,16 +1425,16 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            using (TestContext context =
-                new TestContext(subscriptionInfos, dockerfileInfos))
+            using (TestFixture fixture =
+                new TestFixture(subscriptionInfos, dockerfileInfos))
             {
-                await context.ExecuteCommandAsync();
+                await fixture.ExecuteCommandAsync();
 
                 // No paths are expected
                 Dictionary<Subscription, IList<string>> expectedPathsBySubscription =
                     new Dictionary<Subscription, IList<string>>();
 
-                context.Verify(expectedPathsBySubscription);
+                fixture.Verify(expectedPathsBySubscription);
             }
         }
 
@@ -1501,9 +1501,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            using (TestContext context = new TestContext(subscriptionInfos, dockerfileInfos))
+            using (TestFixture fixture = new TestFixture(subscriptionInfos, dockerfileInfos))
             {
-                await context.ExecuteCommandAsync();
+                await fixture.ExecuteCommandAsync();
 
                 // Only one of the images has a changed digest
                 Dictionary<Subscription, IList<string>> expectedPathsBySubscription =
@@ -1518,7 +1518,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     }
                 };
 
-                context.Verify(expectedPathsBySubscription);
+                fixture.Verify(expectedPathsBySubscription);
             }
         }
 
@@ -1586,16 +1586,16 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            using (TestContext context = new(subscriptionInfos, dockerfileInfos))
+            using (TestFixture fixture = new(subscriptionInfos, dockerfileInfos))
             {
-                context.ImageDigests.Add($"{CustomRegistry}/base1", "alternate-base1digest");
-                context.ImageDigests.Add($"{CustomRegistry}/base2", "alternate-base2digest");
+                fixture.ImageDigests.Add($"{CustomRegistry}/base1", "alternate-base1digest");
+                fixture.ImageDigests.Add($"{CustomRegistry}/base2", "alternate-base2digest");
 
                 // Override the image tags to target a custom registry
-                context.Command.Options.BaseImageOverrideOptions.RegexPattern = "(base.*)";
-                context.Command.Options.BaseImageOverrideOptions.Substitution = "my-registry.io/$1";
+                fixture.Command.Options.BaseImageOverrideOptions.RegexPattern = "(base.*)";
+                fixture.Command.Options.BaseImageOverrideOptions.Substitution = "my-registry.io/$1";
 
-                await context.ExecuteCommandAsync();
+                await fixture.ExecuteCommandAsync();
 
                 // Only one of the images has a changed digest
                 // It should be comparing against the digest of the image from the override.
@@ -1610,7 +1610,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     }
                 };
 
-                context.Verify(expectedPathsBySubscription);
+                fixture.Verify(expectedPathsBySubscription);
             }
         }
 
@@ -1660,7 +1660,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Sets up the test state from the provided metadata, executes the test, and verifies the results.
         /// </summary>
-        private class TestContext : IDisposable
+        private class TestFixture : IDisposable
         {
             private readonly List<string> filesToCleanup = new List<string>();
             private readonly List<string> foldersToCleanup = new List<string>();
@@ -1683,12 +1683,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             public IDictionary<string, string> ImageDigests { get => imageDigests; }
 
             /// <summary>
-            /// Initializes a new instance of <see cref="TestContext"/>.
+            /// Initializes a new instance of <see cref="TestFixture"/>.
             /// </summary>
             /// <param name="subscriptionInfos">Mapping of data to subscriptions.</param>
             /// <param name="dockerfileInfos">A mapping of Git repos to their associated set of Dockerfiles.</param>
             /// <param name="osType">The OS type to filter the command with.</param>
-            public TestContext(
+            public TestFixture(
                 SubscriptionInfo[] subscriptionInfos,
                 Dictionary<GitFile, List<DockerfileInfo>> dockerfileInfos,
                 string osType = "*")

--- a/src/ImageBuilder.Tests/GetStaleImagesCommandTests.cs
+++ b/src/ImageBuilder.Tests/GetStaleImagesCommandTests.cs
@@ -25,12 +25,13 @@ using Moq;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json;
 using WebApi = Microsoft.TeamFoundation.Build.WebApi;
-using Xunit;
+using Shouldly;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ImageInfoHelper;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
+    [TestClass]
     public class GetStaleImagesCommandTests
     {
         private const string GitHubBranch = "my-branch";
@@ -41,7 +42,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// Verifies the correct path arguments are passed to the queued build for a basic
         /// scenario involving one image that has changed.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task GetStaleImagesCommand_SingleDigestChanged()
         {
             const string repo1 = "test-repo";
@@ -126,7 +127,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// Verifies the correct path arguments are passed to the queued build for a multi-stage
         /// Dockerfile scenario involving one image that has changed.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task GetStaleImagesCommand_MultiStage_SingleDigestChanged()
         {
             const string repo1 = "test-repo";
@@ -217,7 +218,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Verifies that a subscription will be skipped if it's associated with a different OS type than the command is assigned with.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task GetStaleImagesCommand_OsTypeFiltering_MatchingCommandFilter()
         {
             const string repo1 = "test-repo";
@@ -283,7 +284,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Verifies that a subscription will be skipped if it's associated with a different OS type than the command is assigned with.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task GetStaleImagesCommand_OsTypeFiltering_NonMatchingCommandFilter()
         {
             const string repo1 = "test-repo";
@@ -342,7 +343,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// Verifies the correct path arguments are passed to the queued build when
         /// the images have no data reflected in the image info data.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task GetStaleImagesCommand_MissingImageInfo()
         {
             const string repo1 = "test-repo";
@@ -403,7 +404,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// Verifies the correct path arguments are passed to the queued builds for two
         /// subscriptions that have changed images.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task GetStaleImagesCommand_MultiSubscription()
         {
             const string repo1 = "test-repo";
@@ -584,7 +585,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Verifies that a base image's digest will be cached and not pulled for a subsequent image.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task GetStaleImagesCommand_BaseImageCaching()
         {
             const string repo1 = "test-repo";
@@ -676,7 +677,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Verifies that no build will be queued if the base image has not changed.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task GetStaleImagesCommand_NoBaseImageChange()
         {
             const string repo1 = "test-repo";
@@ -747,7 +748,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Verifies that no build will be queued for a Dockerfile with no base image.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task GetStaleImagesCommand_NoBaseImage()
         {
             const string repo1 = "test-repo";
@@ -815,7 +816,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// a base image changes where the image referencing that base image has other
         /// images dependent upon it.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task GetStaleImagesCommand_DependencyGraph()
         {
             const string runtimeDepsRepo = "runtimedeps-repo";
@@ -963,7 +964,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// has a dependency on both sdk:jammy and aspnet:jammy-chiseled which come from
         /// different roots.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task GetStaleImagesCommand_DependencyGraph_TwoRoots()
         {
             const string RuntimeDepsRepo = "runtime-deps";
@@ -1111,7 +1112,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// a base image changes where the image referencing that base image has other
         /// images dependent upon it and no image info data exists.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task GetStaleImagesCommand_DependencyGraph_MissingImageInfo()
         {
             const string runtimeDepsRepo = "runtimedeps-repo";
@@ -1205,7 +1206,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// Verifies the correct path arguments are passed to the queued build when an image
         /// built from a custom named Dockerfile.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task GetStaleImagesCommand_CustomDockerfilePath()
         {
             const string repo1 = "test-repo";
@@ -1290,7 +1291,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Verifies an image will be marked to be rebuilt if its base image is not included in the list of image data.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task GetStaleImagesCommand_NoExistingImageData()
         {
             const string repo1 = "test-repo";
@@ -1366,7 +1367,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Verifies that a Dockerfile with only an internal FROM should not be considered stale.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task GetStaleImagesCommand_InternalFromOnly()
         {
             const string repo1 = "test-repo";
@@ -1441,7 +1442,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// Verifies the correct path arguments are passed to the queued build for a
         /// scenario involving two platforms sharing the same Dockerfile.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task GetStaleImagesCommand_SharedDockerfile()
         {
             const string repo1 = "test-repo";
@@ -1525,7 +1526,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// Verifies that the check for a stale base image is done by targeting the tag override rather than the tag
         /// defined in the Dockerfile.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task GetStaleImagesCommand_BaseImageTagOverride()
         {
             const string repo1 = "test-repo";
@@ -1738,7 +1739,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 string message = invocation.Arguments[2].ToString();
                 int variableNameStartIndex = message.IndexOf("=") + 1;
                 string actualVariableName = message.Substring(variableNameStartIndex, message.IndexOf(";") - variableNameStartIndex);
-                Assert.Equal(VariableName, actualVariableName);
+                actualVariableName.ShouldBe(VariableName);
 
                 string variableValue = message
                     .Substring(message.IndexOf("]") + 1);
@@ -1746,14 +1747,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 SubscriptionImagePaths[] pathsBySubscription =
                     JsonConvert.DeserializeObject<SubscriptionImagePaths[]>(variableValue.Replace("\\\"", "\""));
 
-                Assert.Equal(expectedPathsBySubscription.Count, pathsBySubscription.Length);
+                pathsBySubscription.Length.ShouldBe(expectedPathsBySubscription.Count);
 
                 foreach (KeyValuePair<Subscription, IList<string>> kvp in expectedPathsBySubscription)
                 {
                     string[] actualPaths = pathsBySubscription
                         .First(imagePaths => imagePaths.SubscriptionId == kvp.Key.Id).ImagePaths;
 
-                    Assert.Equal(kvp.Value, actualPaths);
+                    actualPaths.ShouldBe(kvp.Value);
                 }
             }
 

--- a/src/ImageBuilder.Tests/GlobalUsings.cs
+++ b/src/ImageBuilder.Tests/GlobalUsings.cs
@@ -1,1 +1,2 @@
 global using Microsoft.Extensions.Logging;
+global using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/ImageBuilder.Tests/Helpers/ImageInfoHelper.cs
+++ b/src/ImageBuilder.Tests/Helpers/ImageInfoHelper.cs
@@ -11,7 +11,7 @@ using System.Security.Cryptography;
 using System.Text;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
 using Newtonsoft.Json;
-using Xunit;
+using Shouldly;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests.Helpers
 {
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests.Helpers
 
         public static void CompareImageArtifactDetails(ImageArtifactDetails expected, ImageArtifactDetails actual)
         {
-            Assert.Equal(JsonHelper.SerializeObject(expected), JsonHelper.SerializeObject(actual));
+            JsonHelper.SerializeObject(actual).ShouldBe(JsonHelper.SerializeObject(expected));
         }
 
         public static ImageArtifactDetails CreateImageInfo(

--- a/src/ImageBuilder.Tests/ImageArtifactDetailsTests.cs
+++ b/src/ImageBuilder.Tests/ImageArtifactDetailsTests.cs
@@ -10,9 +10,8 @@ using System.Linq;
 namespace Microsoft.DotNet.ImageBuilder.Tests;
 
 [TestClass]
-public class ImageArtifactDetailsTests
+public class ImageArtifactDetailsTests(TestContext testContext)
 {
-    public TestContext? TestContext { get; set; }
 
     [TestMethod]
     public void CanReadJsonSchemaVersion1()
@@ -146,10 +145,10 @@ public class ImageArtifactDetailsTests
 
         string actualJson = JsonHelper.SerializeObject(imageInfo);
 
-        TestContext?.WriteLine("Expected JSON:");
-        TestContext?.WriteLine(expectedJson);
-        TestContext?.WriteLine("\nActual JSON:");
-        TestContext?.WriteLine(actualJson);
+        testContext.WriteLine("Expected JSON:");
+        testContext.WriteLine(expectedJson);
+        testContext.WriteLine("\nActual JSON:");
+        testContext.WriteLine(actualJson);
 
         // Normalize line endings and compare
         actualJson.Replace("\r\n", "\n").ShouldBe(expectedJson.Replace("\r\n", "\n"));

--- a/src/ImageBuilder.Tests/ImageArtifactDetailsTests.cs
+++ b/src/ImageBuilder.Tests/ImageArtifactDetailsTests.cs
@@ -2,19 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
 using Shouldly;
 using System.Linq;
-using Xunit;
-using Xunit.Abstractions;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests;
 
-public class ImageArtifactDetailsTests(ITestOutputHelper outputHelper)
+[TestClass]
+public class ImageArtifactDetailsTests
 {
-    private readonly ITestOutputHelper _outputHelper = outputHelper;
+    public TestContext? TestContext { get; set; }
 
-    [Fact]
+    [TestMethod]
     public void CanReadJsonSchemaVersion1()
     {
         ImageArtifactDetails details = ImageArtifactDetails.FromJson(JsonSchemaVersion1);
@@ -45,7 +45,7 @@ public class ImageArtifactDetailsTests(ITestOutputHelper outputHelper)
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void CanReadJsonSchemaVersion2()
     {
         ImageArtifactDetails details = ImageArtifactDetails.FromJson(JsonSchemaVersion2);
@@ -77,7 +77,7 @@ public class ImageArtifactDetailsTests(ITestOutputHelper outputHelper)
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void CanWriteJsonSchemaVersion2()
     {
         ImageArtifactDetails imageInfo = new()
@@ -146,10 +146,10 @@ public class ImageArtifactDetailsTests(ITestOutputHelper outputHelper)
 
         string actualJson = JsonHelper.SerializeObject(imageInfo);
 
-        _outputHelper.WriteLine("Expected JSON:");
-        _outputHelper.WriteLine(expectedJson);
-        _outputHelper.WriteLine("\nActual JSON:");
-        _outputHelper.WriteLine(actualJson);
+        TestContext?.WriteLine("Expected JSON:");
+        TestContext?.WriteLine("{0}", expectedJson);
+        TestContext?.WriteLine("\nActual JSON:");
+        TestContext?.WriteLine("{0}", actualJson);
 
         // Normalize line endings and compare
         actualJson.Replace("\r\n", "\n").ShouldBe(expectedJson.Replace("\r\n", "\n"));

--- a/src/ImageBuilder.Tests/ImageArtifactDetailsTests.cs
+++ b/src/ImageBuilder.Tests/ImageArtifactDetailsTests.cs
@@ -147,9 +147,9 @@ public class ImageArtifactDetailsTests
         string actualJson = JsonHelper.SerializeObject(imageInfo);
 
         TestContext?.WriteLine("Expected JSON:");
-        TestContext?.WriteLine("{0}", expectedJson);
+        TestContext?.WriteLine(expectedJson);
         TestContext?.WriteLine("\nActual JSON:");
-        TestContext?.WriteLine("{0}", actualJson);
+        TestContext?.WriteLine(actualJson);
 
         // Normalize line endings and compare
         actualJson.Replace("\r\n", "\n").ShouldBe(expectedJson.Replace("\r\n", "\n"));

--- a/src/ImageBuilder.Tests/ImageInfoHelperTests.cs
+++ b/src/ImageBuilder.Tests/ImageInfoHelperTests.cs
@@ -12,7 +12,7 @@ using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
 using Moq;
-using Xunit;
+using Shouldly;
 
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.DockerfileHelper;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
@@ -20,9 +20,10 @@ using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ImageInfoHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
+    [TestClass]
     public class ImageInfoHelperTests
     {
-        [Fact]
+        [TestMethod]
         public void LoadFromContent()
         {
             ImageArtifactDetails imageArtifactDetails = new ImageArtifactDetails
@@ -100,20 +101,20 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             ImageArtifactDetails result = ImageInfoHelper.LoadFromContent(expected, manifestInfo);
 
-            Assert.Equal(expected, JsonHelper.SerializeObject(result));
+            JsonHelper.SerializeObject(result).ShouldBe(expected);
             RepoData repo = result.Repos.First();
             ImageData image = repo.Images.First();
             RepoInfo expectedRepo = manifestInfo.AllRepos.First();
             ImageInfo expectedImage = expectedRepo.AllImages.First();
-            Assert.Same(expectedImage, image.ManifestImage);
-            Assert.Same(expectedRepo, image.ManifestRepo);
+            image.ManifestImage.ShouldBeSameAs(expectedImage);
+            image.ManifestRepo.ShouldBeSameAs(expectedRepo);
 
-            Assert.Same(expectedImage, image.Platforms.First().ImageInfo);
-            Assert.Same(expectedImage.AllPlatforms.First(), image.Platforms.First().PlatformInfo);
-            Assert.Same(expectedImage.AllPlatforms.Last(), image.Platforms.Last().PlatformInfo);
+            image.Platforms.First().ImageInfo.ShouldBeSameAs(expectedImage);
+            image.Platforms.First().PlatformInfo.ShouldBeSameAs(expectedImage.AllPlatforms.First());
+            image.Platforms.Last().PlatformInfo.ShouldBeSameAs(expectedImage.AllPlatforms.Last());
         }
 
-        [Fact]
+        [TestMethod]
         public void LoadFromContent_ImagesDifferByPatchVersion()
         {
             ImageArtifactDetails imageArtifactDetails = new ImageArtifactDetails
@@ -169,20 +170,20 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             ImageArtifactDetails result = ImageInfoHelper.LoadFromContent(expected, manifestInfo);
 
-            Assert.Equal(expected, JsonHelper.SerializeObject(result));
+            JsonHelper.SerializeObject(result).ShouldBe(expected);
             RepoData repo = result.Repos.First();
             ImageData image = repo.Images.First();
             RepoInfo expectedRepo = manifestInfo.AllRepos.First();
             ImageInfo expectedImage = expectedRepo.AllImages.First();
-            Assert.Same(expectedImage, image.ManifestImage);
-            Assert.Same(expectedRepo, image.ManifestRepo);
+            image.ManifestImage.ShouldBeSameAs(expectedImage);
+            image.ManifestRepo.ShouldBeSameAs(expectedRepo);
 
-            Assert.Same(expectedImage, image.Platforms.First().ImageInfo);
-            Assert.Same(expectedImage.AllPlatforms.First(), image.Platforms.First().PlatformInfo);
-            Assert.Same(expectedImage.AllPlatforms.Last(), image.Platforms.Last().PlatformInfo);
+            image.Platforms.First().ImageInfo.ShouldBeSameAs(expectedImage);
+            image.Platforms.First().PlatformInfo.ShouldBeSameAs(expectedImage.AllPlatforms.First());
+            image.Platforms.Last().PlatformInfo.ShouldBeSameAs(expectedImage.AllPlatforms.Last());
         }
 
-        [Fact]
+        [TestMethod]
         public void LoadFromContent_DuplicatedPlatforms()
         {
             ImageArtifactDetails imageArtifactDetails = new ImageArtifactDetails
@@ -260,11 +261,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             ImageArtifactDetails result = ImageInfoHelper.LoadFromContent(expected, manifestInfo);
 
-            Assert.Same(manifestInfo.AllRepos.First().AllImages.First(), result.Repos[0].Images[0].ManifestImage);
-            Assert.Same(manifestInfo.AllRepos.First().AllImages.ElementAt(1), result.Repos[0].Images[1].ManifestImage);
+            result.Repos[0].Images[0].ManifestImage.ShouldBeSameAs(manifestInfo.AllRepos.First().AllImages.First());
+            result.Repos[0].Images[1].ManifestImage.ShouldBeSameAs(manifestInfo.AllRepos.First().AllImages.ElementAt(1));
         }
 
-        [Fact]
+        [TestMethod]
         public void ImageInfoHelper_MergeRepos_ImageDigest()
         {
             ImageInfo imageInfo1 = CreateImageInfo();
@@ -328,7 +329,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             CompareImageArtifactDetails(imageArtifactDetails, targetImageArtifactDetails);
         }
 
-        [Fact]
+        [TestMethod]
         public void ImageInfoHelper_MergeRepos_EmptyTarget()
         {
             ImageArtifactDetails imageArtifactDetails = new ImageArtifactDetails
@@ -365,7 +366,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             CompareImageArtifactDetails(imageArtifactDetails, targetImageArtifactDetails);
         }
 
-        [Fact]
+        [TestMethod]
         public void ImageInfoHelper_MergeRepos_ExistingTarget()
         {
             PlatformData repo2Image1;
@@ -543,7 +544,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Verifies that tags are merged between the source and destination.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public void ImageInfoHelper_MergeRepos_MergeTags()
         {
             PlatformData srcImage1;
@@ -697,7 +698,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// if the same tag doesn't exist in the source. This handles cases where
         /// a shared tag has been moved from one image to another.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public void ImageInfoHelper_MergeRepos_RemoveTag()
         {
             PlatformData srcPlatform1;
@@ -849,7 +850,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             CompareImageArtifactDetails(expected, targetImageArtifactDetails);
         }
 
-        [Fact]
+        [TestMethod]
         public void Merge_DuplicatedPlatforms()
         {
             ImageInfo imageInfo1 = CreateImageInfo();
@@ -950,11 +951,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             ImageInfoHelper.MergeImageArtifactDetails(imageArtifactDetails, targetImageArtifactDetails);
             CompareImageArtifactDetails(expectedImageArtifactDetails, targetImageArtifactDetails);
 
-            Assert.Same(imageInfo1, targetImageArtifactDetails.Repos[0].Images[0].ManifestImage);
-            Assert.Same(imageInfo2, targetImageArtifactDetails.Repos[0].Images[1].ManifestImage);
+            targetImageArtifactDetails.Repos[0].Images[0].ManifestImage.ShouldBeSameAs(imageInfo1);
+            targetImageArtifactDetails.Repos[0].Images[1].ManifestImage.ShouldBeSameAs(imageInfo2);
         }
 
-        [Fact]
+        [TestMethod]
         public void Merge_SharedDockerfile_DistinctPlatform()
         {
             ImageArtifactDetails imageArtifactDetails = new ImageArtifactDetails
@@ -1105,7 +1106,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Tests the scenario where a source image defines a manifest that the target doesn't have.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public void ImageInfoHelper_MergeRepos_NewManifest()
         {
             ImageInfo imageInfo1 = CreateImageInfo();
@@ -1179,7 +1180,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Tests the scenario where a target image defines a manifest that the source doesn't have.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public void ImageInfoHelper_MergeRepos_RemovedManifest()
         {
             ImageInfo imageInfo1 = CreateImageInfo();

--- a/src/ImageBuilder.Tests/ImageNameTests.cs
+++ b/src/ImageBuilder.Tests/ImageNameTests.cs
@@ -2,211 +2,212 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
-using Xunit;
+using Shouldly;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests;
 
+[TestClass]
 public class ImageNameTests
 {
-    [Fact]
+    [TestMethod]
     public void Parse_SimpleImageName()
     {
         ImageName result = ImageName.Parse("ubuntu");
 
-        Assert.Equal("", result.Registry);
-        Assert.Equal("ubuntu", result.Repo);
-        Assert.Equal("", result.Tag);
-        Assert.Equal("", result.Digest);
+        result.Registry.ShouldBe("");
+        result.Repo.ShouldBe("ubuntu");
+        result.Tag.ShouldBe("");
+        result.Digest.ShouldBe("");
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_ImageWithTag()
     {
         ImageName result = ImageName.Parse("ubuntu:22.04");
 
-        Assert.Equal("", result.Registry);
-        Assert.Equal("ubuntu", result.Repo);
-        Assert.Equal("22.04", result.Tag);
-        Assert.Equal("", result.Digest);
+        result.Registry.ShouldBe("");
+        result.Repo.ShouldBe("ubuntu");
+        result.Tag.ShouldBe("22.04");
+        result.Digest.ShouldBe("");
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_ImageWithDigest()
     {
         ImageName result = ImageName.Parse("ubuntu@sha256:abc123");
 
-        Assert.Equal("", result.Registry);
-        Assert.Equal("ubuntu", result.Repo);
-        Assert.Equal("", result.Tag);
-        Assert.Equal("sha256:abc123", result.Digest);
+        result.Registry.ShouldBe("");
+        result.Repo.ShouldBe("ubuntu");
+        result.Tag.ShouldBe("");
+        result.Digest.ShouldBe("sha256:abc123");
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_ImageWithRegistry()
     {
         ImageName result = ImageName.Parse("mcr.microsoft.com/dotnet/runtime:8.0");
 
-        Assert.Equal("mcr.microsoft.com", result.Registry);
-        Assert.Equal("dotnet/runtime", result.Repo);
-        Assert.Equal("8.0", result.Tag);
-        Assert.Equal("", result.Digest);
+        result.Registry.ShouldBe("mcr.microsoft.com");
+        result.Repo.ShouldBe("dotnet/runtime");
+        result.Tag.ShouldBe("8.0");
+        result.Digest.ShouldBe("");
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_ImageWithRegistryPort()
     {
         ImageName result = ImageName.Parse("localhost:5000/myimage:latest");
 
-        Assert.Equal("localhost:5000", result.Registry);
-        Assert.Equal("myimage", result.Repo);
-        Assert.Equal("latest", result.Tag);
-        Assert.Equal("", result.Digest);
+        result.Registry.ShouldBe("localhost:5000");
+        result.Repo.ShouldBe("myimage");
+        result.Tag.ShouldBe("latest");
+        result.Digest.ShouldBe("");
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_ImageWithRegistryAndDigest()
     {
         ImageName result = ImageName.Parse("mcr.microsoft.com/dotnet/runtime@sha256:abc123");
 
-        Assert.Equal("mcr.microsoft.com", result.Registry);
-        Assert.Equal("dotnet/runtime", result.Repo);
-        Assert.Equal("", result.Tag);
-        Assert.Equal("sha256:abc123", result.Digest);
+        result.Registry.ShouldBe("mcr.microsoft.com");
+        result.Repo.ShouldBe("dotnet/runtime");
+        result.Tag.ShouldBe("");
+        result.Digest.ShouldBe("sha256:abc123");
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_ImageWithNestedRepo()
     {
         ImageName result = ImageName.Parse("myregistry.azurecr.io/team/project/image:v1");
 
-        Assert.Equal("myregistry.azurecr.io", result.Registry);
-        Assert.Equal("team/project/image", result.Repo);
-        Assert.Equal("v1", result.Tag);
-        Assert.Equal("", result.Digest);
+        result.Registry.ShouldBe("myregistry.azurecr.io");
+        result.Repo.ShouldBe("team/project/image");
+        result.Tag.ShouldBe("v1");
+        result.Digest.ShouldBe("");
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_DockerHubOfficialImage_WithAutoResolve()
     {
         ImageName result = ImageName.Parse("ubuntu", autoResolveImpliedNames: true);
 
-        Assert.Equal(DockerHelper.DockerHubRegistry, result.Registry);
-        Assert.Equal("library/ubuntu", result.Repo);
-        Assert.Equal("", result.Tag);
-        Assert.Equal("", result.Digest);
+        result.Registry.ShouldBe(DockerHelper.DockerHubRegistry);
+        result.Repo.ShouldBe("library/ubuntu");
+        result.Tag.ShouldBe("");
+        result.Digest.ShouldBe("");
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_DockerHubUserImage_WithAutoResolve()
     {
         ImageName result = ImageName.Parse("myuser/myimage:latest", autoResolveImpliedNames: true);
 
-        Assert.Equal(DockerHelper.DockerHubRegistry, result.Registry);
-        Assert.Equal("myuser/myimage", result.Repo);
-        Assert.Equal("latest", result.Tag);
-        Assert.Equal("", result.Digest);
+        result.Registry.ShouldBe(DockerHelper.DockerHubRegistry);
+        result.Repo.ShouldBe("myuser/myimage");
+        result.Tag.ShouldBe("latest");
+        result.Digest.ShouldBe("");
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_ExplicitRegistry_WithAutoResolve()
     {
         ImageName result = ImageName.Parse("mcr.microsoft.com/dotnet/sdk:8.0", autoResolveImpliedNames: true);
 
-        Assert.Equal("mcr.microsoft.com", result.Registry);
-        Assert.Equal("dotnet/sdk", result.Repo);
-        Assert.Equal("8.0", result.Tag);
-        Assert.Equal("", result.Digest);
+        result.Registry.ShouldBe("mcr.microsoft.com");
+        result.Repo.ShouldBe("dotnet/sdk");
+        result.Tag.ShouldBe("8.0");
+        result.Digest.ShouldBe("");
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_SimpleRepoWithSlash_NoRegistry()
     {
         // When there's no dot or colon in the first segment, it's treated as part of the repo
         ImageName result = ImageName.Parse("myuser/myimage:tag");
 
-        Assert.Equal("", result.Registry);
-        Assert.Equal("myuser/myimage", result.Repo);
-        Assert.Equal("tag", result.Tag);
-        Assert.Equal("", result.Digest);
+        result.Registry.ShouldBe("");
+        result.Repo.ShouldBe("myuser/myimage");
+        result.Tag.ShouldBe("tag");
+        result.Digest.ShouldBe("");
     }
 
     #region ToString Tests
 
-    [Fact]
+    [TestMethod]
     public void ToString_WithRegistryAndTag()
     {
         var imageName = new ImageName("mcr.microsoft.com", "dotnet/runtime", "8.0", null);
 
-        Assert.Equal("mcr.microsoft.com/dotnet/runtime:8.0", imageName.ToString());
+        imageName.ToString().ShouldBe("mcr.microsoft.com/dotnet/runtime:8.0");
     }
 
-    [Fact]
+    [TestMethod]
     public void ToString_WithRegistryAndDigest()
     {
         var imageName = new ImageName("mcr.microsoft.com", "dotnet/runtime", null, "sha256:abc123");
 
-        Assert.Equal("mcr.microsoft.com/dotnet/runtime@sha256:abc123", imageName.ToString());
+        imageName.ToString().ShouldBe("mcr.microsoft.com/dotnet/runtime@sha256:abc123");
     }
 
-    [Fact]
+    [TestMethod]
     public void ToString_WithRegistryTagAndDigest()
     {
         var imageName = new ImageName("mcr.microsoft.com", "dotnet/runtime", "8.0", "sha256:abc123");
 
-        Assert.Equal("mcr.microsoft.com/dotnet/runtime:8.0@sha256:abc123", imageName.ToString());
+        imageName.ToString().ShouldBe("mcr.microsoft.com/dotnet/runtime:8.0@sha256:abc123");
     }
 
-    [Fact]
+    [TestMethod]
     public void ToString_RepoOnly()
     {
         var imageName = new ImageName(null, "myimage", null, null);
 
-        Assert.Equal("myimage", imageName.ToString());
+        imageName.ToString().ShouldBe("myimage");
     }
 
-    [Fact]
+    [TestMethod]
     public void ToString_WithEmptyRegistry()
     {
         var imageName = new ImageName("", "myuser/myimage", "latest", null);
 
-        Assert.Equal("myuser/myimage:latest", imageName.ToString());
+        imageName.ToString().ShouldBe("myuser/myimage:latest");
     }
 
     #endregion
 
     #region Implicit Conversion Tests
 
-    [Fact]
+    [TestMethod]
     public void ImplicitConversion_StringToImageName()
     {
         ImageName imageName = "mcr.microsoft.com/dotnet/sdk:8.0";
 
-        Assert.Equal("mcr.microsoft.com", imageName.Registry);
-        Assert.Equal("dotnet/sdk", imageName.Repo);
-        Assert.Equal("8.0", imageName.Tag);
+        imageName.Registry.ShouldBe("mcr.microsoft.com");
+        imageName.Repo.ShouldBe("dotnet/sdk");
+        imageName.Tag.ShouldBe("8.0");
     }
 
-    [Fact]
+    [TestMethod]
     public void ImplicitConversion_StringToImageName_ResolvesDockerHub()
     {
         // Implicit conversion uses autoResolveImpliedNames: true
         ImageName imageName = "ubuntu";
 
-        Assert.Equal(DockerHelper.DockerHubRegistry, imageName.Registry);
-        Assert.Equal("library/ubuntu", imageName.Repo);
+        imageName.Registry.ShouldBe(DockerHelper.DockerHubRegistry);
+        imageName.Repo.ShouldBe("library/ubuntu");
     }
 
-    [Fact]
+    [TestMethod]
     public void ImplicitConversion_ImageNameToString()
     {
         var imageName = new ImageName("mcr.microsoft.com", "dotnet/runtime", "8.0", null);
 
         string result = imageName;
 
-        Assert.Equal("mcr.microsoft.com/dotnet/runtime:8.0", result);
+        result.ShouldBe("mcr.microsoft.com/dotnet/runtime:8.0");
     }
 
-    [Fact]
+    [TestMethod]
     public void ImplicitConversion_CanPassImageNameToStringMethod()
     {
         ImageName imageName = "mcr.microsoft.com/dotnet/sdk:8.0";
@@ -214,7 +215,7 @@ public class ImageNameTests
         // Verifies implicit conversion works when passing to methods expecting string
         string result = AcceptString(imageName);
 
-        Assert.Equal("mcr.microsoft.com/dotnet/sdk:8.0", result);
+        result.ShouldBe("mcr.microsoft.com/dotnet/sdk:8.0");
     }
 
     private static string AcceptString(string value) => value;
@@ -223,20 +224,20 @@ public class ImageNameTests
 
     #region Round-Trip Tests
 
-    [Theory]
-    [InlineData("mcr.microsoft.com/dotnet/runtime:8.0")]
-    [InlineData("mcr.microsoft.com/dotnet/runtime@sha256:abc123")]
-    [InlineData("localhost:5000/myimage:latest")]
-    [InlineData("myregistry.azurecr.io/team/project/image:v1")]
+    [TestMethod]
+    [DataRow("mcr.microsoft.com/dotnet/runtime:8.0")]
+    [DataRow("mcr.microsoft.com/dotnet/runtime@sha256:abc123")]
+    [DataRow("localhost:5000/myimage:latest")]
+    [DataRow("myregistry.azurecr.io/team/project/image:v1")]
     public void RoundTrip_ParseAndToString_WithRegistry(string original)
     {
         ImageName parsed = ImageName.Parse(original);
         string result = parsed.ToString();
 
-        Assert.Equal(original, result);
+        result.ShouldBe(original);
     }
 
-    [Fact]
+    [TestMethod]
     public void RoundTrip_ImplicitConversions()
     {
         string original = "mcr.microsoft.com/dotnet/sdk:8.0";
@@ -244,7 +245,7 @@ public class ImageNameTests
         ImageName imageName = original;
         string roundTripped = imageName;
 
-        Assert.Equal(original, roundTripped);
+        roundTripped.ShouldBe(original);
     }
 
     #endregion

--- a/src/ImageBuilder.Tests/IngestKustoImageInfoCommandTests.cs
+++ b/src/ImageBuilder.Tests/IngestKustoImageInfoCommandTests.cs
@@ -287,11 +287,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             command.LoadManifest();
             await command.ExecuteAsync();
 
-            TestContext?.WriteLine("{0}", $"Expected Image Data: {Environment.NewLine}{expectedImageData}");
-            TestContext?.WriteLine("{0}", $"Actual Image Data: {Environment.NewLine}{ingestedData[command.Options.ImageTable]}");
+            TestContext?.WriteLine($"Expected Image Data: {Environment.NewLine}{expectedImageData}");
+            TestContext?.WriteLine($"Actual Image Data: {Environment.NewLine}{ingestedData[command.Options.ImageTable]}");
 
-            TestContext?.WriteLine("{0}", $"Expected Layer Data: {Environment.NewLine}{expectedLayerData}");
-            TestContext?.WriteLine("{0}", $"Actual Layer Data: {Environment.NewLine}{ingestedData[command.Options.LayerTable]}");
+            TestContext?.WriteLine($"Expected Layer Data: {Environment.NewLine}{expectedLayerData}");
+            TestContext?.WriteLine($"Actual Layer Data: {Environment.NewLine}{ingestedData[command.Options.LayerTable]}");
 
             kustoClientMock.Verify(o => o.IngestFromCsvAsync(
                 It.IsAny<string>(),

--- a/src/ImageBuilder.Tests/IngestKustoImageInfoCommandTests.cs
+++ b/src/ImageBuilder.Tests/IngestKustoImageInfoCommandTests.cs
@@ -15,25 +15,20 @@ using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Newtonsoft.Json;
-using Xunit.Abstractions;
-using Xunit;
+using Shouldly;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
+    [TestClass]
     public class IngestKustoImageInfoCommandTests
     {
-        private readonly ITestOutputHelper _outputHelper;
-
-        public IngestKustoImageInfoCommandTests(ITestOutputHelper outputHelper)
-        {
-            _outputHelper = outputHelper;
-        }
+        public TestContext? TestContext { get; set; }
 
         /// <summary>
         /// Verifies the command will ingest multiple repos.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task IngestKustoImageInfoCommand_MultipleRepos()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -172,7 +167,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Verifies the command will ingest syndicated tags to another repo.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task SyndicatedTag()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -292,11 +287,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             command.LoadManifest();
             await command.ExecuteAsync();
 
-            _outputHelper.WriteLine($"Expected Image Data: {Environment.NewLine}{expectedImageData}");
-            _outputHelper.WriteLine($"Actual Image Data: {Environment.NewLine}{ingestedData[command.Options.ImageTable]}");
+            TestContext?.WriteLine("{0}", $"Expected Image Data: {Environment.NewLine}{expectedImageData}");
+            TestContext?.WriteLine("{0}", $"Actual Image Data: {Environment.NewLine}{ingestedData[command.Options.ImageTable]}");
 
-            _outputHelper.WriteLine($"Expected Layer Data: {Environment.NewLine}{expectedLayerData}");
-            _outputHelper.WriteLine($"Actual Layer Data: {Environment.NewLine}{ingestedData[command.Options.LayerTable]}");
+            TestContext?.WriteLine("{0}", $"Expected Layer Data: {Environment.NewLine}{expectedLayerData}");
+            TestContext?.WriteLine("{0}", $"Actual Layer Data: {Environment.NewLine}{ingestedData[command.Options.LayerTable]}");
 
             kustoClientMock.Verify(o => o.IngestFromCsvAsync(
                 It.IsAny<string>(),
@@ -304,8 +299,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<IServiceConnection>()));
-            Assert.Equal(expectedImageData, ingestedData[command.Options.ImageTable]);
-            Assert.Equal(expectedLayerData, ingestedData[command.Options.LayerTable]);
+            ingestedData[command.Options.ImageTable].ShouldBe(expectedImageData);
+            ingestedData[command.Options.LayerTable].ShouldBe(expectedLayerData);
         }
     }
 }

--- a/src/ImageBuilder.Tests/IngestKustoImageInfoCommandTests.cs
+++ b/src/ImageBuilder.Tests/IngestKustoImageInfoCommandTests.cs
@@ -21,9 +21,8 @@ using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
     [TestClass]
-    public class IngestKustoImageInfoCommandTests
+    public class IngestKustoImageInfoCommandTests(TestContext testContext)
     {
-        public TestContext? TestContext { get; set; }
 
         /// <summary>
         /// Verifies the command will ingest multiple repos.
@@ -287,11 +286,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             command.LoadManifest();
             await command.ExecuteAsync();
 
-            TestContext?.WriteLine($"Expected Image Data: {Environment.NewLine}{expectedImageData}");
-            TestContext?.WriteLine($"Actual Image Data: {Environment.NewLine}{ingestedData[command.Options.ImageTable]}");
+            testContext.WriteLine($"Expected Image Data: {Environment.NewLine}{expectedImageData}");
+            testContext.WriteLine($"Actual Image Data: {Environment.NewLine}{ingestedData[command.Options.ImageTable]}");
 
-            TestContext?.WriteLine($"Expected Layer Data: {Environment.NewLine}{expectedLayerData}");
-            TestContext?.WriteLine($"Actual Layer Data: {Environment.NewLine}{ingestedData[command.Options.LayerTable]}");
+            testContext.WriteLine($"Expected Layer Data: {Environment.NewLine}{expectedLayerData}");
+            testContext.WriteLine($"Actual Layer Data: {Environment.NewLine}{ingestedData[command.Options.LayerTable]}");
 
             kustoClientMock.Verify(o => o.IngestFromCsvAsync(
                 It.IsAny<string>(),

--- a/src/ImageBuilder.Tests/ManifestInfoTests.cs
+++ b/src/ImageBuilder.Tests/ManifestInfoTests.cs
@@ -7,10 +7,11 @@ using System;
 using System.IO;
 using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
-using Xunit;
+using Shouldly;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
+    [TestClass]
     public class ManifestInfoTests
     {
         private static string s_dockerfilePath = "testDockerfile";
@@ -21,7 +22,7 @@ $@"
   ]
 ";
 
-        [Fact]
+        [TestMethod]
         public void Load_Import_Variables()
         {
             string includeManifestPath = "manifest.variables.json";
@@ -49,12 +50,12 @@ $@"
 }}";
 
             ManifestInfo manifestInfo = LoadManifestInfo(manifest, includeManifestPath, includeManifest);
-            Assert.Equal(2, manifestInfo.Model.Variables.Count);
-            Assert.Equal(variableOneValue, manifestInfo.Model.Variables[variableOneName]);
-            Assert.Equal(variableTwoValue, manifestInfo.Model.Variables[variableTwoName]);
+            manifestInfo.Model.Variables.Count.ShouldBe(2);
+            manifestInfo.Model.Variables[variableOneName].ShouldBe(variableOneValue);
+            manifestInfo.Model.Variables[variableTwoName].ShouldBe(variableTwoValue);
         }
 
-        [Fact]
+        [TestMethod]
         public void Load_Import_InvalidPath()
         {
             string manifest =
@@ -66,10 +67,10 @@ $@"
 {s_repoJson}
 }}";
 
-            Assert.Throws<FileNotFoundException>(() => LoadManifestInfo(manifest));
+            Should.Throw<FileNotFoundException>(() => LoadManifestInfo(manifest));
         }
 
-        [Fact]
+        [TestMethod]
         public void Load_Import_DuplicateVariables()
         {
             string includeManifestPath = "manifest.variables.json";
@@ -93,10 +94,10 @@ $@"
   }}
 }}";
 
-            Assert.Throws<InvalidOperationException>(() => LoadManifestInfo(manifest, includeManifestPath, includeManifest));
+            Should.Throw<InvalidOperationException>(() => LoadManifestInfo(manifest, includeManifestPath, includeManifest));
         }
 
-        [Fact]
+        [TestMethod]
         public void Load_Include_Repos()
         {
             const string includeManifestPath1 = "manifest.custom1.json";
@@ -141,14 +142,14 @@ $@"
             IManifestOptionsInfo manifestOptions = ManifestHelper.GetManifestOptions(manifestPath);
             ManifestInfo manifestInfo = TestHelper.CreateManifestJsonService().Load(manifestOptions);
 
-            Assert.Equal(3, manifestInfo.Model.Repos.Length);
-            Assert.Equal("testRepo1", manifestInfo.Model.Repos[0].Name);
-            Assert.Equal("testRepo2", manifestInfo.Model.Repos[1].Name);
-            Assert.Equal("testRepo3", manifestInfo.Model.Repos[2].Name);
+            manifestInfo.Model.Repos.Length.ShouldBe(3);
+            manifestInfo.Model.Repos[0].Name.ShouldBe("testRepo1");
+            manifestInfo.Model.Repos[1].Name.ShouldBe("testRepo2");
+            manifestInfo.Model.Repos[2].Name.ShouldBe("testRepo3");
 
-            Assert.Equal(2, manifestInfo.Model.Repos[0].Images.Length);
-            Assert.Single(manifestInfo.Model.Repos[1].Images);
-            Assert.Single(manifestInfo.Model.Repos[2].Images);
+            manifestInfo.Model.Repos[0].Images.Length.ShouldBe(2);
+            manifestInfo.Model.Repos[1].Images.ShouldHaveSingleItem();
+            manifestInfo.Model.Repos[2].Images.ShouldHaveSingleItem();
         }
 
         private static ManifestInfo LoadManifestInfo(string manifest, string includeManifestPath = null, string includeManifest = null)

--- a/src/ImageBuilder.Tests/ManifestListHelperTests.cs
+++ b/src/ImageBuilder.Tests/ManifestListHelperTests.cs
@@ -11,19 +11,19 @@ using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
 using Shouldly;
-using Xunit;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.DockerfileHelper;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ImageInfoHelper;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests;
 
+[TestClass]
 public class ManifestListHelperTests
 {
     /// <summary>
     /// Verifies that a manifest list is returned containing all built platforms.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void GetManifestListsForImages_BasicMultiPlatform()
     {
         using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -62,7 +62,7 @@ public class ManifestListHelperTests
     /// Verifies that only platforms present in image-info are included in the manifest list.
     /// Platforms defined in the manifest but not built should be excluded.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void GetManifestListsForImages_OnlyIncludesBuiltPlatforms()
     {
         using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -106,7 +106,7 @@ public class ManifestListHelperTests
     /// Verifies that no manifest list is returned when an image has shared tags
     /// but no platforms exist in image-info.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void GetManifestListsForImages_SkipsImageWithNoBuiltPlatforms()
     {
         using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -147,7 +147,7 @@ public class ManifestListHelperTests
     /// Verifies that manifest lists are returned when at least one platform has changed,
     /// including both changed and unchanged platforms.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void GetManifestListsForImages_IncludesPartiallyChangedImages()
     {
         using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -186,7 +186,7 @@ public class ManifestListHelperTests
     /// <summary>
     /// Verifies that images without shared tags do not produce manifest lists.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void GetManifestListsForImages_SkipsImagesWithNoSharedTags()
     {
         using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -217,7 +217,7 @@ public class ManifestListHelperTests
     /// Verifies that when a platform has no tags of its own, it borrows a tag
     /// from a matching platform in another image within the same repo.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void GetManifestListsForImages_DuplicatePlatformCrossReference()
     {
         using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -262,7 +262,7 @@ public class ManifestListHelperTests
     /// <summary>
     /// Verifies that manifest lists are returned for syndicated repos with correct tags.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void GetManifestListsForImages_SyndicatedTags()
     {
         using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -337,7 +337,7 @@ public class ManifestListHelperTests
     /// Verifies that syndicated manifest lists only include platforms that have
     /// matching syndicated tags (not all platforms).
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void GetManifestListsForImages_SyndicatedOnlyIncludesMatchingPlatforms()
     {
         using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -419,7 +419,7 @@ public class ManifestListHelperTests
     /// <summary>
     /// Verifies that repo prefix is correctly applied to image names in manifest lists.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void GetManifestListsForImages_RepoPrefix()
     {
         using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -455,7 +455,7 @@ public class ManifestListHelperTests
     /// <summary>
     /// Verifies that the registry is included in manifest list tag and platform image names.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void GetManifestListsForImages_RegistryInImageNames()
     {
         using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -492,7 +492,7 @@ public class ManifestListHelperTests
     /// Verifies that manifest lists are created even when all platforms are cached (unchanged).
     /// This ensures manifest list tags always exist in staging for digest lookup and signing.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void GetManifestListsForImages_IncludesFullyCachedImages()
     {
         using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();

--- a/src/ImageBuilder.Tests/ManifestServiceDefaultImplementationTests.cs
+++ b/src/ImageBuilder.Tests/ManifestServiceDefaultImplementationTests.cs
@@ -8,18 +8,19 @@ using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Commands;
 using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
 using Moq;
-using Xunit;
+using Shouldly;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
+    [TestClass]
     public class ManifestServiceDefaultImplementationTests
     {
         private const string ManifestDigest = "manifest-digest";
         private const string ManifestListDigest = "manifest-list-digest";
 
-        [Theory]
-        [InlineData("tag1", ManifestDigest)]
-        [InlineData("tag2", ManifestListDigest)]
+        [TestMethod]
+        [DataRow("tag1", ManifestDigest)]
+        [DataRow("tag2", ManifestListDigest)]
         public async Task GetManifestDigestSha(string tag, string expectedDigestSha)
         {
             RegistryCredentialsOptions credsOptions = new()
@@ -43,7 +44,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 .ReturnsAsync(new ManifestQueryResult(ManifestListDigest, new JsonObject()));
 
             string digestSha = await manifestService.Object.GetManifestDigestShaAsync(tag, false);
-            Assert.Equal(expectedDigestSha, digestSha);
+            digestSha.ShouldBe(expectedDigestSha);
         }
     }
 }

--- a/src/ImageBuilder.Tests/MarImageIngestionReporterTests.cs
+++ b/src/ImageBuilder.Tests/MarImageIngestionReporterTests.cs
@@ -10,17 +10,18 @@ using Microsoft.DotNet.ImageBuilder.Models.McrStatus;
 using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
 using Microsoft.Extensions.Logging;
 using Moq;
-using Xunit;
+using Shouldly;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.MarStatusHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
+    [TestClass]
     public class MarImageIngestionReporterTests
     {
-        [Theory]
-        [InlineData("")]
-        [InlineData("public/")]
-        [InlineData("internal/private/")]
+        [TestMethod]
+        [DataRow("")]
+        [DataRow("public/")]
+        [DataRow("internal/private/")]
         public async Task SuccessfulPublish(string repoPrefix)
         {
             DateTime baselineTime = DateTime.Now;
@@ -221,7 +222,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             environmentServiceMock.Verify(o => o.Exit(It.IsAny<int>()), Times.Never);
         }
 
-        [Fact]
+        [TestMethod]
         public async Task SuccessfulPublish_TaglessDigest()
         {
             DateTime baselineTime = DateTime.Now;
@@ -308,7 +309,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             environmentServiceMock.Verify(o => o.Exit(It.IsAny<int>()), Times.Never);
         }
 
-        [Fact]
+        [TestMethod]
         public async Task PublishFailure_TaglessDigest()
         {
             DateTime baselineTime = DateTime.Now;
@@ -402,7 +403,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             environmentServiceMock.Verify(o => o.Exit(1), Times.Once);
         }
 
-        [Fact]
+        [TestMethod]
         public async Task PublishFailure()
         {
             DateTime baselineTime = DateTime.Now;
@@ -571,7 +572,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// Tests the scenario where a given digest has been queued for onboarding multiple times and the minimum queue time isn't set
         /// properly to filter them to just one onboarding request.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task OnboardingRequestsWithDuplicateDigest_Success()
         {
             DateTime baselineTime = DateTime.Now;
@@ -666,7 +667,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// Tests the scenario where a given digest has been queued for onboarding multiple times and the minimum queue time isn't set
         /// properly to filter them to just one onboarding request.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task OnboardingRequestsWithDuplicateDigest_Failed()
         {
             DateTime baselineTime = DateTime.Now;
@@ -799,7 +800,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Tests that the command times out if the publishing takes too long.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task WaitTimeout()
         {
             DateTime baselineTime = DateTime.Now;
@@ -839,7 +840,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     new DigestInfo(DockerHelper.GetDigestSha(platformDigest1), repo1, [platformTag1]),
                 ];
 
-            await Assert.ThrowsAsync<TimeoutException>(() => reporter.ReportImageStatusesAsync(
+            await Should.ThrowAsync<TimeoutException>(() => reporter.ReportImageStatusesAsync(
                 Mock.Of<IServiceConnection>(),
                 digestInfos,
                 TimeSpan.FromSeconds(3),

--- a/src/ImageBuilder.Tests/McrTagsMetadataGeneratorTests.cs
+++ b/src/ImageBuilder.Tests/McrTagsMetadataGeneratorTests.cs
@@ -16,7 +16,7 @@ using Microsoft.DotNet.ImageBuilder.ViewModel;
 using FluentAssertions;
 using Moq;
 using Newtonsoft.Json;
-using Xunit;
+using Shouldly;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
@@ -24,6 +24,7 @@ using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
+    [TestClass]
     public class McrTagsMetadataGeneratorTests
     {
         /// <summary>
@@ -33,12 +34,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// If the source branch isn't set, the commit SHA of the Dockerfile will be used in the URL
         /// See https://github.com/dotnet/dotnet-docker/issues/1436
         /// </remarks>
-        [Theory]
-        [InlineData(true, "branch")]
-        [InlineData(true, null)]
-        [InlineData(false, "branch")]
-        [InlineData(false, null)]
-        public static void DockerfileLink(bool generateGitHubLinks, string sourceRepoBranch)
+        [TestMethod]
+        [DataRow(true, "branch")]
+        [DataRow(true, null)]
+        [DataRow(false, "branch")]
+        [DataRow(false, null)]
+        public void DockerfileLink(bool generateGitHubLinks, string sourceRepoBranch)
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
 
@@ -114,16 +115,16 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 ? $"{SourceRepoUrl}/blob/{branchOrSha}/{DockerfileDir}/Dockerfile"
                 : dockerfileRelativePath;
 
-            Assert.Equal(expectedUrl, tagsMetadata.Repos[0].TagGroups[0].Dockerfile);
+            tagsMetadata.Repos[0].TagGroups[0].Dockerfile.ShouldBe(expectedUrl);
         }
 
         /// <summary>
         /// Verifies that <see cref="McrTagsMetadataGenerator"/> can be run against a platform that has no
         /// documented tags.
         /// </summary>
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
         public void HandlesUndocumentedPlatform(bool hasSharedTag)
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -212,10 +213,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 .Deserialize<TagsMetadata>(result);
 
             // Verify the output only contains the platform with the documented tag
-            Assert.Single(tagsMetadata.Repos[0].TagGroups);
-            Assert.Equal(
-                $"{SourceRepoUrl}/blob/{SourceBranch}/1.0/{RepoName}/os2/Dockerfile",
-                tagsMetadata.Repos[0].TagGroups[0].Dockerfile);
+            tagsMetadata.Repos[0].TagGroups.ShouldHaveSingleItem();
+            tagsMetadata.Repos[0].TagGroups[0].Dockerfile.ShouldBe($"{SourceRepoUrl}/blob/{SourceBranch}/1.0/{RepoName}/os2/Dockerfile");
 
             List<string> expectedTags = new List<string>
             {
@@ -227,14 +226,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 expectedTags.Add("shared");
             }
 
-            Assert.Equal(expectedTags, tagsMetadata.Repos[0].TagGroups[0].Tags);
+            tagsMetadata.Repos[0].TagGroups[0].Tags.ShouldBe(expectedTags);
         }
 
         /// <summary>
         /// Verifies that <see cref="McrTagsMetadataGenerator"/> can be run against a platform that is defined
         /// multiple times in different images within the manifest and have the tags combined into one entry.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public void DuplicatedPlatform()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -314,10 +313,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 .Deserialize<TagsMetadata>(result);
 
             // Verify the output only contains the platform with the documented tag
-            Assert.Single(tagsMetadata.Repos[0].TagGroups);
-            Assert.Equal(
-                $"{SourceRepoUrl}/blob/{SourceBranch}/1.0/{RepoName}/os/Dockerfile",
-                tagsMetadata.Repos[0].TagGroups[0].Dockerfile);
+            tagsMetadata.Repos[0].TagGroups.ShouldHaveSingleItem();
+            tagsMetadata.Repos[0].TagGroups[0].Dockerfile.ShouldBe($"{SourceRepoUrl}/blob/{SourceBranch}/1.0/{RepoName}/os/Dockerfile");
 
             List<string> expectedTags = new List<string>
             {
@@ -328,10 +325,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 "latest"
             };
 
-            Assert.Equal(expectedTags, tagsMetadata.Repos[0].TagGroups[0].Tags);
+            tagsMetadata.Repos[0].TagGroups[0].Tags.ShouldBe(expectedTags);
         }
+    }
 
-        public class MultiPlatformTags : IDisposable
+    [TestClass]
+    public class MultiPlatformTags : IDisposable
         {
             private const string EmptyFileName = "emptyFile.md";
             private const string TagsMetadataTemplateName = "tags.yml";
@@ -377,7 +376,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             private static string[] GetTags(IEnumerable<string> tags, string osVersion, Architecture arch) =>
                 tags.Select(tag => $"{tag}-{osVersion}-{arch.ToString().ToLowerInvariant()}").ToArray();
 
-            [Fact]
+            [TestMethod]
             public void DocumentedPlatformTags()
             {
                 const string tagsMetadataTemplate = $"""
@@ -394,7 +393,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 ValidateMetadataGeneratorOutput(platforms);
             }
 
-            [Fact]
+            [TestMethod]
             public void UndocumentedPlatformTags()
             {
                 const string tagsMetadataTemplate = $"""
@@ -411,7 +410,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 ValidateMetadataGeneratorOutput(platforms);
             }
 
-            [Fact]
+            [TestMethod]
             public void NoPlatformTags()
             {
                 const string tagsMetadataTemplate = $"""
@@ -428,7 +427,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 ValidateMetadataGeneratorOutput(platforms);
             }
 
-            [Fact]
+            [TestMethod]
             public void SharedLinuxAndWindowsTags()
             {
                 // Windows images should be excluded from computation of multi-arch tags
@@ -511,5 +510,4 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 GC.SuppressFinalize(this);
             }
         }
-    }
 }

--- a/src/ImageBuilder.Tests/MergeImageInfoFilesCommandTests.cs
+++ b/src/ImageBuilder.Tests/MergeImageInfoFilesCommandTests.cs
@@ -15,16 +15,16 @@ using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
 using Moq;
 using Newtonsoft.Json;
 using Shouldly;
-using Xunit;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.DockerfileHelper;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ImageInfoHelper;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
+    [TestClass]
     public class MergeImageInfoFilesCommandTests
     {
-        [Fact]
+        [TestMethod]
         public async Task MergeImageInfoFilesCommand_HappyPath()
         {
             using (TempFolderContext context = TestHelper.UseTempFolder())
@@ -321,7 +321,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             }
         }
 
-        [Fact]
+        [TestMethod]
         public async Task MergeImageInfoFilesCommand_DuplicateDockerfilePaths()
         {
             const string OsType = "Linux";
@@ -617,17 +617,17 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             }
         }
 
-        [Fact]
+        [TestMethod]
         public async Task MergeImageInfoFilesCommand_SourceFolderPathNotFound()
         {
             MergeImageInfoCommand command = new MergeImageInfoCommand(TestHelper.CreateManifestJsonService());
             command.Options.SourceImageInfoFolderPath = "foo";
             command.Options.DestinationImageInfoPath = "output.json";
 
-            await Assert.ThrowsAsync<DirectoryNotFoundException>(() => command.ExecuteAsync());
+            await Should.ThrowAsync<DirectoryNotFoundException>(() => command.ExecuteAsync());
         }
 
-        [Fact]
+        [TestMethod]
         public async Task MergeImageInfoFilesCommand_SourceFolderEmpty()
         {
             using (TempFolderContext context = TestHelper.UseTempFolder())
@@ -647,7 +647,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 command.Options.SourceImageInfoFolderPath = context.Path;
                 command.Options.DestinationImageInfoPath = "output.json";
 
-                await Assert.ThrowsAsync<InvalidOperationException>(() => command.ExecuteAsync());
+                await Should.ThrowAsync<InvalidOperationException>(() => command.ExecuteAsync());
             }
         }
 
@@ -657,7 +657,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <remarks>
         /// See https://github.com/dotnet/docker-tools/pull/269
         /// </remarks>
-        [Fact]
+        [TestMethod]
         public async Task MergeImageInfoFilesCommand_Publish_ReplaceContent()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -838,7 +838,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// Verifies the command will remove any out-of-date content that exists within the target image info file,
         /// meaning that it has content which isn't reflected in the manifest.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task MergeImageInfoFilesCommand_Publish_RemoveOutOfDateContent()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -989,7 +989,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             CompareImageArtifactDetails(expectedImageArtifactDetails, actual);
         }
 
-        [Fact]
+        [TestMethod]
         public async Task MergeImageInfoFilesCommand_CommitUrlOverride()
         {
             using TempFolderContext context = TestHelper.UseTempFolder();

--- a/src/ImageBuilder.Tests/Microsoft.DotNet.ImageBuilder.Tests.csproj
+++ b/src/ImageBuilder.Tests/Microsoft.DotNet.ImageBuilder.Tests.csproj
@@ -13,13 +13,13 @@
   <PropertyGroup>
     <IsTestProject>true</IsTestProject>
     <SignAssembly>false</SignAssembly>
+    <TestRunnerName>MSTest</TestRunnerName>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="AwesomeAssertions" Version="8.1.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ImageBuilder.Tests/ModelExtensionsTests.cs
+++ b/src/ImageBuilder.Tests/ModelExtensionsTests.cs
@@ -5,39 +5,40 @@
 
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
-using Xunit;
+using Shouldly;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
+    [TestClass]
     public class ModelExtensionsTests
     {
-        [Theory]
-        [InlineData(Architecture.AMD64, "amd64")]
-        [InlineData(Architecture.ARM, "arm32")]
-        [InlineData(Architecture.ARM64, "arm64")]
-        [InlineData(Architecture.AMD64, "amd64v8", "v8")]
-        [InlineData(Architecture.ARM, "arm32v7", "V7")]
+        [TestMethod]
+        [DataRow(Architecture.AMD64, "amd64")]
+        [DataRow(Architecture.ARM, "arm32")]
+        [DataRow(Architecture.ARM64, "arm64")]
+        [DataRow(Architecture.AMD64, "amd64v8", "v8")]
+        [DataRow(Architecture.ARM, "arm32v7", "V7")]
         public void Architecture_GetDisplayName(Architecture architecture, string expectedDisplayName, string variant = null)
         {
-            Assert.Equal(expectedDisplayName, architecture.GetDisplayName(variant));
+            architecture.GetDisplayName(variant).ShouldBe(expectedDisplayName);
         }
 
-        [Theory]
-        [InlineData(Architecture.AMD64, "x64")]
-        [InlineData(Architecture.ARM, "arm")]
-        [InlineData(Architecture.ARM64, "arm64")]
+        [TestMethod]
+        [DataRow(Architecture.AMD64, "x64")]
+        [DataRow(Architecture.ARM, "arm")]
+        [DataRow(Architecture.ARM64, "arm64")]
         public void Architecture_GetShortName(Architecture architecture, string expectedShortName)
         {
-            Assert.Equal(expectedShortName, architecture.GetShortName());
+            architecture.GetShortName().ShouldBe(expectedShortName);
         }
 
-        [Theory]
-        [InlineData(Architecture.AMD64, "x64")]
-        [InlineData(Architecture.ARM, "arm32")]
-        [InlineData(Architecture.ARM64, "arm64")]
+        [TestMethod]
+        [DataRow(Architecture.AMD64, "x64")]
+        [DataRow(Architecture.ARM, "arm32")]
+        [DataRow(Architecture.ARM64, "arm64")]
         public void Architecture_GetNupkgName(Architecture architecture, string expectedNupkgName)
         {
-            Assert.Equal(expectedNupkgName, architecture.GetNupkgName());
+            architecture.GetNupkgName().ShouldBe(expectedNupkgName);
         }
     }
 }

--- a/src/ImageBuilder.Tests/Models/CustomBuildLegGroupSerializationTests.cs
+++ b/src/ImageBuilder.Tests/Models/CustomBuildLegGroupSerializationTests.cs
@@ -4,7 +4,7 @@
 
 
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
-using Xunit;
+using Shouldly;
 using static Microsoft.DotNet.ImageBuilder.Tests.Models.SerializationHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests.Models;
@@ -13,9 +13,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests.Models;
 /// Serialization and deserialization tests for <see cref="CustomBuildLegGroup"/> model.
 /// These tests ensure that serialization behavior does not change unexpectedly.
 /// </summary>
+[TestClass]
 public class CustomBuildLegGroupSerializationTests
 {
-    [Fact]
+    [TestMethod]
     public void DefaultCustomBuildLegGroup_CannotSerialize()
     {
         // A default CustomBuildLegGroup has null Name, which violates
@@ -25,7 +26,7 @@ public class CustomBuildLegGroupSerializationTests
         AssertSerializationFails(group, nameof(CustomBuildLegGroup.Name));
     }
 
-    [Fact]
+    [TestMethod]
     public void FullyPopulatedCustomBuildLegGroup_Integral_Bidirectional()
     {
         CustomBuildLegGroup group = new()
@@ -50,7 +51,7 @@ public class CustomBuildLegGroupSerializationTests
         AssertBidirectional(group, json, AssertCustomBuildLegGroupsEqual);
     }
 
-    [Fact]
+    [TestMethod]
     public void FullyPopulatedCustomBuildLegGroup_Supplemental_Bidirectional()
     {
         CustomBuildLegGroup group = new()
@@ -73,7 +74,7 @@ public class CustomBuildLegGroupSerializationTests
         AssertBidirectional(group, json, AssertCustomBuildLegGroupsEqual);
     }
 
-    [Fact]
+    [TestMethod]
     public void FullyPopulatedCustomBuildLegGroup_RoundTrip()
     {
         CustomBuildLegGroup group = new()
@@ -86,7 +87,7 @@ public class CustomBuildLegGroupSerializationTests
         AssertRoundTrip(group, AssertCustomBuildLegGroupsEqual);
     }
 
-    [Fact]
+    [TestMethod]
     public void Deserialization_NameIsRequired_Missing()
     {
         string json = """
@@ -99,7 +100,7 @@ public class CustomBuildLegGroupSerializationTests
         AssertDeserializationFails<CustomBuildLegGroup>(json, nameof(CustomBuildLegGroup.Name));
     }
 
-    [Fact]
+    [TestMethod]
     public void Deserialization_NameIsRequired_Null()
     {
         string json = """
@@ -113,7 +114,7 @@ public class CustomBuildLegGroupSerializationTests
         AssertDeserializationFails<CustomBuildLegGroup>(json, nameof(CustomBuildLegGroup.Name));
     }
 
-    [Fact]
+    [TestMethod]
     public void Deserialization_TypeIsRequired_Missing()
     {
         string json = """
@@ -126,7 +127,7 @@ public class CustomBuildLegGroupSerializationTests
         AssertDeserializationFails<CustomBuildLegGroup>(json, nameof(CustomBuildLegGroup.Type));
     }
 
-    [Fact]
+    [TestMethod]
     public void Deserialization_DependenciesIsRequired_Missing()
     {
         string json = """
@@ -139,7 +140,7 @@ public class CustomBuildLegGroupSerializationTests
         AssertDeserializationFails<CustomBuildLegGroup>(json, nameof(CustomBuildLegGroup.Dependencies));
     }
 
-    [Fact]
+    [TestMethod]
     public void Deserialization_DependenciesIsRequired_Null()
     {
         string json = """
@@ -155,8 +156,8 @@ public class CustomBuildLegGroupSerializationTests
 
     private static void AssertCustomBuildLegGroupsEqual(CustomBuildLegGroup expected, CustomBuildLegGroup actual)
     {
-        Assert.Equal(expected.Name, actual.Name);
-        Assert.Equal(expected.Type, actual.Type);
-        Assert.Equal(expected.Dependencies, actual.Dependencies);
+        actual.Name.ShouldBe(expected.Name);
+        actual.Type.ShouldBe(expected.Type);
+        actual.Dependencies.ShouldBe(expected.Dependencies);
     }
 }

--- a/src/ImageBuilder.Tests/Models/ImageSerializationTests.cs
+++ b/src/ImageBuilder.Tests/Models/ImageSerializationTests.cs
@@ -5,7 +5,7 @@
 
 using System.Collections.Generic;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
-using Xunit;
+using Shouldly;
 using static Microsoft.DotNet.ImageBuilder.Tests.Models.SerializationHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests.Models;
@@ -14,9 +14,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests.Models;
 /// Serialization and deserialization tests for <see cref="Image"/> model.
 /// These tests ensure that serialization behavior does not change unexpectedly.
 /// </summary>
+[TestClass]
 public class ImageSerializationTests
 {
-    [Fact]
+    [TestMethod]
     public void DefaultImage_CannotSerialize()
     {
         // A default Image has null Platforms, which violates
@@ -26,7 +27,7 @@ public class ImageSerializationTests
         AssertSerializationFails(image, nameof(Image.Platforms));
     }
 
-    [Fact]
+    [TestMethod]
     public void FullyPopulatedImage_Bidirectional()
     {
         Image image = new()
@@ -57,7 +58,7 @@ public class ImageSerializationTests
         AssertBidirectional(image, json, AssertImagesEqual);
     }
 
-    [Fact]
+    [TestMethod]
     public void FullyPopulatedImage_RoundTrip()
     {
         Image image = new()
@@ -70,7 +71,7 @@ public class ImageSerializationTests
         AssertRoundTrip(image, AssertImagesEqual);
     }
 
-    [Fact]
+    [TestMethod]
     public void MinimalImage_Bidirectional()
     {
         Image image = new()
@@ -87,7 +88,7 @@ public class ImageSerializationTests
         AssertBidirectional(image, json, AssertImagesEqual);
     }
 
-    [Fact]
+    [TestMethod]
     public void Deserialization_PlatformsIsRequired_Missing()
     {
         string json = """
@@ -99,7 +100,7 @@ public class ImageSerializationTests
         AssertDeserializationFails<Image>(json, nameof(Image.Platforms));
     }
 
-    [Fact]
+    [TestMethod]
     public void Deserialization_PlatformsIsRequired_Null()
     {
         string json = """
@@ -112,7 +113,7 @@ public class ImageSerializationTests
         AssertDeserializationFails<Image>(json, nameof(Image.Platforms));
     }
 
-    [Fact]
+    [TestMethod]
     public void Deserialization_SharedTagsIsOptional()
     {
         string json = """
@@ -132,20 +133,20 @@ public class ImageSerializationTests
 
     private static void AssertImagesEqual(Image expected, Image actual)
     {
-        Assert.Equal(expected.Platforms?.Length ?? 0, actual.Platforms?.Length ?? 0);
-        Assert.Equal(expected.ProductVersion, actual.ProductVersion);
+        (actual.Platforms?.Length ?? 0).ShouldBe(expected.Platforms?.Length ?? 0);
+        actual.ProductVersion.ShouldBe(expected.ProductVersion);
 
         if (expected.SharedTags is null)
         {
-            Assert.Null(actual.SharedTags);
+            actual.SharedTags.ShouldBeNull();
         }
         else
         {
-            Assert.NotNull(actual.SharedTags);
-            Assert.Equal(expected.SharedTags.Count, actual.SharedTags.Count);
+            actual.SharedTags.ShouldNotBeNull();
+            actual.SharedTags.Count.ShouldBe(expected.SharedTags.Count);
             foreach (string key in expected.SharedTags.Keys)
             {
-                Assert.True(actual.SharedTags.ContainsKey(key));
+                actual.SharedTags.ContainsKey(key).ShouldBeTrue();
             }
         }
     }

--- a/src/ImageBuilder.Tests/Models/ManifestSerializationTests.cs
+++ b/src/ImageBuilder.Tests/Models/ManifestSerializationTests.cs
@@ -5,7 +5,7 @@
 
 using System.Collections.Generic;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
-using Xunit;
+using Shouldly;
 using static Microsoft.DotNet.ImageBuilder.Tests.Models.SerializationHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests.Models;
@@ -14,9 +14,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests.Models;
 /// Serialization and deserialization tests for <see cref="Manifest"/> model.
 /// These tests ensure that serialization behavior does not change unexpectedly.
 /// </summary>
+[TestClass]
 public class ManifestSerializationTests
 {
-    [Fact]
+    [TestMethod]
     public void DefaultManifest_Bidirectional()
     {
         Manifest manifest = new();
@@ -32,13 +33,13 @@ public class ManifestSerializationTests
         AssertBidirectional(manifest, json, AssertManifestsEqual);
     }
 
-    [Fact]
+    [TestMethod]
     public void DefaultManifest_RoundTrip()
     {
         AssertRoundTrip(new Manifest(), AssertManifestsEqual);
     }
 
-    [Fact]
+    [TestMethod]
     public void FullyPopulatedManifest_Bidirectional()
     {
         Manifest manifest = new()
@@ -76,7 +77,7 @@ public class ManifestSerializationTests
         AssertBidirectional(manifest, json, AssertManifestsEqual);
     }
 
-    [Fact]
+    [TestMethod]
     public void FullyPopulatedManifest_RoundTrip()
     {
         Manifest manifest = new()
@@ -93,20 +94,20 @@ public class ManifestSerializationTests
 
     private static void AssertManifestsEqual(Manifest expected, Manifest actual)
     {
-        Assert.Equal(expected.Includes, actual.Includes);
-        Assert.Equal(expected.Registry, actual.Registry);
-        Assert.Equal(expected.Repos?.Length ?? 0, actual.Repos?.Length ?? 0);
-        Assert.Equal(expected.Variables, actual.Variables);
+        actual.Includes.ShouldBe(expected.Includes);
+        actual.Registry.ShouldBe(expected.Registry);
+        (actual.Repos?.Length ?? 0).ShouldBe(expected.Repos?.Length ?? 0);
+        actual.Variables.ShouldBe(expected.Variables);
 
         if (expected.Readme is null)
         {
-            Assert.Null(actual.Readme);
+            actual.Readme.ShouldBeNull();
         }
         else
         {
-            Assert.NotNull(actual.Readme);
-            Assert.Equal(expected.Readme.Path, actual.Readme.Path);
-            Assert.Equal(expected.Readme.TemplatePath, actual.Readme.TemplatePath);
+            actual.Readme.ShouldNotBeNull();
+            actual.Readme.Path.ShouldBe(expected.Readme.Path);
+            actual.Readme.TemplatePath.ShouldBe(expected.Readme.TemplatePath);
         }
     }
 }

--- a/src/ImageBuilder.Tests/Models/PlatformSerializationTests.cs
+++ b/src/ImageBuilder.Tests/Models/PlatformSerializationTests.cs
@@ -5,7 +5,7 @@
 
 using System.Collections.Generic;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
-using Xunit;
+using Shouldly;
 using static Microsoft.DotNet.ImageBuilder.Tests.Models.SerializationHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests.Models;
@@ -14,9 +14,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests.Models;
 /// Serialization and deserialization tests for <see cref="Platform"/> model.
 /// These tests ensure that serialization behavior does not change unexpectedly.
 /// </summary>
+[TestClass]
 public class PlatformSerializationTests
 {
-    [Fact]
+    [TestMethod]
     public void DefaultPlatform_Bidirectional()
     {
         // A default Platform can be serialized - it has default values for required properties
@@ -39,7 +40,7 @@ public class PlatformSerializationTests
         AssertBidirectional(platform, json, AssertPlatformsEqual);
     }
 
-    [Fact]
+    [TestMethod]
     public void FullyPopulatedPlatform_Bidirectional()
     {
         Platform platform = new()
@@ -88,7 +89,7 @@ public class PlatformSerializationTests
         AssertBidirectional(platform, json, AssertPlatformsEqual);
     }
 
-    [Fact]
+    [TestMethod]
     public void FullyPopulatedPlatform_RoundTrip()
     {
         Platform platform = new()
@@ -107,7 +108,7 @@ public class PlatformSerializationTests
         AssertRoundTrip(platform, AssertPlatformsEqual);
     }
 
-    [Fact]
+    [TestMethod]
     public void MinimalPlatform_Bidirectional()
     {
         // Platform with only required properties, using default Architecture
@@ -137,7 +138,7 @@ public class PlatformSerializationTests
         AssertBidirectional(platform, json, AssertPlatformsEqual);
     }
 
-    [Fact]
+    [TestMethod]
     public void WindowsPlatform_Bidirectional()
     {
         Platform platform = new()
@@ -167,7 +168,7 @@ public class PlatformSerializationTests
         AssertBidirectional(platform, json, AssertPlatformsEqual);
     }
 
-    [Fact]
+    [TestMethod]
     public void Deserialization_DockerfileIsRequired_Missing()
     {
         string json = """
@@ -181,7 +182,7 @@ public class PlatformSerializationTests
         AssertDeserializationFails<Platform>(json, nameof(Platform.Dockerfile));
     }
 
-    [Fact]
+    [TestMethod]
     public void Deserialization_OsIsRequired_Missing()
     {
         string json = """
@@ -195,7 +196,7 @@ public class PlatformSerializationTests
         AssertDeserializationFails<Platform>(json, nameof(Platform.OS));
     }
 
-    [Fact]
+    [TestMethod]
     public void Deserialization_OsVersionIsRequired_Missing()
     {
         string json = """
@@ -209,7 +210,7 @@ public class PlatformSerializationTests
         AssertDeserializationFails<Platform>(json, nameof(Platform.OsVersion));
     }
 
-    [Fact]
+    [TestMethod]
     public void Deserialization_TagsIsRequired_Missing()
     {
         string json = """
@@ -223,7 +224,7 @@ public class PlatformSerializationTests
         AssertDeserializationFails<Platform>(json, nameof(Platform.Tags));
     }
 
-    [Fact]
+    [TestMethod]
     public void Deserialization_TagsIsRequired_Null()
     {
         string json = """
@@ -238,7 +239,7 @@ public class PlatformSerializationTests
         AssertDeserializationFails<Platform>(json, nameof(Platform.Tags));
     }
 
-    [Fact]
+    [TestMethod]
     public void Deserialization_ArchitectureDefaultsToAMD64()
     {
         string json = """
@@ -264,14 +265,14 @@ public class PlatformSerializationTests
 
     private static void AssertPlatformsEqual(Platform expected, Platform actual)
     {
-        Assert.Equal(expected.Architecture, actual.Architecture);
-        Assert.Equal(expected.BuildArgs, actual.BuildArgs);
-        Assert.Equal(expected.Dockerfile, actual.Dockerfile);
-        Assert.Equal(expected.DockerfileTemplate, actual.DockerfileTemplate);
-        Assert.Equal(expected.OS, actual.OS);
-        Assert.Equal(expected.OsVersion, actual.OsVersion);
-        Assert.Equal(expected.Tags?.Count ?? 0, actual.Tags?.Count ?? 0);
-        Assert.Equal(expected.CustomBuildLegGroups?.Length ?? 0, actual.CustomBuildLegGroups?.Length ?? 0);
-        Assert.Equal(expected.Variant, actual.Variant);
+        actual.Architecture.ShouldBe(expected.Architecture);
+        actual.BuildArgs.ShouldBe(expected.BuildArgs);
+        actual.Dockerfile.ShouldBe(expected.Dockerfile);
+        actual.DockerfileTemplate.ShouldBe(expected.DockerfileTemplate);
+        actual.OS.ShouldBe(expected.OS);
+        actual.OsVersion.ShouldBe(expected.OsVersion);
+        (actual.Tags?.Count ?? 0).ShouldBe(expected.Tags?.Count ?? 0);
+        (actual.CustomBuildLegGroups?.Length ?? 0).ShouldBe(expected.CustomBuildLegGroups?.Length ?? 0);
+        actual.Variant.ShouldBe(expected.Variant);
     }
 }

--- a/src/ImageBuilder.Tests/Models/ReadmeSerializationTests.cs
+++ b/src/ImageBuilder.Tests/Models/ReadmeSerializationTests.cs
@@ -4,7 +4,7 @@
 
 
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
-using Xunit;
+using Shouldly;
 using static Microsoft.DotNet.ImageBuilder.Tests.Models.SerializationHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests.Models;
@@ -13,9 +13,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests.Models;
 /// Serialization and deserialization tests for <see cref="Readme"/> model.
 /// These tests ensure that serialization behavior does not change unexpectedly.
 /// </summary>
+[TestClass]
 public class ReadmeSerializationTests
 {
-    [Fact]
+    [TestMethod]
     public void DefaultReadme_Bidirectional()
     {
         Readme readme = new();
@@ -30,13 +31,13 @@ public class ReadmeSerializationTests
         AssertBidirectional(readme, json, AssertReadmesEqual);
     }
 
-    [Fact]
+    [TestMethod]
     public void DefaultReadme_RoundTrip()
     {
         AssertRoundTrip(new Readme(), AssertReadmesEqual);
     }
 
-    [Fact]
+    [TestMethod]
     public void FullyPopulatedReadme_Bidirectional()
     {
         Readme readme = new()
@@ -55,7 +56,7 @@ public class ReadmeSerializationTests
         AssertBidirectional(readme, json, AssertReadmesEqual);
     }
 
-    [Fact]
+    [TestMethod]
     public void FullyPopulatedReadme_RoundTrip()
     {
         Readme readme = new()
@@ -67,7 +68,7 @@ public class ReadmeSerializationTests
         AssertRoundTrip(readme, AssertReadmesEqual);
     }
 
-    [Fact]
+    [TestMethod]
     public void ConstructorWithParameters_Bidirectional()
     {
         Readme readme = new("docs/README.md", "docs/README.template.md");
@@ -82,7 +83,7 @@ public class ReadmeSerializationTests
         AssertBidirectional(readme, json, AssertReadmesEqual);
     }
 
-    [Fact]
+    [TestMethod]
     public void ConstructorWithNullTemplatePath_Bidirectional()
     {
         Readme readme = new("README.md", null);
@@ -97,7 +98,7 @@ public class ReadmeSerializationTests
         AssertBidirectional(readme, json, AssertReadmesEqual);
     }
 
-    [Fact]
+    [TestMethod]
     public void Deserialization_PathIsRequired_Missing()
     {
         // Path has [JsonProperty(Required = Required.Always)]
@@ -111,7 +112,7 @@ public class ReadmeSerializationTests
         AssertDeserializationFails<Readme>(json, nameof(Readme.Path));
     }
 
-    [Fact]
+    [TestMethod]
     public void Deserialization_PathIsRequired_Null()
     {
         // Path has [JsonProperty(Required = Required.Always)]
@@ -126,7 +127,7 @@ public class ReadmeSerializationTests
         AssertDeserializationFails<Readme>(json, nameof(Readme.Path));
     }
 
-    [Fact]
+    [TestMethod]
     public void Deserialization_TemplatePathIsOptional()
     {
         // TemplatePath is optional (nullable, no Required attribute)
@@ -147,7 +148,7 @@ public class ReadmeSerializationTests
 
     private static void AssertReadmesEqual(Readme expected, Readme actual)
     {
-        Assert.Equal(expected.Path, actual.Path);
-        Assert.Equal(expected.TemplatePath, actual.TemplatePath);
+        actual.Path.ShouldBe(expected.Path);
+        actual.TemplatePath.ShouldBe(expected.TemplatePath);
     }
 }

--- a/src/ImageBuilder.Tests/Models/RepoSerializationTests.cs
+++ b/src/ImageBuilder.Tests/Models/RepoSerializationTests.cs
@@ -4,7 +4,7 @@
 
 
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
-using Xunit;
+using Shouldly;
 using static Microsoft.DotNet.ImageBuilder.Tests.Models.SerializationHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests.Models;
@@ -13,9 +13,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests.Models;
 /// Serialization and deserialization tests for <see cref="Repo"/> model.
 /// These tests ensure that serialization behavior does not change unexpectedly.
 /// </summary>
+[TestClass]
 public class RepoSerializationTests
 {
-    [Fact]
+    [TestMethod]
     public void DefaultRepo_CannotSerialize()
     {
         // A default Repo has null Images and Name, which violate
@@ -25,7 +26,7 @@ public class RepoSerializationTests
         AssertSerializationFails(repo, nameof(Repo.Images));
     }
 
-    [Fact]
+    [TestMethod]
     public void FullyPopulatedRepo_Bidirectional()
     {
         Repo repo = new()
@@ -49,7 +50,7 @@ public class RepoSerializationTests
         AssertBidirectional(repo, json, AssertReposEqual);
     }
 
-    [Fact]
+    [TestMethod]
     public void FullyPopulatedRepo_RoundTrip()
     {
         Repo repo = new()
@@ -64,7 +65,7 @@ public class RepoSerializationTests
         AssertRoundTrip(repo, AssertReposEqual);
     }
 
-    [Fact]
+    [TestMethod]
     public void MinimalRepo_Bidirectional()
     {
         Repo repo = new()
@@ -84,7 +85,7 @@ public class RepoSerializationTests
         AssertBidirectional(repo, json, AssertReposEqual);
     }
 
-    [Fact]
+    [TestMethod]
     public void Deserialization_ImagesIsRequired_Missing()
     {
         string json = """
@@ -96,7 +97,7 @@ public class RepoSerializationTests
         AssertDeserializationFails<Repo>(json, nameof(Repo.Images));
     }
 
-    [Fact]
+    [TestMethod]
     public void Deserialization_ImagesIsRequired_Null()
     {
         string json = """
@@ -109,7 +110,7 @@ public class RepoSerializationTests
         AssertDeserializationFails<Repo>(json, nameof(Repo.Images));
     }
 
-    [Fact]
+    [TestMethod]
     public void Deserialization_NameIsRequired_Missing()
     {
         string json = """
@@ -121,7 +122,7 @@ public class RepoSerializationTests
         AssertDeserializationFails<Repo>(json, nameof(Repo.Name));
     }
 
-    [Fact]
+    [TestMethod]
     public void Deserialization_NameIsRequired_Null()
     {
         string json = """
@@ -136,10 +137,10 @@ public class RepoSerializationTests
 
     private static void AssertReposEqual(Repo expected, Repo actual)
     {
-        Assert.Equal(expected.Id, actual.Id);
-        Assert.Equal(expected.Images?.Length ?? 0, actual.Images?.Length ?? 0);
-        Assert.Equal(expected.McrTagsMetadataTemplate, actual.McrTagsMetadataTemplate);
-        Assert.Equal(expected.Name, actual.Name);
-        Assert.Equal(expected.Readmes?.Length ?? 0, actual.Readmes?.Length ?? 0);
+        actual.Id.ShouldBe(expected.Id);
+        (actual.Images?.Length ?? 0).ShouldBe(expected.Images?.Length ?? 0);
+        actual.McrTagsMetadataTemplate.ShouldBe(expected.McrTagsMetadataTemplate);
+        actual.Name.ShouldBe(expected.Name);
+        (actual.Readmes?.Length ?? 0).ShouldBe(expected.Readmes?.Length ?? 0);
     }
 }

--- a/src/ImageBuilder.Tests/Models/SerializationHelper.cs
+++ b/src/ImageBuilder.Tests/Models/SerializationHelper.cs
@@ -7,7 +7,6 @@ using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Shouldly;
-using Xunit;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests.Models;
 
@@ -92,7 +91,7 @@ public static class SerializationHelper
     /// <param name="propertyName">The name of the required property (use nameof()).</param>
     public static void AssertDeserializationFails<T>(string json, string propertyName)
     {
-        JsonSerializationException exception = Assert.Throws<JsonSerializationException>(
+        JsonSerializationException exception = Should.Throw<JsonSerializationException>(
             () => JsonConvert.DeserializeObject<T>(json));
 
         // Newtonsoft.Json error messages use the format: "Required property 'PropertyName' ..."
@@ -108,7 +107,7 @@ public static class SerializationHelper
     /// <param name="propertyName">The name of the required property (use nameof()).</param>
     public static void AssertSerializationFails<T>(T obj, string propertyName)
     {
-        JsonSerializationException exception = Assert.Throws<JsonSerializationException>(
+        JsonSerializationException exception = Should.Throw<JsonSerializationException>(
             () => JsonConvert.SerializeObject(obj, s_serializerSettings));
 
         // Newtonsoft.Json error messages use the format: "Cannot write a null value for property 'name'..."

--- a/src/ImageBuilder.Tests/Models/TagSerializationTests.cs
+++ b/src/ImageBuilder.Tests/Models/TagSerializationTests.cs
@@ -4,7 +4,7 @@
 
 
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
-using Xunit;
+using Shouldly;
 using static Microsoft.DotNet.ImageBuilder.Tests.Models.SerializationHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests.Models;
@@ -13,9 +13,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests.Models;
 /// Serialization and deserialization tests for <see cref="Tag"/> model.
 /// These tests ensure that serialization behavior does not change unexpectedly.
 /// </summary>
+[TestClass]
 public class TagSerializationTests
 {
-    [Fact]
+    [TestMethod]
     public void DefaultTag_Bidirectional()
     {
         Tag tag = new();
@@ -26,13 +27,13 @@ public class TagSerializationTests
         AssertBidirectional(tag, json, AssertTagsEqual);
     }
 
-    [Fact]
+    [TestMethod]
     public void DefaultTag_RoundTrip()
     {
         AssertRoundTrip(new Tag(), AssertTagsEqual);
     }
 
-    [Fact]
+    [TestMethod]
     public void FullyPopulatedTag_Bidirectional()
     {
         Tag tag = new()
@@ -64,7 +65,7 @@ public class TagSerializationTests
         AssertBidirectional(tag, json, AssertTagsEqual);
     }
 
-    [Fact]
+    [TestMethod]
     public void FullyPopulatedTag_RoundTrip()
     {
         Tag tag = new()
@@ -83,18 +84,18 @@ public class TagSerializationTests
 
     private static void AssertTagsEqual(Tag expected, Tag actual)
     {
-        Assert.Equal(expected.DocumentationGroup, actual.DocumentationGroup);
-        Assert.Equal(expected.DocType, actual.DocType);
+        actual.DocumentationGroup.ShouldBe(expected.DocumentationGroup);
+        actual.DocType.ShouldBe(expected.DocType);
 
         if (expected.Syndication is null)
         {
-            Assert.Null(actual.Syndication);
+            actual.Syndication.ShouldBeNull();
         }
         else
         {
-            Assert.NotNull(actual.Syndication);
-            Assert.Equal(expected.Syndication.Repo, actual.Syndication.Repo);
-            Assert.Equal(expected.Syndication.DestinationTags, actual.Syndication.DestinationTags);
+            actual.Syndication.ShouldNotBeNull();
+            actual.Syndication.Repo.ShouldBe(expected.Syndication.Repo);
+            actual.Syndication.DestinationTags.ShouldBe(expected.Syndication.DestinationTags);
         }
     }
 }

--- a/src/ImageBuilder.Tests/Models/TagSyndicationSerializationTests.cs
+++ b/src/ImageBuilder.Tests/Models/TagSyndicationSerializationTests.cs
@@ -4,7 +4,7 @@
 
 
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
-using Xunit;
+using Shouldly;
 using static Microsoft.DotNet.ImageBuilder.Tests.Models.SerializationHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests.Models;
@@ -13,9 +13,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests.Models;
 /// Serialization and deserialization tests for <see cref="TagSyndication"/> model.
 /// These tests ensure that serialization behavior does not change unexpectedly.
 /// </summary>
+[TestClass]
 public class TagSyndicationSerializationTests
 {
-    [Fact]
+    [TestMethod]
     public void DefaultTagSyndication_Bidirectional()
     {
         TagSyndication syndication = new();
@@ -26,13 +27,13 @@ public class TagSyndicationSerializationTests
         AssertBidirectional(syndication, json, AssertTagSyndicationsEqual);
     }
 
-    [Fact]
+    [TestMethod]
     public void DefaultTagSyndication_RoundTrip()
     {
         AssertRoundTrip(new TagSyndication(), AssertTagSyndicationsEqual);
     }
 
-    [Fact]
+    [TestMethod]
     public void FullyPopulatedTagSyndication_Bidirectional()
     {
         TagSyndication syndication = new()
@@ -55,7 +56,7 @@ public class TagSyndicationSerializationTests
         AssertBidirectional(syndication, json, AssertTagSyndicationsEqual);
     }
 
-    [Fact]
+    [TestMethod]
     public void FullyPopulatedTagSyndication_RoundTrip()
     {
         TagSyndication syndication = new()
@@ -67,7 +68,7 @@ public class TagSyndicationSerializationTests
         AssertRoundTrip(syndication, AssertTagSyndicationsEqual);
     }
 
-    [Fact]
+    [TestMethod]
     public void TagSyndicationWithRepoOnly_Bidirectional()
     {
         TagSyndication syndication = new()
@@ -85,7 +86,7 @@ public class TagSyndicationSerializationTests
         AssertBidirectional(syndication, json, AssertTagSyndicationsEqual);
     }
 
-    [Fact]
+    [TestMethod]
     public void TagSyndicationWithDestinationTagsOnly_Bidirectional()
     {
         TagSyndication syndication = new()
@@ -108,7 +109,7 @@ public class TagSyndicationSerializationTests
 
     private static void AssertTagSyndicationsEqual(TagSyndication expected, TagSyndication actual)
     {
-        Assert.Equal(expected.Repo, actual.Repo);
-        Assert.Equal(expected.DestinationTags, actual.DestinationTags);
+        actual.Repo.ShouldBe(expected.Repo);
+        actual.DestinationTags.ShouldBe(expected.DestinationTags);
     }
 }

--- a/src/ImageBuilder.Tests/Oras/OrasCredentialProviderAdapterTests.cs
+++ b/src/ImageBuilder.Tests/Oras/OrasCredentialProviderAdapterTests.cs
@@ -8,13 +8,13 @@ using Microsoft.DotNet.ImageBuilder.Oras;
 using Moq;
 using OrasProject.Oras.Registry.Remote.Auth;
 using Shouldly;
-using Xunit;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests.Oras;
 
+[TestClass]
 public class OrasCredentialProviderAdapterTests
 {
-    [Fact]
+    [TestMethod]
     public async Task ResolveCredentialAsync_ReturnsCredentials_WhenProviderReturnsCredentials()
     {
         var mockProvider = new Mock<IRegistryCredentialsProvider>();
@@ -32,7 +32,7 @@ public class OrasCredentialProviderAdapterTests
         result.AccessToken.ShouldBe(string.Empty);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ResolveCredentialAsync_ReturnsDefault_WhenProviderReturnsNull()
     {
         var mockProvider = new Mock<IRegistryCredentialsProvider>();
@@ -47,7 +47,7 @@ public class OrasCredentialProviderAdapterTests
         result.ShouldBe(default(Credential));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ResolveCredentialAsync_PassesCredentialsHost_WhenProvided()
     {
         var mockProvider = new Mock<IRegistryCredentialsProvider>();
@@ -64,9 +64,9 @@ public class OrasCredentialProviderAdapterTests
         mockProvider.Verify(p => p.GetCredentialsAsync("registry.io", mockHost.Object), Times.Once);
     }
 
-    [Theory]
-    [InlineData("registry-1.docker.io")]
-    [InlineData("REGISTRY-1.DOCKER.IO")]
+    [TestMethod]
+    [DataRow("registry-1.docker.io")]
+    [DataRow("REGISTRY-1.DOCKER.IO")]
     public async Task ResolveCredentialAsync_NormalizesDockerHubApiHostToDockerIo(string apiHost)
     {
         var mockProvider = new Mock<IRegistryCredentialsProvider>();

--- a/src/ImageBuilder.Tests/Oras/OrasDotNetServiceTests.cs
+++ b/src/ImageBuilder.Tests/Oras/OrasDotNetServiceTests.cs
@@ -14,16 +14,16 @@ using Moq;
 using Microsoft.Extensions.Logging;
 using OrasProject.Oras.Oci;
 using Shouldly;
-using Xunit;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests.Oras;
 
+[TestClass]
 public class OrasDotNetServiceTests
 {
-    [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData("   ")]
+    [TestMethod]
+    [DataRow(null)]
+    [DataRow("")]
+    [DataRow("   ")]
     public async Task GetReferrersAsync_NullOrWhitespaceReference_ThrowsArgumentException(string? reference)
     {
         var service = CreateService();
@@ -34,7 +34,7 @@ public class OrasDotNetServiceTests
         exception.ShouldNotBeNull();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task PushSignatureAsync_ReadsPayloadFile()
     {
         var fileSystem = new InMemoryFileSystem();
@@ -53,7 +53,7 @@ public class OrasDotNetServiceTests
         exception.ShouldNotBeNull();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task PushSignatureAsync_ThrowsForNullResult()
     {
         var service = CreateService();
@@ -66,10 +66,10 @@ public class OrasDotNetServiceTests
         exception.ParamName.ShouldBe("result");
     }
 
-    [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData("   ")]
+    [TestMethod]
+    [DataRow(null)]
+    [DataRow("")]
+    [DataRow("   ")]
     public async Task GetDescriptorAsync_NullOrWhitespaceReference_ThrowsArgumentException(string? reference)
     {
         var service = CreateService();
@@ -80,7 +80,7 @@ public class OrasDotNetServiceTests
         exception.ShouldNotBeNull();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task PushSignatureAsync_NullSubjectDescriptor_ThrowsArgumentNullException()
     {
         var service = CreateService();

--- a/src/ImageBuilder.Tests/PlatformDataTests.cs
+++ b/src/ImageBuilder.Tests/PlatformDataTests.cs
@@ -8,16 +8,17 @@ using Microsoft.DotNet.ImageBuilder.Models.Image;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
 using Moq;
-using Xunit;
+using Shouldly;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
+    [TestClass]
     public class PlatformDataTests
     {
-        [Theory]
-        [InlineData("5.0.0-preview.3", "5.0")]
-        [InlineData("5.0", "5.0")]
-        [InlineData("5.0.1", "5.0")]
+        [TestMethod]
+        [DataRow("5.0.0-preview.3", "5.0")]
+        [DataRow("5.0", "5.0")]
+        [DataRow("5.0.1", "5.0")]
         public void GetIdentifier(string productVersion, string expectedVersion)
         {
             PlatformData platform = new PlatformData
@@ -30,7 +31,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             };
 
             string identifier = platform.GetIdentifier();
-            Assert.Equal($"path-amd64-linux-noble-{expectedVersion}", identifier);
+            identifier.ShouldBe($"path-amd64-linux-noble-{expectedVersion}");
         }
 
         private static ImageInfo CreateImage(string productVersion) =>

--- a/src/ImageBuilder.Tests/PlatformInfoTests.cs
+++ b/src/ImageBuilder.Tests/PlatformInfoTests.cs
@@ -9,48 +9,49 @@ using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
 using Moq;
-using Xunit;
+using Shouldly;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
+    [TestClass]
     public class PlatformInfoTests
     {
-        [Theory]
-        [InlineData("debian", "Debian")]
-        [InlineData("trixie", "Debian 13")]
-        [InlineData("trixie-slim", "Debian 13")]
-        [InlineData("noble", "Ubuntu 24.04")]
-        [InlineData("noble-chiseled", "Ubuntu 24.04")]
-        [InlineData("resolute", "Ubuntu 26.04")]
-        [InlineData("resolute-chiseled", "Ubuntu 26.04")]
-        [InlineData("alpine3.12", "Alpine 3.12")]
-        [InlineData("centos8", "Centos 8")]
-        [InlineData("fedora32", "Fedora 32")]
-        [InlineData("cbl-mariner2.0", "CBL-Mariner 2.0")]
-        [InlineData("azurelinux3.0", "Azure Linux 3.0")]
-        [InlineData("azurelinux3.0-distroless", "Azure Linux 3.0")]
+        [TestMethod]
+        [DataRow("debian", "Debian")]
+        [DataRow("trixie", "Debian 13")]
+        [DataRow("trixie-slim", "Debian 13")]
+        [DataRow("noble", "Ubuntu 24.04")]
+        [DataRow("noble-chiseled", "Ubuntu 24.04")]
+        [DataRow("resolute", "Ubuntu 26.04")]
+        [DataRow("resolute-chiseled", "Ubuntu 26.04")]
+        [DataRow("alpine3.12", "Alpine 3.12")]
+        [DataRow("centos8", "Centos 8")]
+        [DataRow("fedora32", "Fedora 32")]
+        [DataRow("cbl-mariner2.0", "CBL-Mariner 2.0")]
+        [DataRow("azurelinux3.0", "Azure Linux 3.0")]
+        [DataRow("azurelinux3.0-distroless", "Azure Linux 3.0")]
         public void GetOSDisplayName_Linux(string osVersion, string expectedDisplayName)
         {
             ValidateGetOSDisplayName(OS.Linux, osVersion, expectedDisplayName);
         }
 
-        [Theory]
-        [InlineData("windowsservercore-ltsc2016", "Windows Server Core 2016")]
-        [InlineData("windowsservercore-ltsc2019", "Windows Server Core 2019")]
-        [InlineData("nanoserver-1809", "Nano Server, version 1809")]
-        [InlineData("windowsservercore-1903", "Windows Server Core, version 1903")]
-        [InlineData("nanoserver-1903", "Nano Server, version 1903")]
-        [InlineData("nanoserver-ltsc2022", "Nano Server 2022")]
+        [TestMethod]
+        [DataRow("windowsservercore-ltsc2016", "Windows Server Core 2016")]
+        [DataRow("windowsservercore-ltsc2019", "Windows Server Core 2019")]
+        [DataRow("nanoserver-1809", "Nano Server, version 1809")]
+        [DataRow("windowsservercore-1903", "Windows Server Core, version 1903")]
+        [DataRow("nanoserver-1903", "Nano Server, version 1903")]
+        [DataRow("nanoserver-ltsc2022", "Nano Server 2022")]
         public void GetOSDisplayName_Windows(string osVersion, string expectedDisplayName)
         {
             ValidateGetOSDisplayName(OS.Windows, osVersion, expectedDisplayName);
         }
 
-        [Theory]
-        [InlineData("VALID", "ubuntu:latest", "$VALID", "ubuntu:latest")]
-        [InlineData("VALID_123", "alpine:latest", "$VALID_123", "alpine:latest")]
-        [InlineData("VALID_123", "alpine:latest", "$VALID_123-other", "alpine:latest-other")]
+        [TestMethod]
+        [DataRow("VALID", "ubuntu:latest", "$VALID", "ubuntu:latest")]
+        [DataRow("VALID_123", "alpine:latest", "$VALID_123", "alpine:latest")]
+        [DataRow("VALID_123", "alpine:latest", "$VALID_123-other", "alpine:latest-other")]
         public void Initialize_ArgPattern(
             string buildArgKey, string buildArgValue, string fromTag, string expectedFromImage)
         {
@@ -72,7 +73,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 platform, "", "test", variableHelper, tempFolderContext.Path);
             platformInfo.Initialize([], "test.azurecr.io");
             
-            Assert.Contains(expectedFromImage, platformInfo.ExternalFromImages);
+            platformInfo.ExternalFromImages.ShouldContain(expectedFromImage);
         }
 
         private void ValidateGetOSDisplayName(OS os, string osVersion, string expectedDisplayName)
@@ -81,7 +82,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             VariableHelper variableHelper = new VariableHelper(new Manifest(), Mock.Of<IManifestOptionsInfo>(), null);
             PlatformInfo platformInfo = PlatformInfo.Create(platform, "", "runtime", variableHelper, "./");
 
-            Assert.Equal(expectedDisplayName, platformInfo.GetOSDisplayName());
+            platformInfo.GetOSDisplayName().ShouldBe(expectedDisplayName);
         }
     }
 }

--- a/src/ImageBuilder.Tests/PublishConfigurationBindingTests.cs
+++ b/src/ImageBuilder.Tests/PublishConfigurationBindingTests.cs
@@ -13,7 +13,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Shouldly;
-using Xunit;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests;
 
@@ -21,6 +20,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests;
 /// Tests that <see cref="PublishConfiguration"/> binds correctly from JSON
 /// via <see cref="Microsoft.Extensions.Configuration"/>.
 /// </summary>
+[TestClass]
 public class PublishConfigurationBindingTests
 {
     private const string FullConfigJson = """
@@ -66,7 +66,7 @@ public class PublishConfigurationBindingTests
         }
         """;
 
-    [Fact]
+    [TestMethod]
     public void AddPublishConfiguration_BindsAllRegistryEndpoints()
     {
         PublishConfiguration config = BuildConfiguration(FullConfigJson);
@@ -84,7 +84,7 @@ public class PublishConfigurationBindingTests
         config.PublicMirrorRegistry.Server.ShouldBe("public-mirror.azurecr.io");
     }
 
-    [Fact]
+    [TestMethod]
     public void AddPublishConfiguration_BindsRegistryAuthenticationList()
     {
         PublishConfiguration config = BuildConfiguration(FullConfigJson);
@@ -94,7 +94,7 @@ public class PublishConfigurationBindingTests
         config.RegistryAuthentication.ShouldContain(a => a.Server == "publish.azurecr.io");
     }
 
-    [Fact]
+    [TestMethod]
     public void AddPublishConfiguration_BindsNestedServiceConnection()
     {
         PublishConfiguration config = BuildConfiguration(FullConfigJson);
@@ -111,7 +111,7 @@ public class PublishConfigurationBindingTests
         buildAuth.Subscription.ShouldBe("sub-build");
     }
 
-    [Fact]
+    [TestMethod]
     public void AddPublishConfiguration_GetKnownRegistries_ReturnsAllEndpoints()
     {
         PublishConfiguration config = BuildConfiguration(FullConfigJson);
@@ -124,7 +124,7 @@ public class PublishConfigurationBindingTests
         knownRegistries.ShouldContain(r => r.Server == "public-mirror.azurecr.io");
     }
 
-    [Fact]
+    [TestMethod]
     public void FindRegistryAuthentication_ExactMatch_ReturnsAuth()
     {
         PublishConfiguration config = BuildConfiguration(FullConfigJson);
@@ -135,7 +135,7 @@ public class PublishConfigurationBindingTests
         auth.ServiceConnection?.TenantId.ShouldBe("tenant-build");
     }
 
-    [Fact]
+    [TestMethod]
     public void FindRegistryAuthentication_NormalizedAcrName_ReturnsAuth()
     {
         PublishConfiguration config = BuildConfiguration(FullConfigJson);
@@ -146,7 +146,7 @@ public class PublishConfigurationBindingTests
         auth.ServiceConnection?.TenantId.ShouldBe("tenant-build");
     }
 
-    [Fact]
+    [TestMethod]
     public void FindRegistryAuthentication_NotFound_ReturnsNull()
     {
         PublishConfiguration config = BuildConfiguration(FullConfigJson);
@@ -156,7 +156,7 @@ public class PublishConfigurationBindingTests
         auth.ShouldBeNull();
     }
 
-    [Fact]
+    [TestMethod]
     public void AddPublishConfiguration_PartialConfig_HandlesNulls()
     {
         const string partialJson = """
@@ -179,7 +179,7 @@ public class PublishConfigurationBindingTests
         config.RegistryAuthentication.ShouldBeEmpty();
     }
 
-    [Fact]
+    [TestMethod]
     public void AddPublishConfiguration_EmptyConfig_DefaultsToEmpty()
     {
         const string emptyJson = """
@@ -197,7 +197,7 @@ public class PublishConfigurationBindingTests
         config.RegistryAuthentication.ShouldBeEmpty();
     }
 
-    [Fact]
+    [TestMethod]
     public void AddPublishConfiguration_SharedAuthentication_MultipleRegistriesCanUseSameAuth()
     {
         const string sharedAuthJson = """

--- a/src/ImageBuilder.Tests/PublishImageInfoCommandTests.cs
+++ b/src/ImageBuilder.Tests/PublishImageInfoCommandTests.cs
@@ -17,11 +17,12 @@ using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.Services.Common;
 using Moq;
 using Newtonsoft.Json;
-using Xunit;
+using Shouldly;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
+    [TestClass]
     public class PublishImageInfoCommandTests : IDisposable
     {
         private readonly List<string> foldersToDelete = new List<string>();
@@ -36,7 +37,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Verifies the command will publish the specified image info to the repo.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task PublishImageInfoCommand_HappyPath()
         {
             using (TempFolderContext tempFolderContext = TestHelper.UseTempFolder())
@@ -161,7 +162,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 command.LoadManifest();
                 await command.ExecuteAsync();
 
-                Assert.Equal(JsonHelper.SerializeObject(srcImageArtifactDetails), actualImageArtifactDetailsContents.Trim());
+                actualImageArtifactDetailsContents.Trim().ShouldBe(JsonHelper.SerializeObject(srcImageArtifactDetails));
 
                 VerifyMocks(repositoryMock);
             }

--- a/src/ImageBuilder.Tests/PublishMcrDocsCommandTests.cs
+++ b/src/ImageBuilder.Tests/PublishMcrDocsCommandTests.cs
@@ -12,12 +12,13 @@ using Microsoft.DotNet.VersionTools.Automation;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Newtonsoft.Json;
-using Xunit;
+using Shouldly;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.DockerfileHelper;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
+    [TestClass]
     public class PublishMcrDocsCommandTests
     {
         private const string ProductFamilyReadmePath = "ProductFamilyReadme.md";
@@ -32,7 +33,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 @"About {{if IS_PRODUCT_FAMILY:Product Family^else:{{SHORT_REPO}}}}
 {{if !IS_PRODUCT_FAMILY:{{InsertTemplate(join(filter([""About"", SHORT_REPO, ""Template"", ""md""], len), "".""))}}}}";
 
-        [Fact]
+        [TestMethod]
         public async Task ExcludeProductFamilyReadme()
         {
             Mock<IGitHubClient> gitHubClientMock = CreateGitHubClientMock();
@@ -79,7 +80,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             Path.GetFileName(objs[1].Path) == TagsYamlPath)));
         }
 
-        [Fact]
+        [TestMethod]
         public async Task RootPathOption()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -149,7 +150,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             gitHubClientMock.VerifyNoOtherCalls();
         }
 
-        [Fact]
+        [TestMethod]
         public async Task DuplicateFilename()
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
@@ -194,7 +195,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             command.Options.ExcludeProductFamilyReadme = true;
             command.LoadManifest();
 
-            await Assert.ThrowsAsync<ValidationException>(() => command.ExecuteAsync());
+            await Should.ThrowAsync<ValidationException>(() => command.ExecuteAsync());
         }
 
         private static string CreateMcrTagsMetadataTemplateFile(TempFolderContext tempFolderContext)

--- a/src/ImageBuilder.Tests/QueueBuildCommandTests.cs
+++ b/src/ImageBuilder.Tests/QueueBuildCommandTests.cs
@@ -21,16 +21,16 @@ using Moq;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json;
 using WebApi = Microsoft.TeamFoundation.Build.WebApi;
-using Xunit;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
+    [TestClass]
     public class QueueBuildCommandTests
     {
         /// <summary>
         /// Verifies that no build is queued if a build is currently in progress.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task QueueBuildCommand_BuildInProgress()
         {
             const string path1 = "path1";
@@ -74,7 +74,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Verifies that no build is queued if there are too many recent failed builds.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task QueueBuildCommand_RecentFailedBuilds_MaxFailed()
         {
             const string path1 = "path1";
@@ -119,7 +119,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Verifies that a build is queued even if there are recent failed builds but not enough to meet the threshold.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task QueueBuildCommand_RecentFailedBuilds_PartialFailed()
         {
             const string path1 = "path1";
@@ -176,7 +176,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Verifies that a build is queued when the set of recent builds consist of some recently succeeded builds.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task QueueBuildCommand_RecentFailedBuilds_SucceededAndFailed()
         {
             const string path1 = "path1";
@@ -239,7 +239,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// Verifies the correct path arguments are passed to the queued builds for two
         /// subscriptions that have image paths.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task QueueBuildCommand_MultiSubscription()
         {
             const string path1 = "path1";
@@ -317,7 +317,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Verifies that no build will be queued if no paths are specified.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task QueueBuildCommand_NoBaseImageChange()
         {
             Subscription[] subscriptions = new Subscription[]
@@ -357,7 +357,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// Verifies the correct path arguments are passed to the queued build a subscription is spread
         /// across multiple path sets.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task QueueBuildCommand_Subscription_MultiSet()
         {
             const string path1 = "path1";

--- a/src/ImageBuilder.Tests/QueueBuildCommandTests.cs
+++ b/src/ImageBuilder.Tests/QueueBuildCommandTests.cs
@@ -60,14 +60,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 CreateBuild("http://contoso")
             };
 
-            using (TestContext context = new(subscriptions, allSubscriptionImagePaths, inProgressBuilds, new PagedList<WebApi.Build>()))
+            using (TestFixture fixture = new(subscriptions, allSubscriptionImagePaths, inProgressBuilds, new PagedList<WebApi.Build>()))
             {
-                await context.ExecuteCommandAsync();
+                await fixture.ExecuteCommandAsync();
 
                 // Normally this state would cause a build to be queued but since
                 // a build is marked as in progress, it doesn't.
 
-                context.Verify(notificationPostCallCount: 1, isQueuedBuildExpected: false);
+                fixture.Verify(notificationPostCallCount: 1, isQueuedBuildExpected: false);
             }
         }
 
@@ -110,10 +110,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 allBuilds.Add(failedBuild);
             }
 
-            using TestContext context = new(subscriptions, allSubscriptionImagePaths, new PagedList<WebApi.Build>(), allBuilds);
-            await context.ExecuteCommandAsync();
+            using TestFixture fixture = new(subscriptions, allSubscriptionImagePaths, new PagedList<WebApi.Build>(), allBuilds);
+            await fixture.ExecuteCommandAsync();
 
-            context.Verify(notificationPostCallCount: 1, isQueuedBuildExpected: false);
+            fixture.Verify(notificationPostCallCount: 1, isQueuedBuildExpected: false);
         }
 
         /// <summary>
@@ -155,8 +155,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 allBuilds.Add(failedBuild);
             }
 
-            using TestContext context = new(subscriptions, allSubscriptionImagePaths, new PagedList<WebApi.Build>(), allBuilds);
-            await context.ExecuteCommandAsync();
+            using TestFixture fixture = new(subscriptions, allSubscriptionImagePaths, new PagedList<WebApi.Build>(), allBuilds);
+            await fixture.ExecuteCommandAsync();
 
 
             Dictionary<Subscription, IList<string>> expectedPathsBySubscription = new()
@@ -170,7 +170,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            context.Verify(notificationPostCallCount: 1, isQueuedBuildExpected: true, expectedPathsBySubscription);
+            fixture.Verify(notificationPostCallCount: 1, isQueuedBuildExpected: true, expectedPathsBySubscription);
         }
 
         /// <summary>
@@ -218,8 +218,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 allBuilds.Add(failedBuild);
             }
 
-            using TestContext context = new(subscriptions, allSubscriptionImagePaths, new PagedList<WebApi.Build>(), allBuilds);
-            await context.ExecuteCommandAsync();
+            using TestFixture fixture = new(subscriptions, allSubscriptionImagePaths, new PagedList<WebApi.Build>(), allBuilds);
+            await fixture.ExecuteCommandAsync();
 
             Dictionary<Subscription, IList<string>> expectedPathsBySubscription = new()
             {
@@ -232,7 +232,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            context.Verify(notificationPostCallCount: 1, isQueuedBuildExpected: true, expectedPathsBySubscription);
+            fixture.Verify(notificationPostCallCount: 1, isQueuedBuildExpected: true, expectedPathsBySubscription);
         }
 
         /// <summary>
@@ -286,9 +286,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            using (TestContext context = new TestContext(subscriptions, allSubscriptionImagePaths))
+            using (TestFixture fixture = new TestFixture(subscriptions, allSubscriptionImagePaths))
             {
-                await context.ExecuteCommandAsync();
+                await fixture.ExecuteCommandAsync();
 
                 Dictionary<Subscription, IList<string>> expectedPathsBySubscription =
                     new Dictionary<Subscription, IList<string>>
@@ -310,7 +310,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     }
                 };
 
-                context.Verify(notificationPostCallCount: 2, isQueuedBuildExpected: true, expectedPathsBySubscription);
+                fixture.Verify(notificationPostCallCount: 2, isQueuedBuildExpected: true, expectedPathsBySubscription);
             }
         }
 
@@ -345,11 +345,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            using (TestContext context = new TestContext(subscriptions, allSubscriptionImagePaths))
+            using (TestFixture fixture = new TestFixture(subscriptions, allSubscriptionImagePaths))
             {
-                await context.ExecuteCommandAsync();
+                await fixture.ExecuteCommandAsync();
 
-                context.Verify(notificationPostCallCount: 0, isQueuedBuildExpected: false);
+                fixture.Verify(notificationPostCallCount: 0, isQueuedBuildExpected: false);
             }
         }
 
@@ -396,9 +396,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            using (TestContext context = new TestContext(subscriptions, allSubscriptionImagePaths))
+            using (TestFixture fixture = new TestFixture(subscriptions, allSubscriptionImagePaths))
             {
-                await context.ExecuteCommandAsync();
+                await fixture.ExecuteCommandAsync();
 
                 Dictionary<Subscription, IList<string>> expectedPathsBySubscription =
                     new Dictionary<Subscription, IList<string>>
@@ -414,7 +414,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     }
                 };
 
-                context.Verify(notificationPostCallCount: 1, isQueuedBuildExpected: true, expectedPathsBySubscription);
+                fixture.Verify(notificationPostCallCount: 1, isQueuedBuildExpected: true, expectedPathsBySubscription);
             }
         }
 
@@ -468,7 +468,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Sets up the test state from the provided metadata, executes the test, and verifies the results.
         /// </summary>
-        private class TestContext : IDisposable
+        private class TestFixture : IDisposable
         {
             private readonly PagedList<WebApi.Build> inProgressBuilds;
             private readonly PagedList<WebApi.Build> allBuilds;
@@ -488,11 +488,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             private static readonly GitHubAuthOptions s_gitHubAuthOptions = new(AuthToken: GitAccessToken);
 
             /// <summary>
-            /// Initializes a new instance of <see cref="TestContext"/>.
+            /// Initializes a new instance of <see cref="TestFixture"/>.
             /// </summary>
             /// <param name="subscriptions">The set of subscription metadata describing the Git repos that are listening for changes to base images.</param>
             /// <param name="allSubscriptionImagePaths">Multiple sets of mappings between subscriptions and their associated image paths.</param>
-            public TestContext(
+            public TestFixture(
                 Subscription[] subscriptions,
                 IEnumerable<IEnumerable<SubscriptionImagePaths>> allSubscriptionImagePaths)
                 : this(subscriptions, allSubscriptionImagePaths, new PagedList<WebApi.Build>(), new PagedList<WebApi.Build>())
@@ -500,13 +500,13 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             }
 
             /// <summary>
-            /// Initializes a new instance of <see cref="TestContext"/>.
+            /// Initializes a new instance of <see cref="TestFixture"/>.
             /// </summary>
             /// <param name="subscriptions">The set of subscription metadata describing the Git repos that are listening for changes to base images.</param>
             /// <param name="allSubscriptionImagePaths">Multiple sets of mappings between subscriptions and their associated image paths.</param>
             /// <param name="inProgressBuilds">The set of in-progress builds that should be configured.</param>
             /// <param name="allBuilds">The set of failed builds that should be configured.</param>
-            public TestContext(
+            public TestFixture(
                 Subscription[] subscriptions,
                 IEnumerable<IEnumerable<SubscriptionImagePaths>> allSubscriptionImagePaths,
                 PagedList<WebApi.Build> inProgressBuilds,

--- a/src/ImageBuilder.Tests/ShowManifestSchemaCommandTests.cs
+++ b/src/ImageBuilder.Tests/ShowManifestSchemaCommandTests.cs
@@ -10,16 +10,16 @@ using Moq;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json;
 using Shouldly;
-using Xunit;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
+    [TestClass]
     public class ShowManifestSchemaCommandTests
     {
         /// <summary>
         /// Simple verification that the output of the command can be deserialized as JSON.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task ShowManifestSchemaCommand_Execute()
         {
             Mock<ILogger<ShowManifestSchemaCommand>> loggerServiceMock = new Mock<ILogger<ShowManifestSchemaCommand>>();

--- a/src/ImageBuilder.Tests/Signing/CertificateChainCalculatorTests.cs
+++ b/src/ImageBuilder.Tests/Signing/CertificateChainCalculatorTests.cs
@@ -8,13 +8,13 @@ using System.Text.Json;
 using Microsoft.DotNet.ImageBuilder.Signing;
 using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
 using Shouldly;
-using Xunit;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests.Signing;
 
+[TestClass]
 public class CertificateChainCalculatorTests
 {
-    [Fact]
+    [TestMethod]
     public void CalculateCertificateChainThumbprints_IntegerKeysOnly_ReturnsThumbprints()
     {
         byte[] cert1 = [0x30, 0x82, 0x01, 0x00];
@@ -31,7 +31,7 @@ public class CertificateChainCalculatorTests
         thumbprints[1].ShouldBe(ComputeSha256Hex(cert2));
     }
 
-    [Fact]
+    [TestMethod]
     public void CalculateCertificateChainThumbprints_MixedIntegerAndTextKeys_ReturnsThumbprints()
     {
         byte[] cert = [0x30, 0x82, 0x03, 0x00];
@@ -46,7 +46,7 @@ public class CertificateChainCalculatorTests
         thumbprints[0].ShouldBe(ComputeSha256Hex(cert));
     }
 
-    [Fact]
+    [TestMethod]
     public void CalculateCertificateChainThumbprints_SingleCert_ReturnsThumbprint()
     {
         byte[] cert = [0x30, 0x82, 0x04, 0x00];
@@ -61,7 +61,7 @@ public class CertificateChainCalculatorTests
         thumbprints[0].ShouldBe(ComputeSha256Hex(cert));
     }
 
-    [Fact]
+    [TestMethod]
     public void CalculateCertificateChainThumbprints_MissingX5Chain_ThrowsException()
     {
         var (fileSystem, filePath) = WriteCoseSign1WithoutX5Chain();

--- a/src/ImageBuilder.Tests/Signing/EsrpSigningServiceTests.cs
+++ b/src/ImageBuilder.Tests/Signing/EsrpSigningServiceTests.cs
@@ -12,16 +12,16 @@ using Microsoft.Extensions.Options;
 using Moq;
 using Microsoft.Extensions.Logging;
 using Shouldly;
-using Xunit;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests.Signing;
 
+[TestClass]
 public class EsrpSigningServiceTests
 {
     private const string MBSignAppFolderEnv = "MBSIGN_APPFOLDER";
     private const string VsEngEsrpSslEnv = "VSENGESRPSSL";
 
-    [Fact]
+    [TestMethod]
     public async Task SignFilesAsync_EmptyFileList_ReturnsWithoutSigning()
     {
         var mockProcess = new Mock<IProcessService>();
@@ -34,7 +34,7 @@ public class EsrpSigningServiceTests
             Times.Never);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SignFilesAsync_MissingMbSignAppFolder_ThrowsInvalidOperation()
     {
         var mockEnv = new Mock<IEnvironmentService>();
@@ -48,7 +48,7 @@ public class EsrpSigningServiceTests
         ex.Message.ShouldContain(MBSignAppFolderEnv);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SignFilesAsync_InvokesProcessWithCorrectArgs()
     {
         var mockProcess = new Mock<IProcessService>();
@@ -71,7 +71,7 @@ public class EsrpSigningServiceTests
             Times.Once);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SignFilesAsync_CleansUpTempFileAfterSigning()
     {
         var mockEnv = CreateEnvironmentWithRequiredVars();
@@ -87,7 +87,7 @@ public class EsrpSigningServiceTests
         fileSystem.FilesDeleted.First().ShouldBe(fileSystem.FilesWritten.First());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SignFilesAsync_CleansUpTempFileOnFailure()
     {
         var mockEnv = CreateEnvironmentWithRequiredVars();
@@ -106,7 +106,7 @@ public class EsrpSigningServiceTests
         fileSystem.FilesDeleted.Count.ShouldBe(1);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SignFilesAsync_WritesSignListJson()
     {
         var mockEnv = CreateEnvironmentWithRequiredVars();

--- a/src/ImageBuilder.Tests/Signing/ImageSigningServiceTests.cs
+++ b/src/ImageBuilder.Tests/Signing/ImageSigningServiceTests.cs
@@ -18,15 +18,15 @@ using Moq;
 using Microsoft.Extensions.Logging;
 using OrasDescriptor = OrasProject.Oras.Oci.Descriptor;
 using Shouldly;
-using Xunit;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests.Signing;
 
+[TestClass]
 public class ImageSigningServiceTests
 {
     private const string ArtifactStagingDir = "/artifacts/staging";
 
-    [Fact]
+    [TestMethod]
     public async Task SignImagesAsync_EmptyInput_ReturnsEmpty()
     {
         var service = CreateService();
@@ -38,7 +38,7 @@ public class ImageSigningServiceTests
         results.ShouldBeEmpty();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SignImagesAsync_SkipsImagesWithoutManifestOrDigest()
     {
         var mockOras = new Mock<IOrasService>();
@@ -71,7 +71,7 @@ public class ImageSigningServiceTests
             Times.Never);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SignImagesAsync_SkipsPlatformsWithoutDigest()
     {
         var mockOras = CreateMockOrasService();
@@ -108,7 +108,7 @@ public class ImageSigningServiceTests
         results.Count.ShouldBe(1);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SignImagesAsync_OrchestratesFullPipeline()
     {
         var mockOras = CreateMockOrasService();
@@ -160,7 +160,7 @@ public class ImageSigningServiceTests
         results[0].SignatureDigest.ShouldBe("sha256:sigdigest");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SignImagesAsync_ResolvesPlatformAndManifestListDigests()
     {
         var mockOras = CreateMockOrasService();
@@ -204,7 +204,7 @@ public class ImageSigningServiceTests
             ignoreOrder: true);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SignImagesAsync_WritesCorrectPayloadToDisk()
     {
         var mockOras = new Mock<IOrasService>();
@@ -254,7 +254,7 @@ public class ImageSigningServiceTests
             path => path.Contains("sha256-manifest123") && path.EndsWith(".payload"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SignImagesAsync_MissingArtifactStagingDir_ThrowsInvalidOperation()
     {
         var mockOras = CreateMockOrasService();
@@ -360,7 +360,7 @@ public class ImageSigningServiceTests
         return writer.Encode();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SignImagesAsync_SkipsAlreadySignedDigests()
     {
         var mockOras = CreateMockOrasService();
@@ -419,7 +419,7 @@ public class ImageSigningServiceTests
             Times.Never);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SignImagesAsync_OnlySignsUnsignedDigests()
     {
         var mockOras = CreateMockOrasService();
@@ -478,7 +478,7 @@ public class ImageSigningServiceTests
             Times.Never);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SignImagesAsync_IgnoresNonSignatureReferrers()
     {
         var mockOras = CreateMockOrasService();

--- a/src/ImageBuilder.Tests/Signing/SignImagesCommandTests.cs
+++ b/src/ImageBuilder.Tests/Signing/SignImagesCommandTests.cs
@@ -14,15 +14,15 @@ using Microsoft.Extensions.Options;
 using Moq;
 using Microsoft.Extensions.Logging;
 using Shouldly;
-using Xunit;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests.Signing;
 
+[TestClass]
 public class SignImagesCommandTests
 {
     private const string ImageInfoPath = "/data/image-info.json";
 
-    [Fact]
+    [TestMethod]
     public async Task ExecuteAsync_SigningDisabled_SkipsSigning()
     {
         var mockSigning = new Mock<IImageSigningService>();
@@ -36,7 +36,7 @@ public class SignImagesCommandTests
             Times.Never);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ExecuteAsync_SigningConfigNull_SkipsSigning()
     {
         var mockSigning = new Mock<IImageSigningService>();
@@ -49,7 +49,7 @@ public class SignImagesCommandTests
             Times.Never);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ExecuteAsync_ImageInfoNotFound_SkipsSigning()
     {
         var mockSigning = new Mock<IImageSigningService>();
@@ -64,7 +64,7 @@ public class SignImagesCommandTests
             Times.Never);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ExecuteAsync_DryRun_SkipsSigning()
     {
         var fileSystem = new InMemoryFileSystem();
@@ -87,7 +87,7 @@ public class SignImagesCommandTests
         contents.ShouldNotBeNullOrEmpty();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ExecuteAsync_SignsWithCorrectKeyCode()
     {
         var fileSystem = new InMemoryFileSystem();

--- a/src/ImageBuilder.Tests/Signing/VerifySignaturesCommandTests.cs
+++ b/src/ImageBuilder.Tests/Signing/VerifySignaturesCommandTests.cs
@@ -113,66 +113,66 @@ public class VerifySignaturesCommandTests
     [TestMethod]
     public async Task VerifySignatures_VerifiesAllImages()
     {
-        TestContext testContext = CreateSeededCommand();
+        TestFixture testFixture = CreateSeededCommand();
 
-        await testContext.Command.ExecuteAsync();
+        await testFixture.Command.ExecuteAsync();
 
-        testContext.NotationClientMock.Verify(
+        testFixture.NotationClientMock.Verify(
             x => x.AddCertificate("ca", TrustStoreName, It.IsAny<string>()),
             Times.Once);
-        testContext.NotationClientMock.Verify(
+        testFixture.NotationClientMock.Verify(
             x => x.ImportTrustPolicy(It.IsAny<string>()),
             Times.Once);
-        testContext.NotationClientMock.Verify(
+        testFixture.NotationClientMock.Verify(
             x => x.Verify(PlatformDigestA, false),
             Times.Once);
-        testContext.NotationClientMock.Verify(
+        testFixture.NotationClientMock.Verify(
             x => x.Verify(PlatformDigestB, false),
             Times.Once);
-        testContext.NotationClientMock.Verify(
+        testFixture.NotationClientMock.Verify(
             x => x.Verify(ManifestDigest, false),
             Times.Once);
-        testContext.NotationClientMock.VerifyNoOtherCalls();
+        testFixture.NotationClientMock.VerifyNoOtherCalls();
     }
 
     [TestMethod]
     public async Task VerifySignatures_DoesNotSetExitCodeOnSuccess()
     {
-        TestContext testContext = CreateSeededCommand();
-        await testContext.Command.ExecuteAsync();
-        testContext.EnvironmentServiceMock.VerifySet(x => x.ExitCode = It.IsAny<int>(), Times.Never);
+        TestFixture testFixture = CreateSeededCommand();
+        await testFixture.Command.ExecuteAsync();
+        testFixture.EnvironmentServiceMock.VerifySet(x => x.ExitCode = It.IsAny<int>(), Times.Never);
     }
 
     [TestMethod]
     public async Task VerifySignatures_FailsWhenVerificationFails()
     {
-        TestContext testContext = CreateSeededCommand();
+        TestFixture testFixture = CreateSeededCommand();
 
-        testContext.NotationClientMock
+        testFixture.NotationClientMock
             .Setup(x => x.Verify(PlatformDigestB, false))
             .Throws(new InvalidOperationException("Verification failed"));
 
-        await testContext.Command.ExecuteAsync();
+        await testFixture.Command.ExecuteAsync();
 
-        testContext.EnvironmentServiceMock.VerifySet(x => x.ExitCode = 1, Times.Once);
-        testContext.NotationClientMock.Verify(x => x.Verify(PlatformDigestA, false), Times.Once);
-        testContext.NotationClientMock.Verify(x => x.Verify(PlatformDigestB, false), Times.Once);
-        testContext.NotationClientMock.Verify(x => x.Verify(ManifestDigest, false), Times.Once);
+        testFixture.EnvironmentServiceMock.VerifySet(x => x.ExitCode = 1, Times.Once);
+        testFixture.NotationClientMock.Verify(x => x.Verify(PlatformDigestA, false), Times.Once);
+        testFixture.NotationClientMock.Verify(x => x.Verify(PlatformDigestB, false), Times.Once);
+        testFixture.NotationClientMock.Verify(x => x.Verify(ManifestDigest, false), Times.Once);
     }
 
     [TestMethod]
     public async Task VerifySignatures_SetsExitCodeOnceForMultipleFailures()
     {
-        TestContext testContext = CreateSeededCommand();
-        testContext.NotationClientMock.Setup(x => x.Verify(PlatformDigestA, false))
+        TestFixture testFixture = CreateSeededCommand();
+        testFixture.NotationClientMock.Setup(x => x.Verify(PlatformDigestA, false))
             .Throws(new InvalidOperationException("fail 1"));
-        testContext.NotationClientMock.Setup(x => x.Verify(PlatformDigestB, false))
+        testFixture.NotationClientMock.Setup(x => x.Verify(PlatformDigestB, false))
             .Throws(new InvalidOperationException("fail 2"));
 
-        await testContext.Command.ExecuteAsync();
+        await testFixture.Command.ExecuteAsync();
 
-        testContext.EnvironmentServiceMock.VerifySet(x => x.ExitCode = 1, Times.Once);
-        testContext.NotationClientMock.Verify(x => x.Verify(ManifestDigest, false), Times.Once);
+        testFixture.EnvironmentServiceMock.VerifySet(x => x.ExitCode = 1, Times.Once);
+        testFixture.NotationClientMock.Verify(x => x.Verify(ManifestDigest, false), Times.Once);
     }
 
     [TestMethod]
@@ -185,8 +185,8 @@ public class VerifySignaturesCommandTests
             TrustStoreName = TrustStoreName
         };
 
-        TestContext testContext = CreateCommand(notationClientMock.Object, signingConfig);
-        await testContext.Command.ExecuteAsync();
+        TestFixture testFixture = CreateCommand(notationClientMock.Object, signingConfig);
+        await testFixture.Command.ExecuteAsync();
         notationClientMock.VerifyNoOtherCalls();
     }
 
@@ -194,9 +194,9 @@ public class VerifySignaturesCommandTests
     public async Task VerifySignatures_SkipsWhenSigningConfigNull()
     {
         var notationClientMock = new Mock<INotationClient>();
-        TestContext testContext = CreateCommand(notationClientMock.Object, signingConfig: null);
+        TestFixture testFixture = CreateCommand(notationClientMock.Object, signingConfig: null);
 
-        await testContext.Command.ExecuteAsync();
+        await testFixture.Command.ExecuteAsync();
 
         notationClientMock.VerifyNoOtherCalls();
     }
@@ -205,10 +205,10 @@ public class VerifySignaturesCommandTests
     public async Task VerifySignatures_SkipsWhenImageInfoMissing()
     {
         var notationClientMock = new Mock<INotationClient>();
-        TestContext testContext = CreateCommand(notationClientMock.Object, CreateDefaultSigningConfig());
-        testContext.Command.Options.ImageInfoPath = "/nonexistent/path/image-info.json";
+        TestFixture testFixture = CreateCommand(notationClientMock.Object, CreateDefaultSigningConfig());
+        testFixture.Command.Options.ImageInfoPath = "/nonexistent/path/image-info.json";
 
-        await testContext.Command.ExecuteAsync();
+        await testFixture.Command.ExecuteAsync();
 
         notationClientMock.VerifyNoOtherCalls();
     }
@@ -216,12 +216,12 @@ public class VerifySignaturesCommandTests
     [TestMethod]
     public async Task VerifySignatures_SkipsWhenDryRun()
     {
-        TestContext testContext = CreateSeededCommand();
-        testContext.Command.Options.IsDryRun = true;
+        TestFixture testFixture = CreateSeededCommand();
+        testFixture.Command.Options.IsDryRun = true;
 
-        await testContext.Command.ExecuteAsync();
+        await testFixture.Command.ExecuteAsync();
 
-        testContext.NotationClientMock.VerifyNoOtherCalls();
+        testFixture.NotationClientMock.VerifyNoOtherCalls();
     }
 
     [TestMethod]
@@ -232,10 +232,10 @@ public class VerifySignaturesCommandTests
         SeedTrustMaterials(fileSystem);
 
         var notationClientMock = new Mock<INotationClient>();
-        TestContext testContext = CreateCommand(notationClientMock.Object, CreateDefaultSigningConfig(), fileSystem);
-        testContext.Command.Options.ImageInfoPath = ImageInfoPath;
+        TestFixture testFixture = CreateCommand(notationClientMock.Object, CreateDefaultSigningConfig(), fileSystem);
+        testFixture.Command.Options.ImageInfoPath = ImageInfoPath;
 
-        await testContext.Command.ExecuteAsync();
+        await testFixture.Command.ExecuteAsync();
 
         notationClientMock.Verify(
             x => x.Verify(It.IsAny<string>(), It.IsAny<bool>()),
@@ -251,10 +251,10 @@ public class VerifySignaturesCommandTests
         SeedPolicy(fileSystem);
 
         var notationClientMock = new Mock<INotationClient>();
-        TestContext testContext = CreateCommand(notationClientMock.Object, CreateDefaultSigningConfig(), fileSystem);
-        testContext.Command.Options.ImageInfoPath = ImageInfoPath;
+        TestFixture testFixture = CreateCommand(notationClientMock.Object, CreateDefaultSigningConfig(), fileSystem);
+        testFixture.Command.Options.ImageInfoPath = ImageInfoPath;
 
-        FileNotFoundException exception = await Should.ThrowAsync<FileNotFoundException>(testContext.Command.ExecuteAsync());
+        FileNotFoundException exception = await Should.ThrowAsync<FileNotFoundException>(testFixture.Command.ExecuteAsync());
         exception.Message.ShouldContain("Root CA certificate not found");
     }
 
@@ -267,33 +267,33 @@ public class VerifySignaturesCommandTests
         SeedCert(fileSystem);
 
         var notationClientMock = new Mock<INotationClient>();
-        TestContext testContext = CreateCommand(notationClientMock.Object, CreateDefaultSigningConfig(), fileSystem);
-        testContext.Command.Options.ImageInfoPath = ImageInfoPath;
+        TestFixture testFixture = CreateCommand(notationClientMock.Object, CreateDefaultSigningConfig(), fileSystem);
+        testFixture.Command.Options.ImageInfoPath = ImageInfoPath;
 
-        FileNotFoundException exception = await Should.ThrowAsync<FileNotFoundException>(testContext.Command.ExecuteAsync());
+        FileNotFoundException exception = await Should.ThrowAsync<FileNotFoundException>(testFixture.Command.ExecuteAsync());
         exception.Message.ShouldContain("Trust policy not found");
     }
 
     /// <summary>
     /// Creates a fully seeded command with image-info and trust materials ready for verification tests.
     /// </summary>
-    private static TestContext CreateSeededCommand()
+    private static TestFixture CreateSeededCommand()
     {
         var fileSystem = new InMemoryFileSystem();
         SeedImageInfoFile(fileSystem);
         SeedTrustMaterials(fileSystem);
 
         var notationClientMock = new Mock<INotationClient>();
-        TestContext testContext = CreateCommand(notationClientMock.Object, CreateDefaultSigningConfig(), fileSystem);
-        testContext.Command.Options.ImageInfoPath = ImageInfoPath;
-        return testContext;
+        TestFixture testFixture = CreateCommand(notationClientMock.Object, CreateDefaultSigningConfig(), fileSystem);
+        testFixture.Command.Options.ImageInfoPath = ImageInfoPath;
+        return testFixture;
     }
 
     /// <summary>
     /// Creates a <see cref="VerifySignaturesCommand"/> with the specified signing configuration and file system.
     /// Pass null for <paramref name="signingConfig"/> to simulate a missing signing configuration.
     /// </summary>
-    private static TestContext CreateCommand(
+    private static TestFixture CreateCommand(
         INotationClient notationClient,
         SigningConfiguration? signingConfig,
         IFileSystem? fileSystem = null)
@@ -316,7 +316,7 @@ public class VerifySignaturesCommandTests
         );
 
         command.Options.TrustMaterialsPath = TrustBasePath;
-        return new TestContext(command, notationClientMock, environmentServiceMock, inMemoryFileSystem);
+        return new TestFixture(command, notationClientMock, environmentServiceMock, inMemoryFileSystem);
     }
 
     /// <summary>
@@ -345,7 +345,7 @@ public class VerifySignaturesCommandTests
     /// <summary>
     /// Holds the command under test and its mocked dependencies for assertion.
     /// </summary>
-    private record TestContext(
+    private record TestFixture(
         VerifySignaturesCommand Command,
         Mock<INotationClient> NotationClientMock,
         Mock<IEnvironmentService> EnvironmentServiceMock,

--- a/src/ImageBuilder.Tests/Signing/VerifySignaturesCommandTests.cs
+++ b/src/ImageBuilder.Tests/Signing/VerifySignaturesCommandTests.cs
@@ -12,10 +12,10 @@ using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
 using Microsoft.Extensions.Options;
 using Moq;
 using Shouldly;
-using Xunit;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests.Signing;
 
+[TestClass]
 public class VerifySignaturesCommandTests
 {
     private const string ImageInfoPath = "/data/image-info.json";
@@ -110,7 +110,7 @@ public class VerifySignaturesCommandTests
         }
         """;
 
-    [Fact]
+    [TestMethod]
     public async Task VerifySignatures_VerifiesAllImages()
     {
         TestContext testContext = CreateSeededCommand();
@@ -135,7 +135,7 @@ public class VerifySignaturesCommandTests
         testContext.NotationClientMock.VerifyNoOtherCalls();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task VerifySignatures_DoesNotSetExitCodeOnSuccess()
     {
         TestContext testContext = CreateSeededCommand();
@@ -143,7 +143,7 @@ public class VerifySignaturesCommandTests
         testContext.EnvironmentServiceMock.VerifySet(x => x.ExitCode = It.IsAny<int>(), Times.Never);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task VerifySignatures_FailsWhenVerificationFails()
     {
         TestContext testContext = CreateSeededCommand();
@@ -160,7 +160,7 @@ public class VerifySignaturesCommandTests
         testContext.NotationClientMock.Verify(x => x.Verify(ManifestDigest, false), Times.Once);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task VerifySignatures_SetsExitCodeOnceForMultipleFailures()
     {
         TestContext testContext = CreateSeededCommand();
@@ -175,7 +175,7 @@ public class VerifySignaturesCommandTests
         testContext.NotationClientMock.Verify(x => x.Verify(ManifestDigest, false), Times.Once);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task VerifySignatures_SkipsWhenSigningDisabled()
     {
         var notationClientMock = new Mock<INotationClient>();
@@ -190,7 +190,7 @@ public class VerifySignaturesCommandTests
         notationClientMock.VerifyNoOtherCalls();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task VerifySignatures_SkipsWhenSigningConfigNull()
     {
         var notationClientMock = new Mock<INotationClient>();
@@ -201,7 +201,7 @@ public class VerifySignaturesCommandTests
         notationClientMock.VerifyNoOtherCalls();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task VerifySignatures_SkipsWhenImageInfoMissing()
     {
         var notationClientMock = new Mock<INotationClient>();
@@ -213,7 +213,7 @@ public class VerifySignaturesCommandTests
         notationClientMock.VerifyNoOtherCalls();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task VerifySignatures_SkipsWhenDryRun()
     {
         TestContext testContext = CreateSeededCommand();
@@ -224,7 +224,7 @@ public class VerifySignaturesCommandTests
         testContext.NotationClientMock.VerifyNoOtherCalls();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task VerifySignatures_SkipsWhenNoDigests()
     {
         var fileSystem = new InMemoryFileSystem();
@@ -242,7 +242,7 @@ public class VerifySignaturesCommandTests
             Times.Never);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task VerifySignatures_ThrowsWhenCertMissing()
     {
         var fileSystem = new InMemoryFileSystem();
@@ -258,7 +258,7 @@ public class VerifySignaturesCommandTests
         exception.Message.ShouldContain("Root CA certificate not found");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task VerifySignatures_ThrowsWhenTrustPolicyMissing()
     {
         var fileSystem = new InMemoryFileSystem();

--- a/src/ImageBuilder.Tests/TestParallelization.cs
+++ b/src/ImageBuilder.Tests/TestParallelization.cs
@@ -1,0 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Match xUnit's default behavior of running test classes in parallel while
+// keeping the tests within a single class serialized. Workers = 0 lets MSTest
+// use the available processor count.
+[assembly: Parallelize(Workers = 0, Scope = ExecutionScope.ClassLevel)]

--- a/src/ImageBuilder.Tests/TrimUnchangedPlatformsCommandTests.cs
+++ b/src/ImageBuilder.Tests/TrimUnchangedPlatformsCommandTests.cs
@@ -10,19 +10,20 @@ using Microsoft.DotNet.ImageBuilder.Models.Image;
 using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
 using Microsoft.Extensions.Logging;
 using Moq;
-using Xunit;
+using Shouldly;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
+    [TestClass]
     public class TrimUnchangedPlatformsCommandTests
     {
-        [Fact]
+        [TestMethod]
         public async Task NoPlatforms()
         {
             await RunTestAsync(new ImageArtifactDetails(), new ImageArtifactDetails());
         }
 
-        [Fact]
+        [TestMethod]
         public async Task MixOfCachedPlatforms()
         {
             ImageArtifactDetails imageArtifactDetails = new ImageArtifactDetails
@@ -143,7 +144,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             await RunTestAsync(imageArtifactDetails, expectedImageArtifactDetails);
         }
 
-        [Fact]
+        [TestMethod]
         public async Task NoCachedPlatforms()
         {
             ImageArtifactDetails imageArtifactDetails = new ImageArtifactDetails
@@ -249,7 +250,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             string expectedContents = JsonHelper.SerializeObject(expectedOutput);
             string actualContents = File.ReadAllText(command.Options.ImageInfoPath);
 
-            Assert.Equal(expectedContents, actualContents);
+            actualContents.ShouldBe(expectedContents);
         }
     }
 }

--- a/src/ImageBuilder.Tests/VariableHelperTests.cs
+++ b/src/ImageBuilder.Tests/VariableHelperTests.cs
@@ -7,14 +7,15 @@ using System.Collections.Generic;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
 using Moq;
-using Xunit;
+using Shouldly;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
+    [TestClass]
     public class VariableHelperTests
     {
-        [Fact]
+        [TestMethod]
         public void NestedVariables()
         {
             Manifest manifest = CreateManifest();
@@ -36,14 +37,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             VariableHelper helper = new(manifest, manifestOptionsInfoMock.Object, id => null);
 
-            Assert.Equal(4, helper.ResolvedVariables.Count);
-            Assert.Equal("abc", helper.ResolvedVariables["test"]);
-            Assert.Equal("abc", helper.ResolvedVariables["test2"]);
-            Assert.Equal("abc", helper.ResolvedVariables["test3"]);
-            Assert.Equal("abc-123", helper.ResolvedVariables["test4"]);
+            helper.ResolvedVariables.Count.ShouldBe(4);
+            helper.ResolvedVariables["test"].ShouldBe("abc");
+            helper.ResolvedVariables["test2"].ShouldBe("abc");
+            helper.ResolvedVariables["test3"].ShouldBe("abc");
+            helper.ResolvedVariables["test4"].ShouldBe("abc-123");
         }
 
-        [Fact]
+        [TestMethod]
         public void ReferenceToUnresolvedVariable()
         {
             Manifest manifest = CreateManifest();
@@ -53,10 +54,10 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 { "test2", "abc" }
             };
 
-            Assert.Throws<NotSupportedException>(() => new VariableHelper(manifest, Mock.Of<IManifestOptionsInfo>(), id => null));
+            Should.Throw<NotSupportedException>(() => new VariableHelper(manifest, Mock.Of<IManifestOptionsInfo>(), id => null));
         }
 
-        [Fact]
+        [TestMethod]
         public void ReferenceToUndefinedVariable()
         {
             Manifest manifest = CreateManifest();
@@ -66,12 +67,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             };
 
 
-            Assert.Throws<InvalidOperationException>(() => new VariableHelper(manifest, Mock.Of<IManifestOptionsInfo>(), id => null));
+            Should.Throw<InvalidOperationException>(() => new VariableHelper(manifest, Mock.Of<IManifestOptionsInfo>(), id => null));
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
         public void ProvideNewVariableThroughOptions(bool hasManifestVariables)
         {
             Manifest manifest = CreateManifest();
@@ -103,15 +104,15 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             if (hasManifestVariables)
             {
-                Assert.Equal(3, helper.ResolvedVariables.Count);
-                Assert.Equal("123", helper.ResolvedVariables["predefinedVar"]);
-                Assert.Equal("abc", helper.ResolvedVariables["newVar"]);
-                Assert.Equal("123456", helper.ResolvedVariables["newDerivativeVar"]);
+                helper.ResolvedVariables.Count.ShouldBe(3);
+                helper.ResolvedVariables["predefinedVar"].ShouldBe("123");
+                helper.ResolvedVariables["newVar"].ShouldBe("abc");
+                helper.ResolvedVariables["newDerivativeVar"].ShouldBe("123456");
             }
             else
             {
-                Assert.Single(helper.ResolvedVariables);
-                Assert.Equal("abc", helper.ResolvedVariables["newVar"]);
+                helper.ResolvedVariables.ShouldHaveSingleItem();
+                helper.ResolvedVariables["newVar"].ShouldBe("abc");
             }
         }
     }

--- a/src/ImageBuilder.Tests/WaitForMarAnnotationIngestionCommandTests.cs
+++ b/src/ImageBuilder.Tests/WaitForMarAnnotationIngestionCommandTests.cs
@@ -10,13 +10,13 @@ using Microsoft.DotNet.ImageBuilder.Commands;
 using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
 using Microsoft.Extensions.Logging;
 using Moq;
-using Xunit;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests;
 
+[TestClass]
 public class WaitForMarAnnotationIngestionCommandTests
 {
-    [Fact]
+    [TestMethod]
     public async Task WaitForMarAnnotationIngestionCommand()
     {
         using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();

--- a/src/ImageBuilder.Tests/WaitForMcrDocIngestionCommandTests.cs
+++ b/src/ImageBuilder.Tests/WaitForMcrDocIngestionCommandTests.cs
@@ -11,14 +11,15 @@ using Microsoft.DotNet.ImageBuilder.Models.McrStatus;
 using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
 using Microsoft.Extensions.Logging;
 using Moq;
-using Xunit;
+using Shouldly;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.MarStatusHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
+    [TestClass]
     public class WaitForMcrDocIngestionCommandTests
     {
-        [Fact]
+        [TestMethod]
         public async Task SuccessfulPublish()
         {
             const string commitDigest = "commit digest";
@@ -97,7 +98,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             statusClientMock.Verify(o => o.GetCommitResultAsync(commitDigest), Times.Exactly(4));
         }
 
-        [Fact]
+        [TestMethod]
         public async Task PublishFailure()
         {
             const string commitDigest = "commit digest";
@@ -180,9 +181,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             command.Options.CommitDigest = commitDigest;
             command.Options.IngestionOptions.WaitTimeout = TimeSpan.FromMinutes(1);
 
-            Exception actualException = await Assert.ThrowsAsync<Exception>(command.ExecuteAsync);
+            Exception actualException = await Should.ThrowAsync<Exception>(command.ExecuteAsync);
 
-            Assert.Same(exitException, actualException);
+            actualException.ShouldBeSameAs(exitException);
             statusClientMock.Verify(o => o.GetCommitResultAsync(commitDigest), Times.Exactly(4));
             statusClientMock.Verify(o => o.GetCommitResultDetailedAsync(commitDigest, onboardingRequestId), Times.Once);
         }
@@ -190,7 +191,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Tests the scenario where a given digest has been queued for onboarding multiple times.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task OnboardingRequestsWithDuplicateDigest_Success()
         {
             const string commitDigest = "commit digest";
@@ -289,7 +290,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Tests the scenario where a given digest has been queued for onboarding multiple times.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task OnboardingRequestsWithDuplicateDigest_Failed()
         {
             const string commitDigest = "commit digest";
@@ -371,9 +372,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             command.Options.CommitDigest = commitDigest;
             command.Options.IngestionOptions.WaitTimeout = TimeSpan.FromMinutes(1);
 
-            Exception actualException = await Assert.ThrowsAsync<Exception>(command.ExecuteAsync);
+            Exception actualException = await Should.ThrowAsync<Exception>(command.ExecuteAsync);
 
-            Assert.Same(exitException, actualException);
+            actualException.ShouldBeSameAs(exitException);
             environmentServiceMock.Verify(o => o.Exit(It.IsAny<int>()), Times.Once);
             statusClientMock.Verify(o => o.GetCommitResultAsync(commitDigest), Times.Exactly(2));
         }
@@ -381,7 +382,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         /// <summary>
         /// Tests that the command times out if the publishing takes too long.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public async Task WaitTimeout()
         {
             const string commitDigest = "commit digest";
@@ -413,7 +414,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             command.Options.IngestionOptions.WaitTimeout = TimeSpan.FromSeconds(3);
 
             environmentServiceMock.Verify(o => o.Exit(It.IsAny<int>()), Times.Never);
-            await Assert.ThrowsAsync<TimeoutException>(command.ExecuteAsync);
+            await Should.ThrowAsync<TimeoutException>(command.ExecuteAsync);
         }
     }
 }

--- a/src/ImageBuilder.Tests/WaitForMcrImageIngestionCommandTests.cs
+++ b/src/ImageBuilder.Tests/WaitForMcrImageIngestionCommandTests.cs
@@ -15,19 +15,19 @@ using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Newtonsoft.Json;
-using Xunit;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.DockerfileHelper;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ImageInfoHelper;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests
 {
+    [TestClass]
     public class WaitForMcrImageIngestionCommandTests
     {
-        [Theory]
-        [InlineData("")]
-        [InlineData("public/")]
-        [InlineData("internal/private/")]
+        [TestMethod]
+        [DataRow("")]
+        [DataRow("public/")]
+        [DataRow("internal/private/")]
         public async Task SuccessfulPublish(string repoPrefix)
         {
             DateTime baselineTime = DateTime.Now;
@@ -160,9 +160,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     It.IsAny<DateTime>()));
         }
 
-        [Theory]
-        [InlineData("manifestDigest1")] // Same as the primary digest
-        [InlineData("manifestDigest2")] // Different from the primary digest
+        [TestMethod]
+        [DataRow("manifestDigest1")] // Same as the primary digest
+        [DataRow("manifestDigest2")] // Different from the primary digest
         public async Task SyndicatedTags(string syndicatedManifestDigest)
         {
             DateTime baselineTime = DateTime.Now;


### PR DESCRIPTION
Converts `ImageBuilder.Tests` from xUnit to MSTest.

A few notes on decisions that aren't obvious from the diff:

- The test runner is selected via the `<TestRunnerName>MSTest</TestRunnerName>` MSBuild property, which tells Arcade to bring in the MSTest packages.
- Assertions were converted to Shouldly rather than `Assert.*`, to match the existing convention in this project.
- `TestParallelization.cs` sets class-level parallelism (`Workers = 0, Scope = ExecutionScope.ClassLevel`) to match xUnit's default behavior, so tests within a class still run serially.
- xUnit's `ITestOutputHelper` is replaced with MSTest's `TestContext.WriteLine`. This keeps the per-test diagnostic output correctly attributed under parallel execution, which `Console.WriteLine` would not guarantee.

Test bodies are otherwise left as-is.
