### PR TITLE
Enable remaining ImageBuilder updater repositories

### DIFF
--- a/src/ImageBuilder.Updater/Program.cs
+++ b/src/ImageBuilder.Updater/Program.cs
@@ -29,13 +29,11 @@ await RunProcessAsync(processRunner, workingDirectory: null, "docker", ["pull", 
 [
     (new("dotnet", "docker-tools"), "main"),
     (new("dotnet", "dotnet-docker"), "nightly"),
-
-    // Temporarily disable stable repos during development.
-    // (new("dotnet", "dotnet-docker"), "main"),
-    // (new("dotnet", "dotnet-buildtools-prereqs-docker"), "main"),
-    // (new("microsoft", "dotnet-framework-docker"), "main"),
-    // (new("microsoft", "go-images"), "microsoft/main"),
-    // (new("microsoft", "go-infra-images"), "main"),
+    (new("dotnet", "dotnet-docker"), "main"),
+    (new("dotnet", "dotnet-buildtools-prereqs-docker"), "main"),
+    (new("microsoft", "dotnet-framework-docker"), "main"),
+    (new("microsoft", "go-images"), "microsoft/main"),
+    (new("microsoft", "go-infra-images"), "main"),
 ];
 
 const string PullRequestTitle = "Update common Docker engineering infrastructure with latest";


### PR DESCRIPTION
This PR restores automatic ImageBuilder updates for stable repositories that were temporarily disabled during development.