### PR TITLE
Update coding agent instructions and skills

### DIFF
--- a/.github/instructions/csharp.instructions.md
+++ b/.github/instructions/csharp.instructions.md
@@ -2,65 +2,54 @@
 applyTo: "**/*.cs"
 ---
 
-# C#/.NET Guidelines
+# C# guidance for ImageBuilder
 
-## Coding style
+## Style anchors
 
-For all new C# code:
+The codebase mixes old and modern styles. For new or modified code, use these files as style
+anchors rather than copying patterns from nearby legacy code.
 
-- Use file-scoped namespaces.
-- Use collection expresions - write `[1, 2, 3]` and not `new List<int> { 1, 2, 3 }`.
-- Use explicit type declarations instead of `var` for local variables.
-- Use switch expressions and pattern matching.
-- Use string interpolation (`$"Hello, {name}!"`) instead of `string.Format` or concatenation.
-- Use `"""triple-quoted strings"""` for multi-line string literals. These can be interpolated as well.
-- Use expression-bodied members for simple getters and setters.
+Type of code | Good examples
+------------ | -------------
+Command | `src/ImageBuilder/Commands/Signing/SignImagesCommand.cs`, `src/ImageBuilder/Commands/Signing/SignImagesOptions.cs`
+Service | `src/ImageBuilder/Oras/IOrasService.cs`, `src/ImageBuilder/Oras/OrasDotNetService.cs`
+Configuration | `src/ImageBuilder/Configuration/RegistryAuthentication.cs`, `src/ImageBuilder/Configuration/PublishConfiguration.cs`
+Data type | `src/ImageBuilder/Signing/ImageSigningRequest.cs`
 
-## Naming
+Prefer simple, direct code. Add helper layers, pass-through methods, factories, or interfaces
+only when they remove real complexity.
 
-- Avoid single-letter variable names, except for simple loop counters (e.g. `i`, `j`).
-- Avoid abbreviations or acronyms in names, except for widely known and accepted abbreviations (e.g. `Id`, `Url`, `Http`).
-- Prefer clarity over brevity - a longer descriptive name is better than a short ambiguous one.
+## Commands and inputs
 
-## Code Design Rules
+Expose ImageBuilder functionality through commands. Command classes have one
+`ExecuteAsync()` method.
 
-- Use immutable records instead of classes for DTOs.
-- Do not default to `public` accessibility for members and classes. Follow the least-exposure rule: `private` > `internal` > `protected` > `public`
-- Do not add unused methods/parameters for use cases that were not asked for.
-- Reuse existing methods or services as much as possible.
-- Use composition over inheritance.
-- Use LINQ instead of for loops when working with collections.
-- Place private nested types at the end of the containing class.
+- Use types in `Microsoft.DotNet.ImageBuilder.Configuration`, populated by
+  `appsettings.json`, for strongly typed values that stay constant across invocations of the
+  same pipeline.
+- Define CLI arguments in options classes for values that can vary by invocation, such as
+  paths, switches, prefixes, filters, and timestamps.
+- Some legacy commands use CLI arguments for configuration values. Migrate them only when
+  that work is in scope.
 
-## Error Handling & Edge Cases
+## Services
 
-- Guard early; use `string.IsNullOrWhiteSpace`, `ArgumentNullException.ThrowIfNull`, or `ArgumentNullException.ThrowIfNullOrWhiteSpace`.
-- Avoid using null for control flow.
-- In methods that return collections, return empty collections instead of null.
-- The null-forgiving operator (`!`) is **always** a code smell.
-- Do not add excessive or unnecessary try/catch blocks within the same assembly.
+Commands own orchestration and make the control flow visible. Services encapsulate bounded
+implementation details behind narrow, domain-based APIs; they should not hide the command's
+workflow. Give services predictable behavior, observability, runtime characteristics, and
+failure modes. Use idiomatic .NET patterns.
 
-## Async Best Practices
+## Logging
 
-- All async methods must have names ending with `Async`.
-- Always await async methods - do not "fire and forget".
-- Always accept and pass along a `CancellationToken` in async code.
-- Don’t add `async/await` if you can simply return a Task directly.
+Follow best practices for Microsoft.Extensions.Logging: use message templates with named
+properties instead of interpolation when logging data. Keep info-level logs low-noise and
+put infrastructure details such as HTTP request logs at debug (or lower) level.
 
-## Testing
+## Data types
 
-- Use Shouldly when writing new assertions.
-- Use clear assertions that verify the outcome expressed by the test name.
-- Tests should be able to run in any order or in parallel.
-- Use or add helper methods for constructing mocks and complex test data objects.
-- Avoid disk I/O if possible; use in-memory alternatives or mocks.
-- Do not add "Arrange-Act-Assert" comments.
+Define new data types used by commands and services as immutable snapshots. Choose an
+appropriate immutable representation, such as a record, readonly record struct, or class with
+get-only properties. Prefer LINQ expressions when they keep transformations clear.
 
