### PR TITLE
Retry transient signature push failures

### DIFF
--- a/src/ImageBuilder.Tests/Oras/OrasDotNetServiceTests.cs
+++ b/src/ImageBuilder.Tests/Oras/OrasDotNetServiceTests.cs
@@ -4,7 +4,9 @@
 
 using System;
 using System.IO;
+using System.Net;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Oras;
 using Microsoft.DotNet.ImageBuilder.Signing;
@@ -13,6 +15,7 @@ using Microsoft.Extensions.Caching.Memory;
 using Moq;
 using Microsoft.Extensions.Logging;
 using OrasProject.Oras.Oci;
+using Polly.Timeout;
 using Shouldly;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests.Oras;
@@ -64,6 +67,14 @@ public class OrasDotNetServiceTests
 
         exception.ShouldNotBeNull();
         exception.ParamName.ShouldBe("result");
+    }
+
+    [TestMethod]
+    public async Task PushSignatureAsync_RetriesAfterTimeout()
+    {
+        var handler = new SignaturePushHandler();
+        await PushSignatureAsync(handler);
+        handler.ManifestPushAttempts.ShouldBeGreaterThan(1);
     }
 
     [TestMethod]
@@ -140,5 +151,71 @@ public class OrasDotNetServiceTests
             .Setup(factory => factory.CreateClient(nameof(OrasDotNetService)))
             .Returns(Mock.Of<HttpClient>());
         return httpClientFactory.Object;
+    }
+
+    private static async Task<string> PushSignatureAsync(SignaturePushHandler handler)
+    {
+        const string payloadFilePath = "/signature.cose";
+        var fileSystem = new InMemoryFileSystem();
+        fileSystem.AddFile(payloadFilePath, [1, 2, 3]);
+
+        using HttpClient httpClient = new(handler);
+        Mock<IHttpClientFactory> httpClientFactory = new();
+        httpClientFactory
+            .Setup(factory => factory.CreateClient(nameof(OrasDotNetService)))
+            .Returns(httpClient);
+
+        OrasDotNetService service = CreateService(fileSystem, httpClientFactory.Object);
+        Descriptor subjectDescriptor = Descriptor.Create([], "application/vnd.oci.image.manifest.v1+json");
+        var result = new PayloadSigningResult(
+            "registry.io/repo:tag",
+            subjectDescriptor,
+            payloadFilePath,
+            "[\"thumbprint\"]");
+
+        return await service.PushSignatureAsync(subjectDescriptor, result);
+    }
+
+    private sealed class SignaturePushHandler : HttpMessageHandler
+    {
+        private int _blobUploadAttempts;
+        private int _manifestPushAttempts;
+
+        public int ManifestPushAttempts => _manifestPushAttempts;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            string path = request.RequestUri!.AbsolutePath;
+
+            if (request.Method == HttpMethod.Post && path.EndsWith("/blobs/uploads/", StringComparison.Ordinal))
+            {
+                int attempt = Interlocked.Increment(ref _blobUploadAttempts);
+                var response = new HttpResponseMessage(HttpStatusCode.Accepted);
+                response.Headers.Location = new Uri($"/v2/repo/blobs/uploads/{attempt}", UriKind.Relative);
+                return Task.FromResult(response);
+            }
+
+            if (request.Method == HttpMethod.Put && path.Contains("/blobs/uploads/", StringComparison.Ordinal))
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Created));
+            }
+
+            if (request.Method == HttpMethod.Put && path.Contains("/manifests/", StringComparison.Ordinal))
+            {
+                if (Interlocked.Increment(ref _manifestPushAttempts) == 1)
+                {
+                    return Task.FromException<HttpResponseMessage>(new TimeoutRejectedException());
+                }
+
+                var response = new HttpResponseMessage(HttpStatusCode.Created);
+                response.Headers.TryAddWithoutValidation("OCI-Subject", "supported");
+                return Task.FromResult(response);
+            }
+
+            return Task.FromException<HttpResponseMessage>(
+                new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}"));
+        }
     }
 }

