### PR TITLE
Fix malformed parameters declaration in set-dry-run.yml

### DIFF
--- a/eng/docker-tools/templates/steps/set-dry-run.yml
+++ b/eng/docker-tools/templates/steps/set-dry-run.yml
@@ -1,5 +1,5 @@
 parameters:
-  name: publishConfig
+- name: publishConfig
   type: object
 
 steps:


### PR DESCRIPTION
## Summary

Fixes a malformed `parameters:` declaration in `eng/docker-tools/templates/steps/set-dry-run.yml`.

The block used YAML map syntax:

```yaml
parameters:
  name: publishConfig
  type: object
```

Azure Pipelines interprets this as defining two parameters named `name` and `type` rather than a single `publishConfig` parameter. This breaks the caller (`templates/jobs/publish.yml`), which passes `publishConfig`, and causes the in-template `${{ parameters.publishConfig.PublishRegistry.repoPrefix }}` reference to fail.

The fix uses the standard typed-list syntax used throughout the other templates:

```yaml
parameters:
- name: publishConfig
  type: object
```

## Context

This addresses the issue raised in https://github.com/dotnet/docker-tools/pull/2159#discussion_r3459891762. PR #2159 moves the `eng/docker-tools` directory, but per request the fix is applied at the source-of-truth location under `eng/docker-tools` instead.

## Validation

- Confirmed the corrected syntax matches sibling step templates (e.g. `reference-service-connections.yml`, `run-imagebuilder.yml`).
- Confirmed the only caller (`templates/jobs/publish.yml`) passes `publishConfig`.
- Non-breaking change (restores intended behavior); no CHANGELOG entry required.
