### PR TITLE
Enable separate build OS and base image OS declarations in manifest

### DIFF
--- a/eng/docker-tools/DEV-GUIDE.md
+++ b/eng/docker-tools/DEV-GUIDE.md
@@ -198,6 +198,28 @@ The stages variable is useful for:
 - Skipping tests during initial development
 - Running isolated stages for debugging
 
+### Decoupling build OS from the base image OS
+
+By default, a platform's `osVersion` represents the base image OS version, but also determines what
+build leg an image is built in. This can cause problems when build image and base image don't match
+up. For example, building a .NET app on Windows Server 2025 and copying the artifacts into a
+Windows Server 2019 base image won't work, because the build matrix generation will attempt to
+build the image on the Server 2019 build leg (which can't run Server 2025 images).
+
+To fix this, set the optional `buildOsVersion` field in order to override only the OS used in the
+build matrix generation. Here is an example of building a Windows Server 2019 image using Windows
+Server 2025:
+
+```jsonc
+{
+  // ...
+  "os": "windows",
+  "osVersion": "windowsservercore-ltsc2019",
+  "buildOsVersion": "windowsservercore-ltsc2025"
+  // ...
+}
+```
+
 ### Image Info Files: The Build's Memory
 
 Image info files (defined by [`ImageArtifactDetails`](https://github.com/dotnet/docker-tools/blob/main/src/ImageBuilder/Models/Image/ImageArtifactDetails.cs)) are the mechanism that tracks what was built:

--- a/src/ImageBuilder.Models/Manifest/OS.cs
+++ b/src/ImageBuilder.Models/Manifest/OS.cs
@@ -4,6 +4,11 @@
 
 namespace Microsoft.DotNet.ImageBuilder.Models.Manifest;
 
+/// <summary>
+/// The generic operating system family of an image. Serialized to the manifest as a lowercase
+/// string (e.g. "linux", "windows"). The specific OS version is captured separately by
+/// <see cref="Platform.OsVersion"/> (e.g. "azurelinux3.0", "windowsservercore-ltsc2025").
+/// </summary>
 public enum OS
 {
     Linux,

--- a/src/ImageBuilder.Models/Manifest/Platform.cs
+++ b/src/ImageBuilder.Models/Manifest/Platform.cs
@@ -41,18 +41,31 @@ public class Platform
     public string? DockerfileTemplate { get; set; }
 
     [Description(
-        "The generic name of the operating system associated with the image."
+        "The generic name of the operating system associated with the image. " +
+        "Examples: linux, windows."
         )]
     [JsonConverter(typeof(StringEnumConverter))]
     [JsonProperty(Required = Required.Always)]
     public OS OS { get; set; }
 
     [Description(
-        "The specific version of the operating system associated with the image. " +
-        "Examples: alpine3.9, bionic, nanoserver-1903."
+        "The specific version of the operating system that this platform targets. This is " +
+        "metadata used to filter which platforms are built (--os-version), recorded in the " +
+        "image-info output, used to derive the OS display name in generated readmes, and " +
+        "(unless overridden by BuildOsVersion) to select the build host." +
+        "Examples: alpine3.2X, jammy, noble, trixie, nanoserver-1809, nanoserver-ltsc2025, " +
+        "windowsservercore-ltsc2025."
         )]
     [JsonProperty(Required = Required.Always)]
     public string OsVersion { get; set; } = string.Empty;
+
+    [Description(
+        "Overrides the operating system version used to select the build host/agent without " +
+        "affecting the --os-version filter or image-info. This allows platforms that target " +
+        "different OS versions to be built together on a single build host. Uses the same value " +
+        "format as OsVersion. When omitted, the build host is selected based on OsVersion."
+        )]
+    public string? BuildOsVersion { get; set; }
 
     [Description(
         "The set of platform-specific tags associated with the image."

--- a/src/ImageBuilder.Tests/GenerateBuildMatrixCommandTests.cs
+++ b/src/ImageBuilder.Tests/GenerateBuildMatrixCommandTests.cs
@@ -420,6 +420,58 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         }
 
         /// <summary>
+        /// Verifies that <see cref="Platform.BuildOsVersion"/> overrides the build host/agent
+        /// (matrix bucket) selection without changing the image's base OS version. Two Windows
+        /// images with different base OS versions (Server 2019 and Server 2025) should be grouped
+        /// into a single Server 2025 build matrix when the 2019 image sets its build OS to 2025,
+        /// while each leg still builds against its own base OS version.
+        /// </summary>
+        [TestMethod]
+        public async Task GenerateBuildMatrixCommand_BuildOsVersionOverride()
+        {
+            using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
+            GenerateBuildMatrixCommand command = CreateCommand();
+            command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
+            command.Options.MatrixType = MatrixType.PlatformDependencyGraph;
+
+            Manifest manifest = CreateManifest(
+                CreateRepo("runtime",
+                    CreateImage(
+                        CreatePlatform(
+                            CreateDockerfile("1.0/runtime/windowsservercore-ltsc2019", tempFolderContext),
+                            new string[] { "ltsc2019" },
+                            os: OS.Windows,
+                            osVersion: "windowsservercore-ltsc2019",
+                            buildOsVersion: "windowsservercore-ltsc2025")),
+                    CreateImage(
+                        CreatePlatform(
+                            CreateDockerfile("1.0/runtime/windowsservercore-ltsc2025", tempFolderContext),
+                            new string[] { "ltsc2025" },
+                            os: OS.Windows,
+                            osVersion: "windowsservercore-ltsc2025")))
+            );
+
+            File.WriteAllText(Path.Combine(tempFolderContext.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));
+
+            command.LoadManifest();
+            IEnumerable<BuildMatrixInfo> matrixInfos = await command.GenerateMatrixInfoAsync();
+
+            BuildMatrixInfo matrixInfo = matrixInfos.ShouldHaveSingleItem();
+            matrixInfo.Name.ShouldBe("windowsLtsc2025Amd64");
+            matrixInfo.Legs.Count.ShouldBe(2);
+
+            foreach (BuildLegInfo leg in matrixInfo.Legs)
+            {
+                leg.Variables.First(variable => variable.Name == "osType").Value.ShouldBe("windows");
+            }
+
+            IEnumerable<string> osVersions = matrixInfo.Legs
+                .Select(leg => leg.Variables.First(variable => variable.Name == "osVersions").Value);
+            osVersions.ShouldContain("--os-version windowsservercore-ltsc2019");
+            osVersions.ShouldContain("--os-version windowsservercore-ltsc2025");
+        }
+
+        /// <summary>
         /// Verifies the platformVersionedOs matrix type is generated correctly when a
         /// custom build leg group is defined that has a parent graph.
         /// </summary>

--- a/src/ImageBuilder.Tests/Helpers/ManifestHelper.cs
+++ b/src/ImageBuilder.Tests/Helpers/ManifestHelper.cs
@@ -82,13 +82,15 @@ namespace Microsoft.DotNet.ImageBuilder.Tests.Helpers
             string variant = null,
             CustomBuildLegGroup[] customBuildLegGroups = null,
             string dockerfileTemplatePath = null,
-            TagDocumentationType tagDocumentationType = TagDocumentationType.Documented)
+            TagDocumentationType tagDocumentationType = TagDocumentationType.Documented,
+            string buildOsVersion = null)
         {
             return new Platform
             {
                 Dockerfile = dockerfilePath,
                 DockerfileTemplate = dockerfileTemplatePath,
                 OsVersion = osVersion,
+                BuildOsVersion = buildOsVersion,
                 OS = os,
                 Tags = tags.ToDictionary(tag => tag, tag => new Tag() { DocType = tagDocumentationType }),
                 Architecture = architecture,

--- a/src/ImageBuilder.Tests/Models/PlatformSerializationTests.cs
+++ b/src/ImageBuilder.Tests/Models/PlatformSerializationTests.cs
@@ -169,6 +169,36 @@ public class PlatformSerializationTests
     }
 
     [TestMethod]
+    public void PlatformWithBuildOsVersion_Bidirectional()
+    {
+        // BuildOsVersion overrides the build host while the base image stays on ltsc2019
+        Platform platform = new()
+        {
+            Dockerfile = "src/runtime/8.0/windowsservercore-ltsc2019/amd64/Dockerfile",
+            OS = OS.Windows,
+            OsVersion = "windowsservercore-ltsc2019",
+            BuildOsVersion = "windowsservercore-ltsc2025",
+            Tags = new Dictionary<string, Tag> { ["8.0-windowsservercore-ltsc2019"] = new Tag() }
+        };
+
+        // buildOsVersion is serialized when set; null is omitted (consistent with other optional fields)
+        string json = """
+            {
+              "buildArgs": {},
+              "dockerfile": "src/runtime/8.0/windowsservercore-ltsc2019/amd64/Dockerfile",
+              "os": "Windows",
+              "osVersion": "windowsservercore-ltsc2019",
+              "buildOsVersion": "windowsservercore-ltsc2025",
+              "tags": {
+                "8.0-windowsservercore-ltsc2019": {}
+              }
+            }
+            """;
+
+        AssertBidirectional(platform, json, AssertPlatformsEqual);
+    }
+
+    [TestMethod]
     public void Deserialization_DockerfileIsRequired_Missing()
     {
         string json = """
@@ -271,6 +301,7 @@ public class PlatformSerializationTests
         actual.DockerfileTemplate.ShouldBe(expected.DockerfileTemplate);
         actual.OS.ShouldBe(expected.OS);
         actual.OsVersion.ShouldBe(expected.OsVersion);
+        actual.BuildOsVersion.ShouldBe(expected.BuildOsVersion);
         (actual.Tags?.Count ?? 0).ShouldBe(expected.Tags?.Count ?? 0);
         (actual.CustomBuildLegGroups?.Length ?? 0).ShouldBe(expected.CustomBuildLegGroups?.Length ?? 0);
         actual.Variant.ShouldBe(expected.Variant);

--- a/src/ImageBuilder/Commands/GenerateBuildMatrixCommand.cs
+++ b/src/ImageBuilder/Commands/GenerateBuildMatrixCommand.cs
@@ -555,13 +555,15 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             string? osVersion;
 
-            if (Options.DistinctMatrixOsVersions.Contains(platform.BaseOsVersion))
+            // The build OS version determines which build host/agent the platform is grouped onto,
+            // which may differ from the base image's OS version (BaseOsVersion).
+            if (Options.DistinctMatrixOsVersions.Contains(platform.BuildOsVersion))
             {
-                osVersion = platform.BaseOsVersion;
+                osVersion = platform.BuildOsVersion;
             }
             else if (platform.Model.OS != OS.Linux)
             {
-                osVersion = GetNormalizedOsVersion(platform.BaseOsVersion);
+                osVersion = GetNormalizedOsVersion(platform.BuildOsVersion);
             }
             else
             {

--- a/src/ImageBuilder/ViewModel/PlatformInfo.cs
+++ b/src/ImageBuilder/ViewModel/PlatformInfo.cs
@@ -23,6 +23,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         private IEnumerable<string> _internalRepos = Enumerable.Empty<string>();
 
         public string BaseOsVersion { get; private set; }
+        public string BuildOsVersion { get; private set; }
         public IDictionary<string, string?> BuildArgs { get; private set; } = ImmutableDictionary<string, string?>.Empty;
         public string BuildContextPath { get; private set; }
         public string DockerfilePath { get; private set; }
@@ -53,6 +54,9 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         {
             Model = model;
             BaseOsVersion = baseOsVersion;
+            BuildOsVersion = model.BuildOsVersion is null
+                ? baseOsVersion
+                : model.BuildOsVersion.TrimEndString("-slim");
             FullRepoModelName = fullRepoModelName;
             RepoName = repoName;
             VariableHelper = variableHelper;


### PR DESCRIPTION
This PR adds the `buildOsVersion` property to the manifest. This allows having separate build OS and base image OS versions. 

This is needed in order to build ImageBuilder on Windows Server 2025 and publish self-contained on Windows Server <= 2019. This is a blocker to moving ImageBuilder to .NET 10, since .NET 10 doesn't publish SDK images for Windows Server <= 2019.

Fixes https://github.com/dotnet/docker-tools/issues/1826, which is needed to unblock #1791.