### PR TITLE
Consume OCI image info in `build`, `generateBuildMatrix`, `getStaleImages`, `mergeImageInfo` commands 

### DIFF
--- a/src/ImageBuilder.Tests/BuildCommandTests.cs
+++ b/src/ImageBuilder.Tests/BuildCommandTests.cs
@@ -14,6 +14,7 @@ using Microsoft.DotNet.ImageBuilder.Commands;
 using Microsoft.DotNet.ImageBuilder.Configuration;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
+using Microsoft.DotNet.ImageBuilder.Oras;
 using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
 using Microsoft.Extensions.Logging;
@@ -831,7 +832,13 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
 
-            Mock<IManifestService> manifestServiceMock = CreateManifestServiceMock(localImageDigestResults: [new($"{runtimeDepsRepo}:{tag}", runtimeDepsDigest)], []);
+            Mock<IManifestService> manifestServiceMock = CreateManifestServiceMock(
+                localImageDigestResults:
+                [
+                    new($"{runtimeDepsRepo}:{tag}", runtimeDepsDigest),
+                    new($"{runtimeDepsRepo}:{newTag}", runtimeDepsDigest)
+                ],
+                []);
             Mock<IManifestServiceFactory> manifestServiceFactoryMock = CreateManifestServiceFactoryMock(manifestServiceMock);
 
             Mock<IDockerService> dockerServiceMock = CreateDockerServiceMock();
@@ -855,13 +862,15 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 .Returns(currentRuntimeDepsCommitSha);
 
             Mock<ICopyImageService> copyImageServiceMock = new();
+            Mock<IImageInfoService> imageInfoServiceMock = new();
 
             BuildCommand command = CreateBuildCommand(
                 dockerService: dockerServiceMock.Object,
                 gitService: gitServiceMock.Object,
                 copyImageService: copyImageServiceMock.Object,
                 manifestServiceFactory: manifestServiceFactoryMock.Object,
-                imageCacheService: new ImageCacheService(Mock.Of<ILogger<ImageCacheService>>(), gitServiceMock.Object));
+                imageCacheService: new ImageCacheService(Mock.Of<ILogger<ImageCacheService>>(), gitServiceMock.Object),
+                imageInfoService: imageInfoServiceMock.Object);
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.ImageInfoOutputPath = Path.Combine(tempFolderContext.Path, "dest-image-info.json");
             command.Options.ImageInfoSourcePath = Path.Combine(tempFolderContext.Path, "src-image-info.json");
@@ -917,8 +926,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 Repos = sourceRepos.ToList()
             };
 
-            string sourceImageArtifactDetailsOutput = JsonHelper.SerializeObject(sourceImageArtifactDetails);
-            File.WriteAllText(command.Options.ImageInfoSourcePath, sourceImageArtifactDetailsOutput);
+            File.WriteAllText(
+                command.Options.ImageInfoSourcePath,
+                JsonHelper.SerializeObject(sourceImageArtifactDetails));
 
             Manifest manifest = CreateManifest(
                 CreateRepo(runtimeDepsRepo,
@@ -1011,6 +1021,49 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     srcRegistryName: null);
 
             dockerServiceMock.VerifyNoOtherCalls();
+        }
+
+        [TestMethod]
+        public async Task BuildCommand_ImageInfoArtifact_UsesManifestRegistryWhenNoOverrideIsSet()
+        {
+            const string registry = "example.azurecr.io";
+
+            using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
+
+            Mock<IImageInfoService> imageInfoServiceMock = new();
+            imageInfoServiceMock
+                .Setup(service => service.PullImageInfoArtifactAsync(
+                    It.IsAny<ManifestInfo>(),
+                    registry,
+                    null,
+                    default))
+                .ReturnsAsync(JsonHelper.SerializeObject(new ImageArtifactDetails()));
+
+            BuildCommand command = CreateBuildCommand(imageInfoService: imageInfoServiceMock.Object);
+            command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
+            command.Options.FilterOptions.Dockerfile.Paths = new string[] { "not-matching" };
+
+            string dockerfile = DockerfileHelper.CreateDockerfile("1.0/runtime/os", tempFolderContext, "scratch");
+            Manifest manifest = CreateManifest(
+                CreateRepo(
+                    "runtime",
+                    CreateImage(CreatePlatform(dockerfile, new string[] { "tag" }))));
+            manifest.Registry = registry;
+            manifest.ImageInfo = new ImageInfoArtifact
+            {
+                Repo = "image-info",
+                Tags = new Dictionary<string, Tag>
+                {
+                    { "latest", new Tag() }
+                }
+            };
+
+            File.WriteAllText(command.Options.Manifest, JsonConvert.SerializeObject(manifest));
+
+            command.LoadManifest();
+            await command.ExecuteAsync();
+
+            imageInfoServiceMock.VerifyAll();
         }
 
         /// <summary>
@@ -3641,7 +3694,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             IManifestServiceFactory? manifestServiceFactory = null,
             IRegistryCredentialsProvider? registryCredentialsProvider = null,
             IAzureTokenCredentialProvider? azureTokenCredentialProvider = null,
-            IImageCacheService? imageCacheService = null)
+            IImageCacheService? imageCacheService = null,
+            IImageInfoService? imageInfoService = null)
         {
             BuildCommand command = new(
                 manifestJsonService ?? TestHelper.CreateManifestJsonService(),
@@ -3653,10 +3707,17 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 manifestServiceFactory ?? Mock.Of<IManifestServiceFactory>(),
                 registryCredentialsProvider ?? Mock.Of<IRegistryCredentialsProvider>(),
                 azureTokenCredentialProvider ?? Mock.Of<IAzureTokenCredentialProvider>(),
-                imageCacheService ?? Mock.Of<IImageCacheService>());
+                imageCacheService ?? Mock.Of<IImageCacheService>(),
+                imageInfoService ?? CreateImageInfoService());
 
             return command;
         }
+
+        private static ImageInfoService CreateImageInfoService() =>
+            new(
+                TestHelper.CreateManifestJsonService(),
+                Mock.Of<IOrasServiceFactory>(),
+                Mock.Of<ILogger<ImageInfoService>>());
         #nullable disable
 
         private static Mock<IDockerService> CreateDockerServiceMock(string buildOutput = null)

--- a/src/ImageBuilder.Tests/GenerateBuildMatrixCommandTests.cs
+++ b/src/ImageBuilder.Tests/GenerateBuildMatrixCommandTests.cs
@@ -12,7 +12,9 @@ using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Commands;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
+using Microsoft.DotNet.ImageBuilder.Oras;
 using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
+using Microsoft.DotNet.ImageBuilder.ViewModel;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Newtonsoft.Json;
@@ -258,7 +260,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             SetCacheResult(imageCacheServiceMock, dockerfileRuntime2Path, ImageCacheState.NotCached);
             SetCacheResult(imageCacheServiceMock, dockerfileSdk2Path, ImageCacheState.NotCached);
 
-            GenerateBuildMatrixCommand command = new(TestHelper.CreateManifestJsonService(), imageCacheServiceMock.Object, Mock.Of<IManifestServiceFactory>(), Mock.Of<ILogger<GenerateBuildMatrixCommand>>());
+            GenerateBuildMatrixCommand command = new(
+                TestHelper.CreateManifestJsonService(),
+                CreateImageInfoService(),
+                imageCacheServiceMock.Object,
+                Mock.Of<IManifestServiceFactory>(),
+                Mock.Of<ILogger<GenerateBuildMatrixCommand>>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.MatrixType = MatrixType.PlatformDependencyGraph;
             command.Options.ImageInfoPath = Path.Combine(tempFolderContext.Path, "imageinfo.json");
@@ -825,11 +832,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         [DataRow(true, true, true, null)]
         public async Task PlatformVersionedOs_Cached(bool isRuntimeCached, bool isAspnetCached, bool isSdkCached, string expectedPaths)
         {
+            const string registry = "example.azurecr.io";
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
-            GenerateBuildMatrixCommand command = CreateCommand();
+            Mock<IImageInfoService> imageInfoServiceMock = new();
+            GenerateBuildMatrixCommand command = CreateCommand(imageInfoServiceMock.Object);
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.MatrixType = MatrixType.PlatformVersionedOs;
-            command.Options.ImageInfoPath = Path.Combine(tempFolderContext.Path, "imageinfo.json");
             command.Options.ProductVersionComponents = 2;
 
             string runtimeDockerfilePath;
@@ -864,6 +872,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         },
                         productVersion: "1.0"))
             );
+            manifest.ImageInfo = new ImageInfoArtifact
+            {
+                Repo = "image-info",
+                Tags = new Dictionary<string, Tag>
+                {
+                    { "latest", new Tag() }
+                }
+            };
 
             File.WriteAllText(Path.Combine(tempFolderContext.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));
 
@@ -918,7 +934,15 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     }
                 }
             };