--- a/src/ImageBuilder.Tests/Oras/OrasDotNetServiceTests.cs
+++ b/src/ImageBuilder.Tests/Oras/OrasDotNetServiceTests.cs
@@ -4,9 +4,7 @@
 
 using System;
 using System.IO;
-using System.Net;
 using System.Net.Http;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.ImageBuilder.Oras;
 using Microsoft.DotNet.ImageBuilder.Signing;
@@ -15,7 +13,6 @@ using Microsoft.Extensions.Caching.Memory;
 using Moq;
 using Microsoft.Extensions.Logging;
 using OrasProject.Oras.Oci;
-using Polly.Timeout;
 using Shouldly;
 
 namespace Microsoft.DotNet.ImageBuilder.Tests.Oras;
@@ -67,14 +64,6 @@ public class OrasDotNetServiceTests
 
         exception.ShouldNotBeNull();
         exception.ParamName.ShouldBe("result");
-    }
-
-    [TestMethod]
-    public async Task PushSignatureAsync_RetriesAfterTimeout()
-    {
-        var handler = new SignaturePushHandler();
-        await PushSignatureAsync(handler);
-        handler.ManifestPushAttempts.ShouldBeGreaterThan(1);
     }
 
     [TestMethod]
@@ -151,71 +140,5 @@ public class OrasDotNetServiceTests
             .Setup(factory => factory.CreateClient(nameof(OrasDotNetService)))
             .Returns(Mock.Of<HttpClient>());
         return httpClientFactory.Object;
-    }
-
-    private static async Task<string> PushSignatureAsync(SignaturePushHandler handler)
-    {
-        const string payloadFilePath = "/signature.cose";
-        var fileSystem = new InMemoryFileSystem();
-        fileSystem.AddFile(payloadFilePath, [1, 2, 3]);
-
-        using HttpClient httpClient = new(handler);
-        Mock<IHttpClientFactory> httpClientFactory = new();
-        httpClientFactory
-            .Setup(factory => factory.CreateClient(nameof(OrasDotNetService)))
-            .Returns(httpClient);
-
-        OrasDotNetService service = CreateService(fileSystem, httpClientFactory.Object);
-        Descriptor subjectDescriptor = Descriptor.Create([], "application/vnd.oci.image.manifest.v1+json");
-        var result = new PayloadSigningResult(
-            "registry.io/repo:tag",
-            subjectDescriptor,
-            payloadFilePath,
-            "[\"thumbprint\"]");
-
-        return await service.PushSignatureAsync(subjectDescriptor, result);
-    }
-
-    private sealed class SignaturePushHandler : HttpMessageHandler
-    {
-        private int _blobUploadAttempts;
-        private int _manifestPushAttempts;
-
-        public int ManifestPushAttempts => _manifestPushAttempts;
-
-        protected override Task<HttpResponseMessage> SendAsync(
-            HttpRequestMessage request,
-            CancellationToken cancellationToken)
-        {
-            string path = request.RequestUri!.AbsolutePath;
-
-            if (request.Method == HttpMethod.Post && path.EndsWith("/blobs/uploads/", StringComparison.Ordinal))
-            {
-                int attempt = Interlocked.Increment(ref _blobUploadAttempts);
-                var response = new HttpResponseMessage(HttpStatusCode.Accepted);
-                response.Headers.Location = new Uri($"/v2/repo/blobs/uploads/{attempt}", UriKind.Relative);
-                return Task.FromResult(response);
-            }
-
-            if (request.Method == HttpMethod.Put && path.Contains("/blobs/uploads/", StringComparison.Ordinal))
-            {
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Created));
-            }
-
-            if (request.Method == HttpMethod.Put && path.Contains("/manifests/", StringComparison.Ordinal))
-            {
-                if (Interlocked.Increment(ref _manifestPushAttempts) == 1)
-                {
-                    return Task.FromException<HttpResponseMessage>(new TimeoutRejectedException());
-                }
-
-                var response = new HttpResponseMessage(HttpStatusCode.Created);
-                response.Headers.TryAddWithoutValidation("OCI-Subject", "supported");
-                return Task.FromResult(response);
-            }
-
-            return Task.FromException<HttpResponseMessage>(
-                new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}"));
-        }
     }
 }

