### PR TITLE
Source OCI image-info from PublishConfiguration and don't pull unless necessary

### DIFF
--- a/src/ImageBuilder.Tests/BuildCommandTests.cs
+++ b/src/ImageBuilder.Tests/BuildCommandTests.cs
@@ -1066,6 +1066,62 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             imageInfoServiceMock.VerifyAll();
         }
 
+        [TestMethod]
+        public async Task BuildCommand_ImageInfoArtifact_UsesPublishRegistryAndPrefix()
+        {
+            const string manifestRegistry = "example.azurecr.io";
+            const string publishRegistry = "publishregistry.azurecr.io";
+            const string publishRepoPrefix = "public/";
+
+            using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
+
+            Mock<IImageInfoService> imageInfoServiceMock = new();
+            imageInfoServiceMock
+                .Setup(service => service.PullImageInfoArtifactAsync(
+                    It.IsAny<ManifestInfo>(),
+                    publishRegistry,
+                    publishRepoPrefix,
+                    default))
+                .ReturnsAsync(JsonHelper.SerializeObject(new ImageArtifactDetails()));
+
+            PublishConfiguration publishConfig = new()
+            {
+                PublishRegistry = new RegistryEndpoint
+                {
+                    Server = publishRegistry,
+                    RepoPrefix = publishRepoPrefix
+                }
+            };
+
+            BuildCommand command = CreateBuildCommand(
+                imageInfoService: imageInfoServiceMock.Object,
+                publishConfig: publishConfig);
+            command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
+            command.Options.FilterOptions.Dockerfile.Paths = new string[] { "not-matching" };
+
+            string dockerfile = DockerfileHelper.CreateDockerfile("1.0/runtime/os", tempFolderContext, "scratch");
+            Manifest manifest = CreateManifest(
+                CreateRepo(
+                    "runtime",
+                    CreateImage(CreatePlatform(dockerfile, new string[] { "tag" }))));
+            manifest.Registry = manifestRegistry;
+            manifest.ImageInfo = new ImageInfoArtifact
+            {
+                Repo = "image-info",
+                Tags = new Dictionary<string, Tag>
+                {
+                    { "latest", new Tag() }
+                }
+            };
+
+            File.WriteAllText(command.Options.Manifest, JsonConvert.SerializeObject(manifest));
+
+            command.LoadManifest();
+            await command.ExecuteAsync();
+
+            imageInfoServiceMock.VerifyAll();
+        }
+
         /// <summary>
         /// Verifies the command outputs an image info correctly when the manifest references a custom named Dockerfile.
         /// </summary>
@@ -3695,7 +3751,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             IRegistryCredentialsProvider? registryCredentialsProvider = null,
             IAzureTokenCredentialProvider? azureTokenCredentialProvider = null,
             IImageCacheService? imageCacheService = null,
-            IImageInfoService? imageInfoService = null)
+            IImageInfoService? imageInfoService = null,
+            PublishConfiguration? publishConfig = null)
         {
             BuildCommand command = new(
                 manifestJsonService ?? TestHelper.CreateManifestJsonService(),
@@ -3708,7 +3765,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 registryCredentialsProvider ?? Mock.Of<IRegistryCredentialsProvider>(),
                 azureTokenCredentialProvider ?? Mock.Of<IAzureTokenCredentialProvider>(),
                 imageCacheService ?? Mock.Of<IImageCacheService>(),
-                imageInfoService ?? CreateImageInfoService());
+                imageInfoService ?? CreateImageInfoService(),
+                Microsoft.Extensions.Options.Options.Create(publishConfig ?? new PublishConfiguration()));
 
             return command;
         }

--- a/src/ImageBuilder.Tests/BuildCommandTests.cs
+++ b/src/ImageBuilder.Tests/BuildCommandTests.cs
@@ -1024,7 +1024,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         }
 
         [TestMethod]
-        public async Task BuildCommand_ImageInfoArtifact_UsesManifestRegistryWhenNoOverrideIsSet()
+        public async Task BuildCommand_ImageInfoArtifact_PulledForCacheCheck()
         {
             const string registry = "example.azurecr.io";
 
@@ -1034,8 +1034,6 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             imageInfoServiceMock
                 .Setup(service => service.PullImageInfoArtifactAsync(
                     It.IsAny<ManifestInfo>(),
-                    registry,
-                    null,
                     default))
                 .ReturnsAsync(JsonHelper.SerializeObject(new ImageArtifactDetails()));
 
@@ -1049,62 +1047,6 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     "runtime",
                     CreateImage(CreatePlatform(dockerfile, new string[] { "tag" }))));
             manifest.Registry = registry;
-            manifest.ImageInfo = new ImageInfoArtifact
-            {
-                Repo = "image-info",
-                Tags = new Dictionary<string, Tag>
-                {
-                    { "latest", new Tag() }
-                }
-            };
-
-            File.WriteAllText(command.Options.Manifest, JsonConvert.SerializeObject(manifest));
-
-            command.LoadManifest();
-            await command.ExecuteAsync();
-
-            imageInfoServiceMock.VerifyAll();
-        }
-
-        [TestMethod]
-        public async Task BuildCommand_ImageInfoArtifact_UsesPublishRegistryAndPrefix()
-        {
-            const string manifestRegistry = "example.azurecr.io";
-            const string publishRegistry = "publishregistry.azurecr.io";
-            const string publishRepoPrefix = "public/";
-
-            using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
-
-            Mock<IImageInfoService> imageInfoServiceMock = new();
-            imageInfoServiceMock
-                .Setup(service => service.PullImageInfoArtifactAsync(
-                    It.IsAny<ManifestInfo>(),
-                    publishRegistry,
-                    publishRepoPrefix,
-                    default))
-                .ReturnsAsync(JsonHelper.SerializeObject(new ImageArtifactDetails()));
-
-            PublishConfiguration publishConfig = new()
-            {
-                PublishRegistry = new RegistryEndpoint
-                {
-                    Server = publishRegistry,
-                    RepoPrefix = publishRepoPrefix
-                }
-            };
-
-            BuildCommand command = CreateBuildCommand(
-                imageInfoService: imageInfoServiceMock.Object,
-                publishConfig: publishConfig);
-            command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
-            command.Options.FilterOptions.Dockerfile.Paths = new string[] { "not-matching" };
-
-            string dockerfile = DockerfileHelper.CreateDockerfile("1.0/runtime/os", tempFolderContext, "scratch");
-            Manifest manifest = CreateManifest(
-                CreateRepo(
-                    "runtime",
-                    CreateImage(CreatePlatform(dockerfile, new string[] { "tag" }))));
-            manifest.Registry = manifestRegistry;
             manifest.ImageInfo = new ImageInfoArtifact
             {
                 Repo = "image-info",
@@ -3751,8 +3693,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             IRegistryCredentialsProvider? registryCredentialsProvider = null,
             IAzureTokenCredentialProvider? azureTokenCredentialProvider = null,
             IImageCacheService? imageCacheService = null,
-            IImageInfoService? imageInfoService = null,
-            PublishConfiguration? publishConfig = null)
+            IImageInfoService? imageInfoService = null)
         {
             BuildCommand command = new(
                 manifestJsonService ?? TestHelper.CreateManifestJsonService(),
@@ -3765,8 +3706,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 registryCredentialsProvider ?? Mock.Of<IRegistryCredentialsProvider>(),
                 azureTokenCredentialProvider ?? Mock.Of<IAzureTokenCredentialProvider>(),
                 imageCacheService ?? Mock.Of<IImageCacheService>(),
-                imageInfoService ?? CreateImageInfoService(),
-                Microsoft.Extensions.Options.Options.Create(publishConfig ?? new PublishConfiguration()));
+                imageInfoService ?? CreateImageInfoService());
 
             return command;
         }
@@ -3775,6 +3715,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             new(
                 TestHelper.CreateManifestJsonService(),
                 Mock.Of<IOrasServiceFactory>(),
+                Microsoft.Extensions.Options.Options.Create(new PublishConfiguration()),
                 Mock.Of<ILogger<ImageInfoService>>());
         #nullable disable
 

--- a/src/ImageBuilder.Tests/GenerateBuildMatrixCommandTests.cs
+++ b/src/ImageBuilder.Tests/GenerateBuildMatrixCommandTests.cs
@@ -266,8 +266,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 CreateImageInfoService(),
                 imageCacheServiceMock.Object,
                 Mock.Of<IManifestServiceFactory>(),
-                Mock.Of<ILogger<GenerateBuildMatrixCommand>>(),
-                Microsoft.Extensions.Options.Options.Create(new PublishConfiguration()));
+                Mock.Of<ILogger<GenerateBuildMatrixCommand>>());
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.MatrixType = MatrixType.PlatformDependencyGraph;
             command.Options.ImageInfoPath = Path.Combine(tempFolderContext.Path, "imageinfo.json");
@@ -949,10 +948,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         }
 
         [TestMethod]
-        public async Task PlatformVersionedOs_ImageInfoArtifact_UsesManifestRegistryWhenNoOverrideIsSet()
+        public async Task PlatformVersionedOs_ImageInfoArtifact_PulledWhenTrimming()
         {
-            const string registry = "example.azurecr.io";
-
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
             Mock<IImageInfoService> imageInfoServiceMock = new();
             GenerateBuildMatrixCommand command = CreateCommand(imageInfoServiceMock.Object);
@@ -966,7 +963,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 CreateRepo(
                     "runtime",
                     CreateImage(CreatePlatform(dockerfile, ["tag"]))));