-            File.WriteAllText(command.Options.ImageInfoPath, JsonHelper.SerializeObject(imageArtifactDetails));
+            command.Options.ImageInfoRegistryOverride = registry;
+            command.Options.ImageInfoRepoPrefix = "prefix/";
+            imageInfoServiceMock
+                .Setup(service => service.PullImageInfoArtifactAsync(
+                    It.IsAny<ManifestInfo>(),
+                    registry,
+                    command.Options.ImageInfoRepoPrefix,
+                    default))
+                .ReturnsAsync(JsonHelper.SerializeObject(imageArtifactDetails));
 
             command.LoadManifest();
             IEnumerable<BuildMatrixInfo> matrixInfos = await command.GenerateMatrixInfoAsync();
@@ -937,6 +961,50 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
                 imageBuilderPaths.ShouldBe(expectedPaths);
             }
+        }
+
+        [TestMethod]
+        public async Task PlatformVersionedOs_ImageInfoArtifact_UsesManifestRegistryWhenNoOverrideIsSet()
+        {
+            const string registry = "example.azurecr.io";
+
+            using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
+            Mock<IImageInfoService> imageInfoServiceMock = new();
+            GenerateBuildMatrixCommand command = CreateCommand(imageInfoServiceMock.Object);
+            command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
+            command.Options.MatrixType = MatrixType.PlatformVersionedOs;
+            command.Options.FilterOptions.Dockerfile.Paths = ["not-matching"];
+
+            string dockerfile = DockerfileHelper.CreateDockerfile("1.0/runtime/os", tempFolderContext);
+            Manifest manifest = CreateManifest(
+                CreateRepo(
+                    "runtime",
+                    CreateImage(CreatePlatform(dockerfile, ["tag"]))));
+            manifest.Registry = registry;
+            manifest.ImageInfo = new ImageInfoArtifact
+            {
+                Repo = "image-info",
+                Tags = new Dictionary<string, Tag>
+                {
+                    { "latest", new Tag() }
+                }
+            };
+
+            File.WriteAllText(command.Options.Manifest, JsonConvert.SerializeObject(manifest));
+
+            imageInfoServiceMock
+                .Setup(service => service.PullImageInfoArtifactAsync(
+                    It.IsAny<ManifestInfo>(),
+                    registry,
+                    null,
+                    default))
+                .ReturnsAsync(JsonHelper.SerializeObject(new ImageArtifactDetails()));
+
+            command.LoadManifest();
+            IEnumerable<BuildMatrixInfo> matrixInfos = await command.GenerateMatrixInfoAsync();
+
+            matrixInfos.ShouldBeEmpty();
+            imageInfoServiceMock.VerifyAll();
         }
 
         /// <summary>
@@ -1713,6 +1781,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             GenerateBuildMatrixCommand command = new(
                 TestHelper.CreateManifestJsonService(),
+                CreateImageInfoService(),
                 imageCacheService,
                 manifestServiceFactoryMock.Object,
                 Mock.Of<ILogger<GenerateBuildMatrixCommand>>());
@@ -1757,7 +1826,18 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             return command;
         }
 
-        private static GenerateBuildMatrixCommand CreateCommand() =>
-            new(TestHelper.CreateManifestJsonService(), Mock.Of<IImageCacheService>(), Mock.Of<IManifestServiceFactory>(), Mock.Of<ILogger<GenerateBuildMatrixCommand>>());
+        private static GenerateBuildMatrixCommand CreateCommand(IImageInfoService imageInfoService = null) =>
+            new(
+                TestHelper.CreateManifestJsonService(),
+                imageInfoService ?? CreateImageInfoService(),
+                Mock.Of<IImageCacheService>(),
+                Mock.Of<IManifestServiceFactory>(),
+                Mock.Of<ILogger<GenerateBuildMatrixCommand>>());
+
+        private static ImageInfoService CreateImageInfoService() =>
+            new(
+                TestHelper.CreateManifestJsonService(),
+                Mock.Of<IOrasServiceFactory>(),
+                Mock.Of<ILogger<ImageInfoService>>());
     }
 }

--- a/src/ImageBuilder.Tests/GetStaleImagesCommandTests.cs
+++ b/src/ImageBuilder.Tests/GetStaleImagesCommandTests.cs
@@ -9,7 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text.Json.Nodes;
-using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using LibGit2Sharp;
 using Microsoft.DotNet.ImageBuilder.Commands;
@@ -17,6 +17,7 @@ using Microsoft.DotNet.ImageBuilder.Models.Image;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 using Microsoft.DotNet.ImageBuilder.Models.Subscription;
 using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
+using Microsoft.DotNet.ImageBuilder.ViewModel;
 using Microsoft.DotNet.VersionTools.Automation;
 using Microsoft.Extensions.Logging;
 using Microsoft.TeamFoundation.Core.WebApi;
@@ -1645,14 +1646,6 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     Owner = GetRepoOwner(testMethodName, index.ToString()),
                     Path = "testmanifest.json"
                 },
-                ImageInfo = new GitFile
-                {
-
-                    Owner = GetStaleImagesCommandTests.GitHubOwner,
-                    Repo = GetStaleImagesCommandTests.GitHubRepo,
-                    Branch = GetStaleImagesCommandTests.GitHubBranch,
-                    Path = "docker/image-info.json"
-                },
                 OsType = osType
             };
         }
@@ -1669,7 +1662,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             private readonly GetStaleImagesCommand command;
             private readonly Mock<ILogger<GetStaleImagesCommand>> loggerServiceMock = new Mock<ILogger<GetStaleImagesCommand>>();
             private readonly string osType;
-            private readonly IOctokitClientFactory octokitClientFactory;
+            private readonly IImageInfoService imageInfoService;
             private readonly IGitService gitService;
 
             private const string VariableName = "my-var";
@@ -1715,7 +1708,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 };
 
                 this.gitService = CreateGitService(subscriptionInfos, dockerfileInfos);
-                this.octokitClientFactory = CreateOctokitClientFactory(subscriptionInfos);
+                this.imageInfoService = CreateImageInfoService(subscriptionInfos);
 
                 (ManifestServiceFactoryMock, ManifestServiceMock) = CreateManifestServiceMocks();
 
@@ -1769,72 +1762,44 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             private GetStaleImagesCommand CreateCommand()
             {
                 GetStaleImagesCommand command = new(
-                    this.ManifestServiceFactoryMock.Object, TestHelper.CreateManifestJsonService(), this.loggerServiceMock.Object, this.octokitClientFactory, this.gitService);
+                    this.ManifestServiceFactoryMock.Object,
+                    TestHelper.CreateManifestJsonService(),
+                    this.loggerServiceMock.Object,
+                    this.gitService,
+                    this.imageInfoService);
                 command.Options.SubscriptionOptions.SubscriptionsPath = this.subscriptionsPath;
                 command.Options.VariableName = VariableName;
                 command.Options.FilterOptions.Platform.OsType = this.osType;
+                command.Options.ImageInfoRegistryOverride = "publish.example.com";
                 command.Options.GitOptions.Email = "test";
                 command.Options.GitOptions.Username = "test";
                 command.Options.GitOptions.GitHubAuthOptions = new GitHubAuthOptions(AuthToken: "test");
                 return command;
             }
 
-            private static IOctokitClientFactory CreateOctokitClientFactory(SubscriptionInfo[] subscriptionInfos)
+            private static IImageInfoService CreateImageInfoService(SubscriptionInfo[] subscriptionInfos)
             {
-                Mock<Octokit.ITreesClient> treesClientMock = new();
-                Mock<Octokit.IBlobsClient> blobsClientMock = new();
-
-                foreach (SubscriptionInfo subscriptionInfo in subscriptionInfos)
-                {
-                    if (subscriptionInfo.ImageInfo != null)
+                Mock<IImageInfoService> imageInfoServiceMock = new();
+                imageInfoServiceMock
+                    .Setup(o => o.PullImageInfoArtifactAsync(
+                        It.IsAny<ManifestInfo>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>(),
+                        It.IsAny<CancellationToken>()))
+                    .ReturnsAsync((
+                        ManifestInfo manifest,
+                        string registry,
+                        string repoPrefix,
+                        CancellationToken cancellationToken) =>
                     {
+                        SubscriptionInfo subscriptionInfo = subscriptionInfos
+                            .First(info => manifest.FilePath.Contains(
+                                $"{info.Subscription.Manifest.Owner}-{info.Subscription.Manifest.Repo}-{info.Subscription.Manifest.Branch}"));
 
-                        string generatedFakeSha = Guid.NewGuid().ToString();
-                        treesClientMock
-                            .Setup(o => o.Get(
-                                subscriptionInfo.Subscription.ImageInfo.Owner,
-                                subscriptionInfo.Subscription.ImageInfo.Repo,
-                                It.Is<string>(reference => reference.StartsWith(subscriptionInfo.Subscription.ImageInfo.Branch))))
-                            .ReturnsAsync(new Octokit.TreeResponse("sha", "url", new List<Octokit.TreeItem>
-                            {
-                                new Octokit.TreeItem(
-                                    "dummy-path",
-                                    "mode",
-                                    Octokit.TreeType.Blob,
-                                    0,
-                                    "sha",
-                                    "url"),
-                                new Octokit.TreeItem(
-                                    Path.GetFileName(subscriptionInfo.Subscription.ImageInfo.Path),
-                                    "mode",
-                                    Octokit.TreeType.Blob,
-                                    0,
-                                    generatedFakeSha,
-                                    "url")
-                            }.AsReadOnly(), false));
+                        return JsonConvert.SerializeObject(subscriptionInfo.ImageInfo);
+                    });
 
-                        string imageInfoContents = JsonConvert.SerializeObject(subscriptionInfo.ImageInfo);
-                        byte[] imageInfoBytes = Encoding.UTF8.GetBytes(imageInfoContents);
-                        string imageInfoBase64 = Convert.ToBase64String(imageInfoBytes);
-
-                        blobsClientMock
-                            .Setup(o => o.Get(
-                                subscriptionInfo.Subscription.ImageInfo.Owner,
-                                subscriptionInfo.Subscription.ImageInfo.Repo,
-                                generatedFakeSha))
-                            .ReturnsAsync(new Octokit.Blob("nodeId", imageInfoBase64, Octokit.EncodingType.Base64, generatedFakeSha, 0));
-                    }
-                }
-
-                Mock<IOctokitClientFactory> octokitClientFactoryMock = new();
-                octokitClientFactoryMock
-                    .Setup(o => o.CreateTreesClientAsync(It.IsAny<GitHubAuthOptions>()))
-                    .ReturnsAsync(treesClientMock.Object);
-                octokitClientFactoryMock
-                    .Setup(o => o.CreateBlobsClientAsync(It.IsAny<GitHubAuthOptions>()))
-                    .ReturnsAsync(blobsClientMock.Object);
-
-                return octokitClientFactoryMock.Object;
+                return imageInfoServiceMock.Object;
             }
 
             private static bool IsMatchingBranch(GitHubBranch branch)

