### PR TITLE
Avoid multiple enumeration during image cleanup

### DIFF
--- a/src/ImageBuilder/Commands/CleanAcrImagesCommand.cs
+++ b/src/ImageBuilder/Commands/CleanAcrImagesCommand.cs
@@ -174,10 +174,9 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         {
             _logger.LogInformation($"Querying manifests for repo '{repository.Name}'");
             IAsyncEnumerable<ArtifactManifestProperties> manifestProperties = repository.GetAllManifestPropertiesAsync();
-            int manifestCount = await manifestProperties.CountAsync();
-            _logger.LogInformation($"Finished querying manifests for repo '{repository.Name}'. Manifest count: {manifestCount}");
-
             ArtifactManifestProperties[] allManifests = await manifestProperties.ToArrayAsync();
+            int manifestCount = allManifests.Length;
+            _logger.LogInformation($"Finished querying manifests for repo '{repository.Name}'. Manifest count: {manifestCount}");
 
             if (!allManifests.Any())
             {


### PR DESCRIPTION
Related: https://github.com/dotnet/docker-tools/issues/2056

Previously, registry manifests were enumerated twice during cleanup: once to count them and once to convert them to an array. Converting to an array first should save over 10 minutes of compute time during cleanup.