### PR TITLE
Bound concurrent ACR requests and decouple ACR rate limiting from timeouts

### DIFF
--- a/src/ImageBuilder/Commands/AnnotateEolDigestsCommand.cs
+++ b/src/ImageBuilder/Commands/AnnotateEolDigestsCommand.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Models.Annotations;
 using Microsoft.DotNet.ImageBuilder.Models.MarBulkDeletion;
 using Microsoft.DotNet.ImageBuilder.Models.Oci;
+using Microsoft.DotNet.ImageBuilder.RateLimiting;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
@@ -54,7 +55,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 Options.IsDryRun,
                 async () =>
                 {
-                    await Parallel.ForEachAsync(eolAnnotations.EolDigests, CancellationToken.None,
+                    await Parallel.ForEachAsync(eolAnnotations.EolDigests, AcrParallelism.CreateOptions(),
                         async (digestData, ct) => await AnnotateDigestAsync(digestData, globalEolDate, ct));
                 },
                 Options.CredentialsOptions,

--- a/src/ImageBuilder/Commands/CleanAcrImagesCommand.cs
+++ b/src/ImageBuilder/Commands/CleanAcrImagesCommand.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using Azure.Containers.ContainerRegistry;
 using Microsoft.DotNet.ImageBuilder.Configuration;
 using Microsoft.DotNet.ImageBuilder.Models.Oci;
+using Microsoft.DotNet.ImageBuilder.RateLimiting;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
 using Microsoft.Extensions.Options;
 using Polly;
@@ -186,7 +187,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             }
 
             ConcurrentBag<ArtifactManifestProperties> expiredImages = [];