--- a/src/ImageBuilder.Tests/ImageInfoServiceTests.cs
+++ b/src/ImageBuilder.Tests/ImageInfoServiceTests.cs
@@ -6,8 +6,10 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.DotNet.ImageBuilder.Models.Image;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 using Microsoft.DotNet.ImageBuilder.Oras;
 using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
@@ -17,6 +19,8 @@ using Moq;
 using Shouldly;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.DockerfileHelper;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.ManifestHelper;
+using OrasDescriptor = OrasProject.Oras.Oci.Descriptor;
+using OrasManifest = OrasProject.Oras.Oci.Manifest;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests;
 
@@ -148,6 +152,138 @@ public class ImageInfoServiceTests
             It.IsAny<CancellationToken>()), Times.Never);
     }
 
+    [TestMethod]
+    public async Task PullImageInfoArtifactAsync_PullsConfiguredArtifact()
+    {
+        using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
+        string dockerfile = CreateDockerfile("1.0/repo/os", tempFolderContext);
+        ManifestInfo manifest = CreateManifestInfo(tempFolderContext, dockerfile);
+        ImageArtifactDetails imageInfo = new()
+        {
+            Repos =
+            [
+                new RepoData
+                {
+                    Repo = "repo"
+                }
+            ]
+        };
+
+        Mock<IOrasService> orasServiceMock = new();
+        orasServiceMock
+            .Setup(o => o.PullAsync(
+                "publish.example.com",
+                "public/dotnet/versions",
+                "latest",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new OciArtifact(
+                CreateManifestDescriptor(),
+                CreateOrasManifest(OciArtifactType.ImageInfo, OciArtifactType.ImageInfo),
+                [CreateBlob(Encoding.UTF8.GetBytes(JsonHelper.SerializeObject(imageInfo)), OciArtifactType.ImageInfo)]));
+        ImageInfoService service = CreateService(orasServiceMock.Object);
+
+        string result = await service.PullImageInfoArtifactAsync(
+            manifest,
+            registry: "publish.example.com",
+            repoPrefix: "public/");
+
+        result.ShouldBe(JsonHelper.SerializeObject(imageInfo));
+        orasServiceMock.VerifyAll();
+    }
+
+    [TestMethod]
+    public async Task PullImageInfoArtifactAsync_WrongArtifactType_Throws()
+    {
+        using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
+        string dockerfile = CreateDockerfile("1.0/repo/os", tempFolderContext);
+        ManifestInfo manifest = CreateManifestInfo(tempFolderContext, dockerfile);
+
+        Mock<IOrasService> orasServiceMock = new();
+        orasServiceMock
+            .Setup(o => o.PullAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new OciArtifact(
+                CreateManifestDescriptor(),
+                CreateOrasManifest("application/vnd.other", OciArtifactType.ImageInfo),
+                [CreateBlob(Encoding.UTF8.GetBytes("{}"), OciArtifactType.ImageInfo)]));
+        ImageInfoService service = CreateService(orasServiceMock.Object);
+
+        InvalidOperationException exception = await Should.ThrowAsync<InvalidOperationException>(() =>
+            service.PullImageInfoArtifactAsync(
+                manifest,
+                registry: "publish.example.com",
+                repoPrefix: "public/"));
+
+        exception.Message.ShouldContain("artifactType 'application/vnd.other'");
+    }
+
+    [TestMethod]
+    public async Task PullImageInfoArtifactAsync_WrongMediaType_Throws()
+    {
+        using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
+        string dockerfile = CreateDockerfile("1.0/repo/os", tempFolderContext);
+        ManifestInfo manifest = CreateManifestInfo(tempFolderContext, dockerfile);
+
+        Mock<IOrasService> orasServiceMock = new();
+        orasServiceMock
+            .Setup(o => o.PullAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new OciArtifact(
+                CreateManifestDescriptor(),
+                CreateOrasManifest(OciArtifactType.ImageInfo, "application/vnd.other"),
+                [CreateBlob(Encoding.UTF8.GetBytes("{}"), "application/vnd.other")]));
+        ImageInfoService service = CreateService(orasServiceMock.Object);
+
+        InvalidOperationException exception = await Should.ThrowAsync<InvalidOperationException>(() =>
+            service.PullImageInfoArtifactAsync(
+                manifest,
+                registry: "publish.example.com",
+                repoPrefix: "public/"));
+
+        exception.Message.ShouldContain("mediaType 'application/vnd.other'");
+    }
+
+    [TestMethod]
+    public async Task PullImageInfoArtifactAsync_MultipleLayers_Throws()
+    {
+        using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
+        string dockerfile = CreateDockerfile("1.0/repo/os", tempFolderContext);
+        ManifestInfo manifest = CreateManifestInfo(tempFolderContext, dockerfile);
+
+        Mock<IOrasService> orasServiceMock = new();
+        orasServiceMock
+            .Setup(o => o.PullAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new OciArtifact(
+                CreateManifestDescriptor(),
+                CreateOrasManifest(
+                    OciArtifactType.ImageInfo,
+                    OciArtifactType.ImageInfo,
+                    OciArtifactType.ImageInfo),
+                [
+                    CreateBlob(Encoding.UTF8.GetBytes("{}"), OciArtifactType.ImageInfo),
+                    CreateBlob(Encoding.UTF8.GetBytes("{}"), OciArtifactType.ImageInfo)
+                ]));
+        ImageInfoService service = CreateService(orasServiceMock.Object);
+
+        InvalidOperationException exception = await Should.ThrowAsync<InvalidOperationException>(() =>
+            service.PullImageInfoArtifactAsync(
+                manifest,
+                registry: "publish.example.com",
+                repoPrefix: "public/"));
+
+        exception.Message.ShouldContain("must have exactly one blob, but has 2");
+    }
+
     private static ImageInfoService CreateService(IOrasService orasService)
     {
         Mock<IOrasServiceFactory> orasServiceFactoryMock = new();
@@ -196,4 +332,34 @@ public class ImageInfoServiceTests
 
         return TestHelper.CreateManifestJsonService().Load(manifestOptionsMock.Object);
     }
+
+    private static OrasDescriptor CreateManifestDescriptor() => new()
+    {
+        MediaType = "application/vnd.oci.image.manifest.v1+json",
+        Digest = "sha256:manifest",
+        Size = 1
+    };
+
+    private static OrasManifest CreateOrasManifest(string artifactType, params string[] layerMediaTypes)
+    {
+        return new OrasManifest
+        {
+            ArtifactType = artifactType,
+            Config = OrasDescriptor.Empty,
+            Layers = layerMediaTypes
+                .Select(CreateLayerDescriptor)
+                .ToList(),
+            SchemaVersion = 2
+        };
+    }
+
+    private static OciBlob CreateBlob(byte[] content, string mediaType) =>
+        new(content, CreateLayerDescriptor(mediaType));
+
+    private static OrasDescriptor CreateLayerDescriptor(string mediaType) => new()
+    {
+        MediaType = mediaType,
+        Digest = "sha256:layer",
+        Size = 1
+    };
 }

--- a/src/ImageBuilder.Tests/MergeImageInfoFilesCommandTests.cs
+++ b/src/ImageBuilder.Tests/MergeImageInfoFilesCommandTests.cs
@@ -12,6 +12,7 @@ using Microsoft.DotNet.ImageBuilder.Commands;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
+using Microsoft.DotNet.ImageBuilder.ViewModel;
 using Moq;
 using Newtonsoft.Json;
 using Shouldly;
