### PR TITLE
Use central package management for source projects

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -36,8 +36,13 @@
     <PackageVersion Include="Polly.RateLimiting" Version="8.7.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.10" />
+
+    <!-- Resolve diamond dependency: Microsoft.TeamFoundationServer.Client transitively requires >= 8.0.0 -->
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="$(SystemPackagesVersion)" />
+
+    <!-- CVE-2021-24112: Upgrade version of System.Drawing.Common implicitly referenced by Microsoft.TeamFoundationServer.Client -->
     <PackageVersion Include="System.Drawing.Common" Version="$(SystemPackagesVersion)" />
+
     <PackageVersion Include="System.Formats.Cbor" Version="$(SystemPackagesVersion)" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.22.0" />
     <PackageVersion Include="System.Threading.RateLimiting" Version="$(SystemPackagesVersion)" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,0 +1,47 @@
+<Project>
+
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <MicrosoftExtensionsVersion>10.0.11</MicrosoftExtensionsVersion>
+    <SystemPackagesVersion>10.0.11</SystemPackagesVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="AwesomeAssertions" Version="8.1.0" />
+    <PackageVersion Include="Azure.Containers.ContainerRegistry" Version="1.3.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.17.1" />
+    <PackageVersion Include="Azure.ResourceManager.ContainerRegistry" Version="1.4.0" />
+    <PackageVersion Include="Azure.Security.KeyVault.Keys" Version="4.8.0" />
+    <PackageVersion Include="Cottle" Version="2.1.0" />
+    <PackageVersion Include="CsCheck" Version="4.7.0" />
+    <PackageVersion Include="LibGit2Sharp" Version="0.32.0" />
+    <PackageVersion Include="Microsoft.Azure.Kusto.Ingest" Version="14.1.1" />
+    <PackageVersion Include="Microsoft.DotNet.VersionTools" Version="9.0.0-beta.25255.5" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.8.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageVersion Include="Microsoft.TeamFoundationServer.Client" Version="20.256.2" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageVersion Include="Newtonsoft.Json.Schema" Version="4.0.1" />
+    <PackageVersion Include="Octokit" Version="14.0.0" />
+    <PackageVersion Include="OrasProject.Oras" Version="0.5.0" />
+    <PackageVersion Include="Polly" Version="8.7.0" />
+    <PackageVersion Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
+    <PackageVersion Include="Polly.RateLimiting" Version="8.7.0" />
+    <PackageVersion Include="Shouldly" Version="4.3.0" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.10" />
+    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="$(SystemPackagesVersion)" />
+    <PackageVersion Include="System.Drawing.Common" Version="$(SystemPackagesVersion)" />
+    <PackageVersion Include="System.Formats.Cbor" Version="$(SystemPackagesVersion)" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.22.0" />
+    <PackageVersion Include="System.Threading.RateLimiting" Version="$(SystemPackagesVersion)" />
+    <PackageVersion Include="YamlDotNet" Version="18.1.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Dockerfile.linux
+++ b/src/Dockerfile.linux
@@ -18,6 +18,7 @@ WORKDIR /image-builder
 
 # restore packages before copying entire source - provides optimizations when rebuilding
 COPY NuGet.config ./
+COPY Directory.Packages.props ./
 COPY ImageBuilder/Microsoft.DotNet.ImageBuilder.csproj ./ImageBuilder/
 COPY ImageBuilder.Models/Microsoft.DotNet.ImageBuilder.Models.csproj ./ImageBuilder.Models/
 COPY Infrastructure/Microsoft.DotNet.DockerTools.Infrastructure.csproj ./Infrastructure/

--- a/src/Dockerfile.linux
+++ b/src/Dockerfile.linux
@@ -17,8 +17,7 @@ RUN mkdir -p notation-trust/certs/test notation-trust/certs/supplychain \
 WORKDIR /image-builder
 
 # restore packages before copying entire source - provides optimizations when rebuilding
-COPY NuGet.config ./
-COPY Directory.Packages.props ./
+COPY NuGet.config Directory.Packages.props ./
 COPY ImageBuilder/Microsoft.DotNet.ImageBuilder.csproj ./ImageBuilder/
 COPY ImageBuilder.Models/Microsoft.DotNet.ImageBuilder.Models.csproj ./ImageBuilder.Models/
 COPY Infrastructure/Microsoft.DotNet.DockerTools.Infrastructure.csproj ./Infrastructure/

--- a/src/Dockerfile.windows
+++ b/src/Dockerfile.windows
@@ -12,8 +12,7 @@ WORKDIR /image-builder
 ENV NUGET_PACKAGES=/nuget
 
 # restore packages before copying entire source - provides optimizations when rebuilding
