### PR TITLE
Narrow documentation maintenance skill trigger

### DIFF
--- a/.github/skills/docs-maintenance/SKILL.md
+++ b/.github/skills/docs-maintenance/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: docs-maintenance
 description: >-
-  Updates or reviews repository documentation after changes to user behavior,
-  shared contracts, pipelines, workflows, or agent guidance.
+  Reviews or updates repository documentation as a dedicated task after implementation is
+  complete. Use before submitting a pull request or when reviewing a pull request.
 ---
 
 # Documentation maintenance


### PR DESCRIPTION
The documentation maintenance skill was triggering during implementation work. Restrict its discovery description to completed implementation work before PR submission and to PR review, keeping documentation maintenance out of active implementation.