@@ -181,7 +182,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     }
                 };
 
-                MergeImageInfoCommand command = new MergeImageInfoCommand(TestHelper.CreateManifestJsonService());
+                MergeImageInfoCommand command = new MergeImageInfoCommand(TestHelper.CreateManifestJsonService(), Mock.Of<IImageInfoService>());
                 command.Options.SourceImageInfoFolderPath = Path.Combine(context.Path, "image-infos");
                 command.Options.DestinationImageInfoPath = Path.Combine(context.Path, "output.json");
                 command.Options.Manifest = Path.Combine(context.Path, "manifest.json");
@@ -485,7 +486,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     }
                 };
 
-                MergeImageInfoCommand command = new MergeImageInfoCommand(TestHelper.CreateManifestJsonService());
+                MergeImageInfoCommand command = new MergeImageInfoCommand(TestHelper.CreateManifestJsonService(), Mock.Of<IImageInfoService>());
                 command.Options.SourceImageInfoFolderPath = Path.Combine(context.Path, "image-infos");
                 command.Options.DestinationImageInfoPath = Path.Combine(context.Path, "output.json");
                 command.Options.Manifest = Path.Combine(context.Path, "manifest.json");
@@ -620,7 +621,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         [TestMethod]
         public async Task MergeImageInfoFilesCommand_SourceFolderPathNotFound()
         {
-            MergeImageInfoCommand command = new MergeImageInfoCommand(TestHelper.CreateManifestJsonService());
+            MergeImageInfoCommand command = new MergeImageInfoCommand(TestHelper.CreateManifestJsonService(), Mock.Of<IImageInfoService>());
             command.Options.SourceImageInfoFolderPath = "foo";
             command.Options.DestinationImageInfoPath = "output.json";
 
@@ -643,7 +644,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 // Store the content in a .txt file which the command should NOT be looking for.
                 File.WriteAllText("image-info.txt", JsonHelper.SerializeObject(imageArtifactDetails));
 
-                MergeImageInfoCommand command = new MergeImageInfoCommand(TestHelper.CreateManifestJsonService());
+                MergeImageInfoCommand command = new MergeImageInfoCommand(TestHelper.CreateManifestJsonService(), Mock.Of<IImageInfoService>());
                 command.Options.SourceImageInfoFolderPath = context.Path;
                 command.Options.DestinationImageInfoPath = "output.json";
 
@@ -772,7 +773,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            MergeImageInfoCommand command = new(TestHelper.CreateManifestJsonService());
+            MergeImageInfoCommand command = new(TestHelper.CreateManifestJsonService(), Mock.Of<IImageInfoService>());
             command.Options.SourceImageInfoFolderPath = Path.Combine(tempFolderContext.Path, "image-infos");
             command.Options.DestinationImageInfoPath = Path.Combine(tempFolderContext.Path, "output.json");
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
@@ -939,7 +940,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            MergeImageInfoCommand command = new(TestHelper.CreateManifestJsonService());
+            MergeImageInfoCommand command = new(TestHelper.CreateManifestJsonService(), Mock.Of<IImageInfoService>());
             command.Options.SourceImageInfoFolderPath = Path.Combine(tempFolderContext.Path, "image-infos");
             command.Options.DestinationImageInfoPath = Path.Combine(tempFolderContext.Path, "output.json");
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
@@ -1118,7 +1119,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             var outputImageInfoFile = Path.Combine(context.Path, "merged-image-info.json");
 
-            MergeImageInfoCommand command = new MergeImageInfoCommand(TestHelper.CreateManifestJsonService());
+            MergeImageInfoCommand command = new MergeImageInfoCommand(TestHelper.CreateManifestJsonService(), Mock.Of<IImageInfoService>());
             command.Options.SourceImageInfoFolderPath = sourceImageInfoDir;
             command.Options.DestinationImageInfoPath = outputImageInfoFile;
             command.Options.InitialImageInfoPath = initialImageInfoFile;
@@ -1153,6 +1154,109 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             initialShaMatches.ShouldHaveSingleItem();
             var initialCommitResult = initialShaMatches[0].Value;
             initialCommitResult.ShouldBe(CommitOverride);
+        }
+
+        [TestMethod]
+        public async Task MergeImageInfoFilesCommand_InitialImageInfoFromOciArtifact()
+        {
+            using TempFolderContext context = TestHelper.UseTempFolder();
+
+            string initialDockerfile = CreateDockerfile("1.0/repo/initial", context);
+            string updatedDockerfile = CreateDockerfile("1.0/repo/updated", context);
+            string sourceImageInfoDir = Path.Combine(context.Path, "image-infos");
+            Directory.CreateDirectory(sourceImageInfoDir);
+
+            ImageArtifactDetails initialImageInfo = new()
+            {
+                Repos =
+                {
+                    new RepoData
+                    {
+                        Repo = "repo",
+                        Images =
+                        {
+                            new ImageData
+                            {
+                                ProductVersion = "1.0",
+                                Platforms =
+                                {
+                                    CreatePlatform(initialDockerfile, simpleTags: ["initial"])
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            ImageArtifactDetails updatedImageInfo = new()
+            {
+                Repos =
+                {
+                    new RepoData
+                    {
+                        Repo = "repo",
+                        Images =
+                        {
+                            new ImageData
+                            {
+                                ProductVersion = "1.0",
+                                Platforms =
+                                {
+                                    CreatePlatform(updatedDockerfile, simpleTags: ["updated"])
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            File.WriteAllText(Path.Combine(sourceImageInfoDir, "updated.json"), JsonHelper.SerializeObject(updatedImageInfo));
+
+            Manifest manifest = CreateManifest(
+                CreateRepo("repo",
+                    CreateImage(
+                        new Platform[]
+                        {
+                            ManifestHelper.CreatePlatform(initialDockerfile, new string[] { "initial" }),
+                            ManifestHelper.CreatePlatform(updatedDockerfile, new string[] { "updated" })
+                        },
+                        productVersion: "1.0")));
+
+            string manifestPath = Path.Combine(context.Path, "manifest.json");
+            File.WriteAllText(manifestPath, JsonConvert.SerializeObject(manifest));
+
+            Mock<IImageInfoService> imageInfoServiceMock = new();
+            string outputPath = Path.Combine(context.Path, "output.json");
+            string initialOutputPath = Path.Combine(context.Path, "initial-output.json");
+            MergeImageInfoCommand command = new(TestHelper.CreateManifestJsonService(), imageInfoServiceMock.Object);
+            imageInfoServiceMock
+                .Setup(service => service.PullImageInfoArtifactAsync(
+                    It.IsAny<ManifestInfo>(),
+                    "example.azurecr.io",
+                    "prefix/",
+                    It.IsAny<System.Threading.CancellationToken>()))
+                .ReturnsAsync(JsonHelper.SerializeObject(initialImageInfo));
+
+            command.Options.SourceImageInfoFolderPath = sourceImageInfoDir;
+            command.Options.DestinationImageInfoPath = outputPath;
+            command.Options.Manifest = manifestPath;
+            command.Options.IsPublishScenario = true;
+            command.Options.InitialImageInfoRegistryOverride = "example.azurecr.io";
+            command.Options.InitialImageInfoRepoPrefix = "prefix/";
+            command.Options.InitialImageInfoOutputPath = initialOutputPath;
+
+            command.LoadManifest();
+            await command.ExecuteAsync();
+
+            ImageArtifactDetails mergedImageInfo = ImageArtifactDetails.FromJson(File.ReadAllText(outputPath));
+            List<PlatformData> mergedPlatforms = mergedImageInfo.Repos.Single().Images
+                .SelectMany(image => image.Platforms)
+                .ToList();
+
+            mergedPlatforms.Select(platform => platform.Dockerfile)
+                .ShouldBe([initialDockerfile, updatedDockerfile], ignoreOrder: true);
+            File.ReadAllText(initialOutputPath).ShouldBe(JsonHelper.SerializeObject(initialImageInfo) + Environment.NewLine);
+            imageInfoServiceMock.VerifyAll();
         }
     }
 }

--- a/src/ImageBuilder.Tests/QueueBuildCommandTests.cs
+++ b/src/ImageBuilder.Tests/QueueBuildCommandTests.cs
@@ -447,13 +447,6 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     Repo = repoName,
                     Owner = GetRepoOwner(testMethodName, index.ToString()),
                     Path = "testmanifest.json"
-                },
-                ImageInfo = new GitFile
-                {
-                    Owner = "dotnetOwner",
-                    Repo = "versionsRepo",
-                    Branch = "mainBranch",
-                    Path = "docker/image-info.json"
                 }
             };
         }

--- a/src/ImageBuilder/Commands/BuildCommand.cs
+++ b/src/ImageBuilder/Commands/BuildCommand.cs
@@ -26,6 +26,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private readonly IRegistryCredentialsProvider _registryCredentialsProvider;
         private readonly IAzureTokenCredentialProvider _tokenCredentialProvider;
         private readonly IImageCacheService _imageCacheService;
+        private readonly IImageInfoService _imageInfoService;
         private readonly ImageDigestCache _imageDigestCache;
         private readonly List<TagInfo> _processedTags = new List<TagInfo>();
         private readonly HashSet<PlatformData> _builtPlatforms = new();
@@ -50,7 +51,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             IManifestServiceFactory manifestServiceFactory,
             IRegistryCredentialsProvider registryCredentialsProvider,
             IAzureTokenCredentialProvider tokenCredentialProvider,
-            IImageCacheService imageCacheService) : base(manifestJsonService)
+            IImageCacheService imageCacheService,
+            IImageInfoService imageInfoService) : base(manifestJsonService)
         {
             _dockerService = new DockerServiceCache(dockerService ?? throw new ArgumentNullException(nameof(dockerService)));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -60,6 +62,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             _registryCredentialsProvider = registryCredentialsProvider ?? throw new ArgumentNullException(nameof(registryCredentialsProvider));
             _tokenCredentialProvider = tokenCredentialProvider ?? throw new ArgumentNullException(nameof(tokenCredentialProvider));
             _imageCacheService = imageCacheService ?? throw new ArgumentNullException(nameof(imageCacheService));
+            _imageInfoService = imageInfoService ?? throw new ArgumentNullException(nameof(imageInfoService));
 
             // Lazily create services which need access to options
             ArgumentNullException.ThrowIfNull(manifestServiceFactory);
@@ -305,9 +308,24 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             _logger.LogInformation("BUILDING IMAGES");
 
             ImageArtifactDetails? srcImageArtifactDetails = null;
-            if (Options.ImageInfoSourcePath != null)
+            if (!string.IsNullOrWhiteSpace(Options.ImageInfoSourcePath))
             {
-                srcImageArtifactDetails = ImageInfoHelper.LoadFromFile(Options.ImageInfoSourcePath, Manifest, skipManifestValidation: true);
+                srcImageArtifactDetails = ImageInfoHelper.LoadFromFile(
+                    Options.ImageInfoSourcePath,
+                    Manifest,
+                    skipManifestValidation: true);
+            }
+            else if (Manifest.Model.ImageInfo is not null)
+            {
+                string imageInfoContent = await _imageInfoService.PullImageInfoArtifactAsync(
+                    Manifest,
+                    string.IsNullOrWhiteSpace(Options.RegistryOverride) ? Manifest.Model.Registry : Options.RegistryOverride,
+                    Options.RepoPrefix);
+
+                srcImageArtifactDetails = ImageInfoHelper.LoadFromContent(
+                    imageInfoContent,
+                    Manifest,
+                    skipManifestValidation: true);
             }
 
             foreach (RepoInfo repoInfo in Manifest.FilteredRepos)

--- a/src/ImageBuilder/Commands/BuildOptions.cs
+++ b/src/ImageBuilder/Commands/BuildOptions.cs
@@ -61,7 +61,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         private static readonly Option<string?> ImageInfoSourcePathOption = new("--image-info-source-path")
         {
-            Description = "Path to source image info"
+            Description = "Optional override for source image info. By default, the image info is pulled from the OCI"
+                + " artifact referenced by the manifest's imageInfo source in the target registry."
         };
 
         private static readonly Option<string?> SourceRepoOption = new("--source-repo")

--- a/src/ImageBuilder/Commands/GenerateBuildMatrixCommand.cs
+++ b/src/ImageBuilder/Commands/GenerateBuildMatrixCommand.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
     {
         private const string VersionRegGroupName = "Version";
 
-        private readonly Lazy<ImageArtifactDetails?> _imageArtifactDetails;
+        private readonly Lazy<Task<ImageArtifactDetails?>> _imageArtifactDetails;
         private static readonly char[] s_pathSeparators = { '/', '\\' };
         private static readonly Regex s_versionRegex = new(@$"^(?<{VersionRegGroupName}>(\d|\.)+).*$");
         private readonly IImageCacheService _imageCacheService;
@@ -26,19 +26,18 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private readonly ImageDigestCache _imageDigestCache;
         private readonly Lazy<ImageNameResolverForMatrix> _imageNameResolver;
 
-        public GenerateBuildMatrixCommand(IManifestJsonService manifestJsonService, IImageCacheService imageCacheService, IManifestServiceFactory manifestServiceFactory, ILogger<GenerateBuildMatrixCommand> logger) : base(manifestJsonService)
+        public GenerateBuildMatrixCommand(
+            IManifestJsonService manifestJsonService,
+            IImageInfoService imageInfoService,
+            IImageCacheService imageCacheService,
+            IManifestServiceFactory manifestServiceFactory,
+            ILogger<GenerateBuildMatrixCommand> logger) : base(manifestJsonService)
         {
+            ArgumentNullException.ThrowIfNull(imageInfoService);
             _imageCacheService = imageCacheService ?? throw new ArgumentNullException(nameof(imageCacheService));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _imageArtifactDetails = new Lazy<ImageArtifactDetails?>(() =>
-            {
-                if (Options.ImageInfoPath != null)
-                {
-                    return ImageInfoHelper.LoadFromFile(Options.ImageInfoPath, Manifest, skipManifestValidation: true);
-                }
-
-                return null;
-            });
+            _imageArtifactDetails = new Lazy<Task<ImageArtifactDetails?>>(() =>
+                LoadImageArtifactDetailsAsync(imageInfoService));
             _imageDigestCache = new ImageDigestCache(
                 new Lazy<IManifestService>(
                     () => manifestServiceFactory.Create(Options.CredentialsOptions)));
@@ -47,6 +46,32 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         }
 
         protected override string Description => "Generate the Azure DevOps build matrix for building the images";
+
+        private async Task<ImageArtifactDetails?> LoadImageArtifactDetailsAsync(IImageInfoService imageInfoService)
+        {
+            if (!string.IsNullOrWhiteSpace(Options.ImageInfoPath))
+            {
+                return ImageInfoHelper.LoadFromFile(
+                    Options.ImageInfoPath,
+                    Manifest,
+                    skipManifestValidation: true);
+            }
+
+            if (Manifest.Model.ImageInfo is null)
+            {
+                return null;
+            }
+
+            string imageInfoContent = await imageInfoService.PullImageInfoArtifactAsync(
+                Manifest,
+                string.IsNullOrWhiteSpace(Options.ImageInfoRegistryOverride) ? Manifest.Model.Registry : Options.ImageInfoRegistryOverride,
+                Options.ImageInfoRepoPrefix);
+
+            return ImageInfoHelper.LoadFromContent(
+                imageInfoContent,
+                Manifest,
+                skipManifestValidation: true);
+        }
 
         public override async Task ExecuteAsync()
         {
@@ -410,8 +435,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private async Task<IEnumerable<PlatformInfo>> GetPlatformsAsync()
         {
             IEnumerable<RepoInfo> filteredRepos = Manifest.FilteredRepos.ToList();
+            ImageArtifactDetails? imageArtifactDetails = await _imageArtifactDetails.Value;
 
-            if (_imageArtifactDetails.Value is null)
+            if (imageArtifactDetails is null)
             {
                 return filteredRepos.SelectMany(repo => repo.FilteredImages).SelectMany(image => image.FilteredPlatforms);
             }
@@ -422,7 +448,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         .SelectMany(image => image.FilteredPlatforms)
                         .Select(platform =>
                         {
-                            (PlatformData Platform, ImageData Image)? matchingPlatform = ImageInfoHelper.GetMatchingPlatformData(platform, repo, _imageArtifactDetails.Value);
+                            (PlatformData Platform, ImageData Image)? matchingPlatform = ImageInfoHelper.GetMatchingPlatformData(platform, repo, imageArtifactDetails);
                             return (platform, matchingPlatform?.Image, matchingPlatform?.Platform);
                         })
                         .Where(platformMapping => platformMapping.Platform is null || !platformMapping.Platform.IsUnchanged));

--- a/src/ImageBuilder/Commands/GenerateBuildMatrixOptions.cs
+++ b/src/ImageBuilder/Commands/GenerateBuildMatrixOptions.cs
@@ -24,6 +24,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public string? SourceRepoUrl { get; set; }
         public RegistryCredentialsOptions CredentialsOptions { get; set; } = new();
         public bool TrimCachedImages { get; set; }
+        public string? ImageInfoRegistryOverride { get; set; }
+        public string? ImageInfoRepoPrefix { get; set; }
 
         private const MatrixType DefaultMatrixType = MatrixType.PlatformDependencyGraph;
 
@@ -48,7 +50,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         private static readonly Option<string?> ImageInfoOption = new("--image-info")
         {
-            Description = "Path to image info file"
+            Description = "Optional override for source image info. By default, the image info is pulled from the OCI"
+                + " artifact referenced by the manifest's imageInfo source in the target registry."
         };
 
         private static readonly Option<string[]> DistinctMatrixOsVersionsOption = new("--distinct-matrix-os-version")
@@ -73,6 +76,16 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             Description = "Whether to trim cached images from the set of paths"
         };
 
+        private static readonly Option<string?> ImageInfoRegistryOverrideOption = new("--image-info-registry-override")
+        {
+            Description = "Registry to pull image-info OCI artifacts from instead of the manifest registry"
+        };
+
+        private static readonly Option<string?> ImageInfoRepoPrefixOption = new("--image-info-repo-prefix")
+        {
+            Description = "Repo prefix to add when pulling image-info OCI artifacts"
+        };
+
         public override IEnumerable<Option> GetCliOptions() =>
         [
             ..base.GetCliOptions(),
@@ -87,6 +100,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             SourceRepoPrefixOption,
             SourceRepoOption,
             TrimCachedImagesOption,
+            ImageInfoRegistryOverrideOption,
+            ImageInfoRepoPrefixOption,
         ];
 
         public override IEnumerable<Argument> GetCliArguments() =>
@@ -111,6 +126,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             SourceRepoPrefix = result.GetValue(SourceRepoPrefixOption);
             SourceRepoUrl = result.GetValue(SourceRepoOption);
             TrimCachedImages = result.GetValue(TrimCachedImagesOption);
+            ImageInfoRegistryOverride = result.GetValue(ImageInfoRegistryOverrideOption);
+            ImageInfoRepoPrefix = result.GetValue(ImageInfoRepoPrefixOption);
         }
     }
 }

--- a/src/ImageBuilder/Commands/GetStaleImagesCommand.cs
+++ b/src/ImageBuilder/Commands/GetStaleImagesCommand.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
 using Newtonsoft.Json;
-using Octokit;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
@@ -21,20 +20,20 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private readonly Lazy<IManifestService> _manifestService;
         private readonly IManifestJsonService _manifestJsonService;
         private readonly ILogger<GetStaleImagesCommand> _logger;
-        private readonly IOctokitClientFactory _octokitClientFactory;
         private readonly IGitService _gitService;
+        private readonly IImageInfoService _imageInfoService;
 
         public GetStaleImagesCommand(
             IManifestServiceFactory manifestServiceFactory,
             IManifestJsonService manifestJsonService,
             ILogger<GetStaleImagesCommand> logger,
-            IOctokitClientFactory octokitClientFactory,
-            IGitService gitService)
+            IGitService gitService,
+            IImageInfoService imageInfoService)
         {
             _manifestJsonService = manifestJsonService ?? throw new ArgumentNullException(nameof(manifestJsonService));
-            _logger = logger;
-            _octokitClientFactory = octokitClientFactory;
-            _gitService = gitService;
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _gitService = gitService ?? throw new ArgumentNullException(nameof(gitService));
+            _imageInfoService = imageInfoService ?? throw new ArgumentNullException(nameof(imageInfoService));
 
             // Don't worry about authenticating to our own ACR, since we are checking base image digests from public
             // registries instead of our staging location. Registry credentials are needed however to prevent rate
@@ -65,7 +64,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     {
                         SubscriptionId = subscriptionManifest.Subscription.Id,
                         ImagePaths =
-                            (await GetPathsToRebuildAsync(subscriptionManifest.Subscription, subscriptionManifest.Manifest))
+                            (await GetPathsToRebuildAsync(subscriptionManifest.Manifest))
                             .ToArray()
                     });
 
@@ -87,9 +86,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 $"Image Paths to be Rebuilt:{Environment.NewLine}{formattedResults}");
         }
 
-        private async Task<IEnumerable<string>> GetPathsToRebuildAsync(Models.Subscription.Subscription subscription, ManifestInfo manifest)
+        private async Task<IEnumerable<string>> GetPathsToRebuildAsync(ManifestInfo manifest)
         {
-            ImageArtifactDetails imageArtifactDetails = await GetImageInfoForSubscriptionAsync(subscription, manifest);
+            ImageArtifactDetails imageArtifactDetails = await PullImageInfoAsync(manifest);
 
             ImageNameResolverForMatrix imageNameResolver = new(
                 Options.BaseImageOverrideOptions,
@@ -203,16 +202,22 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             return [];
         }
 
-        private async Task<ImageArtifactDetails> GetImageInfoForSubscriptionAsync(Models.Subscription.Subscription subscription, ManifestInfo manifest)
+        private async Task<ImageArtifactDetails> PullImageInfoAsync(ManifestInfo manifest)
         {
-            ITreesClient treesClient = await _octokitClientFactory.CreateTreesClientAsync(Options.GitOptions.GitHubAuthOptions);
-            string fileSha = await treesClient.GetFileShaAsync(
-                subscription.ImageInfo.Owner, subscription.ImageInfo.Repo, subscription.ImageInfo.Branch, subscription.ImageInfo.Path);
+            string imageInfoRegistry = Options.ImageInfoRegistryOverride ?? manifest.Model.Registry;
+            if (string.IsNullOrWhiteSpace(imageInfoRegistry))
+            {
+                throw new InvalidOperationException(
+                    $"Manifest '{manifest.FilePath}' must define a registry or --image-info-registry-override must be set " +
+                    "to pull image-info artifact for stale image detection.");
+            }
 
-            IBlobsClient blobsClient = await _octokitClientFactory.CreateBlobsClientAsync(Options.GitOptions.GitHubAuthOptions);
-            string imageDataJson = await blobsClient.GetFileContentAsync(subscription.ImageInfo.Owner, subscription.ImageInfo.Repo, fileSha);
+            string imageInfoContent = await _imageInfoService.PullImageInfoArtifactAsync(
+                manifest,
+                imageInfoRegistry,
+                Options.ImageInfoRepoPrefix);
 
-            return ImageInfoHelper.LoadFromContent(imageDataJson, manifest, skipManifestValidation: true);
+            return ImageInfoHelper.LoadFromContent(imageInfoContent, manifest, skipManifestValidation: true);
         }
     }
 }