-## Comments
-
-- Add XML documentation comments for new **public** or **internal** types and members.
-- Primary documentation belongs on interfaces, implementations should use `<inheritdoc/>` unless additional context is needed.
-- Comments that simply restate the member or parameter name do not provide value.
-- Comments should provide additional context or explain non-obvious behavior, especially for parameters.
-- Comments inside methods should explain "why," not "what".
-- Avoid redundant comments that restate the code - not all code needs comments.
+Manifest schema models under `src/ImageBuilder.Models` are an exception: they must remain
+mutable classes for JSON and schema compatibility.

--- a/.github/skills/docs-maintenance/SKILL.md
+++ b/.github/skills/docs-maintenance/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: docs-maintenance
+description: >-
+  Keeps repository documentation current. Use after code, pipeline, manifest,
+  infrastructure, or agent-instruction changes to either update docs or check
+  for missing documentation updates.
+---
+
+# Documentation maintenance
+
+Use this skill to keep dotnet/docker-tools documentation accurate, discoverable, and
+appropriately scoped as the repo changes.
+
+This skill can run in two modes:
+
+- **Update mode:** analyze the current changes and edit the relevant docs.
+- **Review mode:** analyze the current changes and report missing or unnecessary doc
+  updates without editing unless the user asks you to.
+
+If the user does not specify a mode, infer it from the request. If they ask to "update",
+"fix", "add", or "write" docs, use update mode. If they ask to "check", "review",
+"verify", or "look for missing docs", use review mode.
+
+## Workflow
+
+1. Start from the diff.
+   - Use `git diff --stat`, `git diff --name-only`, and targeted `git diff -- <path>`.
+   - Identify changed behavior, contracts, workflows, generated outputs, and agent
+     expectations before reading docs.
+2. Decide whether docs are required.
+   - Use the update triggers below.
+   - If the change is not user-visible and does not affect how contributors, consumers,
+     or agents should work, say that no doc update is required.
+3. Choose the narrowest matching doc.
+   - Do not duplicate the same guidance across multiple docs unless each audience needs it.
+   - Prefer exact commands, file paths, examples, and migration steps over broad explanation.
+4. In update mode, edit the docs.
+   - Keep docs concise and practical.
+   - Lead with what changed or what problem is fixed.
+   - Explain why a change exists when it is not obvious.
+   - Do not add irrelevant sentences just because they are true.
+   - Avoid em dashes and em-dash-like rewrites.
+   - Preserve existing structure unless it is misleading.
+   - Do not edit files under `eng/common/` unless the user explicitly says they are making
+     the corresponding Arcade change.
+5. In review mode, report the missing or unnecessary doc updates.
+
+## Documentation map
+
+| Doc | Purpose | Update when |
+| --- | --- | --- |
+| `README.md` | Repo landing page: what this repo contains and how to build/test it. | The repo's top-level purpose, tool list, or standard build/test entrypoints change. |
+| `AGENTS.md` | Repo-wide instructions for coding agents. | Project structure, build/test commands, source-of-truth rules, required workflows, or agent-relevant invariants change. Keep it short. |
+| `.github/instructions/*.md` | Lightweight implementation guidance that loads automatically for matching files. | Implementing agents need different exemplars or context to write code correctly. Prefer positive examples over review checklists. |
+| `.github/agents/*.md` | Specialized custom agents for review, maintenance, investigation, or other opt-in workflows. | A specialized agent's scope, trigger conditions, review rules, or expected output changes. |
+| `.github/skills/*/SKILL.md` | Reusable operational workflows for the CLI. | A repeated diagnostic, triage, documentation, or maintenance workflow changes. |
+| `src/README.md` | User-facing ImageBuilder usage and local ImageBuilder container-image build instructions. | ImageBuilder invocation, supported command discovery, packaging, or container-image build workflow changes. |
+| `documentation/manifest-file.md` | Manifest file overview and schema discovery. | Manifest schema concepts, schema generation, or manifest authoring guidance changes. |
+| `documentation/signing.md` | Container image signing setup and operation. | Signing configuration, required variables, certificates, trust-store behavior, or pipeline signing flow changes. |
+| `documentation/base-image-dependency-flow.md` | Conceptual flow for base-image update detection and rebuild automation. | Base-image subscription, digest tracking, image-info usage, or rebuild-trigger behavior changes. |
+| `eng/docker-tools/readme.md` | Warning and entrypoint for synchronized shared docker-tools infrastructure. | Rarely. Only update if the synchronization/source-of-truth guidance changes. |
+| `eng/docker-tools/DEV-GUIDE.md` | Practical guide for using and understanding shared docker-tools infrastructure. | Pipeline architecture, local scripts, ImageBuilder integration, service connections, publishing, testing, troubleshooting, or shared infrastructure capabilities change. |
+| `eng/docker-tools/CHANGELOG.md` | Chronological notes for `eng/docker-tools` breaking changes and notable new features. | A change affects downstream repos, changes template parameters/contracts, requires migration, or adds notable shared infrastructure behavior. Include actionable migration steps for breaking changes. |
+| `eng/tests/pipeline-validation/**/README*.md` | Test fixture content for pipeline validation. | Only when tests intentionally require different fixture README content. |
+| `eng/common/**` docs | Arcade-managed documentation. | Do not edit here from this repo unless explicitly coordinating an Arcade-source change. |
+
+## When docs are required
+
+Require documentation updates for changes that affect any of these:
+
+- **User-visible ImageBuilder behavior:** commands, options, outputs, image packaging,
+  local execution, or supported workflows.
+- **Public or shared file formats:** manifest JSON, image-info JSON, publish
+  configuration, subscription files, or generated artifacts consumed by other repos.
+- **Shared pipeline infrastructure:** templates, parameters, variables, service
+  connections, authentication requirements, publishing flow, signing flow, testing flow,
+  or synchronization behavior under `eng/docker-tools/`.
+- **Breaking changes for downstream repos:** removed or renamed templates/parameters,
+  changed defaults, changed required variables, new authentication requirements, changed
+  artifact locations, or behavior that requires a consuming repo migration.
+- **Operational workflows:** recurring triage, investigation, release, or maintenance
+  procedures that contributors or agents are expected to follow.
+- **Agent behavior:** coding instructions, custom agent scope, review invariants, skills,
+  or source-of-truth guidance for agents.
+
+Authentication and token handling must be especially explicit. Separate Azure service
+connection behavior, API authentication, git CLI tokens, and pipeline variables when those
+concepts appear in the same change.
+
+Docs are usually not required for:
+
+- Internal refactors with no behavior, contract, workflow, or contributor impact.
+- Test-only changes that do not change expected fixture content or documented behavior.
+- Bug fixes whose correct behavior was already documented accurately.
+- Mechanical formatting, dependency updates, or build cleanup with no user-facing impact.
+
+## Changelog expectations
+
+For changes under `eng/docker-tools/`, decide separately whether the changelog is required:
+
+- Add an entry to `eng/docker-tools/CHANGELOG.md` for breaking changes, downstream
+  migrations, new template parameters, new shared capabilities, changed defaults, or
+  behavior that consumers need to know about.
+- The entry should include the date, issue or pull request if known, what changed, and
+  what downstream repos must do.
+- Do not add changelog entries for purely internal refactors or fixes that do not affect
+  downstream repos.
+
+## Output
+
+In update mode:
+
+1. List the docs you changed and why.
+2. State any docs you intentionally did not change when that decision is non-obvious.
+
+In review mode:
+
+1. Report missing doc updates as `path or area - required doc - reason`.
+2. Report unnecessary doc updates only when they create stale, duplicate, or misleading
+   guidance.
+3. If no doc changes are needed, say so plainly.