-COPY NuGet.config ./
-COPY Directory.Packages.props ./
+COPY NuGet.config Directory.Packages.props ./
 COPY ImageBuilder/Microsoft.DotNet.ImageBuilder.csproj ./ImageBuilder/
 COPY ImageBuilder.Models/Microsoft.DotNet.ImageBuilder.Models.csproj ./ImageBuilder.Models/
 COPY Infrastructure/Microsoft.DotNet.DockerTools.Infrastructure.csproj ./Infrastructure/

--- a/src/Dockerfile.windows
+++ b/src/Dockerfile.windows
@@ -13,6 +13,7 @@ ENV NUGET_PACKAGES=/nuget
 
 # restore packages before copying entire source - provides optimizations when rebuilding
 COPY NuGet.config ./
+COPY Directory.Packages.props ./
 COPY ImageBuilder/Microsoft.DotNet.ImageBuilder.csproj ./ImageBuilder/
 COPY ImageBuilder.Models/Microsoft.DotNet.ImageBuilder.Models.csproj ./ImageBuilder.Models/
 COPY Infrastructure/Microsoft.DotNet.DockerTools.Infrastructure.csproj ./Infrastructure/

--- a/src/GitAutomation.Tests/Microsoft.DotNet.GitAutomation.Tests.csproj
+++ b/src/GitAutomation.Tests/Microsoft.DotNet.GitAutomation.Tests.csproj
@@ -16,8 +16,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CsCheck" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageReference Include="CsCheck" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GitAutomation/Microsoft.DotNet.GitAutomation.csproj
+++ b/src/GitAutomation/Microsoft.DotNet.GitAutomation.csproj
@@ -27,11 +27,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
-    <PackageReference Include="Octokit" Version="14.0.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.22.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Keys" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Octokit" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ImageBuilder.Models/Microsoft.DotNet.ImageBuilder.Models.csproj
+++ b/src/ImageBuilder.Models/Microsoft.DotNet.ImageBuilder.Models.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/ImageBuilder.Tests/Microsoft.DotNet.ImageBuilder.Tests.csproj
+++ b/src/ImageBuilder.Tests/Microsoft.DotNet.ImageBuilder.Tests.csproj
@@ -17,9 +17,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AwesomeAssertions" Version="8.1.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
+    <PackageReference Include="AwesomeAssertions" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="Shouldly" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ImageBuilder.Updater/ImageBuilder.Updater.csproj
+++ b/src/ImageBuilder.Updater/ImageBuilder.Updater.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.17.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
+    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ImageBuilder/Microsoft.DotNet.ImageBuilder.csproj
+++ b/src/ImageBuilder/Microsoft.DotNet.ImageBuilder.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <MicrosoftExtensionsVersion>10.0.10</MicrosoftExtensionsVersion>
-    <SystemPackagesVersion>10.0.10</SystemPackagesVersion>
+    <MicrosoftExtensionsVersion>10.0.11</MicrosoftExtensionsVersion>
+    <SystemPackagesVersion>10.0.11</SystemPackagesVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Tool Packaging">