--- a/src/ImageBuilder/Commands/GetStaleImagesOptions.cs
+++ b/src/ImageBuilder/Commands/GetStaleImagesOptions.cs
@@ -27,6 +27,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         public string? SourceRepoPrefix { get; set; }
 
+        public string? ImageInfoRegistryOverride { get; set; }
+
+        public string? ImageInfoRepoPrefix { get; set; }
+
         private static readonly GitOptionsBuilder GitBuilder = GitOptionsBuilder.BuildForRepositoryOperations();
 
         private static readonly Argument<string> VariableNameArgument = new(nameof(VariableName))
@@ -47,6 +51,17 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 "'<registry-override>/<source-repo-prefix><original-repo>:<tag>' instead of their public source."
         };
 
+        private static readonly Option<string?> ImageInfoRegistryOverrideOption = new("--image-info-registry-override")
+        {
+            Description = "Alternative registry to pull the image-info OCI artifact from. Defaults to the registry " +
+                "defined in each subscription's manifest."
+        };
+
+        private static readonly Option<string?> ImageInfoRepoPrefixOption = new("--image-info-repo-prefix")
+        {
+            Description = "Repo prefix used to locate image-info OCI artifacts in the image-info registry."
+        };
+
         public override IEnumerable<Option> GetCliOptions() =>
         [
             ..base.GetCliOptions(),
@@ -57,6 +72,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             ..BaseImageOverrideOptions.GetCliOptions(),
             RegistryOverrideOption,
             SourceRepoPrefixOption,
+            ImageInfoRegistryOverrideOption,
+            ImageInfoRepoPrefixOption,
         ];
 
         public override IEnumerable<Argument> GetCliArguments() =>
