### PR TITLE
Revert "[dependabot]: Bump Azure.Security.KeyVault.Keys from 4.8.0 to 4.10.0"

### DIFF
--- a/src/GitAutomation/Microsoft.DotNet.GitAutomation.csproj
+++ b/src/GitAutomation/Microsoft.DotNet.GitAutomation.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.10.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.8.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
     <PackageReference Include="Octokit" Version="14.0.0" />


### PR DESCRIPTION
Reverts dotnet/docker-tools#2200 which caused the following error:

`src/ImageBuilder.Updater/Program.cs(207,35): error CS0433: The type 'AzureCliCredential' exists in both 'Azure.Core, Version=1.54.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8' and 'Azure.Identity, Version=1.17.1.0, Culture=neutral, PublicKeyToken=92742159e12e44c8' [src/ImageBuilder.Updater/ImageBuilder.Updater.csproj]`

I'll investigate why PR validation didn't catch the issue.