-            manifest.Registry = registry;
+            manifest.Registry = "example.azurecr.io";
             manifest.ImageInfo = new ImageInfoArtifact
             {
                 Repo = "image-info",
@@ -981,58 +978,6 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             imageInfoServiceMock
                 .Setup(service => service.PullImageInfoArtifactAsync(
                     It.IsAny<ManifestInfo>(),
-                    registry,
-                    null,
-                    default))
-                .ReturnsAsync(JsonHelper.SerializeObject(new ImageArtifactDetails()));
-
-            command.LoadManifest();
-            IEnumerable<BuildMatrixInfo> matrixInfos = await command.GenerateMatrixInfoAsync();
-
-            matrixInfos.ShouldBeEmpty();
-            imageInfoServiceMock.VerifyAll();
-        }
-
-        [TestMethod]
-        public async Task PlatformVersionedOs_ImageInfoArtifact_UsesPublishRegistryAndPrefix()
-        {
-            const string publishRegistry = "publish.azurecr.io";
-            const string repoPrefix = "public/";
-
-            using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
-            Mock<IImageInfoService> imageInfoServiceMock = new();
-            PublishConfiguration publishConfig = new()
-            {
-                PublishRegistry = new RegistryEndpoint { Server = publishRegistry, RepoPrefix = repoPrefix }
-            };
-            GenerateBuildMatrixCommand command = CreateCommand(imageInfoServiceMock.Object, publishConfig);
-            command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
-            command.Options.MatrixType = MatrixType.PlatformVersionedOs;
-            command.Options.FilterOptions.Dockerfile.Paths = ["not-matching"];
-            command.Options.TrimCachedImages = true;
-
-            string dockerfile = DockerfileHelper.CreateDockerfile("1.0/runtime/os", tempFolderContext);
-            Manifest manifest = CreateManifest(
-                CreateRepo(
-                    "runtime",
-                    CreateImage(CreatePlatform(dockerfile, ["tag"]))));
-            manifest.Registry = "mcr.microsoft.com";
-            manifest.ImageInfo = new ImageInfoArtifact
-            {
-                Repo = "image-info",
-                Tags = new Dictionary<string, Tag>
-                {
-                    { "latest", new Tag() }
-                }
-            };
-
-            File.WriteAllText(command.Options.Manifest, JsonConvert.SerializeObject(manifest));
-
-            imageInfoServiceMock
-                .Setup(service => service.PullImageInfoArtifactAsync(
-                    It.IsAny<ManifestInfo>(),
-                    publishRegistry,
-                    repoPrefix,
                     default))
                 .ReturnsAsync(JsonHelper.SerializeObject(new ImageArtifactDetails()));
 
@@ -1048,17 +993,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         {
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
             Mock<IImageInfoService> imageInfoServiceMock = new();
-            PublishConfiguration publishConfig = new()
-            {
-                PublishRegistry = new RegistryEndpoint { Server = "publish.azurecr.io", RepoPrefix = "public/" }
-            };
-            GenerateBuildMatrixCommand command = CreateCommand(imageInfoServiceMock.Object, publishConfig);
+            GenerateBuildMatrixCommand command = CreateCommand(imageInfoServiceMock.Object);
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.MatrixType = MatrixType.PlatformVersionedOs;
             command.Options.ProductVersionComponents = 2;
 
-            // A publish registry is configured but trimming is disabled, so the OCI
-            // artifact must not be pulled.
+            // Trimming is disabled, so the OCI artifact must not be pulled.
 
             string dockerfile = DockerfileHelper.CreateDockerfile("1.0/runtime/os", tempFolderContext);
             Manifest manifest = CreateManifest(
@@ -1083,8 +1023,6 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             imageInfoServiceMock.Verify(
                 service => service.PullImageInfoArtifactAsync(
                     It.IsAny<ManifestInfo>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
                     It.IsAny<System.Threading.CancellationToken>()),
                 Times.Never);
         }
@@ -1866,8 +1804,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 CreateImageInfoService(),
                 imageCacheService,
                 manifestServiceFactoryMock.Object,
-                Mock.Of<ILogger<GenerateBuildMatrixCommand>>(),
-                Microsoft.Extensions.Options.Options.Create(new PublishConfiguration()));
+                Mock.Of<ILogger<GenerateBuildMatrixCommand>>());
 
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.MatrixType = MatrixType.PlatformDependencyGraph;
@@ -1910,20 +1847,19 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         }
 
         private static GenerateBuildMatrixCommand CreateCommand(
-            IImageInfoService imageInfoService = null,
-            PublishConfiguration publishConfig = null) =>
+            IImageInfoService imageInfoService = null) =>
             new(
                 TestHelper.CreateManifestJsonService(),
                 imageInfoService ?? CreateImageInfoService(),
                 Mock.Of<IImageCacheService>(),
                 Mock.Of<IManifestServiceFactory>(),
-                Mock.Of<ILogger<GenerateBuildMatrixCommand>>(),
-                Microsoft.Extensions.Options.Options.Create(publishConfig ?? new PublishConfiguration()));
+                Mock.Of<ILogger<GenerateBuildMatrixCommand>>());
 
         private static ImageInfoService CreateImageInfoService() =>
             new(
                 TestHelper.CreateManifestJsonService(),
                 Mock.Of<IOrasServiceFactory>(),
+                Microsoft.Extensions.Options.Options.Create(new PublishConfiguration()),
                 Mock.Of<ILogger<ImageInfoService>>());
     }
 }

--- a/src/ImageBuilder.Tests/GenerateBuildMatrixCommandTests.cs
+++ b/src/ImageBuilder.Tests/GenerateBuildMatrixCommandTests.cs
@@ -959,6 +959,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.MatrixType = MatrixType.PlatformVersionedOs;
             command.Options.FilterOptions.Dockerfile.Paths = ["not-matching"];
+            command.Options.TrimCachedImages = true;
 
             string dockerfile = DockerfileHelper.CreateDockerfile("1.0/runtime/os", tempFolderContext);
             Manifest manifest = CreateManifest(
@@ -1040,6 +1041,52 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             matrixInfos.ShouldBeEmpty();
             imageInfoServiceMock.VerifyAll();
+        }
+
+        [TestMethod]
+        public async Task PlatformVersionedOs_ImageInfoArtifact_NotPulledWhenNotTrimming()
+        {
+            using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
+            Mock<IImageInfoService> imageInfoServiceMock = new();
+            PublishConfiguration publishConfig = new()
+            {
+                PublishRegistry = new RegistryEndpoint { Server = "publish.azurecr.io", RepoPrefix = "public/" }
+            };
+            GenerateBuildMatrixCommand command = CreateCommand(imageInfoServiceMock.Object, publishConfig);
+            command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
+            command.Options.MatrixType = MatrixType.PlatformVersionedOs;
+            command.Options.ProductVersionComponents = 2;
+
+            // A publish registry is configured but trimming is disabled, so the OCI
+            // artifact must not be pulled.
+
+            string dockerfile = DockerfileHelper.CreateDockerfile("1.0/runtime/os", tempFolderContext);
+            Manifest manifest = CreateManifest(
+                CreateRepo(
+                    "runtime",
+                    CreateImage(CreatePlatform(dockerfile, ["tag"]))));
+            manifest.ImageInfo = new ImageInfoArtifact
+            {
+                Repo = "image-info",
+                Tags = new Dictionary<string, Tag>
+                {
+                    { "latest", new Tag() }
+                }
+            };
+
+            File.WriteAllText(command.Options.Manifest, JsonConvert.SerializeObject(manifest));
+
+            command.LoadManifest();
+            IEnumerable<BuildMatrixInfo> matrixInfos = await command.GenerateMatrixInfoAsync();
+
+            matrixInfos.ShouldHaveSingleItem();
+            imageInfoServiceMock.Verify(
+                service => service.PullImageInfoArtifactAsync(
+                    It.IsAny<ManifestInfo>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<System.Threading.CancellationToken>()),
+                Times.Never);
         }
 
         /// <summary>

--- a/src/ImageBuilder.Tests/GenerateBuildMatrixCommandTests.cs
+++ b/src/ImageBuilder.Tests/GenerateBuildMatrixCommandTests.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Commands;
+using Microsoft.DotNet.ImageBuilder.Configuration;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 using Microsoft.DotNet.ImageBuilder.Oras;
@@ -265,7 +266,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 CreateImageInfoService(),
                 imageCacheServiceMock.Object,
                 Mock.Of<IManifestServiceFactory>(),
-                Mock.Of<ILogger<GenerateBuildMatrixCommand>>());
+                Mock.Of<ILogger<GenerateBuildMatrixCommand>>(),
+                Microsoft.Extensions.Options.Options.Create(new PublishConfiguration()));
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.MatrixType = MatrixType.PlatformDependencyGraph;
             command.Options.ImageInfoPath = Path.Combine(tempFolderContext.Path, "imageinfo.json");
@@ -832,7 +834,6 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         [DataRow(true, true, true, null)]
         public async Task PlatformVersionedOs_Cached(bool isRuntimeCached, bool isAspnetCached, bool isSdkCached, string expectedPaths)
         {
-            const string registry = "example.azurecr.io";
             using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
             Mock<IImageInfoService> imageInfoServiceMock = new();
             GenerateBuildMatrixCommand command = CreateCommand(imageInfoServiceMock.Object);
@@ -872,15 +873,6 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                         },
                         productVersion: "1.0"))
             );
-            manifest.ImageInfo = new ImageInfoArtifact
-            {
-                Repo = "image-info",
-                Tags = new Dictionary<string, Tag>
-                {
-                    { "latest", new Tag() }
-                }
-            };
-
             File.WriteAllText(Path.Combine(tempFolderContext.Path, command.Options.Manifest), JsonConvert.SerializeObject(manifest));
 
             ImageArtifactDetails imageArtifactDetails = new ImageArtifactDetails
@@ -934,15 +926,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     }
                 }
             };
-            command.Options.ImageInfoRegistryOverride = registry;
-            command.Options.ImageInfoRepoPrefix = "prefix/";
-            imageInfoServiceMock
-                .Setup(service => service.PullImageInfoArtifactAsync(
-                    It.IsAny<ManifestInfo>(),
-                    registry,
-                    command.Options.ImageInfoRepoPrefix,
-                    default))
-                .ReturnsAsync(JsonHelper.SerializeObject(imageArtifactDetails));
+            command.Options.ImageInfoPath = Path.Combine(tempFolderContext.Path, "image-info.json");
+            File.WriteAllText(command.Options.ImageInfoPath, JsonHelper.SerializeObject(imageArtifactDetails));
 
             command.LoadManifest();
             IEnumerable<BuildMatrixInfo> matrixInfos = await command.GenerateMatrixInfoAsync();
@@ -997,6 +982,56 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     It.IsAny<ManifestInfo>(),
                     registry,
                     null,
