### PR TITLE
Handle missing manifests during ACR cleanup

### DIFF
--- a/src/ImageBuilder.Tests/AnnotateEolDigestsCommandTests.cs
+++ b/src/ImageBuilder.Tests/AnnotateEolDigestsCommandTests.cs
@@ -201,7 +201,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             }
 
             lifecycleMetadataServiceMock
-                .Setup(o => o.IsDigestAnnotatedForEolAsync(digest, It.IsAny<CancellationToken>()))
+                .Setup(o => o.GetLifecycleArtifactAsync(digest, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(manifest);
         }
     }

--- a/src/ImageBuilder.Tests/CleanAcrImagesCommandTest.cs
+++ b/src/ImageBuilder.Tests/CleanAcrImagesCommandTest.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using System.Threading;
+using Azure;
 using Azure.Containers.ContainerRegistry;
 using Microsoft.DotNet.ImageBuilder.Commands;
 using Microsoft.DotNet.ImageBuilder.Configuration;
@@ -278,7 +279,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             const string repo1Digest1 = "sha256:digest1";
             const string repo1Digest2 = "sha256:digest2";
             const string repo1Digest3 = "sha256:digest3";
-            const string annotationdigest = "annotationdigest";
+            const string missingDigest = "sha256:missing";
+            const string referrerDigest = "sha256:referrer";
 
             const int age = 30;
 
@@ -289,7 +291,8 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                     CreateArtifactManifestProperties(repositoryName: repo1Name, digest: repo1Digest1, lastUpdatedOn: DateTimeOffset.Now.Subtract(TimeSpan.FromDays(8)), tags: ["latest"], registryLoginServer: AcrName),
                     CreateArtifactManifestProperties(repositoryName: repo1Name, digest: repo1Digest2, lastUpdatedOn: DateTimeOffset.Now.Subtract(TimeSpan.FromDays(9)), tags: ["latest"], registryLoginServer: AcrName),
                     CreateArtifactManifestProperties(repositoryName: repo1Name, digest: repo1Digest3, lastUpdatedOn: DateTimeOffset.Now.Subtract(TimeSpan.FromDays(10)), tags: ["latest"], registryLoginServer: AcrName),
-                    CreateArtifactManifestProperties(repositoryName: repo1Name, digest: annotationdigest, lastUpdatedOn: DateTimeOffset.Now.Subtract(TimeSpan.FromDays(10)), registryLoginServer: AcrName)
+                    CreateArtifactManifestProperties(repositoryName: repo1Name, digest: missingDigest, lastUpdatedOn: DateTimeOffset.Now.Subtract(TimeSpan.FromDays(10)), registryLoginServer: AcrName),
+                    CreateArtifactManifestProperties(repositoryName: repo1Name, digest: referrerDigest, lastUpdatedOn: DateTimeOffset.Now.Subtract(TimeSpan.FromDays(10)), registryLoginServer: AcrName)
                 ]);
 
             Mock<IAcrClient> acrClientMock = CreateAcrClientMock([repo1]);
@@ -302,8 +305,11 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                             { repo1Digest1, new ManifestQueryResult(string.Empty, []) },
                             { repo1Digest2, new ManifestQueryResult(string.Empty, []) },
                             { repo1Digest3, new ManifestQueryResult(string.Empty, []) },
-                            { annotationdigest, new ManifestQueryResult(string.Empty, new JsonObject { { "subject", "" } }) }
+                            { referrerDigest, new ManifestQueryResult(string.Empty, new JsonObject { { "subject", "" } }) }
                         });
+            repo1ContentClientMock
+                .Setup(o => o.GetManifestAsync(missingDigest))
+                .ThrowsAsync(new RequestFailedException(404, "Manifest not found"));
 
             IAcrContentClientFactory acrContentClientFactory = CreateAcrContentClientFactory(AcrName, [repo1ContentClientMock]);
 
@@ -322,7 +328,13 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             repo1ContentClientMock.Verify(o => o.DeleteManifestAsync(repo1Digest1));
             repo1ContentClientMock.Verify(o => o.DeleteManifestAsync(repo1Digest2), Times.Never);
             repo1ContentClientMock.Verify(o => o.DeleteManifestAsync(repo1Digest3), Times.Never);