--- a/.github/skills/docs-maintenance/SKILL.md
+++ b/.github/skills/docs-maintenance/SKILL.md
@@ -43,8 +43,8 @@ Do not edit files under `eng/common/`; they come from dotnet/arcade and will be 
 | --- | --- |
 | `README.md` | The repository purpose, tool list, or standard build and test entrypoints change. |
 | `AGENTS.md` | Repo-wide project structure, commands, source-of-truth rules, workflows, or agent invariants change. |
-| `.github/instructions/*.md` | Automatically loaded implementation guidance or exemplars change. |
-| `.github/agents/*.md`, `.github/skills/*/SKILL.md` | An opt-in agent or reusable operational workflow changes. |
+| `.github/instructions/*.md` | High-level design guidance that shapes how an agent architects a change needs to be added, updated, or removed. Keep these files focused: they guide structural decisions and should not contain mechanical checklists. |
+| `.github/agents/*.md`, `.github/skills/*/SKILL.md` | An opt-in agent or reusable operational workflow changes. Review skills (such as `reviewing-csharp`) contain mechanical checklists of coding standards enforced during review; update them when a specific standard needs to be added, tightened, or removed. |
 | `src/README.md` | ImageBuilder invocation, command discovery, packaging, or local container-image builds change. |
 | `documentation/manifest-file.md` | Manifest concepts, schema generation, or authoring guidance change. |
 | `documentation/signing.md` | Signing configuration, credentials, certificates, trust stores, or pipeline flow change. |

--- a/.github/skills/docs-maintenance/SKILL.md
+++ b/.github/skills/docs-maintenance/SKILL.md
@@ -1,121 +1,65 @@
 ---
 name: docs-maintenance
 description: >-
-  Keeps repository documentation current. Use after code, pipeline, manifest,
-  infrastructure, or agent-instruction changes to either update docs or check
-  for missing documentation updates.
+  Updates or reviews repository documentation after changes to user behavior,
+  shared contracts, pipelines, workflows, or agent guidance.
 ---
 
 # Documentation maintenance
 
-Use this skill to keep dotnet/docker-tools documentation accurate, discoverable, and
-appropriately scoped as the repo changes.
+Keep dotnet/docker-tools documentation accurate and scoped to the audience affected by a
+change.
 
-This skill can run in two modes:
+## Mode
 
