### PR TITLE
Publish image info as OCI artifact

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <!-- Follow https://semver.org/spec/v2.0.0.html -->
     <MajorVersion>0</MajorVersion>
-    <MinorVersion>3</MinorVersion>
+    <MinorVersion>4</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>

--- a/eng/docker-tools/templates/jobs/publish.yml
+++ b/eng/docker-tools/templates/jobs/publish.yml
@@ -232,7 +232,7 @@ jobs:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         SYSTEM_OIDCREQUESTURI: $(System.OidcRequestUri)
       condition: and(succeeded(), eq(variables['publishImageInfo'], 'true'))
-      displayName: Publish Image Info Artifact
+      displayName: Publish Image Info
   - ${{ else }}:
     - script: >
         $(runImageBuilderCmd) publishImageInfo

--- a/eng/docker-tools/templates/jobs/publish.yml
+++ b/eng/docker-tools/templates/jobs/publish.yml
@@ -15,6 +15,11 @@ parameters:
   # Service connections not in publishConfig.RegistryAuthentication that need OIDC
   # token access during publish (e.g., kusto, marStatus). Shape: [{ name: string }]
   additionalServiceConnections: []
+  # When true, the merged image info is published as an OCI artifact to the publish
+  # registry instead of being committed to the GitHub versions repo. Note that the
+  # `publishImageInfo` variable must also be set to 'true' for either form of image
+  # info publishing to run.
+  useOciArtifactForImageInfo: false
 
 jobs:
 - job: Publish
@@ -217,20 +222,32 @@ jobs:
       acr: ${{ parameters.publishConfig.PublishRegistry }}
       dataFile: $(artifactsPath)/eol-annotation-data/eol-annotation-data.json
 
-  - script: >
-      $(runImageBuilderCmd) publishImageInfo
-      '$(imageInfoContainerDir)/full-image-info-new.json'
-      '$(gitHubVersionsRepoInfo.userName)'
-      '$(gitHubVersionsRepoInfo.email)'
-      $(gitHubVersionsRepoInfo.authArgs)
-      --git-owner '$(gitHubVersionsRepoInfo.org)'
-      --git-repo '$(gitHubVersionsRepoInfo.repo)'
-      --git-branch '$(gitHubVersionsRepoInfo.branch)'
-      --git-path '$(gitHubImageInfoVersionsPath)'
-      $(dryRunArg)
-      $(imageBuilder.commonCmdArgs)
-    condition: and(succeeded(), eq(variables['publishImageInfo'], 'true'))
-    displayName: Publish Image Info
+  - ${{ if eq(parameters.useOciArtifactForImageInfo, true) }}:
+    - script: >
+        $(runAuthedImageBuilderCmd) publishImageInfoArtifact
+        '$(imageInfoContainerDir)/full-image-info-new.json'
+        $(dryRunArg)
+        $(imageBuilder.commonCmdArgs)
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        SYSTEM_OIDCREQUESTURI: $(System.OidcRequestUri)
+      condition: and(succeeded(), eq(variables['publishImageInfo'], 'true'))
+      displayName: Publish Image Info Artifact
+  - ${{ else }}:
+    - script: >
+        $(runImageBuilderCmd) publishImageInfo
+        '$(imageInfoContainerDir)/full-image-info-new.json'
+        '$(gitHubVersionsRepoInfo.userName)'
+        '$(gitHubVersionsRepoInfo.email)'
+        $(gitHubVersionsRepoInfo.authArgs)
+        --git-owner '$(gitHubVersionsRepoInfo.org)'
+        --git-repo '$(gitHubVersionsRepoInfo.repo)'
+        --git-branch '$(gitHubVersionsRepoInfo.branch)'
+        --git-path '$(gitHubImageInfoVersionsPath)'
+        $(dryRunArg)
+        $(imageBuilder.commonCmdArgs)
+      condition: and(succeeded(), eq(variables['publishImageInfo'], 'true'))
+      displayName: Publish Image Info
 
   # Task displayNames names are hardcoded to reference the task prefix used by 1ES official
   # pipelines in eng/docker-tools/templates/1es-official.yml.

--- a/eng/docker-tools/templates/stages/dotnet/build-test-publish-repo.yml
+++ b/eng/docker-tools/templates/stages/dotnet/build-test-publish-repo.yml
@@ -32,6 +32,10 @@ parameters:
   # Publish parameters
   customPublishInitSteps: []
 
+  # When true, the merged image info is published as an OCI artifact to the publish
+  # registry instead of being committed to the GitHub versions repo.
+  useOciArtifactForImageInfo: false
+
   # Additional service connections not in publishConfig.RegistryAuthentication
   # that need OIDC token access (e.g., kusto, marStatus). Shape: [{ name: string }]
   additionalServiceConnections: []
@@ -82,3 +86,4 @@ stages:
     additionalServiceConnections: ${{ parameters.additionalServiceConnections }}
     sourceBuildPipelineRunId: ${{ parameters.sourceBuildPipelineRunId }}
     versionsRepoRef: ${{ parameters.versionsRepoRef }}
+    useOciArtifactForImageInfo: ${{ parameters.useOciArtifactForImageInfo }}

--- a/eng/docker-tools/templates/stages/dotnet/publish.yml
+++ b/eng/docker-tools/templates/stages/dotnet/publish.yml
@@ -16,6 +16,9 @@ parameters:
   # Service connections not in publishConfig.RegistryAuthentication that need OIDC
   # token access during publish (e.g., kusto, marStatus). Shape: [{ name: string }]
   additionalServiceConnections: []
+  # When true, the merged image info is published as an OCI artifact to the publish
+  # registry instead of being committed to the GitHub versions repo.
+  useOciArtifactForImageInfo: false
 
 stages:
 - template: /eng/docker-tools/templates/stages/publish.yml@self
@@ -30,6 +33,7 @@ stages:
     sourceBuildPipelineRunId: ${{ parameters.sourceBuildPipelineRunId }}
     versionsRepoRef: ${{ parameters.versionsRepoRef }}
     overrideImageInfoCommit: ${{ parameters.overrideImageInfoCommit }}
+    useOciArtifactForImageInfo: ${{ parameters.useOciArtifactForImageInfo }}
 
     customPublishInitSteps:
     - pwsh: |

--- a/eng/docker-tools/templates/stages/publish.yml
+++ b/eng/docker-tools/templates/stages/publish.yml
@@ -29,6 +29,10 @@ parameters:
   # token access during publish (e.g., kusto, marStatus). Shape: [{ name: string }]
   additionalServiceConnections: []
 
+  # When true, the merged image info is published as an OCI artifact to the publish
+  # registry instead of being committed to the GitHub versions repo.
+  useOciArtifactForImageInfo: false
+
 ################################################################################
 # Publish Images
 ################################################################################
@@ -86,3 +90,4 @@ stages:
       versionsRepoPath: ${{ parameters.versionsRepoPath }}
       overrideImageInfoCommit: ${{ parameters.overrideImageInfoCommit }}
       additionalServiceConnections: ${{ parameters.additionalServiceConnections }}
+      useOciArtifactForImageInfo: ${{ parameters.useOciArtifactForImageInfo }}

--- a/src/ImageBuilder.Models/Manifest/ImageInfoArtifact.cs
+++ b/src/ImageBuilder.Models/Manifest/ImageInfoArtifact.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.ImageBuilder.Models.Manifest;
+
+[Description("Describes where to publish an info about what images were built."
+    + " The info will be published as an OCI artifact containing json.")]
+public class ImageInfoArtifact()
+{
+    [Description("The repo where the artifact will be published, not including the registry.")]
+    [JsonProperty(Required = Required.Always)]
+    public string Repo { get; set; } = string.Empty;
+
+    [Description("Tags for the OCI artifact. Requires at least one.")]
+    [JsonProperty(Required = Required.Always)]
+    public IDictionary<string, Tag> Tags { get; set; } = new Dictionary<string, Tag>();
+}