+                    default))
+                .ReturnsAsync(JsonHelper.SerializeObject(new ImageArtifactDetails()));
+
+            command.LoadManifest();
+            IEnumerable<BuildMatrixInfo> matrixInfos = await command.GenerateMatrixInfoAsync();
+
+            matrixInfos.ShouldBeEmpty();
+            imageInfoServiceMock.VerifyAll();
+        }
+
+        [TestMethod]
+        public async Task PlatformVersionedOs_ImageInfoArtifact_UsesPublishRegistryAndPrefix()
+        {
+            const string publishRegistry = "publish.azurecr.io";
+            const string repoPrefix = "public/";
+
+            using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
+            Mock<IImageInfoService> imageInfoServiceMock = new();
+            PublishConfiguration publishConfig = new()
+            {
+                PublishRegistry = new RegistryEndpoint { Server = publishRegistry, RepoPrefix = repoPrefix }
+            };
+            GenerateBuildMatrixCommand command = CreateCommand(imageInfoServiceMock.Object, publishConfig);
+            command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
+            command.Options.MatrixType = MatrixType.PlatformVersionedOs;
+            command.Options.FilterOptions.Dockerfile.Paths = ["not-matching"];
+            command.Options.TrimCachedImages = true;
+
+            string dockerfile = DockerfileHelper.CreateDockerfile("1.0/runtime/os", tempFolderContext);
+            Manifest manifest = CreateManifest(
+                CreateRepo(
+                    "runtime",
+                    CreateImage(CreatePlatform(dockerfile, ["tag"]))));
+            manifest.Registry = "mcr.microsoft.com";
+            manifest.ImageInfo = new ImageInfoArtifact
+            {
+                Repo = "image-info",
+                Tags = new Dictionary<string, Tag>
+                {
+                    { "latest", new Tag() }
+                }
+            };
+
+            File.WriteAllText(command.Options.Manifest, JsonConvert.SerializeObject(manifest));
+
+            imageInfoServiceMock
+                .Setup(service => service.PullImageInfoArtifactAsync(
+                    It.IsAny<ManifestInfo>(),
+                    publishRegistry,
+                    repoPrefix,
                     default))
                 .ReturnsAsync(JsonHelper.SerializeObject(new ImageArtifactDetails()));
 
@@ -1784,7 +1819,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 CreateImageInfoService(),
                 imageCacheService,
                 manifestServiceFactoryMock.Object,
-                Mock.Of<ILogger<GenerateBuildMatrixCommand>>());
+                Mock.Of<ILogger<GenerateBuildMatrixCommand>>(),
+                Microsoft.Extensions.Options.Options.Create(new PublishConfiguration()));
 
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
             command.Options.MatrixType = MatrixType.PlatformDependencyGraph;
@@ -1826,13 +1862,16 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             return command;
         }
 
-        private static GenerateBuildMatrixCommand CreateCommand(IImageInfoService imageInfoService = null) =>
+        private static GenerateBuildMatrixCommand CreateCommand(
+            IImageInfoService imageInfoService = null,
+            PublishConfiguration publishConfig = null) =>
             new(
                 TestHelper.CreateManifestJsonService(),
                 imageInfoService ?? CreateImageInfoService(),
                 Mock.Of<IImageCacheService>(),
                 Mock.Of<IManifestServiceFactory>(),
-                Mock.Of<ILogger<GenerateBuildMatrixCommand>>());
+                Mock.Of<ILogger<GenerateBuildMatrixCommand>>(),
+                Microsoft.Extensions.Options.Options.Create(publishConfig ?? new PublishConfiguration()));
 
         private static ImageInfoService CreateImageInfoService() =>
             new(

--- a/src/ImageBuilder.Tests/GetStaleImagesCommandTests.cs
+++ b/src/ImageBuilder.Tests/GetStaleImagesCommandTests.cs
@@ -13,6 +13,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using LibGit2Sharp;
 using Microsoft.DotNet.ImageBuilder.Commands;
+using Microsoft.DotNet.ImageBuilder.Configuration;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 using Microsoft.DotNet.ImageBuilder.Models.Subscription;
@@ -1761,16 +1762,20 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             private GetStaleImagesCommand CreateCommand()
             {
+                PublishConfiguration publishConfig = new()
+                {
+                    PublishRegistry = new RegistryEndpoint { Server = "publish.example.com" }
+                };
                 GetStaleImagesCommand command = new(
                     this.ManifestServiceFactoryMock.Object,
                     TestHelper.CreateManifestJsonService(),
                     this.loggerServiceMock.Object,
                     this.gitService,
-                    this.imageInfoService);
+                    this.imageInfoService,
+                    Microsoft.Extensions.Options.Options.Create(publishConfig));
                 command.Options.SubscriptionOptions.SubscriptionsPath = this.subscriptionsPath;
                 command.Options.VariableName = VariableName;
                 command.Options.FilterOptions.Platform.OsType = this.osType;
-                command.Options.ImageInfoRegistryOverride = "publish.example.com";
                 command.Options.GitOptions.Email = "test";
                 command.Options.GitOptions.Username = "test";
                 command.Options.GitOptions.GitHubAuthOptions = new GitHubAuthOptions(AuthToken: "test");

--- a/src/ImageBuilder.Tests/GetStaleImagesCommandTests.cs
+++ b/src/ImageBuilder.Tests/GetStaleImagesCommandTests.cs
@@ -1762,17 +1762,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             private GetStaleImagesCommand CreateCommand()
             {
-                PublishConfiguration publishConfig = new()
-                {
-                    PublishRegistry = new RegistryEndpoint { Server = "publish.example.com" }
-                };
                 GetStaleImagesCommand command = new(
                     this.ManifestServiceFactoryMock.Object,
                     TestHelper.CreateManifestJsonService(),
                     this.loggerServiceMock.Object,
                     this.gitService,
-                    this.imageInfoService,
-                    Microsoft.Extensions.Options.Options.Create(publishConfig));
+                    this.imageInfoService);
                 command.Options.SubscriptionOptions.SubscriptionsPath = this.subscriptionsPath;
                 command.Options.VariableName = VariableName;
                 command.Options.FilterOptions.Platform.OsType = this.osType;
@@ -1788,13 +1783,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 imageInfoServiceMock
                     .Setup(o => o.PullImageInfoArtifactAsync(
                         It.IsAny<ManifestInfo>(),
-                        It.IsAny<string>(),
-                        It.IsAny<string>(),
                         It.IsAny<CancellationToken>()))
                     .ReturnsAsync((
                         ManifestInfo manifest,
-                        string registry,
-                        string repoPrefix,
                         CancellationToken cancellationToken) =>
                     {
                         SubscriptionInfo subscriptionInfo = subscriptionInfos

--- a/src/ImageBuilder.Tests/ImageInfoServiceTests.cs
+++ b/src/ImageBuilder.Tests/ImageInfoServiceTests.cs
@@ -9,12 +9,14 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.DotNet.ImageBuilder.Configuration;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 using Microsoft.DotNet.ImageBuilder.Oras;
 using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Moq;
 using Shouldly;
 using static Microsoft.DotNet.ImageBuilder.Tests.Helpers.DockerfileHelper;
@@ -182,10 +184,43 @@ public class ImageInfoServiceTests
                 [CreateBlob(Encoding.UTF8.GetBytes(JsonHelper.SerializeObject(imageInfo)), OciArtifactType.ImageInfo)]));
         ImageInfoService service = CreateService(orasServiceMock.Object);
 
-        string result = await service.PullImageInfoArtifactAsync(
-            manifest,
-            registry: "publish.example.com",
-            repoPrefix: "public/");
+        string result = await service.PullImageInfoArtifactAsync(manifest);
+
+        result.ShouldBe(JsonHelper.SerializeObject(imageInfo));
+        orasServiceMock.VerifyAll();
+    }
+
+    [TestMethod]
+    public async Task PullImageInfoArtifactAsync_NoPublishRegistry_FallsBackToManifestRegistry()
+    {
+        using TempFolderContext tempFolderContext = TestHelper.UseTempFolder();
+        string dockerfile = CreateDockerfile("1.0/repo/os", tempFolderContext);
+        ManifestInfo manifest = CreateManifestInfo(tempFolderContext, dockerfile);
+        ImageArtifactDetails imageInfo = new()
+        {
+            Repos =
+            [
+                new RepoData
+                {
+                    Repo = "repo"
+                }
+            ]
+        };
+
+        Mock<IOrasService> orasServiceMock = new();
+        orasServiceMock
+            .Setup(o => o.PullAsync(
+                "public.example.com",
+                "dotnet/versions",
+                "latest",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new OciArtifact(
+                CreateManifestDescriptor(),
+                CreateOrasManifest(OciArtifactType.ImageInfo, OciArtifactType.ImageInfo),
+                [CreateBlob(Encoding.UTF8.GetBytes(JsonHelper.SerializeObject(imageInfo)), OciArtifactType.ImageInfo)]));
+        ImageInfoService service = CreateService(orasServiceMock.Object, new PublishConfiguration());
+
+        string result = await service.PullImageInfoArtifactAsync(manifest);
 
         result.ShouldBe(JsonHelper.SerializeObject(imageInfo));
         orasServiceMock.VerifyAll();
@@ -212,10 +247,7 @@ public class ImageInfoServiceTests
         ImageInfoService service = CreateService(orasServiceMock.Object);
 
         InvalidOperationException exception = await Should.ThrowAsync<InvalidOperationException>(() =>
-            service.PullImageInfoArtifactAsync(
-                manifest,
-                registry: "publish.example.com",
-                repoPrefix: "public/"));
+            service.PullImageInfoArtifactAsync(manifest));
 
         exception.Message.ShouldContain("artifactType 'application/vnd.other'");
     }
@@ -241,10 +273,7 @@ public class ImageInfoServiceTests
         ImageInfoService service = CreateService(orasServiceMock.Object);
 
         InvalidOperationException exception = await Should.ThrowAsync<InvalidOperationException>(() =>
-            service.PullImageInfoArtifactAsync(
-                manifest,
-                registry: "publish.example.com",
-                repoPrefix: "public/"));
+            service.PullImageInfoArtifactAsync(manifest));
 
         exception.Message.ShouldContain("mediaType 'application/vnd.other'");
     }
@@ -276,23 +305,27 @@ public class ImageInfoServiceTests
         ImageInfoService service = CreateService(orasServiceMock.Object);
 
         InvalidOperationException exception = await Should.ThrowAsync<InvalidOperationException>(() =>
-            service.PullImageInfoArtifactAsync(
-                manifest,
-                registry: "publish.example.com",
-                repoPrefix: "public/"));
+            service.PullImageInfoArtifactAsync(manifest));
 
         exception.Message.ShouldContain("must have exactly one blob, but has 2");
     }
 
-    private static ImageInfoService CreateService(IOrasService orasService)
+    private static ImageInfoService CreateService(
+        IOrasService orasService,
+        PublishConfiguration? publishConfig = null)
     {
         Mock<IOrasServiceFactory> orasServiceFactoryMock = new();
         orasServiceFactoryMock
             .Setup(f => f.Create(It.IsAny<IRegistryCredentialsHost?>()))
             .Returns(orasService);
+        publishConfig ??= new PublishConfiguration
+        {
+            PublishRegistry = new RegistryEndpoint { Server = "publish.example.com", RepoPrefix = "public/" }
+        };
         return new ImageInfoService(
             TestHelper.CreateManifestJsonService(),
             orasServiceFactoryMock.Object,
+            Options.Create(publishConfig),
             NullLogger<ImageInfoService>.Instance);
     }
 