-- **Update mode:** analyze the current changes and edit the relevant docs.
-- **Review mode:** analyze the current changes and report missing or unnecessary doc
-  updates without editing unless the user asks you to.
+- **Update:** edit the required documentation.
+- **Review:** report missing, unnecessary, or misleading documentation changes without
+  editing.
 
-If the user does not specify a mode, infer it from the request. If they ask to "update",
-"fix", "add", or "write" docs, use update mode. If they ask to "check", "review",
-"verify", or "look for missing docs", use review mode.
+Infer the mode from the request. Requests to update, fix, add, or write documentation authorize
+updates; requests to check, review, or verify documentation use review mode.
 
 ## Workflow
 
-1. Start from the diff.
-   - Use `git diff --stat`, `git diff --name-only`, and targeted `git diff -- <path>`.
-   - Identify changed behavior, contracts, workflows, generated outputs, and agent
-     expectations before reading docs.
-2. Decide whether docs are required.
-   - Use the update triggers below.
-   - If the change is not user-visible and does not affect how contributors, consumers,
-     or agents should work, say that no doc update is required.
-3. Choose the narrowest matching doc.
-   - Do not duplicate the same guidance across multiple docs unless each audience needs it.
-   - Prefer exact commands, file paths, examples, and migration steps over broad explanation.
-4. In update mode, edit the docs.
-   - Keep docs concise and practical.
-   - Lead with what changed or what problem is fixed.
-   - Explain why a change exists when it is not obvious.
-   - Do not add irrelevant sentences just because they are true.
-   - Avoid em dashes and em-dash-like rewrites.
-   - Preserve existing structure unless it is misleading.
-   - Do not edit files under `eng/common/` unless the user explicitly says they are making
-     the corresponding Arcade change.
-5. In review mode, report the missing or unnecessary doc updates.
+1. Inspect the diff and identify changes to behavior, contracts, workflows, generated outputs,
+   and agent expectations.
+2. Decide whether contributors, consumers, users, or agents need new information. Documentation
+   is normally unnecessary for internal refactors, mechanical changes, test-only changes, or
+   fixes whose intended behavior is already documented.
+3. Choose the narrowest document for the affected audience. Do not duplicate guidance unless
+   distinct audiences need it.
+4. In update mode, make the documentation changes. Prefer exact commands, paths, examples, and
+   migration steps. Preserve the existing structure unless it is misleading.
+5. In review mode, report only actionable documentation gaps or unnecessary changes.
+
+Authentication documentation must distinguish Azure service connections, API authentication,
+git credentials, and pipeline variables when more than one appears in the change.
+
+Do not edit files under `eng/common/`; they come from dotnet/arcade and will be overwritten.
 
 ## Documentation map
 
-| Doc | Purpose | Update when |
-| --- | --- | --- |
-| `README.md` | Repo landing page: what this repo contains and how to build/test it. | The repo's top-level purpose, tool list, or standard build/test entrypoints change. |
-| `AGENTS.md` | Repo-wide instructions for coding agents. | Project structure, build/test commands, source-of-truth rules, required workflows, or agent-relevant invariants change. Keep it short. |
-| `.github/instructions/*.md` | Lightweight implementation guidance that loads automatically for matching files. | Implementing agents need different exemplars or context to write code correctly. Prefer positive examples over review checklists. |
-| `.github/agents/*.md` | Specialized custom agents for review, maintenance, investigation, or other opt-in workflows. | A specialized agent's scope, trigger conditions, review rules, or expected output changes. |
-| `.github/skills/*/SKILL.md` | Reusable operational workflows for the CLI. | A repeated diagnostic, triage, documentation, or maintenance workflow changes. |
-| `src/README.md` | User-facing ImageBuilder usage and local ImageBuilder container-image build instructions. | ImageBuilder invocation, supported command discovery, packaging, or container-image build workflow changes. |
-| `documentation/manifest-file.md` | Manifest file overview and schema discovery. | Manifest schema concepts, schema generation, or manifest authoring guidance changes. |
-| `documentation/signing.md` | Container image signing setup and operation. | Signing configuration, required variables, certificates, trust-store behavior, or pipeline signing flow changes. |
-| `documentation/base-image-dependency-flow.md` | Conceptual flow for base-image update detection and rebuild automation. | Base-image subscription, digest tracking, image-info usage, or rebuild-trigger behavior changes. |
-| `eng/docker-tools/readme.md` | Warning and entrypoint for synchronized shared docker-tools infrastructure. | Rarely. Only update if the synchronization/source-of-truth guidance changes. |
-| `eng/docker-tools/DEV-GUIDE.md` | Practical guide for using and understanding shared docker-tools infrastructure. | Pipeline architecture, local scripts, ImageBuilder integration, service connections, publishing, testing, troubleshooting, or shared infrastructure capabilities change. |
-| `eng/docker-tools/CHANGELOG.md` | Chronological notes for `eng/docker-tools` breaking changes and notable new features. | A change affects downstream repos, changes template parameters/contracts, requires migration, or adds notable shared infrastructure behavior. Include actionable migration steps for breaking changes. |
-| `eng/tests/pipeline-validation/**/README*.md` | Test fixture content for pipeline validation. | Only when tests intentionally require different fixture README content. |
-| `eng/common/**` docs | Arcade-managed documentation. | Do not edit here from this repo unless explicitly coordinating an Arcade-source change. |
+| Document | Update when |
+| --- | --- |
+| `README.md` | The repository purpose, tool list, or standard build and test entrypoints change. |
+| `AGENTS.md` | Repo-wide project structure, commands, source-of-truth rules, workflows, or agent invariants change. |
+| `.github/instructions/*.md` | Automatically loaded implementation guidance or exemplars change. |
+| `.github/agents/*.md`, `.github/skills/*/SKILL.md` | An opt-in agent or reusable operational workflow changes. |
+| `src/README.md` | ImageBuilder invocation, command discovery, packaging, or local container-image builds change. |
+| `documentation/manifest-file.md` | Manifest concepts, schema generation, or authoring guidance change. |
+| `documentation/signing.md` | Signing configuration, credentials, certificates, trust stores, or pipeline flow change. |
+| `documentation/base-image-dependency-flow.md` | Base-image subscriptions, digest tracking, image-info usage, or rebuild triggers change. |
+| `eng/docker-tools/DEV-GUIDE.md` | Shared pipeline architecture, scripts, ImageBuilder integration, authentication, publishing, testing, or troubleshooting change. |
+| `eng/docker-tools/CHANGELOG.md` | A shared change affects downstream repositories, changes a contract or default, adds a capability, or requires migration. |
+| `eng/tests/pipeline-validation/**/README*.md` | A pipeline-validation fixture intentionally requires different README content. |
 
