### PR TITLE
Simplify automated rebuild failure gating

### DIFF
--- a/src/ImageBuilder.Tests/QueueBuildCommandTests.cs
+++ b/src/ImageBuilder.Tests/QueueBuildCommandTests.cs
@@ -104,7 +104,6 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             for (int i = 0; i < QueueBuildCommand.BuildFailureLimit; i++)
             {
                 WebApi.Build failedBuild = CreateBuild($"https://failedbuild-{i}");
-                failedBuild.Tags.Add(AzdoTags.AutoBuilder);
                 failedBuild.Status = WebApi.BuildStatus.Completed;
                 failedBuild.Result = WebApi.BuildResult.Failed;
                 allBuilds.Add(failedBuild);
@@ -149,7 +148,6 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             for (int i = 0; i < QueueBuildCommand.BuildFailureLimit - 1; i++)
             {
                 WebApi.Build failedBuild = CreateBuild($"https://failedbuild-{i}");
-                failedBuild.Tags.Add(AzdoTags.AutoBuilder);
                 failedBuild.Status = WebApi.BuildStatus.Completed;
                 failedBuild.Result = WebApi.BuildResult.Failed;
                 allBuilds.Add(failedBuild);
@@ -203,8 +201,9 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
 
             PagedList<WebApi.Build> allBuilds = new();
 
-            WebApi.Build succeeded = CreateBuild($"https://succeededbuild");
-            succeeded.Tags.Add(AzdoTags.AutoBuilder);
+            DateTime queueTime = DateTime.UtcNow;
+            WebApi.Build succeeded = CreateBuild("https://succeededbuild");
+            succeeded.QueueTime = queueTime;
             succeeded.Status = WebApi.BuildStatus.Completed;
             succeeded.Result = WebApi.BuildResult.Succeeded;
             allBuilds.Add(succeeded);
@@ -212,7 +211,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             for (int i = 0; i < QueueBuildCommand.BuildFailureLimit; i++)
             {
                 WebApi.Build failedBuild = CreateBuild($"https://failedbuild-{i}");
-                failedBuild.Tags.Add(AzdoTags.AutoBuilder);
+                failedBuild.QueueTime = queueTime.AddMinutes(-(i + 1));
                 failedBuild.Status = WebApi.BuildStatus.Completed;
                 failedBuild.Result = WebApi.BuildResult.Failed;
                 allBuilds.Add(failedBuild);

--- a/src/ImageBuilder/Commands/QueueBuildCommand.cs
+++ b/src/ImageBuilder/Commands/QueueBuildCommand.cs
@@ -203,7 +203,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
                 builder.AppendLine();
                 builder.AppendLine(
-                    $"Please investigate the cause of the failures, resolve the issue, and manually queue a build for the Dockerfile paths listed above. You must manually tag the build with a tag named '{AzdoTags.AutoBuilder}' in order for AutoBuilder to recognize that a successful build has occurred.");
+                    "Please investigate the cause of the failures, resolve the issue, and manually queue a build for the Dockerfile paths listed above. A successful build will allow AutoBuilder to resume queueing builds.");
 
                 string message = builder.ToString();
 
@@ -285,19 +285,18 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
             return builds.Select(build => build.GetWebLink());
         }
 
-		private static async Task<(bool ShouldSkipBuild, IEnumerable<string> RecentFailedBuilds)> ShouldDisallowBuildDueToRecentFailuresAsync(
+        private static async Task<(bool ShouldSkipBuild, IEnumerable<string> RecentFailedBuilds)> ShouldDisallowBuildDueToRecentFailuresAsync(
             IBuildHttpClient client, int pipelineId, Guid projectId)
         {
-            List<WebApi.Build> autoBuilderBuilds = (await client.GetBuildsAsync(projectId, definitions: new int[] { pipelineId }))
-                .Where(build => build.Tags.Contains(AzdoTags.AutoBuilder))
+            List<WebApi.Build> recentBuilds = (await client.GetBuildsAsync(projectId, definitions: new int[] { pipelineId }))
                 .OrderByDescending(build => build.QueueTime)
                 .Take(BuildFailureLimit)
                 .ToList();
 
-            if (autoBuilderBuilds.Count == BuildFailureLimit &&
-                autoBuilderBuilds.All(build => build.Status == WebApi.BuildStatus.Completed && build.Result == WebApi.BuildResult.Failed))
+            if (recentBuilds.Count == BuildFailureLimit &&
+                recentBuilds.All(build => build.Status == WebApi.BuildStatus.Completed && build.Result == WebApi.BuildResult.Failed))
             {
-                return (true, autoBuilderBuilds.Select(build => build.GetWebLink()));
+                return (true, recentBuilds.Select(build => build.GetWebLink()));
             }
 
             return (false, Enumerable.Empty<string>());

--- a/src/Infrastructure/Content/DEV-GUIDE.md
+++ b/src/Infrastructure/Content/DEV-GUIDE.md
@@ -352,12 +352,10 @@ The system has built-in retry logic but requires manual intervention after repea
 
 Once you've fixed the underlying problem (Dockerfile change, test fix, etc.) and have a successful build:
 
-1. Navigate to the successful pipeline run in Azure DevOps
-2. Add the `autobuilder` label to that run
-3. This signals to the infrastructure that a successful build has occurred
-4. The system will resume automatic rebuilds for that image as needed
+1. Manually queue a build for the affected image paths
+2. After the build succeeds, the system will resume automatic rebuilds for that image as needed
 
-The `autobuilder` label is how the infrastructure tracks that the failure cycle has been broken and normal operations can resume.
+The infrastructure considers the three most recent pipeline runs, so any successful run breaks the failure cycle.
 
 ---
 


### PR DESCRIPTION
Automated rebuilds currently only count pipeline runs tagged `autobuilder`, which makes recovery depend on manually tagging a successful run. This change bases the safeguard solely on pipeline history.

The rebuild workflow now blocks only when the three most recent runs all failed. Any successful run breaks the failure streak, and the recovery guidance and focused tests reflect the new behavior.