--- a/src/ImageBuilder.Tests/MergeImageInfoFilesCommandTests.cs
+++ b/src/ImageBuilder.Tests/MergeImageInfoFilesCommandTests.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Commands;
+using Microsoft.DotNet.ImageBuilder.Configuration;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 using Microsoft.DotNet.ImageBuilder.Tests.Helpers;
@@ -182,7 +183,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     }
                 };
 
-                MergeImageInfoCommand command = new MergeImageInfoCommand(TestHelper.CreateManifestJsonService(), Mock.Of<IImageInfoService>());
+                MergeImageInfoCommand command = new MergeImageInfoCommand(TestHelper.CreateManifestJsonService(), Mock.Of<IImageInfoService>(), Microsoft.Extensions.Options.Options.Create(new PublishConfiguration()));
                 command.Options.SourceImageInfoFolderPath = Path.Combine(context.Path, "image-infos");
                 command.Options.DestinationImageInfoPath = Path.Combine(context.Path, "output.json");
                 command.Options.Manifest = Path.Combine(context.Path, "manifest.json");
@@ -486,7 +487,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     }
                 };
 
-                MergeImageInfoCommand command = new MergeImageInfoCommand(TestHelper.CreateManifestJsonService(), Mock.Of<IImageInfoService>());
+                MergeImageInfoCommand command = new MergeImageInfoCommand(TestHelper.CreateManifestJsonService(), Mock.Of<IImageInfoService>(), Microsoft.Extensions.Options.Options.Create(new PublishConfiguration()));
                 command.Options.SourceImageInfoFolderPath = Path.Combine(context.Path, "image-infos");
                 command.Options.DestinationImageInfoPath = Path.Combine(context.Path, "output.json");
                 command.Options.Manifest = Path.Combine(context.Path, "manifest.json");
@@ -621,7 +622,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         [TestMethod]
         public async Task MergeImageInfoFilesCommand_SourceFolderPathNotFound()
         {
-            MergeImageInfoCommand command = new MergeImageInfoCommand(TestHelper.CreateManifestJsonService(), Mock.Of<IImageInfoService>());
+            MergeImageInfoCommand command = new MergeImageInfoCommand(TestHelper.CreateManifestJsonService(), Mock.Of<IImageInfoService>(), Microsoft.Extensions.Options.Options.Create(new PublishConfiguration()));
             command.Options.SourceImageInfoFolderPath = "foo";
             command.Options.DestinationImageInfoPath = "output.json";
 
@@ -644,7 +645,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 // Store the content in a .txt file which the command should NOT be looking for.
                 File.WriteAllText("image-info.txt", JsonHelper.SerializeObject(imageArtifactDetails));
 
-                MergeImageInfoCommand command = new MergeImageInfoCommand(TestHelper.CreateManifestJsonService(), Mock.Of<IImageInfoService>());
+                MergeImageInfoCommand command = new MergeImageInfoCommand(TestHelper.CreateManifestJsonService(), Mock.Of<IImageInfoService>(), Microsoft.Extensions.Options.Options.Create(new PublishConfiguration()));
                 command.Options.SourceImageInfoFolderPath = context.Path;
                 command.Options.DestinationImageInfoPath = "output.json";
 
@@ -773,7 +774,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            MergeImageInfoCommand command = new(TestHelper.CreateManifestJsonService(), Mock.Of<IImageInfoService>());
+            MergeImageInfoCommand command = new(TestHelper.CreateManifestJsonService(), Mock.Of<IImageInfoService>(), Microsoft.Extensions.Options.Options.Create(new PublishConfiguration()));
             command.Options.SourceImageInfoFolderPath = Path.Combine(tempFolderContext.Path, "image-infos");
             command.Options.DestinationImageInfoPath = Path.Combine(tempFolderContext.Path, "output.json");
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
@@ -940,7 +941,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            MergeImageInfoCommand command = new(TestHelper.CreateManifestJsonService(), Mock.Of<IImageInfoService>());
+            MergeImageInfoCommand command = new(TestHelper.CreateManifestJsonService(), Mock.Of<IImageInfoService>(), Microsoft.Extensions.Options.Options.Create(new PublishConfiguration()));
             command.Options.SourceImageInfoFolderPath = Path.Combine(tempFolderContext.Path, "image-infos");
             command.Options.DestinationImageInfoPath = Path.Combine(tempFolderContext.Path, "output.json");
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
@@ -1119,7 +1120,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             var outputImageInfoFile = Path.Combine(context.Path, "merged-image-info.json");
 
-            MergeImageInfoCommand command = new MergeImageInfoCommand(TestHelper.CreateManifestJsonService(), Mock.Of<IImageInfoService>());
+            MergeImageInfoCommand command = new MergeImageInfoCommand(TestHelper.CreateManifestJsonService(), Mock.Of<IImageInfoService>(), Microsoft.Extensions.Options.Options.Create(new PublishConfiguration()));
             command.Options.SourceImageInfoFolderPath = sourceImageInfoDir;
             command.Options.DestinationImageInfoPath = outputImageInfoFile;
             command.Options.InitialImageInfoPath = initialImageInfoFile;
@@ -1228,7 +1229,14 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Mock<IImageInfoService> imageInfoServiceMock = new();
             string outputPath = Path.Combine(context.Path, "output.json");
             string initialOutputPath = Path.Combine(context.Path, "initial-output.json");
-            MergeImageInfoCommand command = new(TestHelper.CreateManifestJsonService(), imageInfoServiceMock.Object);
+            PublishConfiguration publishConfig = new()
+            {
+                PublishRegistry = new RegistryEndpoint { Server = "example.azurecr.io", RepoPrefix = "prefix/" }
+            };
+            MergeImageInfoCommand command = new(
+                TestHelper.CreateManifestJsonService(),
+                imageInfoServiceMock.Object,
+                Microsoft.Extensions.Options.Options.Create(publishConfig));
             imageInfoServiceMock
                 .Setup(service => service.PullImageInfoArtifactAsync(
                     It.IsAny<ManifestInfo>(),
@@ -1241,8 +1249,6 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             command.Options.DestinationImageInfoPath = outputPath;
             command.Options.Manifest = manifestPath;
             command.Options.IsPublishScenario = true;
-            command.Options.InitialImageInfoRegistryOverride = "example.azurecr.io";
-            command.Options.InitialImageInfoRepoPrefix = "prefix/";
             command.Options.InitialImageInfoOutputPath = initialOutputPath;
 
             command.LoadManifest();

--- a/src/ImageBuilder.Tests/MergeImageInfoFilesCommandTests.cs
+++ b/src/ImageBuilder.Tests/MergeImageInfoFilesCommandTests.cs
@@ -183,7 +183,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     }
                 };
 
-                MergeImageInfoCommand command = new MergeImageInfoCommand(TestHelper.CreateManifestJsonService(), Mock.Of<IImageInfoService>(), Microsoft.Extensions.Options.Options.Create(new PublishConfiguration()));
+                MergeImageInfoCommand command = new MergeImageInfoCommand(TestHelper.CreateManifestJsonService(), Mock.Of<IImageInfoService>());
                 command.Options.SourceImageInfoFolderPath = Path.Combine(context.Path, "image-infos");
                 command.Options.DestinationImageInfoPath = Path.Combine(context.Path, "output.json");
                 command.Options.Manifest = Path.Combine(context.Path, "manifest.json");
@@ -487,7 +487,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     }
                 };
 
-                MergeImageInfoCommand command = new MergeImageInfoCommand(TestHelper.CreateManifestJsonService(), Mock.Of<IImageInfoService>(), Microsoft.Extensions.Options.Options.Create(new PublishConfiguration()));
+                MergeImageInfoCommand command = new MergeImageInfoCommand(TestHelper.CreateManifestJsonService(), Mock.Of<IImageInfoService>());
                 command.Options.SourceImageInfoFolderPath = Path.Combine(context.Path, "image-infos");
                 command.Options.DestinationImageInfoPath = Path.Combine(context.Path, "output.json");
                 command.Options.Manifest = Path.Combine(context.Path, "manifest.json");
@@ -622,7 +622,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         [TestMethod]
         public async Task MergeImageInfoFilesCommand_SourceFolderPathNotFound()
         {
-            MergeImageInfoCommand command = new MergeImageInfoCommand(TestHelper.CreateManifestJsonService(), Mock.Of<IImageInfoService>(), Microsoft.Extensions.Options.Options.Create(new PublishConfiguration()));
+            MergeImageInfoCommand command = new MergeImageInfoCommand(TestHelper.CreateManifestJsonService(), Mock.Of<IImageInfoService>());
             command.Options.SourceImageInfoFolderPath = "foo";
             command.Options.DestinationImageInfoPath = "output.json";
 
@@ -645,7 +645,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 // Store the content in a .txt file which the command should NOT be looking for.
                 File.WriteAllText("image-info.txt", JsonHelper.SerializeObject(imageArtifactDetails));
 
-                MergeImageInfoCommand command = new MergeImageInfoCommand(TestHelper.CreateManifestJsonService(), Mock.Of<IImageInfoService>(), Microsoft.Extensions.Options.Options.Create(new PublishConfiguration()));
+                MergeImageInfoCommand command = new MergeImageInfoCommand(TestHelper.CreateManifestJsonService(), Mock.Of<IImageInfoService>());
                 command.Options.SourceImageInfoFolderPath = context.Path;
                 command.Options.DestinationImageInfoPath = "output.json";
 
@@ -774,7 +774,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            MergeImageInfoCommand command = new(TestHelper.CreateManifestJsonService(), Mock.Of<IImageInfoService>(), Microsoft.Extensions.Options.Options.Create(new PublishConfiguration()));
+            MergeImageInfoCommand command = new(TestHelper.CreateManifestJsonService(), Mock.Of<IImageInfoService>());
             command.Options.SourceImageInfoFolderPath = Path.Combine(tempFolderContext.Path, "image-infos");
             command.Options.DestinationImageInfoPath = Path.Combine(tempFolderContext.Path, "output.json");
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
@@ -941,7 +941,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 }
             };
 
-            MergeImageInfoCommand command = new(TestHelper.CreateManifestJsonService(), Mock.Of<IImageInfoService>(), Microsoft.Extensions.Options.Options.Create(new PublishConfiguration()));
+            MergeImageInfoCommand command = new(TestHelper.CreateManifestJsonService(), Mock.Of<IImageInfoService>());
             command.Options.SourceImageInfoFolderPath = Path.Combine(tempFolderContext.Path, "image-infos");
             command.Options.DestinationImageInfoPath = Path.Combine(tempFolderContext.Path, "output.json");
             command.Options.Manifest = Path.Combine(tempFolderContext.Path, "manifest.json");