--- a/src/ImageBuilder.Models/Manifest/Manifest.cs
+++ b/src/ImageBuilder.Models/Manifest/Manifest.cs
@@ -35,6 +35,12 @@ public class Manifest
     public string Registry { get; set; }
 
     [Description(
+        "Metadata describing where this manifest's image info is published as an " +
+        "OCI artifact. When omitted, image info is not published as an OCI artifact."
+        )]
+    public ImageInfoArtifact ImageInfo { get; set; }
+
+    [Description(
         "The set of Docker repositories described by this manifest."
         )]
     public Repo[] Repos { get; set; } = Array.Empty<Repo>();

--- a/src/ImageBuilder.Tests/ImageInfoServiceTests.cs
+++ b/src/ImageBuilder.Tests/ImageInfoServiceTests.cs
@@ -53,7 +53,7 @@ public class ImageInfoServiceTests
     }
 
     [TestMethod]
-    public async Task PushImageInfoArtifactAsync_MultipleTags_PushesOnceWithAllTags()
+    public async Task PushImageInfoArtifactAsync_MultipleTags_PushesOneArtifactWithAllTags()
     {
         using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
         string dockerfile = CreateDockerfile("1.0/repo/os", tempFolderContext);
@@ -87,6 +87,7 @@ public class ImageInfoServiceTests
             It.Is<IEnumerable<string>>(tags =>
                 tags.OrderBy(t => t).SequenceEqual(new[] { "latest", "main" })),
             It.IsAny<CancellationToken>()), Times.Once);
+        orasServiceMock.VerifyNoOtherCalls();
     }
 
     [TestMethod]