@@ -85,6 +102,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             BaseImageOverrideOptions.Bind(result);
             RegistryOverride = result.GetValue(RegistryOverrideOption);
             SourceRepoPrefix = result.GetValue(SourceRepoPrefixOption);
+            ImageInfoRegistryOverride = result.GetValue(ImageInfoRegistryOverrideOption);
+            ImageInfoRepoPrefix = result.GetValue(ImageInfoRepoPrefixOption);
             VariableName = result.GetValue(VariableNameArgument) ?? string.Empty;
         }
     }

--- a/src/ImageBuilder/Commands/MergeImageInfoCommand.cs
+++ b/src/ImageBuilder/Commands/MergeImageInfoCommand.cs
@@ -15,11 +15,16 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     public partial class MergeImageInfoCommand : ManifestCommand<MergeImageInfoOptions>
     {
-        public MergeImageInfoCommand(IManifestJsonService manifestJsonService) : base(manifestJsonService) { }
+        private readonly IImageInfoService _imageInfoService;
+
+        public MergeImageInfoCommand(IManifestJsonService manifestJsonService, IImageInfoService imageInfoService) : base(manifestJsonService)
+        {
+            _imageInfoService = imageInfoService ?? throw new ArgumentNullException(nameof(imageInfoService));
+        }
 
         protected override string Description => "Merges the content of multiple image info files into one file";
 
-        public override Task ExecuteAsync()
+        public override async Task ExecuteAsync()
         {
             IEnumerable<string> imageInfoFiles = Directory.EnumerateFiles(
                 Options.SourceImageInfoFolderPath,
@@ -49,10 +54,38 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             // Keep track of initial state to identify updated images
             ImageArtifactDetails? initialImageArtifactDetails = null;
 
-            ImageArtifactDetails targetImageArtifactDetails;
-            if (Options.InitialImageInfoPath != null)
+            ImageArtifactDetails? sourceImageArtifactDetails = null;
+            if (!string.IsNullOrWhiteSpace(Options.InitialImageInfoPath))
             {
-                targetImageArtifactDetails = srcImageArtifactDetailsList.First(item => item.Path == Options.InitialImageInfoPath).ImageArtifactDetails;
+                sourceImageArtifactDetails = srcImageArtifactDetailsList
+                    .First(item => item.Path == Options.InitialImageInfoPath)
+                    .ImageArtifactDetails;
+            }
+            else if (!string.IsNullOrWhiteSpace(Options.InitialImageInfoRegistryOverride) ||
+                !string.IsNullOrWhiteSpace(Options.InitialImageInfoRepoPrefix))
+            {
+                string imageInfoContent = await _imageInfoService.PullImageInfoArtifactAsync(
+                    Manifest,
+                    string.IsNullOrWhiteSpace(Options.InitialImageInfoRegistryOverride) ? Manifest.Model.Registry : Options.InitialImageInfoRegistryOverride,
+                    Options.InitialImageInfoRepoPrefix);
+
+                sourceImageArtifactDetails = ImageInfoHelper.LoadFromContent(
+                    imageInfoContent,
+                    Manifest,
+                    skipManifestValidation: Options.IsPublishScenario);
+            }
+
+            ImageArtifactDetails targetImageArtifactDetails;
+            if (sourceImageArtifactDetails is not null)
+            {
+                targetImageArtifactDetails = sourceImageArtifactDetails;
+
+                if (Options.InitialImageInfoOutputPath is not null)
+                {
+                    File.WriteAllText(
+                        Options.InitialImageInfoOutputPath,
+                        JsonHelper.SerializeObject(targetImageArtifactDetails) + Environment.NewLine);
+                }
 
                 // Store a deep copy of the initial state for comparison if CommitUrlOverride is specified
                 if (!string.IsNullOrEmpty(Options.CommitOverride))
@@ -90,8 +123,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             string destinationContents = JsonHelper.SerializeObject(targetImageArtifactDetails) + Environment.NewLine;
             File.WriteAllText(Options.DestinationImageInfoPath, destinationContents);
-
-            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/src/ImageBuilder/Commands/MergeImageInfoOptions.cs
+++ b/src/ImageBuilder/Commands/MergeImageInfoOptions.cs
@@ -16,6 +16,12 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         public string? InitialImageInfoPath { get; set; }
 
+        public string? InitialImageInfoOutputPath { get; set; }
+
+        public string? InitialImageInfoRegistryOverride { get; set; }
+
+        public string? InitialImageInfoRepoPrefix { get; set; }
+
         public bool IsPublishScenario { get; set; }
 
         public string? CommitOverride { get; set; }
@@ -40,6 +46,21 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             Description = "Path to the image info file to be used as the initial merge target"
         };
 
+        private static readonly Option<string?> InitialImageInfoOutputPathOption = new("--initial-image-info-output-path")
+        {
+            Description = "Path to write the initial image info used as the merge target"
+        };
+
+        private static readonly Option<string?> InitialImageInfoRegistryOverrideOption = new("--initial-image-info-registry-override")
+        {
+            Description = "Registry to pull the initial image-info OCI artifact from instead of the manifest registry"
+        };
+
+        private static readonly Option<string?> InitialImageInfoRepoPrefixOption = new("--initial-image-info-repo-prefix")
+        {
+            Description = "Repo prefix to add when pulling the initial image-info OCI artifact"
+        };
+
         private static readonly Option<string?> CommitOverrideOption = new("--commit-override")
         {
             Description = "Override the commit in the commitUrl property for images that were updated compared to the"
@@ -58,6 +79,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             ..base.GetCliOptions(),
             PublishOption,
             InitialImageInfoPathOption,
+            InitialImageInfoOutputPathOption,
+            InitialImageInfoRegistryOverrideOption,
+            InitialImageInfoRepoPrefixOption,
             CommitOverrideOption,
         ];
 
@@ -68,6 +92,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             DestinationImageInfoPath = result.GetValue(DestinationImageInfoPathArgument) ?? string.Empty;
             IsPublishScenario = result.GetValue(PublishOption);
             InitialImageInfoPath = result.GetValue(InitialImageInfoPathOption);
+            InitialImageInfoOutputPath = result.GetValue(InitialImageInfoOutputPathOption);
+            InitialImageInfoRegistryOverride = result.GetValue(InitialImageInfoRegistryOverrideOption);
+            InitialImageInfoRepoPrefix = result.GetValue(InitialImageInfoRepoPrefixOption);
             CommitOverride = result.GetValue(CommitOverrideOption);
         }
     }

--- a/src/ImageBuilder/IImageInfoService.cs
+++ b/src/ImageBuilder/IImageInfoService.cs
@@ -34,4 +34,22 @@ public interface IImageInfoService
         string? repoPrefix,
         bool isDryRun,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Pulls image-info from the OCI artifact declared by the manifest's <c>imageInfo</c> object.
+    /// </summary>
+    /// <param name="manifest">The manifest declaring the image-info artifact repository and tags.</param>
+    /// <param name="registry">The registry to pull the artifact from (e.g. the publish registry).</param>
+    /// <param name="repoPrefix">A prefix to prepend to the artifact's repository name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The image-info JSON content.</returns>
+    /// <remarks>
+    /// When the manifest does not declare an <c>imageInfo</c> object, the pull fails because the
+    /// artifact source and tag are required manifest metadata.
+    /// </remarks>
+    Task<string> PullImageInfoArtifactAsync(
+        ManifestInfo manifest,
+        string registry,
+        string? repoPrefix,
+        CancellationToken cancellationToken = default);
 }