-## When docs are required
-
-Require documentation updates for changes that affect any of these:
-
-- **User-visible ImageBuilder behavior:** commands, options, outputs, image packaging,
-  local execution, or supported workflows.
-- **Public or shared file formats:** manifest JSON, image-info JSON, publish
-  configuration, subscription files, or generated artifacts consumed by other repos.
-- **Shared pipeline infrastructure:** templates, parameters, variables, service
-  connections, authentication requirements, publishing flow, signing flow, testing flow,
-  or synchronization behavior under `eng/docker-tools/`.
-- **Breaking changes for downstream repos:** removed or renamed templates/parameters,
-  changed defaults, changed required variables, new authentication requirements, changed
-  artifact locations, or behavior that requires a consuming repo migration.
-- **Operational workflows:** recurring triage, investigation, release, or maintenance
-  procedures that contributors or agents are expected to follow.
-- **Agent behavior:** coding instructions, custom agent scope, review invariants, skills,
-  or source-of-truth guidance for agents.
-
-Authentication and token handling must be especially explicit. Separate Azure service
-connection behavior, API authentication, git CLI tokens, and pipeline variables when those
-concepts appear in the same change.
-
-Docs are usually not required for:
-
-- Internal refactors with no behavior, contract, workflow, or contributor impact.
-- Test-only changes that do not change expected fixture content or documented behavior.
-- Bug fixes whose correct behavior was already documented accurately.
-- Mechanical formatting, dependency updates, or build cleanup with no user-facing impact.
-
-## Changelog expectations
-
-For changes under `eng/docker-tools/`, decide separately whether the changelog is required:
-
-- Add an entry to `eng/docker-tools/CHANGELOG.md` for breaking changes, downstream
-  migrations, new template parameters, new shared capabilities, changed defaults, or
-  behavior that consumers need to know about.
-- The entry should include the date, issue or pull request if known, what changed, and
-  what downstream repos must do.
-- Do not add changelog entries for purely internal refactors or fixes that do not affect
-  downstream repos.
+For `eng/docker-tools/CHANGELOG.md`, include the date, issue or pull request when known, what
+changed, and required downstream action. Do not add entries for internal changes with no
+consumer impact.
 
 ## Output
 
-In update mode:
-
-1. List the docs you changed and why.
-2. State any docs you intentionally did not change when that decision is non-obvious.
-
-In review mode:
-
-1. Report missing doc updates as `path or area - required doc - reason`.
-2. Report unnecessary doc updates only when they create stale, duplicate, or misleading
-   guidance.
-3. If no doc changes are needed, say so plainly.
+- **Update:** list each document changed and why; mention intentionally unchanged documents only
+  when the choice is non-obvious.
+- **Review:** report each gap as `changed area - required document - reason`. Report unnecessary
+  updates only when they would be stale, duplicated, or misleading. If none are needed, say so.