-            await Parallel.ForEachAsync(allManifests, async (manifest, token) =>
+            await Parallel.ForEachAsync(allManifests, AcrParallelism.CreateOptions(), async (manifest, token) =>
             {
                 if (!IsExcludedManifest(manifest) && await canDeleteManifest(manifest))
                 {

--- a/src/ImageBuilder/Commands/CopyAcrImagesCommand.cs
+++ b/src/ImageBuilder/Commands/CopyAcrImagesCommand.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
+using Microsoft.DotNet.ImageBuilder.RateLimiting;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
@@ -49,30 +50,27 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 return;
             }
 
-            IEnumerable<Task> platformImportTasks = Manifest.FilteredRepos
-                .Select(repo =>
+            IEnumerable<(string SourceTag, string DestinationTag)> platformTagInfos = Manifest.FilteredRepos
+                .SelectMany(repo =>
                     repo.FilteredImages
                         .SelectMany(image => image.FilteredPlatforms)
-                        .SelectMany(platform => GetPlatformTagInfos(repo, platform))
-                        .Select(tagInfo =>
-                            ImportImageAsync(
-                                DockerHelper.TrimRegistry(tagInfo.DestinationTag, Manifest.Registry),
-                                Manifest.Registry,
-                                DockerHelper.TrimRegistry(tagInfo.SourceTag, Options.SourceRegistry),
-                                copyReferrers: true,
-                                srcRegistryName: Options.SourceRegistry)))
-                .SelectMany(tasks => tasks);
+                        .SelectMany(platform => GetPlatformTagInfos(repo, platform)));
 
-            IEnumerable<Task> manifestListImportTasks = GetManifestListTagInfos()
-                .Select(tagInfo =>
-                    ImportImageAsync(
+            IEnumerable<(string SourceTag, string DestinationTag)> allTagInfos =
+                platformTagInfos.Concat(GetManifestListTagInfos());
+
+            // Bound concurrency so ImportImageAsync's ORAS referrer lookups don't stampede ACR's
+            // rate limiter. See AcrParallelism for details.
+            await Parallel.ForEachAsync(
+                allTagInfos,
+                AcrParallelism.CreateOptions(),
+                async (tagInfo, cancellationToken) =>
+                    await ImportImageAsync(
                         DockerHelper.TrimRegistry(tagInfo.DestinationTag, Manifest.Registry),
                         Manifest.Registry,
                         DockerHelper.TrimRegistry(tagInfo.SourceTag, Options.SourceRegistry),
                         copyReferrers: true,
                         srcRegistryName: Options.SourceRegistry));
-
-            await Task.WhenAll(platformImportTasks.Concat(manifestListImportTasks));
         }
 
         private IEnumerable<(string SourceTag, string DestinationTag)> GetPlatformTagInfos(RepoInfo repo, PlatformInfo platform)

--- a/src/ImageBuilder/Commands/CopyBaseImagesCommand.cs
+++ b/src/ImageBuilder/Commands/CopyBaseImagesCommand.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Azure.ResourceManager.ContainerRegistry.Models;
+using Microsoft.DotNet.ImageBuilder.RateLimiting;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
@@ -66,12 +67,15 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 fullRegistryName = Options.RegistryOverride;
             }
 
-            IEnumerable<Task> copyImageTasks = manifests
+            IEnumerable<string> fromImages = manifests
                 .SelectMany(manifest => GetFromImages(manifest))
-                .Distinct()
-                .Select(fromImage => CopyImageAsync(fromImage, fullRegistryName));
+                .Distinct();
 
-            await Task.WhenAll(copyImageTasks);
+            // Bound concurrency for consistency with the other ACR copy paths. See AcrParallelism.
+            await Parallel.ForEachAsync(
+                fromImages,
+                AcrParallelism.CreateOptions(),
+                async (fromImage, cancellationToken) => await CopyImageAsync(fromImage, fullRegistryName));
         }
 
         private IEnumerable<string> GetFromImages(ManifestInfo manifest) =>

--- a/src/ImageBuilder/Commands/GenerateEolAnnotationDataCommandBase.cs
+++ b/src/ImageBuilder/Commands/GenerateEolAnnotationDataCommandBase.cs
@@ -12,6 +12,7 @@ using Azure;
 using Azure.Containers.ContainerRegistry;
 using Microsoft.DotNet.ImageBuilder.Configuration;
 using Microsoft.DotNet.ImageBuilder.Models.Annotations;
+using Microsoft.DotNet.ImageBuilder.RateLimiting;
 using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands;
@@ -73,7 +74,7 @@ public abstract class GenerateEolAnnotationDataCommandBase<TOptions>
                      .Where(repo => repoNameFilter is null || repoNameFilter(repo));
 
         ConcurrentBag<(string Digest, string? Tag)> digests = [];
-        await Parallel.ForEachAsync(repositoryNames, async (repositoryName, outerCT) =>
+        await Parallel.ForEachAsync(repositoryNames, AcrParallelism.CreateOptions(), async (repositoryName, outerCT) =>
         {
             IAcrContentClient contentClient =
                 _acrContentClientFactory.Create(
@@ -82,7 +83,7 @@ public abstract class GenerateEolAnnotationDataCommandBase<TOptions>
 
             ContainerRepository repo = acrClient.GetRepository(repositoryName);
             IAsyncEnumerable<ArtifactManifestProperties> manifests = repo.GetAllManifestPropertiesAsync();
-            await Parallel.ForEachAsync(manifests, outerCT, async (manifestProps, innerCT) =>
+            await Parallel.ForEachAsync(manifests, AcrParallelism.CreateOptions(outerCT), async (manifestProps, innerCT) =>
             {
                 ManifestQueryResult manifestResult;
                 try
@@ -139,7 +140,7 @@ public abstract class GenerateEolAnnotationDataCommandBase<TOptions>
         }
 
         ConcurrentBag<EolDigestData> digestsToAnnotate = [];
-        await Parallel.ForEachAsync(unsupportedDigests, CancellationToken.None, async (digest, ct) =>
+        await Parallel.ForEachAsync(unsupportedDigests, AcrParallelism.CreateOptions(), async (digest, ct) =>
         {
             _logger.LogInformation($"Checking digest for existing annotation: {digest.Digest}");
             if (await _lifecycleMetadataService.IsDigestAnnotatedForEolAsync(digest.Digest, ct) is null)

--- a/src/ImageBuilder/ImageBuilder.cs
+++ b/src/ImageBuilder/ImageBuilder.cs
@@ -65,30 +65,30 @@ public static class ImageBuilder
 
             builder.Services.ConfigureHttpClientDefaults(httpClientBuilder =>
             {
-                // Add standard HTTP client retry policy
-                httpClientBuilder.AddResilienceHandler("image-builder", pipeline =>
-                    {
-                        var retryOptions = new HttpRetryStrategyOptions()
-                        {
-                            MaxRetryAttempts = 3,
-                            BackoffType = DelayBackoffType.Exponential,
-                            Delay = TimeSpan.FromSeconds(2),
-                            UseJitter = true,
-                        };
-                        // Don't retry for requests that might not be idempotent
-                        retryOptions.DisableForUnsafeHttpMethods();
+                var retryOptions = new HttpRetryStrategyOptions()
+                {
+                    MaxRetryAttempts = 5,
+                    BackoffType = DelayBackoffType.Exponential,
+                    Delay = TimeSpan.FromSeconds(3),
+                    UseJitter = true,
+                };
+                // Don't retry for requests that might not be idempotent
+                retryOptions.DisableForUnsafeHttpMethods();
 
-                        pipeline
-                            // Timeout for the whole pipeline
-                            .AddTimeout(TimeSpan.FromSeconds(30))
-                            .AddRetry(retryOptions)
-                            // Timeout for each individual request
-                            .AddTimeout(TimeSpan.FromSeconds(10));
-                    }
-                );
+                // Retry should be the outer-most policy
+                httpClientBuilder.AddResilienceHandler(
+                    "image-builder-retry",
+                    pipeline => pipeline.AddRetry(retryOptions));
 
-                // Add ACR rate limiting
+                // ACR rate limiting must be per-retry-attempt, otherwise retries would eat up rate
+                // limited requests without acquiring additional rate limiting leases/tokens.
                 httpClientBuilder.AddHttpMessageHandler<AcrRateLimitingHandler>();
+
+                // Per-request timeout covers individual requests, and doesn't apply to the outer
+                // retry policy.
+                httpClientBuilder.AddResilienceHandler(
+                    "image-builder-timeout",
+                    pipeline => pipeline.AddTimeout(TimeSpan.FromSeconds(10)));
             });
 
             builder.Services.AddSingleton<IImageCacheService, ImageCacheService>();

--- a/src/ImageBuilder/RateLimiting/AcrParallelism.cs
+++ b/src/ImageBuilder/RateLimiting/AcrParallelism.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.ImageBuilder.RateLimiting;
+
+/// <summary>
+/// Helpers for bounding the concurrency of fan-out operations that issue ACR data-plane
+/// requests (e.g. ORAS referrer lookups, manifest reads, annotations).
+/// </summary>
+internal static class AcrParallelism
+{
+    /// <summary>
+    /// Maximum number of concurrent in-flight ACR requests.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="AcrRateLimiter"/> already handles hard rate limiting for ACR requests.
+    /// However, flooding the limiter with thousands of simultaneous permit-waiters hurts
+    /// throughput. Keeping a small number of active requests in flight at once keeps pipeline
+    /// saturated at the rate limiter target throughput. Testing indicated that bounded parallelism
+    /// allows about 4x more request throughput without tripping rate limits.
+    /// </remarks>
+    private const int MaxDegreeOfParallelism = 8;
+
+    /// <summary>
+    /// Creates bounded <see cref="ParallelOptions"/> that ensure ACR requests/rate limiting is not overloaded.
+    /// </summary>
+    public static ParallelOptions CreateOptions(CancellationToken cancellationToken = default) =>
+        new()
+        {
+            MaxDegreeOfParallelism = MaxDegreeOfParallelism,
+            CancellationToken = cancellationToken,
+        };
+}

--- a/src/ImageBuilder/Signing/ImageSigningService.cs
+++ b/src/ImageBuilder/Signing/ImageSigningService.cs
@@ -13,6 +13,7 @@ using Microsoft.DotNet.ImageBuilder.Configuration;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
 using Microsoft.DotNet.ImageBuilder.Models.Notary;
 using Microsoft.DotNet.ImageBuilder.Oras;
+using Microsoft.DotNet.ImageBuilder.RateLimiting;
 using Microsoft.Extensions.Options;
 using static Microsoft.DotNet.ImageBuilder.Signing.CertificateChainCalculator;
 using OrasDescriptor = OrasProject.Oras.Oci.Descriptor;
@@ -60,7 +61,8 @@ public class ImageSigningService(
 
         // Filter out digests that already have Notary v2 signatures
         ConcurrentBag<string> unsignedDigests = [];
-        await Parallel.ForEachAsync(imageDigests, cancellationToken, async (imageDigest, ct) =>
+        await Parallel.ForEachAsync(imageDigests, AcrParallelism.CreateOptions(cancellationToken),
+            async (imageDigest, ct) =>
         {
             IReadOnlyList<ReferrerInfo> referrers =
                 await _orasService.GetReferrersAsync(imageDigest, isDryRun: false, ct);
@@ -89,7 +91,8 @@ public class ImageSigningService(
         // Step 1: Generate signing requests by fetching OCI descriptors
         _logger.LogInformation("Generating {Count} signing requests.", unsignedDigests.Count);
         ConcurrentBag<ImageSigningRequest> requests = [];
-        await Parallel.ForEachAsync(unsignedDigests, cancellationToken, async (imageDigest, ct) =>
+        await Parallel.ForEachAsync(unsignedDigests, AcrParallelism.CreateOptions(cancellationToken),
+            async (imageDigest, ct) =>
         {
             OrasDescriptor descriptor = await _orasService.GetDescriptorAsync(imageDigest, ct);
             ImageSigningRequest request = ConstructSigningRequest(imageDigest, descriptor);
@@ -104,7 +107,8 @@ public class ImageSigningService(
         // Step 3: Push signatures to registry in parallel
         _logger.LogInformation("Pushing {Count} signatures to registry.", signedPayloads.Count);
         ConcurrentBag<ImageSigningResult> results = [];
-        await Parallel.ForEachAsync(signedPayloads, cancellationToken, async (signedPayload, ct) =>
+        await Parallel.ForEachAsync(signedPayloads, AcrParallelism.CreateOptions(cancellationToken),
+            async (signedPayload, ct) =>
         {
             string signatureDigest =
                 await _orasService.PushSignatureAsync(signedPayload.Descriptor, signedPayload, ct);


### PR DESCRIPTION
Related: #2137 

Spurious timeouts were occurring during high-volume ACR operations (e.g. ORAS referrer lookups). Time spent waiting in the client-side rate limiter's queue was being charged against the request timeout

- **Split the resilience pipeline into three levels:** `Retry → RateLimiter → per-attempt Timeout`. The limiter now sits *inside* retry (so each attempt is counted) but *outside* the per-attempt timeout (so queue-wait isn't timed). Retries no longer bypass the limiter.
- **Bound concurrency** for all ACR operations. Keeps the rate limiting from becoming overloaded/throttling too hard. This increases throughput from ~1.4 → ~3.5 req/s in my local testing.