--- a/src/ImageBuilder.Tests/ImageInfoServiceTests.cs
+++ b/src/ImageBuilder.Tests/ImageInfoServiceTests.cs
@@ -1,0 +1,198 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.DotNet.ImageBuilder.Models.Manifest;
+using Microsoft.DotNet.ImageBuilder.Oras;
+using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
+using Microsoft.DotNet.ImageBuilder.ViewModel;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Shouldly;
+using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.DockerfileHelper;
+using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
+
+namespace Microsoft.DotNet.ImageBuilder.Tests;
+
+[TestClass]
+public class ImageInfoServiceTests
+{
+    private static readonly byte[] ImageInfoContent = [];
+
+    [TestMethod]
+    public async Task PushImageInfoArtifactAsync_PushesToGivenRegistryWithRepoPrefixAndManifestTag()
+    {
+        using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
+        string dockerfile = CreateDockerfile("1.0/repo/os", tempFolderContext);
+        ManifestInfo manifest = CreateManifestInfo(tempFolderContext, dockerfile);
+
+        Mock<IOrasService> orasServiceMock = new();
+        ImageInfoService service = CreateService(orasServiceMock.Object);
+
+        await service.PushImageInfoArtifactAsync(
+            manifest,
+            ImageInfoContent,
+            registry: "publish.example.com",
+            repoPrefix: "public/",
+            isDryRun: false);
+
+        orasServiceMock.Verify(o => o.PushArtifactAsync(
+            ImageInfoContent,
+            OciArtifactType.ImageInfo,
+            OciArtifactType.ImageInfo,
+            "publish.example.com",
+            "public/dotnet/versions",
+            It.Is<IEnumerable<string>>(tags => tags.SequenceEqual(new[] { "latest" })),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task PushImageInfoArtifactAsync_MultipleTags_PushesOnceWithAllTags()
+    {
+        using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
+        string dockerfile = CreateDockerfile("1.0/repo/os", tempFolderContext);
+        ImageInfoArtifact imageInfoArtifact = new()
+        {
+            Repo = "dotnet/versions",
+            Tags = new Dictionary<string, Tag>
+            {
+                ["latest"] = new(),
+                ["main"] = new(),
+            }
+        };
+        ManifestInfo manifest = CreateManifestInfo(tempFolderContext, dockerfile, imageInfoArtifact);
+
+        Mock<IOrasService> orasServiceMock = new();
+        ImageInfoService service = CreateService(orasServiceMock.Object);
+
+        await service.PushImageInfoArtifactAsync(
+            manifest,
+            ImageInfoContent,
+            registry: "publish.example.com",
+            repoPrefix: null,
+            isDryRun: false);
+
+        orasServiceMock.Verify(o => o.PushArtifactAsync(
+            ImageInfoContent,
+            OciArtifactType.ImageInfo,
+            OciArtifactType.ImageInfo,
+            "publish.example.com",
+            "dotnet/versions",
+            It.Is<IEnumerable<string>>(tags =>
+                tags.OrderBy(t => t).SequenceEqual(new[] { "latest", "main" })),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task PushImageInfoArtifactAsync_DryRun_DoesNotPush()
+    {
+        using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
+        string dockerfile = CreateDockerfile("1.0/repo/os", tempFolderContext);
+        ManifestInfo manifest = CreateManifestInfo(tempFolderContext, dockerfile);
+
+        Mock<IOrasService> orasServiceMock = new();
+        ImageInfoService service = CreateService(orasServiceMock.Object);
+
+        await service.PushImageInfoArtifactAsync(
+            manifest,
+            ImageInfoContent,
+            registry: "publish.example.com",
+            repoPrefix: "public/",
+            isDryRun: true);
+
+        orasServiceMock.Verify(o => o.PushArtifactAsync(
+            It.IsAny<byte[]>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<IEnumerable<string>>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task PushImageInfoArtifactAsync_NoManifestImageInfo_Throws()
+    {
+        using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
+        string dockerfile = CreateDockerfile("1.0/repo/os", tempFolderContext);
+        ManifestInfo manifest = CreateManifestInfo(
+            tempFolderContext,
+            dockerfile,
+            includeImageInfoArtifact: false);
+
+        Mock<IOrasService> orasServiceMock = new();
+        ImageInfoService service = CreateService(orasServiceMock.Object);
+
+        await Should.ThrowAsync<InvalidOperationException>(() =>
+            service.PushImageInfoArtifactAsync(
+                manifest,
+                ImageInfoContent,
+                registry: "publish.example.com",
+                repoPrefix: "public/",
+                isDryRun: false));
+
+        orasServiceMock.Verify(o => o.PushArtifactAsync(
+            It.IsAny<byte[]>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<IEnumerable<string>>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private static ImageInfoService CreateService(IOrasService orasService)
+    {
+        Mock<IOrasServiceFactory> orasServiceFactoryMock = new();
+        orasServiceFactoryMock
+            .Setup(f => f.Create(It.IsAny<IRegistryCredentialsHost?>()))
+            .Returns(orasService);
+        return new ImageInfoService(
+            TestHelper.CreateManifestJsonService(),
+            orasServiceFactoryMock.Object,
+            NullLogger<ImageInfoService>.Instance);
+    }
+
+    private static ManifestInfo CreateManifestInfo(
+        TempFolderContext tempFolderContext,
+        string dockerfile,
+        ImageInfoArtifact? imageInfoArtifact = null,
+        bool includeImageInfoArtifact = true)
+    {
+        string manifestPath = Path.Combine(tempFolderContext.Path, "manifest.json");
+        Manifest manifest = CreateManifest(
+            CreateRepo("repo",
+                CreateImage(
+                    CreatePlatform(dockerfile, ["tag"]))));
+        manifest.Registry = "public.example.com";
+        if (includeImageInfoArtifact)
+        {
+            manifest.ImageInfo = imageInfoArtifact ?? new ImageInfoArtifact
+            {
+                Repo = "dotnet/versions",
+                Tags = new Dictionary<string, Tag>
+                {
+                    ["latest"] = new()
+                }
+            };
+        }
+
+        File.WriteAllText(manifestPath, JsonHelper.SerializeObject(manifest));
+
+        Mock<IManifestOptionsInfo> manifestOptionsMock = new();
+        manifestOptionsMock
+            .SetupGet(o => o.Manifest)
+            .Returns(manifestPath);
+        manifestOptionsMock
+            .Setup(o => o.GetManifestFilter())
+            .Returns(new ManifestFilter([]));
+
+        return TestHelper.CreateManifestJsonService().Load(manifestOptionsMock.Object);
+    }
+}

--- a/src/ImageBuilder.Tests/Models/ImageInfoArtifactSerializationTests.cs
+++ b/src/ImageBuilder.Tests/Models/ImageInfoArtifactSerializationTests.cs
@@ -2,80 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
-using Shouldly;
 using static Microsoft.DotNet.ImageBuilder.Tests.Models.SerializationHelper;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests.Models;
 
 /// <summary>
-/// Serialization and deserialization tests for <see cref="ImageInfoArtifact"/> model.
-/// These tests ensure that serialization behavior does not change unexpectedly.
+/// Schema contract tests for <see cref="ImageInfoArtifact"/> model.
 /// </summary>
 [TestClass]
 public class ImageInfoArtifactSerializationTests
 {
-    [TestMethod]
-    public void DefaultImageInfoArtifact_Bidirectional()
-    {
-        ImageInfoArtifact imageInfo = new();
-
-        // Required properties are serialized even when empty.
-        string json = """
-            {
-              "repo": "",
-              "tags": {}
-            }
-            """;
-
-        AssertBidirectional(imageInfo, json, AssertImageInfosEqual);
-    }
-
-    [TestMethod]
-    public void FullyPopulatedImageInfoArtifact_Bidirectional()
-    {
-        ImageInfoArtifact imageInfo = new()
-        {
-            Repo = "dotnet/versions",
-            Tags = new Dictionary<string, Tag>
-            {
-                ["latest"] = new()
-                {
-                    DocumentationGroup = "versions"
-                }
-            }
-        };
-
-        string json = """
-            {
-              "repo": "dotnet/versions",
-              "tags": {
-                "latest": {
-                  "documentationGroup": "versions"
-                }
-              }
-            }
-            """;
-
-        AssertBidirectional(imageInfo, json, AssertImageInfosEqual);
-    }
-
-    [TestMethod]
-    public void FullyPopulatedImageInfoArtifact_RoundTrip()
-    {
-        ImageInfoArtifact imageInfo = new()
-        {
-            Repo = "dotnet/versions",
-            Tags = new Dictionary<string, Tag>
-            {
-                ["latest"] = new()
-            }
-        };
-
-        AssertRoundTrip(imageInfo, AssertImageInfosEqual);
-    }
-
     [TestMethod]
     public void MissingRepo_DeserializationFails()
     {
@@ -124,19 +61,5 @@ public class ImageInfoArtifactSerializationTests
             """;
 
         AssertDeserializationFails<ImageInfoArtifact>(json, nameof(ImageInfoArtifact.Tags));
-    }
-
-    private static void AssertImageInfosEqual(ImageInfoArtifact expected, ImageInfoArtifact actual)
-    {
-        actual.Repo.ShouldBe(expected.Repo);
-        actual.Tags.Count.ShouldBe(expected.Tags.Count);
-
-        foreach ((string tagName, Tag expectedTag) in expected.Tags)
-        {
-            actual.Tags.ContainsKey(tagName).ShouldBeTrue();
-            actual.Tags[tagName].DocumentationGroup.ShouldBe(expectedTag.DocumentationGroup);
-            actual.Tags[tagName].DocType.ShouldBe(expectedTag.DocType);
-            actual.Tags[tagName].Syndication.ShouldBe(expectedTag.Syndication);
-        }
     }
 }

--- a/src/ImageBuilder.Tests/Models/ImageInfoArtifactSerializationTests.cs
+++ b/src/ImageBuilder.Tests/Models/ImageInfoArtifactSerializationTests.cs
@@ -1,0 +1,142 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Microsoft.DotNet.ImageBuilder.Models.Manifest;
+using Shouldly;
+using static Microsoft.DotNet.ImageBuilder.Tests.Models.SerializationHelper;
+
+namespace Microsoft.DotNet.ImageBuilder.Tests.Models;
+
+/// <summary>
+/// Serialization and deserialization tests for <see cref="ImageInfoArtifact"/> model.
+/// These tests ensure that serialization behavior does not change unexpectedly.
+/// </summary>
+[TestClass]
+public class ImageInfoArtifactSerializationTests
+{
+    [TestMethod]
+    public void DefaultImageInfoArtifact_Bidirectional()
+    {
+        ImageInfoArtifact imageInfo = new();
+
+        // Required properties are serialized even when empty.
+        string json = """
+            {
+              "repo": "",
+              "tags": {}
+            }
+            """;
+
+        AssertBidirectional(imageInfo, json, AssertImageInfosEqual);
+    }
+
+    [TestMethod]
+    public void FullyPopulatedImageInfoArtifact_Bidirectional()
+    {
+        ImageInfoArtifact imageInfo = new()
+        {
+            Repo = "dotnet/versions",
+            Tags = new Dictionary<string, Tag>
+            {
+                ["latest"] = new()
+                {
+                    DocumentationGroup = "versions"
+                }
+            }
+        };
+
+        string json = """
+            {
+              "repo": "dotnet/versions",
+              "tags": {
+                "latest": {
+                  "documentationGroup": "versions"
+                }
+              }
+            }
+            """;
+
+        AssertBidirectional(imageInfo, json, AssertImageInfosEqual);
+    }
+
+    [TestMethod]
+    public void FullyPopulatedImageInfoArtifact_RoundTrip()
+    {
+        ImageInfoArtifact imageInfo = new()
+        {
+            Repo = "dotnet/versions",
+            Tags = new Dictionary<string, Tag>
+            {
+                ["latest"] = new()
+            }
+        };
+
+        AssertRoundTrip(imageInfo, AssertImageInfosEqual);
+    }
+
+    [TestMethod]
+    public void MissingRepo_DeserializationFails()
+    {
+        string json = """
+            {
+              "tags": {}
+            }
+            """;
+
+        AssertDeserializationFails<ImageInfoArtifact>(json, nameof(ImageInfoArtifact.Repo));
+    }
+
+    [TestMethod]
+    public void NullRepo_DeserializationFails()
+    {
+        string json = """
+            {
+              "repo": null,
+              "tags": {}
+            }
+            """;
+
+        AssertDeserializationFails<ImageInfoArtifact>(json, nameof(ImageInfoArtifact.Repo));
+    }
+
+    [TestMethod]
+    public void MissingTags_DeserializationFails()
+    {
+        string json = """
+            {
+              "repo": "dotnet/versions"
+            }
+            """;
+
+        AssertDeserializationFails<ImageInfoArtifact>(json, nameof(ImageInfoArtifact.Tags));
+    }
+
+    [TestMethod]
+    public void NullTags_DeserializationFails()
+    {
+        string json = """
+            {
+              "repo": "dotnet/versions",
+              "tags": null
+            }
+            """;
+
+        AssertDeserializationFails<ImageInfoArtifact>(json, nameof(ImageInfoArtifact.Tags));
+    }
+
+    private static void AssertImageInfosEqual(ImageInfoArtifact expected, ImageInfoArtifact actual)
+    {
+        actual.Repo.ShouldBe(expected.Repo);
+        actual.Tags.Count.ShouldBe(expected.Tags.Count);
+
+        foreach ((string tagName, Tag expectedTag) in expected.Tags)
+        {
+            actual.Tags.ContainsKey(tagName).ShouldBeTrue();
+            actual.Tags[tagName].DocumentationGroup.ShouldBe(expectedTag.DocumentationGroup);
+            actual.Tags[tagName].DocType.ShouldBe(expectedTag.DocType);
+            actual.Tags[tagName].Syndication.ShouldBe(expectedTag.Syndication);
+        }
+    }
+}

--- a/src/ImageBuilder.Tests/Models/ManifestSerializationTests.cs
+++ b/src/ImageBuilder.Tests/Models/ManifestSerializationTests.cs
@@ -47,6 +47,14 @@ public class ManifestSerializationTests
             Includes = ["include1.json", "include2.json"],
             Readme = new Readme("README.md", "README.template.md"),
             Registry = "mcr.microsoft.com",
+            ImageInfo = new ImageInfoArtifact
+            {
+                Repo = "dotnet/versions",
+                Tags = new Dictionary<string, Tag>
+                {
+                    ["latest"] = new()
+                }
+            },
             Repos = [],
             Variables = new Dictionary<string, string>
             {
@@ -67,6 +75,12 @@ public class ManifestSerializationTests
                 "templatePath": "README.template.md"
               },
               "registry": "mcr.microsoft.com",
+              "imageInfo": {
+                "repo": "dotnet/versions",
+                "tags": {
+                  "latest": {}
+                }
+              },
               "variables": {
                 "version": "8.0",
                 "osVersion": "jammy"
@@ -96,6 +110,7 @@ public class ManifestSerializationTests
     {
         actual.Includes.ShouldBe(expected.Includes);
         actual.Registry.ShouldBe(expected.Registry);
+        AssertImageInfosEqual(expected.ImageInfo, actual.ImageInfo);
         (actual.Repos?.Length ?? 0).ShouldBe(expected.Repos?.Length ?? 0);
         actual.Variables.ShouldBe(expected.Variables);
 
@@ -108,6 +123,42 @@ public class ManifestSerializationTests
             actual.Readme.ShouldNotBeNull();
             actual.Readme.Path.ShouldBe(expected.Readme.Path);
             actual.Readme.TemplatePath.ShouldBe(expected.Readme.TemplatePath);
+        }
+    }
+
+    private static void AssertImageInfosEqual(ImageInfoArtifact expected, ImageInfoArtifact actual)
+    {
+        if (expected is null)
+        {
+            actual.ShouldBeNull();
+            return;
+        }
+
+        actual.ShouldNotBeNull();
+        actual.Repo.ShouldBe(expected.Repo);
+        actual.Tags.Count.ShouldBe(expected.Tags.Count);
+
+        foreach ((string tagName, Tag expectedTag) in expected.Tags)
+        {
+            actual.Tags.ContainsKey(tagName).ShouldBeTrue();
+            AssertTagsEqual(expectedTag, actual.Tags[tagName]);
+        }
+    }
+
+    private static void AssertTagsEqual(Tag expected, Tag actual)
+    {
+        actual.DocumentationGroup.ShouldBe(expected.DocumentationGroup);
+        actual.DocType.ShouldBe(expected.DocType);
+
+        if (expected.Syndication is null)
+        {
+            actual.Syndication.ShouldBeNull();
+        }
+        else
+        {
+            actual.Syndication.ShouldNotBeNull();
+            actual.Syndication.Repo.ShouldBe(expected.Syndication.Repo);
+            actual.Syndication.DestinationTags.ShouldBe(expected.Syndication.DestinationTags);
         }
     }
 }

--- a/src/ImageBuilder.Tests/Models/ManifestSerializationTests.cs
+++ b/src/ImageBuilder.Tests/Models/ManifestSerializationTests.cs
@@ -47,14 +47,6 @@ public class ManifestSerializationTests
             Includes = ["include1.json", "include2.json"],
             Readme = new Readme("README.md", "README.template.md"),
             Registry = "mcr.microsoft.com",
-            ImageInfo = new ImageInfoArtifact
-            {
-                Repo = "dotnet/versions",
-                Tags = new Dictionary<string, Tag>
-                {
-                    ["latest"] = new()
-                }
-            },
             Repos = [],
             Variables = new Dictionary<string, string>
             {
@@ -75,12 +67,6 @@ public class ManifestSerializationTests
                 "templatePath": "README.template.md"
               },
               "registry": "mcr.microsoft.com",
-              "imageInfo": {
-                "repo": "dotnet/versions",
-                "tags": {
-                  "latest": {}
-                }
-              },
               "variables": {
                 "version": "8.0",
                 "osVersion": "jammy"
@@ -110,7 +96,6 @@ public class ManifestSerializationTests
     {
         actual.Includes.ShouldBe(expected.Includes);
         actual.Registry.ShouldBe(expected.Registry);
-        AssertImageInfosEqual(expected.ImageInfo, actual.ImageInfo);
         (actual.Repos?.Length ?? 0).ShouldBe(expected.Repos?.Length ?? 0);
         actual.Variables.ShouldBe(expected.Variables);
 
@@ -123,42 +108,6 @@ public class ManifestSerializationTests
             actual.Readme.ShouldNotBeNull();
             actual.Readme.Path.ShouldBe(expected.Readme.Path);
             actual.Readme.TemplatePath.ShouldBe(expected.Readme.TemplatePath);
-        }
-    }
-
-    private static void AssertImageInfosEqual(ImageInfoArtifact expected, ImageInfoArtifact actual)
-    {
-        if (expected is null)
-        {
-            actual.ShouldBeNull();
-            return;
-        }
-
-        actual.ShouldNotBeNull();
-        actual.Repo.ShouldBe(expected.Repo);
-        actual.Tags.Count.ShouldBe(expected.Tags.Count);
-
-        foreach ((string tagName, Tag expectedTag) in expected.Tags)
-        {
-            actual.Tags.ContainsKey(tagName).ShouldBeTrue();
-            AssertTagsEqual(expectedTag, actual.Tags[tagName]);
-        }
-    }
-
-    private static void AssertTagsEqual(Tag expected, Tag actual)
-    {
-        actual.DocumentationGroup.ShouldBe(expected.DocumentationGroup);
-        actual.DocType.ShouldBe(expected.DocType);
-
-        if (expected.Syndication is null)
-        {
-            actual.Syndication.ShouldBeNull();
-        }
-        else
-        {
-            actual.Syndication.ShouldNotBeNull();
-            actual.Syndication.Repo.ShouldBe(expected.Syndication.Repo);
-            actual.Syndication.DestinationTags.ShouldBe(expected.Syndication.DestinationTags);
         }
     }
 }

--- a/src/ImageBuilder.Tests/PublishConfigurationBindingTests.cs
+++ b/src/ImageBuilder.Tests/PublishConfigurationBindingTests.cs
@@ -85,6 +85,27 @@ public class PublishConfigurationBindingTests
     }
 
     [TestMethod]
+    public void AddPublishConfiguration_BindsRegistryEndpointRepoPrefix()
+    {
+        const string configJson = """
+            {
+              "PublishConfiguration": {
+                "PublishRegistry": {
+                  "Server": "publish.azurecr.io",
+                  "RepoPrefix": "public/"
+                }
+              }
+            }
+            """;
+
+        PublishConfiguration config = BuildConfiguration(configJson);
+
+        config.PublishRegistry.ShouldNotBeNull();
+        config.PublishRegistry.Server.ShouldBe("publish.azurecr.io");
+        config.PublishRegistry.RepoPrefix.ShouldBe("public/");
+    }
+
+    [TestMethod]
     public void AddPublishConfiguration_BindsRegistryAuthenticationList()
     {
         PublishConfiguration config = BuildConfiguration(FullConfigJson);

--- a/src/ImageBuilder.Tests/PublishImageInfoArtifactCommandTests.cs
+++ b/src/ImageBuilder.Tests/PublishImageInfoArtifactCommandTests.cs
@@ -1,0 +1,113 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.DotNet.ImageBuilder.Commands;
+using Microsoft.DotNet.ImageBuilder.Configuration;
+using Microsoft.DotNet.ImageBuilder.Models.Image;
+using Microsoft.DotNet.ImageBuilder.Models.Manifest;
+using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
+using Microsoft.DotNet.ImageBuilder.ViewModel;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Newtonsoft.Json;
+using Shouldly;
+using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
+
+namespace Microsoft.DotNet.ImageBuilder.Tests;
+
+[TestClass]
+public class PublishImageInfoArtifactCommandTests
+{
+    [TestMethod]
+    public async Task PublishImageInfoArtifactCommand_PushesImageInfoArtifact()
+    {
+        using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
+        string dockerfilePath = DockerfileHelper.CreateDockerfile("1.0/runtime/os", tempFolderContext);
+        Manifest manifest = CreateManifest(
+            CreateRepo("repo1",
+                CreateImage(
+                    [CreatePlatform(dockerfilePath, ["tag1"])],
+                    productVersion: "1.0")));
+
+        string imageInfoContent = JsonHelper.SerializeObject(new ImageArtifactDetails());
+        string imageInfoFile = Path.Combine(tempFolderContext.Path, "image-info.json");
+        File.WriteAllText(imageInfoFile, imageInfoContent);
+
+        Mock<IImageInfoService> imageInfoServiceMock = new();
+        PublishConfiguration publishConfig = new()
+        {
+            PublishRegistry = new RegistryEndpoint
+            {
+                Server = "publish.azurecr.io",
+                RepoPrefix = "public/"
+            }
+        };
+
+        PublishImageInfoArtifactCommand command = CreateCommand(imageInfoServiceMock.Object, publishConfig);
+        command.Options.ImageInfoPath = imageInfoFile;
+        command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
+        File.WriteAllText(command.Options.Manifest, JsonConvert.SerializeObject(manifest));
+
+        command.LoadManifest();
+        await command.ExecuteAsync();
+
+        imageInfoServiceMock.Verify(
+            o => o.PushImageInfoArtifactAsync(
+                It.IsAny<ManifestInfo>(),
+                It.IsAny<byte[]>(),
+                "publish.azurecr.io",
+                "public/",
+                false,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [TestMethod]
+    public async Task PublishImageInfoArtifactCommand_NoPublishRegistry_Throws()
+    {
+        using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
+        string dockerfilePath = DockerfileHelper.CreateDockerfile("1.0/runtime/os", tempFolderContext);
+        Manifest manifest = CreateManifest(
+            CreateRepo("repo1",
+                CreateImage(
+                    [CreatePlatform(dockerfilePath, ["tag1"])],
+                    productVersion: "1.0")));
+
+        string imageInfoFile = Path.Combine(tempFolderContext.Path, "image-info.json");
+        File.WriteAllText(imageInfoFile, JsonHelper.SerializeObject(new ImageArtifactDetails()));
+
+        Mock<IImageInfoService> imageInfoServiceMock = new();
+        PublishImageInfoArtifactCommand command = CreateCommand(imageInfoServiceMock.Object, new PublishConfiguration());
+        command.Options.ImageInfoPath = imageInfoFile;
+        command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
+        File.WriteAllText(command.Options.Manifest, JsonConvert.SerializeObject(manifest));
+
+        command.LoadManifest();
+
+        await Should.ThrowAsync<InvalidOperationException>(command.ExecuteAsync());
+
+        imageInfoServiceMock.Verify(
+            o => o.PushImageInfoArtifactAsync(
+                It.IsAny<ManifestInfo>(),
+                It.IsAny<byte[]>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private static PublishImageInfoArtifactCommand CreateCommand(
+        IImageInfoService imageInfoService,
+        PublishConfiguration publishConfiguration) =>
+        new(
+            TestHelper.CreateManifestJsonService(),
+            imageInfoService,
+            Microsoft.Extensions.Options.Options.Create(publishConfiguration),
+            NullLogger<PublishImageInfoArtifactCommand>.Instance);
+}

--- a/src/ImageBuilder.Tests/PublishImageInfoArtifactCommandTests.cs
+++ b/src/ImageBuilder.Tests/PublishImageInfoArtifactCommandTests.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Commands;
@@ -24,7 +25,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests;
 public class PublishImageInfoArtifactCommandTests
 {
     [TestMethod]
-    public async Task PublishImageInfoArtifactCommand_PushesImageInfoArtifact()
+    public async Task PublishImageInfoArtifactCommand_PassesImageInfoFileBytesToService()
     {
         using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
         string dockerfilePath = DockerfileHelper.CreateDockerfile("1.0/runtime/os", tempFolderContext);
@@ -37,6 +38,7 @@ public class PublishImageInfoArtifactCommandTests
         string imageInfoContent = JsonHelper.SerializeObject(new ImageArtifactDetails());
         string imageInfoFile = Path.Combine(tempFolderContext.Path, "image-info.json");
         File.WriteAllText(imageInfoFile, imageInfoContent);
+        byte[] expectedImageInfoContent = File.ReadAllBytes(imageInfoFile);
 
         Mock<IImageInfoService> imageInfoServiceMock = new();
         PublishConfiguration publishConfig = new()
@@ -59,7 +61,7 @@ public class PublishImageInfoArtifactCommandTests
         imageInfoServiceMock.Verify(
             o => o.PushImageInfoArtifactAsync(
                 It.IsAny<ManifestInfo>(),
-                It.IsAny<byte[]>(),
+                It.Is<byte[]>(content => content.SequenceEqual(expectedImageInfoContent)),
                 "publish.azurecr.io",
                 "public/",
                 false,

--- a/src/ImageBuilder/Commands/PublishImageInfoArtifactCommand.cs
+++ b/src/ImageBuilder/Commands/PublishImageInfoArtifactCommand.cs
@@ -37,7 +37,7 @@ public class PublishImageInfoArtifactCommand(
         if (string.IsNullOrWhiteSpace(publishRegistry?.Server))
         {
             throw new InvalidOperationException(
-                "No publish registry is configured. Skipping image-info artifact push."
+                "No publish registry is configured. Cannot publish image-info artifact."
             );
         }
 

--- a/src/ImageBuilder/Commands/PublishImageInfoArtifactCommand.cs
+++ b/src/ImageBuilder/Commands/PublishImageInfoArtifactCommand.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.DotNet.ImageBuilder.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.DotNet.ImageBuilder.Commands;
+
+public class PublishImageInfoArtifactCommand(
+    IManifestJsonService manifestJsonService,
+    IImageInfoService imageInfoService,
+    IOptions<PublishConfiguration> publishConfigOptions,
+    ILogger<PublishImageInfoArtifactCommand> logger
+) : ManifestCommand<PublishImageInfoArtifactOptions>(manifestJsonService)
+{
+    private readonly IImageInfoService _imageInfoService =
+        imageInfoService ?? throw new ArgumentNullException(nameof(imageInfoService));
+
+    private readonly PublishConfiguration _publishConfiguration =
+        publishConfigOptions?.Value ?? throw new ArgumentNullException(nameof(publishConfigOptions));
+
+    private readonly ILogger<PublishImageInfoArtifactCommand> _logger =
+        logger ?? throw new ArgumentNullException(nameof(logger));
+
+    protected override string Description => "Publishes a build's image info as an OCI artifact.";
+
+    public override async Task ExecuteAsync()
+    {
+        _logger.LogInformation("Publishing image info as OCI artifact");
+
+        RegistryEndpoint? publishRegistry = _publishConfiguration.PublishRegistry;
+
+        if (string.IsNullOrWhiteSpace(publishRegistry?.Server))
+        {
+            throw new InvalidOperationException(
+                "No publish registry is configured. Skipping image-info artifact push."
+            );
+        }
+
+        byte[] imageInfoContent = File.ReadAllBytes(Options.ImageInfoPath);
+
+        await _imageInfoService.PushImageInfoArtifactAsync(
+            manifest: Manifest,
+            imageInfoContent: imageInfoContent,
+            registry: publishRegistry.Server,
+            repoPrefix: publishRegistry.RepoPrefix,
+            isDryRun: Options.IsDryRun);
+    }
+}
+
+public class PublishImageInfoArtifactOptions : ImageInfoOptions
+{
+}

--- a/src/ImageBuilder/Configuration/RegistryEndpoint.cs
+++ b/src/ImageBuilder/Configuration/RegistryEndpoint.cs
@@ -20,4 +20,10 @@ public sealed record RegistryEndpoint
     /// "mcr.microsoft.com", "ghcr.io", "localhost:5000".
     /// </summary>
     public string? Server { get; set; }
+
+    /// <summary>
+    /// An optional prefix prepended to repository names pushed to or pulled from this registry
+    /// (e.g. "staging/" or "public/").
+    /// </summary>
+    public string? RepoPrefix { get; set; }
 }

--- a/src/ImageBuilder/IImageInfoService.cs
+++ b/src/ImageBuilder/IImageInfoService.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.DotNet.ImageBuilder.ViewModel;
+
+namespace Microsoft.DotNet.ImageBuilder;
+
+/// <summary>
+/// Publishes image-info content as OCI artifacts.
+/// </summary>
+public interface IImageInfoService
+{
+    /// <summary>
+    /// Pushes the given image-info content as an OCI artifact to the given registry, using the
+    /// repository and tags declared by the manifest's <c>imageInfo</c> object.
+    /// </summary>
+    /// <param name="manifest">The manifest declaring the image-info artifact repository and tags.</param>
+    /// <param name="imageInfoContent">The image-info content to push.</param>
+    /// <param name="registry">The registry to push the artifact to (e.g. the publish registry).</param>
+    /// <param name="repoPrefix">A prefix to prepend to the artifact's repository name.</param>
+    /// <param name="isDryRun">When <see langword="true"/>, no artifact is pushed.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <remarks>
+    /// When the manifest does not declare an <c>imageInfo</c> object, the push is skipped and a
+    /// warning is logged rather than throwing, so that publishing is not blocked.
+    /// </remarks>
+    Task PushImageInfoArtifactAsync(
+        ManifestInfo manifest,
+        byte[] imageInfoContent,
+        string registry,
+        string? repoPrefix,
+        bool isDryRun,
+        CancellationToken cancellationToken = default);
+}

--- a/src/ImageBuilder/IImageInfoService.cs
+++ b/src/ImageBuilder/IImageInfoService.cs
@@ -24,8 +24,8 @@ public interface IImageInfoService
     /// <param name="isDryRun">When <see langword="true"/>, no artifact is pushed.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <remarks>
-    /// When the manifest does not declare an <c>imageInfo</c> object, the push is skipped and a
-    /// warning is logged rather than throwing, so that publishing is not blocked.
+    /// When the manifest does not declare an <c>imageInfo</c> object, the push fails because the
+    /// artifact destination and tags are required manifest metadata.
     /// </remarks>
     Task PushImageInfoArtifactAsync(
         ManifestInfo manifest,

--- a/src/ImageBuilder/IManifestJsonService.cs
+++ b/src/ImageBuilder/IManifestJsonService.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
 
 namespace Microsoft.DotNet.ImageBuilder;
@@ -32,4 +33,16 @@ public interface IManifestJsonService
     /// </param>
     /// <returns>A fully initialized <see cref="ManifestInfo"/> with repos, images, and platforms resolved.</returns>
     ManifestInfo Load(IManifestOptionsInfo options);
+
+    /// <summary>
+    /// Returns the manifest's image-info artifact definition with all manifest variables resolved
+    /// in its repository name and tags.
+    /// </summary>
+    /// <param name="manifest">The manifest whose image-info artifact definition should be resolved.</param>
+    /// <returns>A new <see cref="ImageInfoArtifact"/> with variable substitutions applied.</returns>
+    /// <exception cref="System.InvalidOperationException">
+    /// Thrown when the manifest does not define an image-info artifact, or when its repository name
+    /// or a tag resolves to an invalid value after variable substitution.
+    /// </exception>
+    ImageInfoArtifact GetImageInfoArtifact(ManifestInfo manifest);
 }

--- a/src/ImageBuilder/ImageBuilder.cs
+++ b/src/ImageBuilder/ImageBuilder.cs
@@ -88,6 +88,7 @@ public static class ImageBuilder
         });
 
         builder.Services.AddSingleton<IImageCacheService, ImageCacheService>();
+        builder.Services.AddSingleton<IImageInfoService, ImageInfoService>();
         builder.Services.AddSingleton<IKustoClient, KustoClientWrapper>();
         builder.Services.AddSingleton<ILifecycleMetadataService, LifecycleMetadataService>();
         builder.Services.AddMemoryCache();
@@ -126,6 +127,7 @@ public static class ImageBuilder
         builder.Services.AddSingleton<ICommand, MergeImageInfoCommand>();
         builder.Services.AddSingleton<ICommand, PostPublishNotificationCommand>();
         builder.Services.AddSingleton<ICommand, PublishImageInfoCommand>();
+        builder.Services.AddSingleton<ICommand, PublishImageInfoArtifactCommand>();
         builder.Services.AddSingleton<ICommand, PublishMcrDocsCommand>();
         builder.Services.AddSingleton<ICommand, PullImagesCommand>();
         builder.Services.AddSingleton<ICommand, QueueBuildCommand>();

--- a/src/ImageBuilder/ImageInfoService.cs
+++ b/src/ImageBuilder/ImageInfoService.cs
@@ -49,16 +49,16 @@ public class ImageInfoService(
                 "The manifest's imageInfo property must define at least one tag in order to push "
                 + "image-info as an OCI artifact.");
 
+        string repo = $"{repoPrefix}{imageInfoArtifact.Repo}";
+        _logger.LogInformation(
+            "Image info will be published to registry={registry}, repo={Repo}, dryRun={DryRun}",
+            registry, repo, isDryRun);
+
         if (isDryRun)
         {
             _logger.LogInformation("Skipping image info artifact push due to dry run.");
             return;
         }
-
-        string repo = $"{repoPrefix}{imageInfoArtifact.Repo}";
-        _logger.LogInformation(
-            "Image info will be published to registry={registry}, repo={Repo}, dryRun={DryRun}",
-            registry, repo, isDryRun);
 
         IOrasService orasService = _orasServiceFactory.Create();
 

--- a/src/ImageBuilder/ImageInfoService.cs
+++ b/src/ImageBuilder/ImageInfoService.cs
@@ -1,0 +1,74 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.DotNet.ImageBuilder.Models.Manifest;
+using Microsoft.DotNet.ImageBuilder.Oras;
+using Microsoft.DotNet.ImageBuilder.ViewModel;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.DotNet.ImageBuilder;
+
+/// <inheritdoc/>
+public class ImageInfoService(
+    IManifestJsonService manifestJsonService,
+    IOrasServiceFactory orasServiceFactory,
+    ILogger<ImageInfoService> logger
+) : IImageInfoService
+{
+    private readonly IManifestJsonService _manifestJsonService =
+        manifestJsonService ?? throw new ArgumentNullException(nameof(manifestJsonService));
+
+    private readonly IOrasServiceFactory _orasServiceFactory =
+        orasServiceFactory ?? throw new ArgumentNullException(nameof(orasServiceFactory));
+
+    private readonly ILogger<ImageInfoService> _logger =
+        logger ?? throw new ArgumentNullException(nameof(logger));
+
+    /// <inheritdoc/>
+    public async Task PushImageInfoArtifactAsync(
+        ManifestInfo manifest,
+        byte[] imageInfoContent,
+        string registry,
+        string? repoPrefix,
+        bool isDryRun,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(manifest);
+        ArgumentNullException.ThrowIfNull(imageInfoContent);
+        ArgumentException.ThrowIfNullOrWhiteSpace(registry);
+
+        ImageInfoArtifact imageInfoArtifact = _manifestJsonService.GetImageInfoArtifact(manifest);
+
+        if (imageInfoArtifact.Tags.Count == 0)
+            throw new InvalidOperationException(
+                "The manifest's imageInfo property must define at least one tag in order to push "
+                + "image-info as an OCI artifact.");
+
+        if (isDryRun)
+        {
+            _logger.LogInformation("Skipping image info artifact push due to dry run.");
+            return;
+        }
+
+        string repo = $"{repoPrefix}{imageInfoArtifact.Repo}";
+        _logger.LogInformation(
+            "Image info will be published to registry={registry}, repo={Repo}, dryRun={DryRun}",
+            registry, repo, isDryRun);
+
+        IOrasService orasService = _orasServiceFactory.Create();
+
+        await orasService.PushArtifactAsync(
+            imageInfoContent,
+            OciArtifactType.ImageInfo,
+            OciArtifactType.ImageInfo,
+            registry,
+            repo,
+            imageInfoArtifact.Tags.Keys,
+            cancellationToken: cancellationToken);
+    }
+}

--- a/src/ImageBuilder/ManifestJsonService.cs
+++ b/src/ImageBuilder/ManifestJsonService.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using Kusto.Cloud.Platform.Text;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
 using Newtonsoft.Json;

--- a/src/ImageBuilder/ManifestJsonService.cs
+++ b/src/ImageBuilder/ManifestJsonService.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using Kusto.Cloud.Platform.Text;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
 using Newtonsoft.Json;
@@ -52,17 +53,21 @@ public class ManifestJsonService(IFileSystem fileSystem, ILogger<ManifestJsonSer
     /// Creates a fully initialized <see cref="ManifestInfo"/> from the manifest file at
     /// <paramref name="manifestPath"/>, applying the given filter and options.
     /// </summary>
-    private ManifestInfo Create(string manifestPath, ManifestFilter manifestFilter, IManifestOptionsInfo options)
+    private ManifestInfo Create(string filePath, ManifestFilter manifestFilter, IManifestOptionsInfo options)
     {
-        string manifestDirectory = PathHelper.GetNormalizedDirectory(manifestPath);
-        Manifest model = LoadModel(manifestPath, manifestDirectory);
-        model.Validate(manifestDirectory);
+        filePath = PathHelper.NormalizePath(filePath);
+        string fullPath = Path.GetFullPath(filePath);
+        string directory = Path.GetDirectoryName(fullPath) ?? "";
+        string fileName = Path.GetFileName(fullPath);
+
+        Manifest model = LoadModel(fullPath, directory);
+        model.Validate(directory);
 
         ManifestInfo manifestInfo = new()
         {
             Model = model,
             Registry = options.RegistryOverride ?? model.Registry,
-            Directory = manifestDirectory
+            FilePath = filePath
         };
 
         manifestInfo.VariableHelper = new VariableHelper(model, options, manifestInfo.GetRepoById);
@@ -98,6 +103,37 @@ public class ManifestJsonService(IFileSystem fileSystem, ILogger<ManifestJsonSer
             .ToArray();
 
         return manifestInfo;
+    }
+
+    /// <inheritdoc />
+    public ImageInfoArtifact GetImageInfoArtifact(ManifestInfo manifest)
+    {
+        ArgumentNullException.ThrowIfNull(manifest);
+
+        var model = manifest.Model.ImageInfo
+            ?? throw new InvalidOperationException(
+                $"The 'imageInfo' field is not set in {manifest.FilePath}."
+                + " It is required in order to publish or fetch image info as an OCI artifact.");
+
+        var repo = manifest.VariableHelper.SubstituteValues(model.Repo)
+            ?? throw new InvalidOperationException(
+                $"After resolving variables, imageInfo.repo is not valid in {manifest.FilePath}."
+                + $" Original value: '{model.Repo}'."
+                + " It is required in order to publish or fetch image info as an OCI artifact.");
+
+        ImageInfoArtifact resolved = new() { Repo = repo };
+        foreach ((string tag, Tag tagValue) in model.Tags)
+        {
+            var resolvedTag = manifest.VariableHelper.SubstituteValues(tag)
+                ?? throw new InvalidOperationException(
+                    $"After resolving variables, a tag in imageInfo was empty in {manifest.FilePath}."
+                    + $" Original value: '{tag}'."
+                    + " It is required in order to publish or fetch image info as an OCI artifact.");
+
+            resolved.Tags[resolvedTag] = tagValue;
+        }
+
+        return resolved;
     }
 
     /// <summary>

--- a/src/ImageBuilder/Oras/IOrasService.cs
+++ b/src/ImageBuilder/Oras/IOrasService.cs
@@ -71,4 +71,25 @@ public interface IOrasService
         string artifactType,
         IDictionary<string, string> annotations,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Pushes text content to the registry as a single standalone OCI artifact and applies one or
+    /// more tags to it, so that the same artifact can later be pulled by any of those tags.
+    /// </summary>
+    /// <param name="content">The artifact content to store as the single layer (e.g., image-info JSON).</param>
+    /// <param name="mediaType">The media type of the content layer.</param>
+    /// <param name="artifactType">The OCI artifact type recorded on the manifest.</param>
+    /// <param name="registry">The target registry host (e.g., "myregistry.azurecr.io").</param>
+    /// <param name="repository">The target repository within the registry (e.g., "dotnet/versions").</param>
+    /// <param name="tags">The tags to apply to the pushed artifact. At least one tag is required.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The digest of the single pushed artifact manifest.</returns>
+    Task<string> PushArtifactAsync(
+        byte[] content,
+        string mediaType,
+        string artifactType,
+        string registry,
+        string repository,
+        IEnumerable<string> tags,
+        CancellationToken cancellationToken = default);
 }

--- a/src/ImageBuilder/Oras/IOrasService.cs
+++ b/src/ImageBuilder/Oras/IOrasService.cs
@@ -73,7 +73,7 @@ public interface IOrasService
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Pushes text content to the registry as a single standalone OCI artifact and applies one or
+    /// Pushes content to the registry as a single standalone OCI artifact and applies one or
     /// more tags to it, so that the same artifact can later be pulled by any of those tags.
     /// </summary>
     /// <param name="content">The artifact content to store as the single layer (e.g., image-info JSON).</param>

--- a/src/ImageBuilder/Oras/OciArtifactType.cs
+++ b/src/ImageBuilder/Oras/OciArtifactType.cs
@@ -18,4 +18,10 @@ public static class OciArtifactType
     /// Microsoft artifact lifecycle metadata.
     /// </summary>
     public const string Lifecycle = "application/vnd.microsoft.artifact.lifecycle";
+
+    /// <summary>
+    /// Image info artifact describing the set of images produced by a build. This value is used
+    /// both as the OCI manifest's artifactType and as the media type of the JSON content layer.
+    /// </summary>
+    public const string ImageInfo = "application/vnd.microsoft.dotnet.image-info.v1+json";
 }

--- a/src/ImageBuilder/Oras/OrasDotNetService.cs
+++ b/src/ImageBuilder/Oras/OrasDotNetService.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Text.Json.Nodes;
 using System.Threading;
@@ -221,24 +222,94 @@ public class OrasDotNetService(
         return artifactDescriptor.Digest;
     }
 
+    /// <inheritdoc/>
+    public async Task<string> PushArtifactAsync(
+        byte[] content,
+        string mediaType,
+        string artifactType,
+        string registry,
+        string repository,
+        IEnumerable<string> tags,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        ArgumentException.ThrowIfNullOrWhiteSpace(mediaType);
+        ArgumentException.ThrowIfNullOrWhiteSpace(artifactType);
+        ArgumentException.ThrowIfNullOrWhiteSpace(registry);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repository);
+        ArgumentNullException.ThrowIfNull(tags);
+
+        // Build the full registry/repo:tag reference for each tag so they're unambiguous.
+        List<string> taggedReferences = tags
+            .Select(tag => new ImageName(registry, repository, tag, digest: null))
+            .Select(imageName => imageName.ToString())
+            .ToList();
+        if (taggedReferences.Count == 0)
+        {
+            throw new ArgumentException("At least one tag must be provided.", nameof(tags));
+        }
+
+        Repository repo = CreateRepository(registry, repository);
+
+        Descriptor layerDescriptor = Descriptor.Create(content, mediaType);
+        await repo.PushAsync(layerDescriptor, new MemoryStream(content), cancellationToken);
+
+        PackManifestOptions options = new()
+        {
+            Layers = [layerDescriptor]
+        };
+
+        long startTime = Stopwatch.GetTimestamp();
+        Descriptor manifestDescriptor =
+            await Packer.PackManifestAsync(
+                pusher: repo,
+                version: Packer.ManifestVersion.Version1_1,
+                artifactType: artifactType,
+                options: options,
+                cancellationToken);
+
+        // Packer pushes the manifest by digest only. Apply each tag to the same manifest so that
+        // identical content isn't pushed multiple times under different digests.
+        foreach (string taggedReference in taggedReferences)
+        {
+            await repo.TagAsync(manifestDescriptor, taggedReference, cancellationToken);
+        }
+
+        TimeSpan elapsed = Stopwatch.GetElapsedTime(startTime);
+        _logger.LogInformation(
+            "Pushed artifact to {Registry}/{Repository}: digest={Digest}, artifactType={ArtifactType}, tags=[{Tags}] in {Elapsed}",
+            registry, repository, manifestDescriptor.Digest, artifactType, string.Join(", ", taggedReferences), elapsed);
+
+        return manifestDescriptor.Digest;
+    }
+
     /// <summary>
     /// Creates an authenticated ORAS repository client for the given reference.
     /// </summary>
     /// <param name="reference">Full registry reference (e.g., "registry.io/repo:tag").</param>
-    private Repository CreateRepository(string reference)
+    private Repository CreateRepository(string reference) =>
+        CreateRepository(Reference.Parse(reference));
+
+    /// <summary>
+    /// Creates an authenticated ORAS repository client for the given registry and repository.
+    /// </summary>
+    /// <param name="registry">Registry host (e.g., "registry.io").</param>
+    /// <param name="repository">Repository name (e.g., "repo").</param>
+    private Repository CreateRepository(string registry, string repository) =>
+        CreateRepository(new Reference(registry, repository));
+
+    private Repository CreateRepository(Reference reference)
     {
-        _logger.LogTrace("Creating ORAS repository for: {Reference}", reference);
-        Reference parsedRef = Reference.Parse(reference);
         _logger.LogTrace(
-            "Parsed reference: Registry={Registry}, Repository={Repository}, Reference={ContentReference}",
-            parsedRef.Registry, parsedRef.Repository, parsedRef.ContentReference);
+            "Creating ORAS repository for: Registry={Registry}, Repository={Repository}, Reference={ContentReference}",
+            reference.Registry, reference.Repository, reference.ContentReference);
 
         HttpClient httpClient = _httpClientFactory.CreateClient();
         Client authClient = new(httpClient, _credentialProvider, _orasCache);
 
         RepositoryOptions repositoryOptions = new()
         {
-            Reference = parsedRef,
+            Reference = reference,
             Client = authClient
         };
 

--- a/src/ImageBuilder/PathHelper.cs
+++ b/src/ImageBuilder/PathHelper.cs
@@ -31,10 +31,5 @@ namespace Microsoft.DotNet.ImageBuilder
 
             return result;
         }
-
-        public static string GetNormalizedDirectory(string path)
-        {
-            return PathHelper.NormalizePath(Path.GetDirectoryName(path));
-        }
     }
 }

--- a/src/ImageBuilder/ViewModel/ManifestInfo.cs
+++ b/src/ImageBuilder/ViewModel/ManifestInfo.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 
@@ -46,9 +47,14 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         public VariableHelper VariableHelper { get; internal set; }
 
         /// <summary>
-        /// Gets the directory of the manifest file.
+        /// Full path to the file this ManifestInfo was read from.
         /// </summary>
-        public string Directory { get; internal set; }
+        public string FilePath { get; internal set; }
+
+        /// <summary>
+        /// Directory containing the file this ManifestInfo was read from.
+        /// </summary>
+        public string Directory => Path.GetDirectoryName(FilePath) ?? "";
 
         /// <summary>
         /// Path to the manifest's readme file, if defined.
@@ -65,7 +71,7 @@ namespace Microsoft.DotNet.ImageBuilder.ViewModel
         }
 
         public IEnumerable<ImageInfo> GetAllImages() => AllRepos.SelectMany(repo => repo.AllImages);
-        
+
         public ImageInfo GetImageByPlatform(PlatformInfo platform) =>
             GetAllImages()
                 .FirstOrDefault(image => image.AllPlatforms.Contains(platform));


### PR DESCRIPTION
This is part 1/2 of #2142. This contains the publishing side of things. Follow-up PR will be the consumption side.

This PR is focused on being as small as possible while adding the OCI artifact publishing.

Contents:
- New command, `publishImageInfoArtifact`, that can be used in the exact same place as the existing `publishImageInfo` command.
- New service, `ImageInfoService`, that handles publishing the image info artifact. It will also handle pulling the artifact later, in the consumption side of things.
- New field in `manifest.json` for specifying where the image info artifact will be published to.
- The artifact is of type `application/vnd.microsoft.dotnet.image-info.v1+json`.

Other notes:
- `RepoPrefix` is read directly from publishConfig into `publishImageInfoArtifact` without going through a CLI option (first command that does this, it should be the pattern going forwards).