-            repo1ContentClientMock.Verify(o => o.DeleteManifestAsync(annotationdigest), Times.Never);
+            repo1ContentClientMock.Verify(o => o.DeleteManifestAsync(missingDigest), Times.Never);
+            repo1ContentClientMock.Verify(o => o.DeleteManifestAsync(referrerDigest), Times.Never);
+            lifecycleMetadataServiceMock.Verify(
+                o => o.GetLifecycleArtifactAsync(
+                    $"{AcrName}/{repo1Name}@{missingDigest}",
+                    It.IsAny<CancellationToken>()),
+                Times.Never);
         }
 
         [TestMethod]
@@ -414,7 +426,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             }
 
             lifecycleMetadataServiceMock
-                .Setup(o => o.IsDigestAnnotatedForEolAsync(reference, It.IsAny<CancellationToken>()))
+                .Setup(o => o.GetLifecycleArtifactAsync(reference, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(manifest);
         }
     }

--- a/src/ImageBuilder.Tests/GenerateEolAnnotationDataForPublishCommandTests.cs
+++ b/src/ImageBuilder.Tests/GenerateEolAnnotationDataForPublishCommandTests.cs
@@ -436,7 +436,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
             Manifest lifecycleArtifactManifest = new();
             Mock<ILifecycleMetadataService> lifecycleMetadataServiceMock = new();
             lifecycleMetadataServiceMock
