### PR TITLE
Disable Renovate vulnerability alerts

### DIFF
--- a/eng/renovate.json
+++ b/eng/renovate.json
@@ -8,6 +8,11 @@
     "custom.regex"
   ],
 
+  // Vulnerability alerts are handled separately and are not available to the Renovate bot
+  "vulnerabilityAlerts": {
+    "enabled": false
+  },
+
   // Extend the base config with additional presets
   // https://docs.renovatebot.com/configuration-options/#extends
   // https://docs.renovatebot.com/key-concepts/presets/


### PR DESCRIPTION
Renovate queries GitHub vulnerability alerts by default, but the bot account does not have permission to access them. The resulting warning causes the Arcade pipeline template to mark otherwise successful runs as succeeded with issues.

Disable vulnerability alerts in the repository config, matching Arcade's documented baseline while leaving the custom-regex dependency updates unchanged.