@@ -1120,7 +1120,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             var outputImageInfoFile = Path.Combine(context.Path, "merged-image-info.json");
 
-            MergeImageInfoCommand command = new MergeImageInfoCommand(TestHelper.CreateManifestJsonService(), Mock.Of<IImageInfoService>(), Microsoft.Extensions.Options.Options.Create(new PublishConfiguration()));
+            MergeImageInfoCommand command = new MergeImageInfoCommand(TestHelper.CreateManifestJsonService(), Mock.Of<IImageInfoService>());
             command.Options.SourceImageInfoFolderPath = sourceImageInfoDir;
             command.Options.DestinationImageInfoPath = outputImageInfoFile;
             command.Options.InitialImageInfoPath = initialImageInfoFile;
@@ -1229,19 +1229,12 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Mock<IImageInfoService> imageInfoServiceMock = new();
             string outputPath = Path.Combine(context.Path, "output.json");
             string initialOutputPath = Path.Combine(context.Path, "initial-output.json");
-            PublishConfiguration publishConfig = new()
-            {
-                PublishRegistry = new RegistryEndpoint { Server = "example.azurecr.io", RepoPrefix = "prefix/" }
-            };
             MergeImageInfoCommand command = new(
                 TestHelper.CreateManifestJsonService(),
-                imageInfoServiceMock.Object,
-                Microsoft.Extensions.Options.Options.Create(publishConfig));
+                imageInfoServiceMock.Object);
             imageInfoServiceMock
                 .Setup(service => service.PullImageInfoArtifactAsync(
                     It.IsAny<ManifestInfo>(),
-                    "example.azurecr.io",
-                    "prefix/",
                     It.IsAny<System.Threading.CancellationToken>()))
                 .ReturnsAsync(JsonHelper.SerializeObject(initialImageInfo));
 

--- a/src/ImageBuilder/Commands/BuildCommand.cs
+++ b/src/ImageBuilder/Commands/BuildCommand.cs
@@ -7,13 +7,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
-using System.Threading;
 using System.Threading.Tasks;
-using Azure.Core;
-using Microsoft.DotNet.ImageBuilder.Configuration;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
-using Microsoft.Extensions.Options;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
@@ -29,7 +25,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private readonly IAzureTokenCredentialProvider _tokenCredentialProvider;
         private readonly IImageCacheService _imageCacheService;
         private readonly IImageInfoService _imageInfoService;
-        private readonly PublishConfiguration _publishConfig;
         private readonly ImageDigestCache _imageDigestCache;
         private readonly List<TagInfo> _processedTags = new List<TagInfo>();
         private readonly HashSet<PlatformData> _builtPlatforms = new();
@@ -55,8 +50,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             IRegistryCredentialsProvider registryCredentialsProvider,
             IAzureTokenCredentialProvider tokenCredentialProvider,
             IImageCacheService imageCacheService,
-            IImageInfoService imageInfoService,
-            IOptions<PublishConfiguration> publishConfigOptions) : base(manifestJsonService)
+            IImageInfoService imageInfoService) : base(manifestJsonService)
         {
             _dockerService = new DockerServiceCache(dockerService ?? throw new ArgumentNullException(nameof(dockerService)));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -67,7 +61,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             _tokenCredentialProvider = tokenCredentialProvider ?? throw new ArgumentNullException(nameof(tokenCredentialProvider));
             _imageCacheService = imageCacheService ?? throw new ArgumentNullException(nameof(imageCacheService));
             _imageInfoService = imageInfoService ?? throw new ArgumentNullException(nameof(imageInfoService));
-            _publishConfig = publishConfigOptions.Value;
 
             // Lazily create services which need access to options
             ArgumentNullException.ThrowIfNull(manifestServiceFactory);
@@ -322,34 +315,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             }
             else if (Manifest.Model.ImageInfo is not null)
             {
-                // The build-time cache check reads the previously-published image info, which lives in the
-                // publish registry (where publishImageInfoArtifact writes it). Fall back to the manifest
-                // registry when no publish registry is configured (e.g. public PR builds without appsettings).
-                string? imageInfoRegistry;
-                string? imageInfoRepoPrefix;
-                if (!string.IsNullOrWhiteSpace(_publishConfig.PublishRegistry?.Server))
-                {
-                    imageInfoRegistry = _publishConfig.PublishRegistry.Server;
-                    imageInfoRepoPrefix = _publishConfig.PublishRegistry.RepoPrefix;
-                }
-                else
-                {
-                    imageInfoRegistry = Manifest.Model.Registry;
-                    imageInfoRepoPrefix = null;
-                }
-
-                if (string.IsNullOrWhiteSpace(imageInfoRegistry))
-                {
-                    throw new InvalidOperationException(
-                        $"Manifest '{Manifest.FilePath}' must define a registry or a publish registry must be " +
-                        "configured to pull the image-info artifact for the build-time cache check.");
-                }
-
-                string imageInfoContent = await _imageInfoService.PullImageInfoArtifactAsync(
-                    Manifest,
-                    imageInfoRegistry,
-                    imageInfoRepoPrefix);
-
+                string imageInfoContent = await _imageInfoService.PullImageInfoArtifactAsync(Manifest);
                 srcImageArtifactDetails = ImageInfoHelper.LoadFromContent(
                     imageInfoContent,
                     Manifest,

--- a/src/ImageBuilder/Commands/BuildCommand.cs
+++ b/src/ImageBuilder/Commands/BuildCommand.cs
@@ -10,8 +10,10 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
+using Microsoft.DotNet.ImageBuilder.Configuration;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
@@ -27,6 +29,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private readonly IAzureTokenCredentialProvider _tokenCredentialProvider;
         private readonly IImageCacheService _imageCacheService;
         private readonly IImageInfoService _imageInfoService;
+        private readonly PublishConfiguration _publishConfig;
         private readonly ImageDigestCache _imageDigestCache;
         private readonly List<TagInfo> _processedTags = new List<TagInfo>();
         private readonly HashSet<PlatformData> _builtPlatforms = new();
@@ -52,7 +55,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             IRegistryCredentialsProvider registryCredentialsProvider,
             IAzureTokenCredentialProvider tokenCredentialProvider,
             IImageCacheService imageCacheService,
-            IImageInfoService imageInfoService) : base(manifestJsonService)
+            IImageInfoService imageInfoService,
+            IOptions<PublishConfiguration> publishConfigOptions) : base(manifestJsonService)
         {
             _dockerService = new DockerServiceCache(dockerService ?? throw new ArgumentNullException(nameof(dockerService)));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -63,6 +67,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             _tokenCredentialProvider = tokenCredentialProvider ?? throw new ArgumentNullException(nameof(tokenCredentialProvider));
             _imageCacheService = imageCacheService ?? throw new ArgumentNullException(nameof(imageCacheService));
             _imageInfoService = imageInfoService ?? throw new ArgumentNullException(nameof(imageInfoService));
+            _publishConfig = publishConfigOptions.Value;
 
             // Lazily create services which need access to options
             ArgumentNullException.ThrowIfNull(manifestServiceFactory);
@@ -317,10 +322,17 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             }
             else if (Manifest.Model.ImageInfo is not null)
             {
+                // The build-time cache check reads the previously-published image info, which lives in the
+                // publish registry (where publishImageInfoArtifact writes it). Fall back to the manifest
+                // registry when no publish registry is configured (e.g. public PR builds without appsettings).
+                string imageInfoRegistry = string.IsNullOrWhiteSpace(_publishConfig.PublishRegistry?.Server)
+                    ? Manifest.Model.Registry
+                    : _publishConfig.PublishRegistry.Server;
+
                 string imageInfoContent = await _imageInfoService.PullImageInfoArtifactAsync(
                     Manifest,
-                    string.IsNullOrWhiteSpace(Options.RegistryOverride) ? Manifest.Model.Registry : Options.RegistryOverride,
-                    Options.RepoPrefix);
+                    imageInfoRegistry,
+                    _publishConfig.PublishRegistry?.RepoPrefix);
 
                 srcImageArtifactDetails = ImageInfoHelper.LoadFromContent(
                     imageInfoContent,

--- a/src/ImageBuilder/Commands/BuildCommand.cs
+++ b/src/ImageBuilder/Commands/BuildCommand.cs
@@ -325,14 +325,30 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 // The build-time cache check reads the previously-published image info, which lives in the
                 // publish registry (where publishImageInfoArtifact writes it). Fall back to the manifest
                 // registry when no publish registry is configured (e.g. public PR builds without appsettings).
-                string imageInfoRegistry = string.IsNullOrWhiteSpace(_publishConfig.PublishRegistry?.Server)
-                    ? Manifest.Model.Registry
-                    : _publishConfig.PublishRegistry.Server;
+                string? imageInfoRegistry;
+                string? imageInfoRepoPrefix;
+                if (!string.IsNullOrWhiteSpace(_publishConfig.PublishRegistry?.Server))
+                {
+                    imageInfoRegistry = _publishConfig.PublishRegistry.Server;
+                    imageInfoRepoPrefix = _publishConfig.PublishRegistry.RepoPrefix;
+                }
+                else
+                {
+                    imageInfoRegistry = Manifest.Model.Registry;
+                    imageInfoRepoPrefix = null;
+                }
+
+                if (string.IsNullOrWhiteSpace(imageInfoRegistry))
+                {
+                    throw new InvalidOperationException(
+                        $"Manifest '{Manifest.FilePath}' must define a registry or a publish registry must be " +
+                        "configured to pull the image-info artifact for the build-time cache check.");
+                }
 
                 string imageInfoContent = await _imageInfoService.PullImageInfoArtifactAsync(
                     Manifest,
                     imageInfoRegistry,
-                    _publishConfig.PublishRegistry?.RepoPrefix);
+                    imageInfoRepoPrefix);
 
                 srcImageArtifactDetails = ImageInfoHelper.LoadFromContent(
                     imageInfoContent,

--- a/src/ImageBuilder/Commands/GenerateBuildMatrixCommand.cs
+++ b/src/ImageBuilder/Commands/GenerateBuildMatrixCommand.cs
@@ -62,7 +62,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     skipManifestValidation: true);
             }
 
-            if (Manifest.Model.ImageInfo is null)
+            // The OCI image-info artifact is only consumed to trim cached images from the matrix.
+            // Pulling it requires authenticated access to the publish registry, so skip the pull
+            // entirely unless trimming was requested.
+            if (Manifest.Model.ImageInfo is null || !Options.TrimCachedImages)
             {
                 return null;
             }