--- a/src/ImageBuilder/Microsoft.DotNet.ImageBuilder.csproj
+++ b/src/ImageBuilder/Microsoft.DotNet.ImageBuilder.csproj
@@ -12,11 +12,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <MicrosoftExtensionsVersion>10.0.11</MicrosoftExtensionsVersion>
-    <SystemPackagesVersion>10.0.11</SystemPackagesVersion>
-  </PropertyGroup>
-
   <PropertyGroup Label="Tool Packaging">
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
@@ -31,36 +26,36 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Containers.ContainerRegistry" Version="1.3.0" />
-    <PackageReference Include="Azure.Identity" Version="1.17.1" />
-    <PackageReference Include="Azure.ResourceManager.ContainerRegistry" Version="1.4.0" />
-    <PackageReference Include="Cottle" Version="2.1.0" />
-    <PackageReference Include="LibGit2Sharp" Version="0.32.0" />
-    <PackageReference Include="Microsoft.Azure.Kusto.Ingest" Version="14.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.8.0" />
-    <PackageReference Include="Microsoft.DotNet.VersionTools" Version="9.0.0-beta.25255.5" />
-    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="20.256.2" />
-    <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
-    <PackageReference Include="Octokit" Version="14.0.0" />
-    <PackageReference Include="OrasProject.Oras" Version="0.5.0" />
-    <PackageReference Include="Polly" Version="8.7.0" />
-    <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
-    <PackageReference Include="Polly.RateLimiting" Version="8.7.0" />
-    <PackageReference Include="System.CommandLine" Version="2.0.10" />
-    <PackageReference Include="System.Formats.Cbor" Version="$(SystemPackagesVersion)" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.22.0" />
-    <PackageReference Include="System.Threading.RateLimiting" Version="$(SystemPackagesVersion)" />
-    <PackageReference Include="YamlDotNet" Version="18.1.0" />
+    <PackageReference Include="Azure.Containers.ContainerRegistry" />
+    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Azure.ResourceManager.ContainerRegistry" />
+    <PackageReference Include="Cottle" />
+    <PackageReference Include="LibGit2Sharp" />
+    <PackageReference Include="Microsoft.Azure.Kusto.Ingest" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
+    <PackageReference Include="Microsoft.DotNet.VersionTools" />
+    <PackageReference Include="Microsoft.TeamFoundationServer.Client" />
+    <PackageReference Include="Newtonsoft.Json.Schema" />
+    <PackageReference Include="Octokit" />
+    <PackageReference Include="OrasProject.Oras" />
+    <PackageReference Include="Polly" />
+    <PackageReference Include="Polly.Contrib.WaitAndRetry" />
+    <PackageReference Include="Polly.RateLimiting" />
+    <PackageReference Include="System.CommandLine" />
+    <PackageReference Include="System.Formats.Cbor" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
+    <PackageReference Include="System.Threading.RateLimiting" />
+    <PackageReference Include="YamlDotNet" />
 
     <!-- Resolve diamond dependency: Microsoft.TeamFoundationServer.Client transitively requires >= 8.0.0 -->
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemPackagesVersion)" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" />
 
     <!-- CVE-2021-24112: Upgrade version of System.Drawing.Common implicitly referenced by Microsoft.TeamFoundationServer.Client -->
-    <PackageReference Include="System.Drawing.Common" Version="$(SystemPackagesVersion)" />
+    <PackageReference Include="System.Drawing.Common" />
 
   </ItemGroup>
 

--- a/src/ImageBuilder/Microsoft.DotNet.ImageBuilder.csproj
+++ b/src/ImageBuilder/Microsoft.DotNet.ImageBuilder.csproj
@@ -12,6 +12,11 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <MicrosoftExtensionsVersion>10.0.10</MicrosoftExtensionsVersion>
+    <SystemPackagesVersion>10.0.10</SystemPackagesVersion>
+  </PropertyGroup>
+
   <PropertyGroup Label="Tool Packaging">
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
@@ -32,10 +37,10 @@
     <PackageReference Include="Cottle" Version="2.1.0" />
     <PackageReference Include="LibGit2Sharp" Version="0.32.0" />
     <PackageReference Include="Microsoft.Azure.Kusto.Ingest" Version="14.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="$(MicrosoftExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.8.0" />
     <PackageReference Include="Microsoft.DotNet.VersionTools" Version="9.0.0-beta.25255.5" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="20.256.2" />
@@ -46,16 +51,16 @@
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Include="Polly.RateLimiting" Version="8.7.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.10" />
-    <PackageReference Include="System.Formats.Cbor" Version="10.0.10" />
+    <PackageReference Include="System.Formats.Cbor" Version="$(SystemPackagesVersion)" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.22.0" />
-    <PackageReference Include="System.Threading.RateLimiting" Version="10.0.10" />
+    <PackageReference Include="System.Threading.RateLimiting" Version="$(SystemPackagesVersion)" />
     <PackageReference Include="YamlDotNet" Version="18.1.0" />
 
     <!-- Resolve diamond dependency: Microsoft.TeamFoundationServer.Client transitively requires >= 8.0.0 -->
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemPackagesVersion)" />
 
     <!-- CVE-2021-24112: Upgrade version of System.Drawing.Common implicitly referenced by Microsoft.TeamFoundationServer.Client -->
-    <PackageReference Include="System.Drawing.Common" Version="10.0.10" />
+    <PackageReference Include="System.Drawing.Common" Version="$(SystemPackagesVersion)" />
 
   </ItemGroup>
 

--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -5,4 +5,13 @@
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="dotnet-eng">
+      <package pattern="Microsoft.Arcade.*" />
+      <package pattern="Microsoft.DotNet.VersionTools" />
+    </packageSource>
+    <packageSource key="dotnet-public">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
Package versions under `src` were declared independently in each project, which made shared dependency updates easy to miss.

This PR enables NuGet central package management for all source projects through `src/Directory.Packages.props`.

- Centralizes every direct package version under `src`
- Updates the shared Microsoft.Extensions and System package versions from 10.0.10 to 10.0.11
- Keeps packages on independent release tracks at their existing versions
- Adds package source mappings for the public and engineering feeds
- Copies the central package file into the Linux and Windows ImageBuilder container restore layers