--- a/src/ImageBuilder/ImageInfoService.cs
+++ b/src/ImageBuilder/ImageInfoService.cs
@@ -3,7 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
@@ -38,16 +39,11 @@ public class ImageInfoService(
         bool isDryRun,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(manifest);
         ArgumentNullException.ThrowIfNull(imageInfoContent);
         ArgumentException.ThrowIfNullOrWhiteSpace(registry);
+        ArgumentNullException.ThrowIfNull(manifest);
 
-        ImageInfoArtifact imageInfoArtifact = _manifestJsonService.GetImageInfoArtifact(manifest);
-
-        if (imageInfoArtifact.Tags.Count == 0)
-            throw new InvalidOperationException(
-                "The manifest's imageInfo property must define at least one tag in order to push "
-                + "image-info as an OCI artifact.");
+        ImageInfoArtifact imageInfoArtifact = GetValidatedImageInfoArtifact(manifest);
 
         string repo = $"{repoPrefix}{imageInfoArtifact.Repo}";
         _logger.LogInformation(
@@ -70,5 +66,66 @@ public class ImageInfoService(
             repo,
             imageInfoArtifact.Tags.Keys,
             cancellationToken: cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<string> PullImageInfoArtifactAsync(
+        ManifestInfo manifest,
+        string registry,
+        string? repoPrefix,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(registry);
+        ArgumentNullException.ThrowIfNull(manifest);
+
+        ImageInfoArtifact imageInfoArtifact = GetValidatedImageInfoArtifact(manifest);
+
+        string repo = $"{repoPrefix}{imageInfoArtifact.Repo}";
+        string tag = imageInfoArtifact.Tags.Keys.First();
+
+        _logger.LogInformation(
+            "Image info will be pulled from registry={registry}, repo={Repo}, tag={Tag}",
+            registry, repo, tag);
+
+        IOrasService orasService = _orasServiceFactory.Create();
+        OciArtifact artifact = await orasService.PullAsync(
+            registry,
+            repo,
+            tag,
+            cancellationToken);
+        if (!string.Equals(artifact.Manifest.ArtifactType, OciArtifactType.ImageInfo, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Artifact '{repo}:{tag}' has artifactType '{artifact.Manifest.ArtifactType}', expected '{OciArtifactType.ImageInfo}'.");
+        }
+
+        if (artifact.Blobs.Count != 1)
+        {
+            throw new InvalidOperationException(
+                $"Image info artifact '{repo}:{tag}' must have exactly one blob, but has {artifact.Blobs.Count}.");
+        }
+
+        OciBlob blob = artifact.Blobs[0];
+        if (!string.Equals(blob.Descriptor.MediaType, OciArtifactType.ImageInfo, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Artifact '{repo}:{tag}' blob has mediaType '{blob.Descriptor.MediaType}', expected '{OciArtifactType.ImageInfo}'.");
+        }
+
+        return Encoding.UTF8.GetString(blob.Content);
+    }
+
+    private ImageInfoArtifact GetValidatedImageInfoArtifact(ManifestInfo manifest)
+    {
+        ImageInfoArtifact imageInfoArtifact = _manifestJsonService.GetImageInfoArtifact(manifest);
+
+        if (imageInfoArtifact.Tags.Count == 0)
+        {
+            throw new InvalidOperationException(
+                "The manifest's imageInfo property must define at least one tag in order to use "
+                + "image-info as an OCI artifact.");
+        }
+
+        return imageInfoArtifact;
     }
 }

--- a/src/ImageBuilder/Models/Subscription/Subscription.cs
+++ b/src/ImageBuilder/Models/Subscription/Subscription.cs
@@ -13,9 +13,6 @@ namespace Microsoft.DotNet.ImageBuilder.Models.Subscription
         public SubscriptionManifest Manifest { get; set; }
 
         [JsonProperty(Required = Required.Always)]
-        public GitFile ImageInfo { get; set; }
-
-        [JsonProperty(Required = Required.Always)]
         public PipelineTrigger PipelineTrigger { get; set; }
 
         public string OsType { get; set; }

--- a/src/ImageBuilder/Oras/IOrasService.cs
+++ b/src/ImageBuilder/Oras/IOrasService.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Signing;
@@ -91,5 +92,33 @@ public interface IOrasService
         string registry,
         string repository,
         IEnumerable<string> tags,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Pulls content layers from a standalone OCI artifact tag.
+    /// </summary>
+    /// <param name="registry">The registry host (e.g., "myregistry.azurecr.io").</param>
+    /// <param name="repository">The repository within the registry (e.g., "dotnet/versions").</param>
+    /// <param name="tag">The artifact tag to pull.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The OCI artifact manifest/descriptors and pulled blob content.</returns>
+    Task<OciArtifact> PullAsync(
+        string registry,
+        string repository,
+        string tag,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Fetches the blob identified by the given descriptor.
+    /// </summary>
+    /// <param name="registry">The registry host (e.g., "myregistry.azurecr.io").</param>
+    /// <param name="repository">The repository within the registry (e.g., "dotnet/versions").</param>
+    /// <param name="descriptor">The descriptor of the blob to fetch.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A stream for the blob content. The caller is responsible for disposing it.</returns>
+    Task<Stream> FetchBlobAsync(
+        string registry,
+        string repository,
+        Descriptor descriptor,
         CancellationToken cancellationToken = default);
 }

--- a/src/ImageBuilder/Oras/IOrasService.cs
+++ b/src/ImageBuilder/Oras/IOrasService.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Signing;
@@ -106,19 +105,5 @@ public interface IOrasService
         string registry,
         string repository,
         string tag,
-        CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Fetches the blob identified by the given descriptor.
-    /// </summary>
-    /// <param name="registry">The registry host (e.g., "myregistry.azurecr.io").</param>
-    /// <param name="repository">The repository within the registry (e.g., "dotnet/versions").</param>
-    /// <param name="descriptor">The descriptor of the blob to fetch.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>A stream for the blob content. The caller is responsible for disposing it.</returns>
-    Task<Stream> FetchBlobAsync(
-        string registry,
-        string repository,
-        Descriptor descriptor,
         CancellationToken cancellationToken = default);
 }

--- a/src/ImageBuilder/Oras/OciArtifact.cs
+++ b/src/ImageBuilder/Oras/OciArtifact.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using OrasProject.Oras.Oci;
+
+namespace Microsoft.DotNet.ImageBuilder.Oras;
+
+/// <summary>
+/// Content and manifest metadata pulled from an OCI artifact.
+/// </summary>
+/// <param name="ManifestDescriptor">The descriptor for the pulled OCI manifest.</param>
+/// <param name="Manifest">The pulled OCI manifest.</param>
+/// <param name="Blobs">The pulled content blobs.</param>
+public sealed record OciArtifact(Descriptor ManifestDescriptor, Manifest Manifest, IReadOnlyList<OciBlob> Blobs);

--- a/src/ImageBuilder/Oras/OciBlob.cs
+++ b/src/ImageBuilder/Oras/OciBlob.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using OrasProject.Oras.Oci;
+
+namespace Microsoft.DotNet.ImageBuilder.Oras;
+
+/// <summary>
+/// Content and descriptor metadata for a pulled OCI blob.
+/// </summary>
+/// <param name="Content">The blob content.</param>
+/// <param name="Descriptor">The descriptor for the pulled content blob.</param>
+public sealed record OciBlob(byte[] Content, Descriptor Descriptor);

--- a/src/ImageBuilder/Oras/OrasDotNetService.cs
+++ b/src/ImageBuilder/Oras/OrasDotNetService.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
@@ -281,6 +282,64 @@ public class OrasDotNetService(
             registry, repository, manifestDescriptor.Digest, artifactType, string.Join(", ", taggedReferences), elapsed);
 
         return manifestDescriptor.Digest;
+    }
+
+    /// <inheritdoc/>
+    public async Task<OciArtifact> PullAsync(
+        string registry,
+        string repository,
+        string tag,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(registry);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repository);
+        ArgumentException.ThrowIfNullOrWhiteSpace(tag);
+
+        ImageName imageName = new(registry, repository, tag, digest: null);
+        string taggedReference = imageName.ToString();
+        Repository repo = CreateRepository(registry, repository);
+
+        long startTime = Stopwatch.GetTimestamp();
+        (Descriptor manifestDescriptor, Stream manifestStream) = await repo.FetchAsync(taggedReference, cancellationToken);
+        Manifest manifest;
+        await using (manifestStream)
+        {
+            manifest = await JsonSerializer.DeserializeAsync<Manifest>(
+                manifestStream,
+                cancellationToken: cancellationToken)
+                ?? throw new InvalidOperationException($"Invalid JSON artifact manifest for '{taggedReference}'.");
+        }
+
+        List<OciBlob> blobs = [];
+        foreach (Descriptor layerDescriptor in manifest.Layers)
+        {
+            await using Stream layerContent = await repo.FetchAsync(layerDescriptor, cancellationToken);
+            using MemoryStream memoryStream = new();
+            await layerContent.CopyToAsync(memoryStream, cancellationToken);
+            blobs.Add(new OciBlob(memoryStream.ToArray(), layerDescriptor));
+        }
+
+        TimeSpan elapsed = Stopwatch.GetElapsedTime(startTime);
+        _logger.LogInformation(
+            "Pulled OCI artifact from {Registry}/{Repository}:{Tag}: manifestDigest={Digest}, artifactType={ArtifactType}, blobs={BlobCount} in {Elapsed}",
+            registry, repository, tag, manifestDescriptor.Digest, manifest.ArtifactType, blobs.Count, elapsed);
+
+        return new OciArtifact(manifestDescriptor, manifest, blobs);
+    }
+
+    /// <inheritdoc/>
+    public Task<Stream> FetchBlobAsync(
+        string registry,
+        string repository,
+        Descriptor descriptor,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(registry);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repository);
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        Repository repo = CreateRepository(registry, repository);
+        return repo.FetchAsync(descriptor, cancellationToken);
     }
 
     /// <summary>