--- a/src/ImageBuilder/Commands/GenerateBuildMatrixCommand.cs
+++ b/src/ImageBuilder/Commands/GenerateBuildMatrixCommand.cs
@@ -8,9 +8,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Microsoft.DotNet.ImageBuilder.Configuration;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
@@ -23,6 +25,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private static readonly Regex s_versionRegex = new(@$"^(?<{VersionRegGroupName}>(\d|\.)+).*$");
         private readonly IImageCacheService _imageCacheService;
         private readonly ILogger<GenerateBuildMatrixCommand> _logger;
+        private readonly PublishConfiguration _publishConfig;
         private readonly ImageDigestCache _imageDigestCache;
         private readonly Lazy<ImageNameResolverForMatrix> _imageNameResolver;
 
@@ -31,11 +34,13 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             IImageInfoService imageInfoService,
             IImageCacheService imageCacheService,
             IManifestServiceFactory manifestServiceFactory,
-            ILogger<GenerateBuildMatrixCommand> logger) : base(manifestJsonService)
+            ILogger<GenerateBuildMatrixCommand> logger,
+            IOptions<PublishConfiguration> publishConfigOptions) : base(manifestJsonService)
         {
             ArgumentNullException.ThrowIfNull(imageInfoService);
             _imageCacheService = imageCacheService ?? throw new ArgumentNullException(nameof(imageCacheService));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _publishConfig = publishConfigOptions.Value;
             _imageArtifactDetails = new Lazy<Task<ImageArtifactDetails?>>(() =>
                 LoadImageArtifactDetailsAsync(imageInfoService));
             _imageDigestCache = new ImageDigestCache(
@@ -62,10 +67,16 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 return null;
             }
 
+            // The image-info artifact lives in the publish registry (where it was last published).
+            // Fall back to the manifest registry when no publish registry is configured.
+            string imageInfoRegistry = string.IsNullOrWhiteSpace(_publishConfig.PublishRegistry?.Server)
+                ? Manifest.Model.Registry
+                : _publishConfig.PublishRegistry.Server;
+
             string imageInfoContent = await imageInfoService.PullImageInfoArtifactAsync(
                 Manifest,
-                string.IsNullOrWhiteSpace(Options.ImageInfoRegistryOverride) ? Manifest.Model.Registry : Options.ImageInfoRegistryOverride,
-                Options.ImageInfoRepoPrefix);
+                imageInfoRegistry,
+                _publishConfig.PublishRegistry?.RepoPrefix);
 
             return ImageInfoHelper.LoadFromContent(
                 imageInfoContent,

--- a/src/ImageBuilder/Commands/GenerateBuildMatrixCommand.cs
+++ b/src/ImageBuilder/Commands/GenerateBuildMatrixCommand.cs
@@ -8,11 +8,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Microsoft.DotNet.ImageBuilder.Configuration;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
-using Microsoft.Extensions.Options;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
@@ -25,7 +23,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private static readonly Regex s_versionRegex = new(@$"^(?<{VersionRegGroupName}>(\d|\.)+).*$");
         private readonly IImageCacheService _imageCacheService;
         private readonly ILogger<GenerateBuildMatrixCommand> _logger;
-        private readonly PublishConfiguration _publishConfig;
         private readonly ImageDigestCache _imageDigestCache;
         private readonly Lazy<ImageNameResolverForMatrix> _imageNameResolver;
 
@@ -34,13 +31,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             IImageInfoService imageInfoService,
             IImageCacheService imageCacheService,
             IManifestServiceFactory manifestServiceFactory,
-            ILogger<GenerateBuildMatrixCommand> logger,
-            IOptions<PublishConfiguration> publishConfigOptions) : base(manifestJsonService)
+            ILogger<GenerateBuildMatrixCommand> logger) : base(manifestJsonService)
         {
             ArgumentNullException.ThrowIfNull(imageInfoService);
             _imageCacheService = imageCacheService ?? throw new ArgumentNullException(nameof(imageCacheService));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _publishConfig = publishConfigOptions.Value;
             _imageArtifactDetails = new Lazy<Task<ImageArtifactDetails?>>(() =>
                 LoadImageArtifactDetailsAsync(imageInfoService));
             _imageDigestCache = new ImageDigestCache(
@@ -70,32 +65,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 return null;
             }
 
-            // The image-info artifact lives in the publish registry (where it was last published).
-            // Fall back to the manifest registry when no publish registry is configured.
-            string? imageInfoRegistry;
-            string? imageInfoRepoPrefix;
-            if (!string.IsNullOrWhiteSpace(_publishConfig.PublishRegistry?.Server))
-            {
-                imageInfoRegistry = _publishConfig.PublishRegistry.Server;
-                imageInfoRepoPrefix = _publishConfig.PublishRegistry.RepoPrefix;
-            }
-            else
-            {
-                imageInfoRegistry = Manifest.Model.Registry;
-                imageInfoRepoPrefix = null;
-            }
-
-            if (string.IsNullOrWhiteSpace(imageInfoRegistry))
-            {
-                throw new InvalidOperationException(
-                    $"Manifest '{Manifest.FilePath}' must define a registry or a publish registry must be " +
-                    "configured to pull the image-info artifact for matrix cache trimming.");
-            }
-
-            string imageInfoContent = await imageInfoService.PullImageInfoArtifactAsync(
-                Manifest,
-                imageInfoRegistry,
-                imageInfoRepoPrefix);
+            string imageInfoContent = await imageInfoService.PullImageInfoArtifactAsync(Manifest);
 
             return ImageInfoHelper.LoadFromContent(
                 imageInfoContent,

--- a/src/ImageBuilder/Commands/GenerateBuildMatrixCommand.cs
+++ b/src/ImageBuilder/Commands/GenerateBuildMatrixCommand.cs
@@ -72,14 +72,30 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             // The image-info artifact lives in the publish registry (where it was last published).
             // Fall back to the manifest registry when no publish registry is configured.
-            string imageInfoRegistry = string.IsNullOrWhiteSpace(_publishConfig.PublishRegistry?.Server)
-                ? Manifest.Model.Registry
-                : _publishConfig.PublishRegistry.Server;
+            string? imageInfoRegistry;
+            string? imageInfoRepoPrefix;
+            if (!string.IsNullOrWhiteSpace(_publishConfig.PublishRegistry?.Server))
+            {
+                imageInfoRegistry = _publishConfig.PublishRegistry.Server;
+                imageInfoRepoPrefix = _publishConfig.PublishRegistry.RepoPrefix;
+            }
+            else
+            {
+                imageInfoRegistry = Manifest.Model.Registry;
+                imageInfoRepoPrefix = null;
+            }
+
+            if (string.IsNullOrWhiteSpace(imageInfoRegistry))
+            {
+                throw new InvalidOperationException(
+                    $"Manifest '{Manifest.FilePath}' must define a registry or a publish registry must be " +
+                    "configured to pull the image-info artifact for matrix cache trimming.");
+            }
 
             string imageInfoContent = await imageInfoService.PullImageInfoArtifactAsync(
                 Manifest,
                 imageInfoRegistry,
-                _publishConfig.PublishRegistry?.RepoPrefix);
+                imageInfoRepoPrefix);
 
             return ImageInfoHelper.LoadFromContent(
                 imageInfoContent,

--- a/src/ImageBuilder/Commands/GenerateBuildMatrixOptions.cs
+++ b/src/ImageBuilder/Commands/GenerateBuildMatrixOptions.cs
@@ -24,8 +24,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         public string? SourceRepoUrl { get; set; }
         public RegistryCredentialsOptions CredentialsOptions { get; set; } = new();
         public bool TrimCachedImages { get; set; }
-        public string? ImageInfoRegistryOverride { get; set; }
-        public string? ImageInfoRepoPrefix { get; set; }
 
         private const MatrixType DefaultMatrixType = MatrixType.PlatformDependencyGraph;
 
@@ -76,16 +74,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             Description = "Whether to trim cached images from the set of paths"
         };
 
-        private static readonly Option<string?> ImageInfoRegistryOverrideOption = new("--image-info-registry-override")
-        {
-            Description = "Registry to pull image-info OCI artifacts from instead of the manifest registry"
-        };
-
-        private static readonly Option<string?> ImageInfoRepoPrefixOption = new("--image-info-repo-prefix")
-        {
-            Description = "Repo prefix to add when pulling image-info OCI artifacts"
-        };
-
         public override IEnumerable<Option> GetCliOptions() =>
         [
             ..base.GetCliOptions(),
@@ -100,8 +88,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             SourceRepoPrefixOption,
             SourceRepoOption,
             TrimCachedImagesOption,
-            ImageInfoRegistryOverrideOption,
-            ImageInfoRepoPrefixOption,
         ];
 
         public override IEnumerable<Argument> GetCliArguments() =>
@@ -126,8 +112,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             SourceRepoPrefix = result.GetValue(SourceRepoPrefixOption);
             SourceRepoUrl = result.GetValue(SourceRepoOption);
             TrimCachedImages = result.GetValue(TrimCachedImagesOption);
-            ImageInfoRegistryOverride = result.GetValue(ImageInfoRegistryOverrideOption);
-            ImageInfoRepoPrefix = result.GetValue(ImageInfoRepoPrefixOption);
         }
     }
 }

--- a/src/ImageBuilder/Commands/GetStaleImagesCommand.cs
+++ b/src/ImageBuilder/Commands/GetStaleImagesCommand.cs
@@ -7,10 +7,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.DotNet.ImageBuilder.Configuration;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
-using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
@@ -24,21 +22,18 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private readonly ILogger<GetStaleImagesCommand> _logger;
         private readonly IGitService _gitService;
         private readonly IImageInfoService _imageInfoService;
