### PR TITLE
Fix ImageBuilder update pipeline .NET installation on Linux

### DIFF
--- a/eng/pipelines/update-image-builder-tag.yml
+++ b/eng/pipelines/update-image-builder-tag.yml
@@ -37,12 +37,12 @@ jobs:
       Write-Host "$image refers to $imageBuilderRef"
 
       Write-Host "##[section]Building ImageBuilder.Updater"
-      & pwsh ./eng/common/build.ps1 `
-          -ci `
-          -restore `
-          -build `
-          -configuration Release `
-          -projects src/ImageBuilder.Updater/ImageBuilder.Updater.csproj
+      & bash ./eng/common/build.sh `
+          --ci `
+          --restore `
+          --build `
+          --configuration Release `
+          --projects src/ImageBuilder.Updater/ImageBuilder.Updater.csproj
 
       if ($LASTEXITCODE -ne 0) {
           Write-Host "##vso[task.logissue type=error]Failed to build ImageBuilder.Updater."

--- a/eng/pipelines/update-image-builder-tag.yml
+++ b/eng/pipelines/update-image-builder-tag.yml
@@ -38,6 +38,7 @@ jobs:
 
       Write-Host "##[section]Building ImageBuilder.Updater"
       & pwsh ./eng/common/build.ps1 `
+          -ci `
           -restore `
           -build `
           -configuration Release `

--- a/eng/pipelines/update-image-builder-tag.yml
+++ b/eng/pipelines/update-image-builder-tag.yml
@@ -42,7 +42,7 @@ jobs:
           --restore `
           --build `
           --configuration Release `
-          --projects src/ImageBuilder.Updater/ImageBuilder.Updater.csproj
+          --projects "$env:BUILD_SOURCESDIRECTORY/src/ImageBuilder.Updater/ImageBuilder.Updater.csproj"
 
       if ($LASTEXITCODE -ne 0) {
           Write-Host "##vso[task.logissue type=error]Failed to build ImageBuilder.Updater."


### PR DESCRIPTION
The ImageBuilder updater pipeline (from #2159) failed when using PowerShell to run the arcade build. Seems to work fine with bash instead. Also needed to add the --ci argument and fully qualify the project path.

Validated by successful Azure Pipelines build: https://dev.azure.com/dnceng/internal/_build/results?buildId=3025322

...which successfully submitted this PR: #2177 