--- a/src/ImageBuilder/Oras/OrasDotNetService.cs
+++ b/src/ImageBuilder/Oras/OrasDotNetService.cs
@@ -327,21 +327,6 @@ public class OrasDotNetService(
         return new OciArtifact(manifestDescriptor, manifest, blobs);
     }
 
-    /// <inheritdoc/>
-    public Task<Stream> FetchBlobAsync(
-        string registry,
-        string repository,
-        Descriptor descriptor,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(registry);
-        ArgumentException.ThrowIfNullOrWhiteSpace(repository);
-        ArgumentNullException.ThrowIfNull(descriptor);
-
-        Repository repo = CreateRepository(registry, repository);
-        return repo.FetchAsync(descriptor, cancellationToken);
-    }
-
     /// <summary>
     /// Creates an authenticated ORAS repository client for the given reference.
     /// </summary>


### PR DESCRIPTION
Part 2/3 of #2142. Part 3/3 will be documentation/pipeline changes.

Each commit is independently reviewable. I am taking a slightly different/refined approach compared to https://github.com/dotnet/docker-tools/pull/2155. Here are the invariants I followed:

- OCI image info is not optional.
- OCI image info is always the source of truth.
- Commands that previously relied on a file for image info input now pull the artifact directly using ORAS.
- During builds, image info is always pulled from the publish repo, not a public repo (unless doing a PR build, etc.). This means we don't have to rely on MAR for correctness. It also unlocks internal/private image info tracking for free.
- Individual image publishers decide whether they want to make OCI image info public or not by choosing the repo destination (one that's onboarded to MAR or not).
- Publishing to GitHub is downstream of the OCI image info and optional + disabled by default. Eventually we will disable/remove this feature since the automation would be extremely simple to write in a separate GitHub workflow or Azure pipeline something. It doesn't need to be in the publish pipeline.

Out of scope for this MVP:

- Publishing image infos for individual build legs. These stay as pipeline artifacts for now.
- Publishing un-merged image info to the build staging registry. Stays as pipeline artifact.
- Commands that take multiple image infos. Since individual image infos are pipeline artifacts these are still read from files.

Pipeline changes (part 3/3) are currently WIP, pushed here: https://github.com/dotnet/docker-tools/tree/lbussell/oci-image-info-pipelines