-        private readonly PublishConfiguration _publishConfig;
 
         public GetStaleImagesCommand(
             IManifestServiceFactory manifestServiceFactory,
             IManifestJsonService manifestJsonService,
             ILogger<GetStaleImagesCommand> logger,
             IGitService gitService,
-            IImageInfoService imageInfoService,
-            IOptions<PublishConfiguration> publishConfigOptions)
+            IImageInfoService imageInfoService)
         {
             _manifestJsonService = manifestJsonService ?? throw new ArgumentNullException(nameof(manifestJsonService));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _gitService = gitService ?? throw new ArgumentNullException(nameof(gitService));
             _imageInfoService = imageInfoService ?? throw new ArgumentNullException(nameof(imageInfoService));
-            _publishConfig = publishConfigOptions.Value;
 
             // Don't worry about authenticating to our own ACR, since we are checking base image digests from public
             // registries instead of our staging location. Registry credentials are needed however to prevent rate
@@ -209,33 +204,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         private async Task<ImageArtifactDetails> PullImageInfoAsync(ManifestInfo manifest)
         {
-            // The image-info artifact lives in the publish registry (where it was last published).
-            // Fall back to the manifest registry when no publish registry is configured.
-            string? imageInfoRegistry;
-            string? imageInfoRepoPrefix;
-            if (!string.IsNullOrWhiteSpace(_publishConfig.PublishRegistry?.Server))
-            {
-                imageInfoRegistry = _publishConfig.PublishRegistry.Server;
-                imageInfoRepoPrefix = _publishConfig.PublishRegistry.RepoPrefix;
-            }
-            else
-            {
-                imageInfoRegistry = manifest.Model.Registry;
-                imageInfoRepoPrefix = null;
-            }
-
-            if (string.IsNullOrWhiteSpace(imageInfoRegistry))
-            {
-                throw new InvalidOperationException(
-                    $"Manifest '{manifest.FilePath}' must define a registry or a publish registry must be configured " +
-                    "to pull image-info artifact for stale image detection.");
-            }
-
-            string imageInfoContent = await _imageInfoService.PullImageInfoArtifactAsync(
-                manifest,
-                imageInfoRegistry,
-                imageInfoRepoPrefix);
-
+            string imageInfoContent = await _imageInfoService.PullImageInfoArtifactAsync(manifest);
             return ImageInfoHelper.LoadFromContent(imageInfoContent, manifest, skipManifestValidation: true);
         }
     }

--- a/src/ImageBuilder/Commands/GetStaleImagesCommand.cs
+++ b/src/ImageBuilder/Commands/GetStaleImagesCommand.cs
@@ -211,9 +211,19 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             // The image-info artifact lives in the publish registry (where it was last published).
             // Fall back to the manifest registry when no publish registry is configured.
-            string imageInfoRegistry = string.IsNullOrWhiteSpace(_publishConfig.PublishRegistry?.Server)
-                ? manifest.Model.Registry
-                : _publishConfig.PublishRegistry.Server;
+            string? imageInfoRegistry;
+            string? imageInfoRepoPrefix;
+            if (!string.IsNullOrWhiteSpace(_publishConfig.PublishRegistry?.Server))
+            {
+                imageInfoRegistry = _publishConfig.PublishRegistry.Server;
+                imageInfoRepoPrefix = _publishConfig.PublishRegistry.RepoPrefix;
+            }
+            else
+            {
+                imageInfoRegistry = manifest.Model.Registry;
+                imageInfoRepoPrefix = null;
+            }
+
             if (string.IsNullOrWhiteSpace(imageInfoRegistry))
             {
                 throw new InvalidOperationException(
@@ -224,7 +234,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             string imageInfoContent = await _imageInfoService.PullImageInfoArtifactAsync(
                 manifest,
                 imageInfoRegistry,
-                _publishConfig.PublishRegistry?.RepoPrefix);
+                imageInfoRepoPrefix);
 
             return ImageInfoHelper.LoadFromContent(imageInfoContent, manifest, skipManifestValidation: true);
         }

--- a/src/ImageBuilder/Commands/GetStaleImagesCommand.cs
+++ b/src/ImageBuilder/Commands/GetStaleImagesCommand.cs
@@ -7,8 +7,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.DotNet.ImageBuilder.Configuration;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
@@ -22,18 +24,21 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private readonly ILogger<GetStaleImagesCommand> _logger;
         private readonly IGitService _gitService;
         private readonly IImageInfoService _imageInfoService;
+        private readonly PublishConfiguration _publishConfig;
 
         public GetStaleImagesCommand(
             IManifestServiceFactory manifestServiceFactory,
             IManifestJsonService manifestJsonService,
             ILogger<GetStaleImagesCommand> logger,
             IGitService gitService,
-            IImageInfoService imageInfoService)
+            IImageInfoService imageInfoService,
+            IOptions<PublishConfiguration> publishConfigOptions)
         {
             _manifestJsonService = manifestJsonService ?? throw new ArgumentNullException(nameof(manifestJsonService));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _gitService = gitService ?? throw new ArgumentNullException(nameof(gitService));
             _imageInfoService = imageInfoService ?? throw new ArgumentNullException(nameof(imageInfoService));
+            _publishConfig = publishConfigOptions.Value;
 
             // Don't worry about authenticating to our own ACR, since we are checking base image digests from public
             // registries instead of our staging location. Registry credentials are needed however to prevent rate
@@ -204,18 +209,22 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         private async Task<ImageArtifactDetails> PullImageInfoAsync(ManifestInfo manifest)
         {
-            string imageInfoRegistry = Options.ImageInfoRegistryOverride ?? manifest.Model.Registry;
+            // The image-info artifact lives in the publish registry (where it was last published).
+            // Fall back to the manifest registry when no publish registry is configured.
+            string imageInfoRegistry = string.IsNullOrWhiteSpace(_publishConfig.PublishRegistry?.Server)
+                ? manifest.Model.Registry
+                : _publishConfig.PublishRegistry.Server;
             if (string.IsNullOrWhiteSpace(imageInfoRegistry))
             {
                 throw new InvalidOperationException(
-                    $"Manifest '{manifest.FilePath}' must define a registry or --image-info-registry-override must be set " +
+                    $"Manifest '{manifest.FilePath}' must define a registry or a publish registry must be configured " +
                     "to pull image-info artifact for stale image detection.");
             }
 
             string imageInfoContent = await _imageInfoService.PullImageInfoArtifactAsync(
                 manifest,
                 imageInfoRegistry,
-                Options.ImageInfoRepoPrefix);
+                _publishConfig.PublishRegistry?.RepoPrefix);
 
             return ImageInfoHelper.LoadFromContent(imageInfoContent, manifest, skipManifestValidation: true);
         }

--- a/src/ImageBuilder/Commands/GetStaleImagesOptions.cs
+++ b/src/ImageBuilder/Commands/GetStaleImagesOptions.cs
@@ -27,10 +27,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         public string? SourceRepoPrefix { get; set; }
 
-        public string? ImageInfoRegistryOverride { get; set; }
-
-        public string? ImageInfoRepoPrefix { get; set; }
-
         private static readonly GitOptionsBuilder GitBuilder = GitOptionsBuilder.BuildForRepositoryOperations();
 
         private static readonly Argument<string> VariableNameArgument = new(nameof(VariableName))
@@ -51,17 +47,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 "'<registry-override>/<source-repo-prefix><original-repo>:<tag>' instead of their public source."
         };
 
-        private static readonly Option<string?> ImageInfoRegistryOverrideOption = new("--image-info-registry-override")
-        {
-            Description = "Alternative registry to pull the image-info OCI artifact from. Defaults to the registry " +
-                "defined in each subscription's manifest."
-        };
-
-        private static readonly Option<string?> ImageInfoRepoPrefixOption = new("--image-info-repo-prefix")
-        {
-            Description = "Repo prefix used to locate image-info OCI artifacts in the image-info registry."
-        };
-
         public override IEnumerable<Option> GetCliOptions() =>
         [
             ..base.GetCliOptions(),
@@ -72,8 +57,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             ..BaseImageOverrideOptions.GetCliOptions(),
             RegistryOverrideOption,
             SourceRepoPrefixOption,
-            ImageInfoRegistryOverrideOption,
-            ImageInfoRepoPrefixOption,
         ];
 
         public override IEnumerable<Argument> GetCliArguments() =>
@@ -102,8 +85,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             BaseImageOverrideOptions.Bind(result);
             RegistryOverride = result.GetValue(RegistryOverrideOption);
             SourceRepoPrefix = result.GetValue(SourceRepoPrefixOption);
-            ImageInfoRegistryOverride = result.GetValue(ImageInfoRegistryOverrideOption);
-            ImageInfoRepoPrefix = result.GetValue(ImageInfoRepoPrefixOption);
             VariableName = result.GetValue(VariableNameArgument) ?? string.Empty;
         }
     }

--- a/src/ImageBuilder/Commands/MergeImageInfoCommand.cs
+++ b/src/ImageBuilder/Commands/MergeImageInfoCommand.cs
@@ -8,18 +8,25 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Microsoft.DotNet.ImageBuilder.Configuration;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     public partial class MergeImageInfoCommand : ManifestCommand<MergeImageInfoOptions>
     {
         private readonly IImageInfoService _imageInfoService;
+        private readonly PublishConfiguration _publishConfig;
 
-        public MergeImageInfoCommand(IManifestJsonService manifestJsonService, IImageInfoService imageInfoService) : base(manifestJsonService)
+        public MergeImageInfoCommand(
+            IManifestJsonService manifestJsonService,
+            IImageInfoService imageInfoService,
+            IOptions<PublishConfiguration> publishConfigOptions) : base(manifestJsonService)
         {
             _imageInfoService = imageInfoService ?? throw new ArgumentNullException(nameof(imageInfoService));
+            _publishConfig = publishConfigOptions.Value;
         }
 
         protected override string Description => "Merges the content of multiple image info files into one file";
@@ -61,13 +68,19 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     .First(item => item.Path == Options.InitialImageInfoPath)
                     .ImageArtifactDetails;
             }
