### PR TITLE
Update .NET 9 packages to 9.0.18

### DIFF
--- a/src/GitAutomation.Tests/Microsoft.DotNet.GitAutomation.Tests.csproj
+++ b/src/GitAutomation.Tests/Microsoft.DotNet.GitAutomation.Tests.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="CsCheck" Version="4.6.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.17" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.18" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GitAutomation/Microsoft.DotNet.GitAutomation.csproj
+++ b/src/GitAutomation/Microsoft.DotNet.GitAutomation.csproj
@@ -26,8 +26,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.17" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.17" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.18" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.18" />
     <PackageReference Include="Octokit" Version="14.0.0" />
   </ItemGroup>
 

--- a/src/ImageBuilder/Microsoft.DotNet.ImageBuilder.csproj
+++ b/src/ImageBuilder/Microsoft.DotNet.ImageBuilder.csproj
@@ -32,10 +32,10 @@
     <PackageReference Include="Cottle" Version="2.1.0" />
     <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
     <PackageReference Include="Microsoft.Azure.Kusto.Ingest" Version="14.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.16" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.16" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.18" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.18" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.18" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.18" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.10.0" />
     <PackageReference Include="Microsoft.DotNet.VersionTools" Version="9.0.0-beta.25255.5" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="20.256.2" />
@@ -46,9 +46,9 @@
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Include="Polly.RateLimiting" Version="8.6.6" />
     <PackageReference Include="System.CommandLine" Version="2.0.7" />
-    <PackageReference Include="System.Formats.Cbor" Version="9.0.16" />
+    <PackageReference Include="System.Formats.Cbor" Version="9.0.18" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />
-    <PackageReference Include="System.Threading.RateLimiting" Version="9.0.16" />
+    <PackageReference Include="System.Threading.RateLimiting" Version="9.0.18" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
     <PackageReference Include="YamlDotNet" Version="18.0.0" />
 


### PR DESCRIPTION
Align the repository's .NET 9 servicing dependencies with the latest 9.0.18 release.

Updates applicable `Microsoft.Extensions.*`, `System.Formats.Cbor`, and `System.Threading.RateLimiting` package references to 9.0.18. Independently versioned packages remain unchanged.

Validation: `build.cmd`