--- a/src/ImageBuilder/Oras/OrasDotNetService.cs
+++ b/src/ImageBuilder/Oras/OrasDotNetService.cs
@@ -37,8 +37,6 @@ public class OrasDotNetService(
     IRegistryCredentialsHost? credentialsHost = null)
         : IOrasService
 {
-    private const int PushSignatureMaxRetryAttempts = 2;
-
     /// <summary>
     /// Media type for COSE signature envelopes per the Notary v2 spec.
     /// </summary>
@@ -49,14 +47,15 @@ public class OrasDotNetService(
     /// </summary>
     private const string CertificateChainAnnotation = "io.cncf.notary.x509chain.thumbprint#S256";
 
+    private const int PushSignatureMaxRetryAttempts = 2;
+
     private readonly IHttpClientFactory _httpClientFactory = httpClientFactory;
     private readonly Cache _orasCache = new(cache);
     private readonly IFileSystem _fileSystem = fileSystem;
     private readonly ILogger<OrasDotNetService> _logger = logger;
     private readonly OrasCredentialProviderAdapter _credentialProvider = new(credentialsProvider, credentialsHost);
 
-    private readonly ResiliencePipeline _pushSignatureRetryPipeline =
-        CreatePushSignatureRetryPipeline(logger);
+    private readonly ResiliencePipeline _pushSignatureRetryPipeline = CreatePushSignatureRetryPipeline(logger);
 
     /// <inheritdoc/>
     public async Task<Descriptor> GetDescriptorAsync(string reference, CancellationToken cancellationToken = default)
@@ -272,9 +271,8 @@ public class OrasDotNetService(
             .AddRetry(
                 new RetryStrategyOptions
                 {
-                    ShouldHandle = new PredicateBuilder()
-                        .Handle<TimeoutRejectedException>()
-                        .Handle<HttpRequestException>(IsTransientHttpException),
+                    // Targeted fix for https://github.com/dotnet/docker-tools/issue/2168
+                    ShouldHandle = new PredicateBuilder().Handle<TimeoutRejectedException>(),
                     MaxRetryAttempts = PushSignatureMaxRetryAttempts,
                     BackoffType = DelayBackoffType.Exponential,
                     Delay = TimeSpan.FromSeconds(3),
@@ -283,18 +281,14 @@ public class OrasDotNetService(
                     {
                         logger.LogWarning(
                             args.Outcome.Exception,
-                            "Retrying signature push after transient failure in {RetryDelay} (Attempt {RetryAttempt} of {MaxRetryAttempts})",
+                            "Retrying signature push in {RetryDelay} (Attempt {RetryAttempt} of {MaxRetryAttempts})",
                             args.RetryDelay,
                             args.AttemptNumber + 1,
-                            PushSignatureMaxRetryAttempts);
+                            PushSignatureMaxRetryAttempts
+                        );
                         return default;
                     },
                 }
             )
             .Build();
-
-    private static bool IsTransientHttpException(HttpRequestException exception) =>
-        exception.StatusCode is null
-        || exception.StatusCode is HttpStatusCode.RequestTimeout or HttpStatusCode.TooManyRequests
-        || (exception.StatusCode is { } statusCode && (int)statusCode >= 500);
 }

--- a/src/ImageBuilder/Oras/OrasDotNetService.cs
+++ b/src/ImageBuilder/Oras/OrasDotNetService.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Net;
 using System.Net.Http;
 using System.Text.Json.Nodes;
 using System.Threading;
@@ -18,6 +19,9 @@ using OrasProject.Oras.Oci;
 using OrasProject.Oras.Registry;
 using OrasProject.Oras.Registry.Remote;
 using OrasProject.Oras.Registry.Remote.Auth;
+using Polly;
+using Polly.Retry;
+using Polly.Timeout;
 
 namespace Microsoft.DotNet.ImageBuilder.Oras;
 
@@ -33,6 +37,8 @@ public class OrasDotNetService(
     IRegistryCredentialsHost? credentialsHost = null)
         : IOrasService
 {
+    private const int PushSignatureMaxRetryAttempts = 2;
+
     /// <summary>
     /// Media type for COSE signature envelopes per the Notary v2 spec.
     /// </summary>
@@ -48,6 +54,9 @@ public class OrasDotNetService(
     private readonly IFileSystem _fileSystem = fileSystem;
     private readonly ILogger<OrasDotNetService> _logger = logger;
     private readonly OrasCredentialProviderAdapter _credentialProvider = new(credentialsProvider, credentialsHost);
+
+    private readonly ResiliencePipeline _pushSignatureRetryPipeline =
+        CreatePushSignatureRetryPipeline(logger);
 
     /// <inheritdoc/>
     public async Task<Descriptor> GetDescriptorAsync(string reference, CancellationToken cancellationToken = default)
@@ -106,10 +115,22 @@ public class OrasDotNetService(
         ArgumentNullException.ThrowIfNull(subjectDescriptor);
         ArgumentNullException.ThrowIfNull(result);
 
-        Repository repository = CreateRepository(result.ImageName);
-
         byte[] payloadBytes = await _fileSystem.ReadAllBytesAsync(result.SignedPayloadFilePath, cancellationToken);
         Descriptor signatureLayerDescriptor = Descriptor.Create(payloadBytes, CoseMediaType);
+
+        return await _pushSignatureRetryPipeline.ExecuteAsync(
+            ct => PushSignatureAttemptAsync(subjectDescriptor, result, signatureLayerDescriptor, payloadBytes, ct),
+            cancellationToken);
+    }
+
+    private async ValueTask<string> PushSignatureAttemptAsync(
+        Descriptor subjectDescriptor,
+        PayloadSigningResult result,
+        Descriptor signatureLayerDescriptor,
+        byte[] payloadBytes,
+        CancellationToken cancellationToken)
+    {
+        Repository repository = CreateRepository(result.ImageName);
 
         using MemoryStream payloadStream = new(payloadBytes);
         await repository.PushAsync(signatureLayerDescriptor, payloadStream, cancellationToken);
@@ -245,4 +266,35 @@ public class OrasDotNetService(
         Repository repository = new(repositoryOptions);
         return repository;
     }
+
+    private static ResiliencePipeline CreatePushSignatureRetryPipeline(ILogger<OrasDotNetService> logger) =>
+        new ResiliencePipelineBuilder()
+            .AddRetry(
+                new RetryStrategyOptions
+                {
+                    ShouldHandle = new PredicateBuilder()
+                        .Handle<TimeoutRejectedException>()
+                        .Handle<HttpRequestException>(IsTransientHttpException),
+                    MaxRetryAttempts = PushSignatureMaxRetryAttempts,
+                    BackoffType = DelayBackoffType.Exponential,
+                    Delay = TimeSpan.FromSeconds(3),
+                    UseJitter = true,
+                    OnRetry = args =>
+                    {
+                        logger.LogWarning(
+                            args.Outcome.Exception,
+                            "Retrying signature push after transient failure in {RetryDelay} (Attempt {RetryAttempt} of {MaxRetryAttempts})",
+                            args.RetryDelay,
+                            args.AttemptNumber + 1,
+                            PushSignatureMaxRetryAttempts);
+                        return default;
+                    },
+                }
+            )
+            .Build();
+
+    private static bool IsTransientHttpException(HttpRequestException exception) =>
+        exception.StatusCode is null
+        || exception.StatusCode is HttpStatusCode.RequestTimeout or HttpStatusCode.TooManyRequests
+        || (exception.StatusCode is { } statusCode && (int)statusCode >= 500);
 }


### PR DESCRIPTION
This PR fixes #2168 by adding a targeted retry handler to the push operation for signatures. 

Related to #2137, #2139, and #2143.