--- a/.github/skills/reviewing-csharp/SKILL.md
+++ b/.github/skills/reviewing-csharp/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: reviewing-csharp
+description: >-
+  Reviews C# changes in the ImageBuilder codebase against the repo's modern C#
+  conventions and invariants. Use when reviewing a C# diff, pull request, or
+  staged/unstaged changes and you want anti-patterns caught before merge.
+---
+
+# Reviewing C# changes
+
+Review changed C# code in dotnet/docker-tools for high-confidence violations of repository
+conventions. Read `.github/instructions/csharp.instructions.md` first and treat it as the
+source of truth for implementation guidance.
+
+## Scope
+
+- Review the C# diff and behavior directly affected by it. Do not report unrelated,
+  pre-existing code.
+- Report only issues with clear maintenance, correctness, or operational impact. Skip
+  subjective style preferences and uncertain findings.
+- Do not edit code.
+- Use the exemplars in `.github/instructions/csharp.instructions.md` when recommending a
+  repository-specific pattern.
+
+## Review checks
+
+### Language and API design
+
+- New files use file-scoped namespaces and do not disable nullable reference types.
+- New code is null-annotation clean. Flag `!` when it masks a nullable-correctness problem, but
+  not deliberate negative tests such as passing `null!` to verify a guard.
+- Use the least accessibility needed; do not introduce public APIs without a demonstrated
+  caller.
+- Reuse existing methods and services. Flag unused or speculative methods, parameters, and
+  abstractions.
+
+### Async
+
+- Async methods end with `Async`; async calls are awaited rather than discarded.
+- Thread a `CancellationToken` through async I/O.
+- Do not add `async`/`await` when directly returning the task preserves behavior.
+- Do not add `ConfigureAwait(...)`; this repository does not use it.
+
+### Control flow and failures
+
+- Use LINQ for transformations and loops for side effects or async work.
+- Avoid multiple enumeration when it can change behavior or repeat meaningful work.
+- Return empty collections rather than using `null` as control flow.
+- Flag broad catches, success-shaped fallbacks, or swallowed failures without an explicit
+  recovery path.
+
+### Tests
+
+- Use MSTest attributes, Shouldly for new assertions, and Moq for mocks.
+- Tests must run in any order and in parallel; no shared mutable state or ordering assumptions.
+- Reuse test helpers under `src/ImageBuilder.Tests/Helpers/`. Avoid disk I/O when an in-memory
+  alternative or mock tests the same behavior.
+- Do not add comments that only label Arrange, Act, or Assert sections.
+
+### Documentation and comments
+
+- New public or internal APIs have XML documentation where their contract is not obvious.
+  Primary XML doc comments go directly on interfaces. Implementations use `<inheritdoc/>`.
+- Comments should explain the intention behind code; do not accept comments that merely restate
+  the code.
+- Comments identify ambiguous input requirements such as fully qualified vs. relative
+  paths, string formats, etc. Include examples where appropriate.
+
+## Output format
+
+Group findings by file. For each finding, return:
+
+`path:line - <rule violated> - <concrete impact> - <suggested fix>`
+
+End with `N issues to address` or `No convention violations found`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,137 +1,69 @@
-# AGENTS.md
+# Repository guidance
 
-This file provides guidance to coding agents when working with code in this repository.
+This repository contains tooling for building and publishing container images.
+The primary tool is ImageBuilder, a .NET CLI app that orchestrates builds from manifest metadata.
 
-## Overview
+## Project map
 
-This repository contains tooling for building and publishing Docker images in various .NET repos.
-The primary tool is **ImageBuilder**, a .NET CLI application that orchestrates Docker image builds based on manifest metadata files.
+| Path | Purpose |
+| --- | --- |
+| `src/ImageBuilder/` | ImageBuilder CLI and commands |
+| `src/ImageBuilder.Models/` | Manifest and image metadata models |
+| `src/ImageBuilder.Tests/` | MSTest, Moq, and Shouldly tests |
+| `eng/src/file-pusher/` | Storage file-pushing utility |
+| `eng/src/yaml-updater/` | YAML update utility |
+| `eng/docker-tools/` | Shared scripts and Azure Pipelines templates synchronized to other .NET Docker repositories |
 
-## Project Structure
+ImageBuilder commands inherit from `Command<TOptions>` and use System.CommandLine.
+The manifest schema starts at `src/ImageBuilder.Models/Manifest/Manifest.cs`; generated image
+metadata starts at `src/ImageBuilder.Models/Image/ImageArtifactDetails.cs`.
 
-This repo contains several projects:
+## Build and validation
 
-- **`src/ImageBuilder/`** - The main ImageBuilder CLI tool (executable)
-- **`src/ImageBuilder.Models/`** - Shared model definitions for manifest files and image metadata
-- **`src/ImageBuilder.Tests/`** - Unit tests using xUnit, Moq, and Shouldly
-- **`eng/src/file-pusher/`** - Utility for pushing files to storage
-- **`eng/src/yaml-updater/`** - Utility for updating YAML files
+- Build, test, and pack on Windows: `build.cmd`
+- Build, test, and pack on Linux or macOS: `./build.sh`
+- Run ImageBuilder locally after building:
+  `.dotnet/dotnet run --project src/ImageBuilder -- --help` (use `.dotnet/dotnet.exe` on Windows).
 
-## Building and Testing
+See `src/README.md` for local ImageBuilder container-image build instructions.
 