-                .Setup(o => o.IsDigestAnnotatedForEolAsync(armDigest, It.IsAny<CancellationToken>()))
+                .Setup(o => o.GetLifecycleArtifactAsync(armDigest, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(lifecycleArtifactManifest);
 
             IAcrContentClientFactory registryContentClientFactory = CreateAcrContentClientFactory(AcrName,
@@ -1160,7 +1160,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
         {
             Mock<ILifecycleMetadataService> lifecycleMetadataServiceMock = new();
             lifecycleMetadataServiceMock
-                .Setup(o => o.IsDigestAnnotatedForEolAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Setup(o => o.GetLifecycleArtifactAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync((Manifest)null);
 
             foreach (KeyValuePair<string, bool> digestAnnotated in digestAnnotatedMapping)
@@ -1168,7 +1168,7 @@ namespace Microsoft.DotNet.ImageBuilder.Tests
                 if (digestAnnotated.Value)
                 {
                     lifecycleMetadataServiceMock
-                        .Setup(o => o.IsDigestAnnotatedForEolAsync(digestAnnotated.Key, It.IsAny<CancellationToken>()))
+                        .Setup(o => o.GetLifecycleArtifactAsync(digestAnnotated.Key, It.IsAny<CancellationToken>()))
                         .ReturnsAsync(new Manifest());
                 }
             }

--- a/src/ImageBuilder.Tests/LifecycleMetadataServiceTests.cs
+++ b/src/ImageBuilder.Tests/LifecycleMetadataServiceTests.cs
@@ -28,7 +28,7 @@ public class LifecycleMetadataServiceTests
     /// digests be re-annotated with a conflicting EOL date.
     /// </summary>
     [TestMethod]
-    public async Task IsDigestAnnotatedForEolAsync_DoesNotSwallowRegistryErrors()
+    public async Task GetLifecycleArtifactAsync_DoesNotSwallowRegistryErrors()
     {
         ResponseException rateLimitException = CreateRateLimitException();
 
@@ -40,12 +40,12 @@ public class LifecycleMetadataServiceTests
         LifecycleMetadataService service = CreateService(orasServiceMock.Object);
 
         ResponseException thrown = await Should.ThrowAsync<ResponseException>(
-            () => service.IsDigestAnnotatedForEolAsync(Digest));
+            () => service.GetLifecycleArtifactAsync(Digest));
         thrown.StatusCode.ShouldBe(HttpStatusCode.TooManyRequests);
     }
 
     [TestMethod]
-    public async Task IsDigestAnnotatedForEolAsync_NoReferrers_ReturnsNull()
+    public async Task GetLifecycleArtifactAsync_NoReferrers_ReturnsNull()
     {
         Mock<IOrasService> orasServiceMock = new();
         orasServiceMock
@@ -54,13 +54,13 @@ public class LifecycleMetadataServiceTests
 
         LifecycleMetadataService service = CreateService(orasServiceMock.Object);
 
-        Manifest? result = await service.IsDigestAnnotatedForEolAsync(Digest);
+        Manifest? result = await service.GetLifecycleArtifactAsync(Digest);
 
         result.ShouldBeNull();
     }
 
     [TestMethod]
-    public async Task IsDigestAnnotatedForEolAsync_ExistingLifecycleReferrer_ReturnsManifest()
+    public async Task GetLifecycleArtifactAsync_ExistingLifecycleReferrer_ReturnsManifest()
     {
         ReferrerInfo lifecycleReferrer = new(
             Digest: "myregistry.azurecr.io/public/dotnet/runtime@sha256:annotationdigest",
@@ -79,7 +79,7 @@ public class LifecycleMetadataServiceTests
 
         LifecycleMetadataService service = CreateService(orasServiceMock.Object);
 
-        Manifest? result = await service.IsDigestAnnotatedForEolAsync(Digest);
+        Manifest? result = await service.GetLifecycleArtifactAsync(Digest);
 
         result.ShouldNotBeNull();
         result.Annotations[LifecycleMetadataService.EndOfLifeAnnotation].ShouldBe("2026-05-22");

--- a/src/ImageBuilder/Commands/AnnotateEolDigestsCommand.cs
+++ b/src/ImageBuilder/Commands/AnnotateEolDigestsCommand.cs
@@ -121,7 +121,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                 return;
             }
 
-            Manifest? existingAnnotationManifest = await _lifecycleMetadataService.IsDigestAnnotatedForEolAsync(digestData.Digest, cancellationToken);
+            Manifest? existingAnnotationManifest = await _lifecycleMetadataService.GetLifecycleArtifactAsync(digestData.Digest, cancellationToken);
             if (existingAnnotationManifest is null)
             {
                 _logger.LogInformation($"Annotating EOL for digest '{digestData.Digest}', date '{eolDate}'");

--- a/src/ImageBuilder/Commands/CleanAcrImagesCommand.cs
+++ b/src/ImageBuilder/Commands/CleanAcrImagesCommand.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure;
 using Azure.Containers.ContainerRegistry;
 using Microsoft.DotNet.ImageBuilder.Configuration;
 using Microsoft.DotNet.ImageBuilder.Models.Oci;
@@ -124,9 +125,15 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                         acrClient,
                         acrContentClient,
                         repository,
-                        async (manifest, ct) =>
-                            !await IsAnnotationManifestAsync(manifest, acrContentClient)
-                            && await HasExpiredEolAsync(manifest, Options.Age, ct),
+                        canDeleteManifest: async (manifest, ct) =>
+                        {
+                            ManifestQueryResult? manifestResult =
+                                await TryGetManifestAsync(manifest, acrContentClient);
+
+                            return manifestResult is not null
+                                && !manifestResult.IsReferrer()
+                                && await HasExpiredEndOfLifeAnnotationAsync(manifest, Options.Age, ct);
+                        },
                         cancellationToken);
                     break;
 
@@ -335,27 +342,38 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
         private static bool IsExpired(DateTimeOffset dateTime, int expirationDays) => dateTime.AddDays(expirationDays) < DateTimeOffset.Now;
 
-        private async Task<bool> IsAnnotationManifestAsync(
+        private async Task<ManifestQueryResult?> TryGetManifestAsync(
             ArtifactManifestProperties manifest,
             IAcrContentClient acrContentClient)
         {
-            ManifestQueryResult manifestResult = await acrContentClient.GetManifestAsync(manifest.Digest);
+            ManifestQueryResult manifestResult;
+            try
+            {
+                manifestResult = await acrContentClient.GetManifestAsync(manifest.Digest);
+            }
+            catch (RequestFailedException ex) when (ex.Status == 404)
+            {
+                _logger.LogWarning(
+                    "GET manifest {Digest} in repository {Repository} returned 404. Skipping.",
+                    manifest.Digest,
+                    manifest.RepositoryName);
+                return null;
+            }
 
-            // An annotation is just a referrer and referrers are indicated by the presence of a subject field.
-            return manifestResult.Manifest["subject"] is not null;
+            return manifestResult;
         }
 
-        private async Task<bool> HasExpiredEolAsync(
+        private async Task<bool> HasExpiredEndOfLifeAnnotationAsync(
             ArtifactManifestProperties manifest,
             int eolGracePeriodDays,
             CancellationToken cancellationToken)
         {
-            Manifest? lifecycleArtifactManifest = await _lifecycleMetadataService.IsDigestAnnotatedForEolAsync(
+            Manifest? lifecycleArtifact = await _lifecycleMetadataService.GetLifecycleArtifactAsync(
                 $"{manifest.RegistryLoginServer}/{manifest.RepositoryName}@{manifest.Digest}",
                 cancellationToken);
 
-            if (lifecycleArtifactManifest?.Annotations is not null
-                && lifecycleArtifactManifest.Annotations.TryGetValue(
+            if (lifecycleArtifact?.Annotations is not null
+                && lifecycleArtifact.Annotations.TryGetValue(
                     LifecycleMetadataService.EndOfLifeAnnotation,
                     out string? endOfLifeValue)
                 && DateTimeOffset.TryParse(endOfLifeValue, out DateTimeOffset endOfLifeDateTime))

--- a/src/ImageBuilder/Commands/GenerateEolAnnotationDataCommandBase.cs
+++ b/src/ImageBuilder/Commands/GenerateEolAnnotationDataCommandBase.cs
@@ -142,7 +142,7 @@ public abstract class GenerateEolAnnotationDataCommandBase<TOptions>
         await Parallel.ForEachAsync(unsupportedDigests, CancellationToken.None, async (digest, ct) =>
         {
             _logger.LogInformation($"Checking digest for existing annotation: {digest.Digest}");
-            if (await _lifecycleMetadataService.IsDigestAnnotatedForEolAsync(digest.Digest, ct) is null)
+            if (await _lifecycleMetadataService.GetLifecycleArtifactAsync(digest.Digest, ct) is null)
             {
                 digestsToAnnotate.Add(digest);
             }

--- a/src/ImageBuilder/ILifecycleMetadataService.cs
+++ b/src/ImageBuilder/ILifecycleMetadataService.cs
@@ -12,12 +12,12 @@ namespace Microsoft.DotNet.ImageBuilder;
 public interface ILifecycleMetadataService
 {
     /// <summary>
-    /// Checks whether the given digest has an existing lifecycle (EOL) annotation.
+    /// Gets the lifecycle artifact that refers to the given digest.
     /// </summary>
     /// <param name="digest">Fully-qualified digest reference (e.g., "registry.io/repo@sha256:...").</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The lifecycle artifact manifest if annotated, or null if not.</returns>
-    Task<Manifest?> IsDigestAnnotatedForEolAsync(string digest, CancellationToken cancellationToken = default);
+    /// <returns>The lifecycle artifact manifest, or null if none exists.</returns>
+    Task<Manifest?> GetLifecycleArtifactAsync(string digest, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Annotates the given digest with an end-of-life date.

--- a/src/ImageBuilder/LifecycleMetadataService.cs
+++ b/src/ImageBuilder/LifecycleMetadataService.cs
@@ -27,7 +27,7 @@ public class LifecycleMetadataService : ILifecycleMetadataService
         _logger = logger;
     }
 
-    public async Task<Manifest?> IsDigestAnnotatedForEolAsync(string digest, CancellationToken cancellationToken = default)
+    public async Task<Manifest?> GetLifecycleArtifactAsync(string digest, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(digest);
 

--- a/src/ImageBuilder/ManifestQueryResult.cs
+++ b/src/ImageBuilder/ManifestQueryResult.cs
@@ -26,3 +26,9 @@ public class ManifestQueryResult
         Manifest = manifest;
     }
 }
+
+internal static class ManifestQueryResultExtensions
+{
+    public static bool IsReferrer(this ManifestQueryResult manifestResult) =>
+        manifestResult.Manifest["subject"] is not null;
+}


### PR DESCRIPTION
ACR can return a manifest from repository enumeration and then return 404 when ImageBuilder fetches that digest. The cleanup command currently treats that expected LIST-to-GET inconsistency as fatal, which blocks all subsequent cleanup work.

This is the same registry behavior handled by #2055 in `GenerateEolAnnotationDataCommandBase`. This change applies that established caller-level 404 handling to `CleanAcrImagesCommand`.

This change:
- skips only manifest GETs that return 404 while preserving all other failures
- keeps the missing manifest out of lifecycle lookup and deletion
- exposes referrer classification through `ManifestQueryResult.IsReferrer()`
- renames the lifecycle metadata lookup to `GetLifecycleArtifactAsync` so its name matches its nullable artifact return value

Targeted lifecycle and cleanup tests cover the missing-manifest path and updated API.