-            else if (!string.IsNullOrWhiteSpace(Options.InitialImageInfoRegistryOverride) ||
-                !string.IsNullOrWhiteSpace(Options.InitialImageInfoRepoPrefix))
+            else if (!string.IsNullOrWhiteSpace(_publishConfig.PublishRegistry?.Server))
             {
+                // The previously-published image info (the merge target) is pulled from the publish
+                // registry's OCI artifact. Fall back to the manifest registry when no publish registry
+                // is configured.
+                string imageInfoRegistry = string.IsNullOrWhiteSpace(_publishConfig.PublishRegistry.Server)
+                    ? Manifest.Model.Registry
+                    : _publishConfig.PublishRegistry.Server;
+
                 string imageInfoContent = await _imageInfoService.PullImageInfoArtifactAsync(
                     Manifest,
-                    string.IsNullOrWhiteSpace(Options.InitialImageInfoRegistryOverride) ? Manifest.Model.Registry : Options.InitialImageInfoRegistryOverride,
-                    Options.InitialImageInfoRepoPrefix);
+                    imageInfoRegistry,
+                    _publishConfig.PublishRegistry.RepoPrefix);
 
                 sourceImageArtifactDetails = ImageInfoHelper.LoadFromContent(
                     imageInfoContent,

--- a/src/ImageBuilder/Commands/MergeImageInfoCommand.cs
+++ b/src/ImageBuilder/Commands/MergeImageInfoCommand.cs
@@ -8,25 +8,20 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Microsoft.DotNet.ImageBuilder.Configuration;
 using Microsoft.DotNet.ImageBuilder.Models.Image;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
-using Microsoft.Extensions.Options;
 
 namespace Microsoft.DotNet.ImageBuilder.Commands
 {
     public partial class MergeImageInfoCommand : ManifestCommand<MergeImageInfoOptions>
     {
         private readonly IImageInfoService _imageInfoService;
-        private readonly PublishConfiguration _publishConfig;
 
         public MergeImageInfoCommand(
             IManifestJsonService manifestJsonService,
-            IImageInfoService imageInfoService,
-            IOptions<PublishConfiguration> publishConfigOptions) : base(manifestJsonService)
+            IImageInfoService imageInfoService) : base(manifestJsonService)
         {
             _imageInfoService = imageInfoService ?? throw new ArgumentNullException(nameof(imageInfoService));
-            _publishConfig = publishConfigOptions.Value;
         }
 
         protected override string Description => "Merges the content of multiple image info files into one file";
@@ -68,14 +63,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     .First(item => item.Path == Options.InitialImageInfoPath)
                     .ImageArtifactDetails;
             }
-            else if (Options.IsPublishScenario && !string.IsNullOrWhiteSpace(_publishConfig.PublishRegistry?.Server))
+            else if (Options.IsPublishScenario)
             {
                 // When publishing, the previously-published image info (the merge target) is pulled from the
                 // publish registry's OCI artifact.
-                string imageInfoContent = await _imageInfoService.PullImageInfoArtifactAsync(
-                    Manifest,
-                    _publishConfig.PublishRegistry.Server,
-                    _publishConfig.PublishRegistry.RepoPrefix);
+                string imageInfoContent = await _imageInfoService.PullImageInfoArtifactAsync(Manifest);
 
                 sourceImageArtifactDetails = ImageInfoHelper.LoadFromContent(
                     imageInfoContent,

--- a/src/ImageBuilder/Commands/MergeImageInfoCommand.cs
+++ b/src/ImageBuilder/Commands/MergeImageInfoCommand.cs
@@ -71,15 +71,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             else if (Options.IsPublishScenario && !string.IsNullOrWhiteSpace(_publishConfig.PublishRegistry?.Server))
             {
                 // When publishing, the previously-published image info (the merge target) is pulled from the
-                // publish registry's OCI artifact. Fall back to the manifest registry when no publish registry
-                // is configured.
-                string imageInfoRegistry = string.IsNullOrWhiteSpace(_publishConfig.PublishRegistry.Server)
-                    ? Manifest.Model.Registry
-                    : _publishConfig.PublishRegistry.Server;
-
+                // publish registry's OCI artifact.
                 string imageInfoContent = await _imageInfoService.PullImageInfoArtifactAsync(
                     Manifest,
-                    imageInfoRegistry,
+                    _publishConfig.PublishRegistry.Server,
                     _publishConfig.PublishRegistry.RepoPrefix);
 
                 sourceImageArtifactDetails = ImageInfoHelper.LoadFromContent(

--- a/src/ImageBuilder/Commands/MergeImageInfoCommand.cs
+++ b/src/ImageBuilder/Commands/MergeImageInfoCommand.cs
@@ -68,10 +68,10 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     .First(item => item.Path == Options.InitialImageInfoPath)
                     .ImageArtifactDetails;
             }
-            else if (!string.IsNullOrWhiteSpace(_publishConfig.PublishRegistry?.Server))
+            else if (Options.IsPublishScenario && !string.IsNullOrWhiteSpace(_publishConfig.PublishRegistry?.Server))
             {
-                // The previously-published image info (the merge target) is pulled from the publish
-                // registry's OCI artifact. Fall back to the manifest registry when no publish registry
+                // When publishing, the previously-published image info (the merge target) is pulled from the
+                // publish registry's OCI artifact. Fall back to the manifest registry when no publish registry
                 // is configured.
                 string imageInfoRegistry = string.IsNullOrWhiteSpace(_publishConfig.PublishRegistry.Server)
                     ? Manifest.Model.Registry

--- a/src/ImageBuilder/Commands/MergeImageInfoOptions.cs
+++ b/src/ImageBuilder/Commands/MergeImageInfoOptions.cs
@@ -18,10 +18,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         public string? InitialImageInfoOutputPath { get; set; }
 
-        public string? InitialImageInfoRegistryOverride { get; set; }
-
-        public string? InitialImageInfoRepoPrefix { get; set; }
-
         public bool IsPublishScenario { get; set; }
 
         public string? CommitOverride { get; set; }
@@ -51,16 +47,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             Description = "Path to write the initial image info used as the merge target"
         };
 
-        private static readonly Option<string?> InitialImageInfoRegistryOverrideOption = new("--initial-image-info-registry-override")
-        {
-            Description = "Registry to pull the initial image-info OCI artifact from instead of the manifest registry"
-        };
-
-        private static readonly Option<string?> InitialImageInfoRepoPrefixOption = new("--initial-image-info-repo-prefix")
-        {
-            Description = "Repo prefix to add when pulling the initial image-info OCI artifact"
-        };
-
         private static readonly Option<string?> CommitOverrideOption = new("--commit-override")
         {
             Description = "Override the commit in the commitUrl property for images that were updated compared to the"
@@ -80,8 +66,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             PublishOption,
             InitialImageInfoPathOption,
             InitialImageInfoOutputPathOption,
-            InitialImageInfoRegistryOverrideOption,
-            InitialImageInfoRepoPrefixOption,
             CommitOverrideOption,
         ];
 
@@ -93,8 +77,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             IsPublishScenario = result.GetValue(PublishOption);
             InitialImageInfoPath = result.GetValue(InitialImageInfoPathOption);
             InitialImageInfoOutputPath = result.GetValue(InitialImageInfoOutputPathOption);
-            InitialImageInfoRegistryOverride = result.GetValue(InitialImageInfoRegistryOverrideOption);
-            InitialImageInfoRepoPrefix = result.GetValue(InitialImageInfoRepoPrefixOption);
             CommitOverride = result.GetValue(CommitOverrideOption);
         }
     }

--- a/src/ImageBuilder/IImageInfoService.cs
+++ b/src/ImageBuilder/IImageInfoService.cs
@@ -47,9 +47,5 @@ public interface IImageInfoService
     /// When the manifest does not declare an <c>imageInfo</c> object, the pull fails because the
     /// artifact source and tag are required manifest metadata.
     /// </remarks>
-    Task<string> PullImageInfoArtifactAsync(
-        ManifestInfo manifest,
-        string registry,
-        string? repoPrefix,
-        CancellationToken cancellationToken = default);
+    Task<string> PullImageInfoArtifactAsync(ManifestInfo manifest, CancellationToken cancellationToken = default);
 }

--- a/src/ImageBuilder/ImageInfoService.cs
+++ b/src/ImageBuilder/ImageInfoService.cs
@@ -7,10 +7,11 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.DotNet.ImageBuilder.Configuration;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 using Microsoft.DotNet.ImageBuilder.Oras;
 using Microsoft.DotNet.ImageBuilder.ViewModel;
-using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.DotNet.ImageBuilder;
 
@@ -18,6 +19,7 @@ namespace Microsoft.DotNet.ImageBuilder;
 public class ImageInfoService(
     IManifestJsonService manifestJsonService,
     IOrasServiceFactory orasServiceFactory,
+    IOptions<PublishConfiguration> publishConfigOptions,
     ILogger<ImageInfoService> logger
 ) : IImageInfoService
 {
@@ -29,6 +31,9 @@ public class ImageInfoService(
 
     private readonly ILogger<ImageInfoService> _logger =
         logger ?? throw new ArgumentNullException(nameof(logger));
+
+    private readonly PublishConfiguration _publishConfig =
+        publishConfigOptions?.Value ?? throw new ArgumentNullException(nameof(publishConfigOptions));
 
     /// <inheritdoc/>
     public async Task PushImageInfoArtifactAsync(
@@ -71,14 +76,25 @@ public class ImageInfoService(
     /// <inheritdoc/>
     public async Task<string> PullImageInfoArtifactAsync(
         ManifestInfo manifest,
-        string registry,
-        string? repoPrefix,
         CancellationToken cancellationToken = default)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(registry);
         ArgumentNullException.ThrowIfNull(manifest);
 
         ImageInfoArtifact imageInfoArtifact = GetValidatedImageInfoArtifact(manifest);
+
+        string registry;
+        string repoPrefix;
+
+        if (!string.IsNullOrWhiteSpace(_publishConfig.PublishRegistry?.Server))
+        {
+            registry = _publishConfig.PublishRegistry.Server;
+            repoPrefix = _publishConfig.PublishRegistry.RepoPrefix ?? "";
+        }
+        else
+        {
+            registry = manifest.Model.Registry;
+            repoPrefix = "";
+        }
 
         string repo = $"{repoPrefix}{imageInfoArtifact.Repo}";
         string tag = imageInfoArtifact.Tags.Keys.First();
@@ -88,11 +104,8 @@ public class ImageInfoService(
             registry, repo, tag);
 
         IOrasService orasService = _orasServiceFactory.Create();
-        OciArtifact artifact = await orasService.PullAsync(
-            registry,
-            repo,
-            tag,
-            cancellationToken);
+        OciArtifact artifact = await orasService.PullAsync(registry, repo, tag, cancellationToken);
+
         if (!string.Equals(artifact.Manifest.ArtifactType, OciArtifactType.ImageInfo, StringComparison.Ordinal))
         {
             throw new InvalidOperationException(


### PR DESCRIPTION
Previously, ImageBuilder pulled OCI image info using using CLI options. It also wasn't consistent across commands. This change resolves the artifact's location from `PublishConfiguration` (which is already injected via `appsettings.json`), so every command pulls from the registry where image-info was last published, falling back to the public registry when no publish registry is configured. The pulls are also gated to the scenarios that actually consume the image info, so commands don't need publish registry access when they don't use it.

These are ImageBuilder code-only changes; the corresponding pipeline template updates follow as a separate step per the two-step change process.

- Resolve build-time image-info source from `PublishConfiguration`.
- Resolve `getStaleImages` image-info source from `PublishConfiguration`, removing the override options.
- Resolve `generateBuildMatrix` image-info source from `PublishConfiguration`, removing the override options.
- Resolve `mergeImageInfo` initial image-info source from `PublishConfiguration`, removing the override options.
- Only pull image-info in `generateBuildMatrix` when `--trim-cached-images` is set.
- Only pull the initial image-info in `mergeImageInfo` when publishing.