-- To build all projects, run `dotnet build`.
-- To run tests, run `dotnet test`.
-- If you run into permission issues during builds relating to copying `.dll` files, run `dotnet clean` and/or `build.sh -clean` and then build again.
+## Repository invariants
 
-### Build ImageBuilder Container Image
+- `eng/docker-tools/` is the source of truth for infrastructure synchronized to consuming
+  repositories. Document breaking changes there in `eng/docker-tools/CHANGELOG.md` with
+  actionable migration steps.
+- Files under `eng/common/` come from dotnet/arcade and are overwritten by automation. Do not
+  edit them here; make the source change in Arcade.
+- `publishConfig` is the source of truth for registry authentication. Registry service
+  connections belong in `publishConfig.RegistryAuthentication`; non-registry connections
+  remain separate or use `additionalServiceConnections`.
+- ImageBuilder runs in a container. Pass `SYSTEM_ACCESSTOKEN` and `SYSTEM_OIDCREQUESTURI`
+  explicitly into that container for OIDC authentication.
+- Jobs using `AzurePipelinesCredential` must include
+  `reference-service-connections.yml` with only the connections they need. Templates
+  supporting Linux and Windows must pass `dockerClientOS`.
 
-See [src/README.md](src/README.md) for instructions on building single-platform and multi-arch ImageBuilder container images locally.
+## ImageBuilder deployment constraint
 
-## ImageBuilder Architecture
+ImageBuilder builds its own published container image. Pipelines select that image through
+`imageNames.imageBuilder` in `eng/docker-tools/templates/variables/docker-images.yml`.
+Changes that require both new ImageBuilder behavior and pipeline adoption normally use two pull requests:
 
-ImageBuilder is a command-based CLI tool that operates on manifest files.
-The manifest file (`manifest.json`) is the primary metadata source that defines which Docker images to build, their tags, platforms, and dependencies.
+1. Merge and publish the ImageBuilder code change.
+2. After automation updates the ImageBuilder tag, merge the dependent pipeline or manifest change.
 
-### Key Components
+For combined development validation, use the engineering validation unofficial pipeline defined
+in `eng/pipelines/dotnet-docker-tools-eng-validation-unofficial.yml` with the parameter
+`bootstrapImageBuilder: true`; each job then builds and uses ImageBuilder from the current source.
 
-- **Commands** (`src/ImageBuilder/Commands/`) - Each command implements a specific operation (build, publish, generateBuildMatrix, etc.). Commands inherit from `Command<TOptions>` and use System.CommandLine for argument parsing.
-- **Models** (`src/ImageBuilder.Models/Manifest/`) - Defines the manifest schema and image metadata structures
-- **Services** - Abstracted services for Docker operations, Azure Container Registry interactions, Git operations, etc.
+## Documentation
 
-### Running ImageBuilder Locally
+Update only the narrowest documentation affected by the change:
 
