### PR TITLE
Align ImageBuilder updater log format

### DIFF
--- a/src/ImageBuilder.Updater/Program.cs
+++ b/src/ImageBuilder.Updater/Program.cs
@@ -15,7 +15,13 @@ if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
 string imageBuilderRef = args[0];
 
 // Setup services
-using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddSimpleConsole());
+// Keep these options in sync with ImageBuilder's logging configuration in src/ImageBuilder/ImageBuilder.cs.
+using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddSimpleConsole(options =>
+{
+    options.IncludeScopes = true;
+    options.SingleLine = true;
+    options.TimestampFormat = "HH:mm:ss ";
+}));
 ProcessRunner processRunner = new(loggerFactory.CreateLogger<ProcessRunner>());
 ILogger logger = loggerFactory.CreateLogger("ImageBuilder.Updater");
 CancellationToken cancellationToken = GetCancellationToken();

--- a/src/ImageBuilder/ImageBuilder.cs
+++ b/src/ImageBuilder/ImageBuilder.cs
@@ -32,6 +32,7 @@ public static class ImageBuilder
 
         // Logging
         builder.Logging.SetMinimumLevel(LogLevel.Debug);
+        // Keep these options in sync with the updater's logging configuration in src/ImageBuilder.Updater/Program.cs.
         builder.Logging.AddSimpleConsole(options =>
         {
             options.IncludeScopes = true;


### PR DESCRIPTION
Aligns `ImageBuilder.Updater` console logging with ImageBuilder so pipeline output consistently uses single-line entries with timestamps and scopes.

Adds reciprocal comments to keep the two logger configurations synchronized.