-For quick validation during local development, use `dotnet run`:
-
-```bash
-dotnet run --project src/ImageBuilder -- --help
-```
-
-## `eng/docker-tools` Infrastructure
-
-The `eng/docker-tools/` directory contains shared PowerShell scripts and Azure Pipelines templates used across all .NET Docker repositories.
-This repository is the source of truth for these files - changes made here are automatically synchronized to consuming repositories.
-Breaking changes to `eng/docker-tools/` must be documented in `eng/docker-tools/CHANGELOG.md` with actionable migration steps for downstream repos.
-
-For comprehensive documentation on the docker-tools infrastructure, pipeline architecture, image building workflows, and troubleshooting, see [eng/docker-tools/DEV-GUIDE.md](eng/docker-tools/DEV-GUIDE.md).
-
-### Service Connections and Authentication
-
-`publishConfig` is the source of truth for registry authentication. Registry service connections live in `publishConfig.RegistryAuthentication`. Non-registry connections (e.g., kusto, marStatus, cleanServiceConnection) are separate fields or passed via `additionalServiceConnections`.
-
-ImageBuilder runs inside a Docker container. The env vars `SYSTEM_ACCESSTOKEN` and `SYSTEM_OIDCREQUESTURI` must be explicitly passed into the container for OIDC authentication to work. Config is baked into the container via `appsettings.json`.
-
-Every job that authenticates to Azure via `AzurePipelinesCredential` must include `reference-service-connections.yml` with only the service connections it actually needs. Pipeline templates that run on both Linux and Windows must pass `dockerClientOS` to `reference-service-connections.yml` so it uses the correct PowerShell variant.
-
-## ImageBuilder Build and Deployment Workflow
-
-ImageBuilder is published as a container image to the Microsoft Artifact Registry (MAR) at `mcr.microsoft.com/dotnet-buildtools/image-builder`.
-The ImageBuilder container image is defined in `src/manifest.json`.
-It is built from Dockerfiles `src/Dockerfile.linux` and `src/Dockerfile.windows`.
-
-ImageBuilder uses itself to build its own container image.
-This means changes to ImageBuilder code and pipeline templates must be coordinated carefully in a two-step process.
-The version of ImageBuilder used by pipelines is specified in `eng/docker-tools/templates/variables/docker-images.yml` (`imageNames.imageBuilder` variable).
-
-### Two-Step Change Process
-
-When making changes that affect both ImageBuilder code and pipeline behavior:
-
-1. **Step 1: Update ImageBuilder code**
-   - Make code changes to ImageBuilder source
-   - Test locally using `dotnet run --project src/ImageBuilder`
-   - Propose changes in a pull request and wait for it to be merged and for CI to run.
-   - A pull request will automatically be created that updates `docker-images.yml` with the new ImageBuilder tag.
-2. **Step 2: Update pipeline/manifest to use new ImageBuilder**
-   - Once the new ImageBuilder image is published, pipeline templates in `eng/docker-tools/` can reference new features/commands
-   - Consuming repositories will get the updated pipeline templates AND the new ImageBuilder image
-
-### Why This Matters
-
-- **Pipeline templates** in `eng/docker-tools/templates/` invoke ImageBuilder commands
-- These templates run using a specific version/tag of the ImageBuilder container image
-- If you add a new ImageBuilder command or change command behavior, pipelines can't use it until a new ImageBuilder image is published
-- This means code changes and pipeline template changes that depend on them must be done in separate steps
-
-### Bootstrap Option for Development
-
-To test ImageBuilder code changes and pipeline template changes together without waiting for the two-step process, use the `bootstrapImageBuilder` parameter in the unofficial pipeline (`eng/pipelines/dotnet-buildtools-image-builder-unofficial.yml`).
-
-When `bootstrapImageBuilder: true`:
-
-- ImageBuilder is built from source at the start of every pipeline job
-- The pipeline uses the freshly-built ImageBuilder instead of pulling from MCR
-- This allows validating ImageBuilder changes and pipeline template changes in a single pipeline run
-
-Once changes are validated together via the bootstrap process, then changes can be proposed via the normal two-step change process described above.
-
-## Key File Formats
-
-### manifest.json (Input)
-
-Manifest files define metadata about which Docker images ImageBuilder will build. The schema is defined by the `Manifest` model in `src/ImageBuilder.Models/Manifest/Manifest.cs`. For detailed documentation, see [documentation/manifest-file.md](documentation/manifest-file.md).
-
-### image-info.json (Output)
-
-Image info files are ImageBuilder's output that describe which images were built.
-The schema is defined by the `ImageArtifactDetails` model in `src/ImageBuilder.Models/Image/ImageArtifactDetails.cs`.
-These files contain:
-
-- Image digests for each built platform
-- Tags applied to each image
-- Dockerfile paths and commit information
-- Build timestamps
-
-Image info files are used by subsequent pipeline stages and are published to the versions repository to track what was built.
-See [eng/docker-tools/DEV-GUIDE.md](eng/docker-tools/DEV-GUIDE.md) for more details on how image info flows through pipelines.
-
-## Documentation Maintenance
-
-When making changes to ImageBuilder, pipeline templates, or infrastructure:
-
-- Update [eng/docker-tools/DEV-GUIDE.md](eng/docker-tools/DEV-GUIDE.md) if you change pipeline architecture, workflows, or add new capabilities
-- Update [src/README.md](src/README.md) if you change how ImageBuilder container images are built
-- Update [documentation/manifest-file.md](documentation/manifest-file.md) if you modify the manifest schema
-- Update [eng/docker-tools/CHANGELOG.md](eng/docker-tools/CHANGELOG.md) if you make breaking changes to `eng/docker-tools/` templates
-- Update this file (AGENTS.md) if you add projects, change fundamental workflows, or modify architecture that affects how developers work with the codebase
-
-Keep documentation synchronized with code changes so future developers have accurate guidance.
+| Change | Documentation |
+| --- | --- |
+| Pipeline architecture, workflows, or capabilities | `eng/docker-tools/DEV-GUIDE.md` |
+| ImageBuilder container-image build workflow | `src/README.md` |
+| Manifest schema | `documentation/manifest-file.md` |
+| Breaking shared template behavior | `eng/docker-tools/CHANGELOG.md` |
+| Fundamental project or agent workflow | `AGENTS.md` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ The primary tool is ImageBuilder, a .NET CLI app that orchestrates builds from m
 
 ImageBuilder commands inherit from `Command<TOptions>` and use System.CommandLine.
 The manifest schema starts at `src/ImageBuilder.Models/Manifest/Manifest.cs`; generated image
-metadata starts at `src/ImageBuilder.Models/Image/ImageArtifactDetails.cs`.
+metadata starts at `src/ImageBuilder/Models/Image/ImageArtifactDetails.cs`.
 
 ## Build and validation
 


### PR DESCRIPTION
## Why

Newer Claude and GPT models perform better with shorter, focused prompts that emphasize repository-specific constraints instead of repeating default agent behavior. This PR refreshes all the agent-facing documentation in the repo.

## What changed

- Updated AGENTS.md
- Split C# instructions into:
  - High level guidance for architecting ImageBuilder changes
  - Focused C# review skill for handling correctness + validation of repo invariants
- Added new skill for maintaining repo documentation