### PR TITLE
Add GitAutomation.AzureDevOps library

### DIFF
--- a/Microsoft.DotNet.DockerTools.slnx
+++ b/Microsoft.DotNet.DockerTools.slnx
@@ -7,6 +7,7 @@
   <Project Path="src/ImageBuilder/Microsoft.DotNet.ImageBuilder.csproj" />
   <Project Path="src/ImageBuilder.Updater/ImageBuilder.Updater.csproj" />
   <Project Path="src/GitAutomation/Microsoft.DotNet.GitAutomation.csproj" />
+  <Project Path="src/GitAutomation.AzureDevOps/Microsoft.DotNet.GitAutomation.AzureDevOps.csproj" />
   <Project Path="src/GitAutomation.Tests/Microsoft.DotNet.GitAutomation.Tests.csproj" />
   <Project Path="src/ImageBuilder.Models/Microsoft.DotNet.ImageBuilder.Models.csproj" />
   <Project Path="src/ImageBuilder.Tests/Microsoft.DotNet.ImageBuilder.Tests.csproj" />

--- a/src/GitAutomation.AzureDevOps/AuthenticationHandler.cs
+++ b/src/GitAutomation.AzureDevOps/AuthenticationHandler.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Net.Http.Headers;
+
+namespace Microsoft.DotNet.GitAutomation.AzureDevOps;
+
+internal sealed class AuthenticationHandler(string accessToken) : DelegatingHandler
+{
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        return await base.SendAsync(request, cancellationToken);
+    }
+}

--- a/src/GitAutomation.AzureDevOps/AzureDevOpsClient.cs
+++ b/src/GitAutomation.AzureDevOps/AzureDevOpsClient.cs
@@ -1,0 +1,210 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Net.Http.Json;
+
+namespace Microsoft.DotNet.GitAutomation.AzureDevOps;
+
+/// <summary>Calls the Azure DevOps Git HTTP API.</summary>
+/// <remarks>The caller owns <paramref name="httpClient"/>.</remarks>
+/// <param name="httpClient">The configured HTTP client.</param>
+public sealed class AzureDevOpsClient(HttpClient httpClient) : IDisposable
+{
+    private readonly HttpClient _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+
+    // Whether or not this client constructed its own HttpClient or if one was
+    // provided by the caller. Used to determine whether the HttpClient should
+    // be disposed or not.
+    private readonly bool _ownsHttpClient;
+
+    /// <summary>Creates a client for one Azure DevOps organization and project.</summary>
+    /// <param name="organization">Azure DevOps organization name.</param>
+    /// <param name="project">Azure DevOps project name or ID.</param>
+    /// <param name="accessToken">Azure DevOps access token.</param>
+    public AzureDevOpsClient(string organization, string project, string accessToken)
+        : this(CreateHttpClient(organization, project, accessToken))
+    {
+        // This is a convenience constructor that allows the client to be used
+        // without a DI container and without a ton of boilerplate code.
+        // We create our own HttpClient, so we must dispose it when we're done.
+        // If the caller provides their own HttpClient, they are responsible
+        // for disposing it.
+        _ownsHttpClient = true;
+    }
+
+    /// <summary>Gets a repository by name or ID.</summary>
+    /// <param name="repository">The repository name or ID.</param>
+    /// <param name="cancellationToken">Stops the request.</param>
+    public async Task<AzureDevOpsRepository> GetRepositoryAsync(string repository, CancellationToken cancellationToken)
+    {
+        string uri = new RequestUriBuilder(repository).Build();
+
+        return await _httpClient.GetFromJsonAsync(
+            uri,
+            JsonContext.Default.AzureDevOpsRepository,
+            cancellationToken)
+                ?? throw new InvalidOperationException("Azure DevOps returned null for a repository response.");
+    }
+
+    /// <summary>Lists active pull requests from a source ref.</summary>
+    /// <param name="repository">The repository name or ID.</param>
+    /// <param name="sourceRefName">The full source ref name.</param>
+    /// <param name="cancellationToken">Stops the request.</param>
+    public async Task<AzureDevOpsPullRequest[]> ListActivePullRequestsAsync(
+        string repository,
+        string sourceRefName,
+        CancellationToken cancellationToken)
+    {
+        string uri = new RequestUriBuilder(repository)
+            .AppendPath("pullrequests")
+            .AddQueryParameter("searchCriteria.status", "active")
+            .AddQueryParameter("searchCriteria.sourceRefName", sourceRefName)
+            .Build();
+
+        ArrayResponse<AzureDevOpsPullRequest> response = await _httpClient.GetFromJsonAsync(
+            uri,
+            JsonContext.Default.ArrayResponseAzureDevOpsPullRequest,
+            cancellationToken)
+                ?? throw new InvalidOperationException("Azure DevOps returned null for a pull request list response.");
+
+        return response.Value;
+    }
+
+    /// <summary>Gets a pull request by ID.</summary>
+    /// <param name="repository">The repository name or ID.</param>
+    /// <param name="pullRequestId">The pull request ID.</param>
+    /// <param name="cancellationToken">Stops the request.</param>
+    public async Task<AzureDevOpsPullRequest> GetPullRequestAsync(
+        string repository,
+        int pullRequestId,
+        CancellationToken cancellationToken)
+    {
+        string uri = new RequestUriBuilder(repository)
+            .AppendPath("pullrequests")
+            .AppendPath(pullRequestId)
+            .Build();
+
+        return await _httpClient.GetFromJsonAsync(uri, JsonContext.Default.AzureDevOpsPullRequest, cancellationToken)
+            ?? throw new InvalidOperationException("Azure DevOps returned null for a pull request response.");
+    }
+
+    /// <summary>Gets all commits in a pull request.</summary>
+    /// <param name="repository">The repository name or ID.</param>
+    /// <param name="pullRequestId">The pull request ID.</param>
+    /// <param name="cancellationToken">Stops the request.</param>
+    public IAsyncEnumerable<AzureDevOpsCommit> GetPullRequestCommits(
+        string repository,
+        int pullRequestId,
+        CancellationToken cancellationToken)
+    {
+        return _httpClient.GetAllPages(
+            getPageUrl: continuationToken =>
+            {
+                RequestUriBuilder uri = new RequestUriBuilder(repository)
+                    .AppendPath("pullrequests")
+                    .AppendPath(pullRequestId)
+                    .AppendPath("commits");
+
+                if (continuationToken is not null)
+                    uri.AddQueryParameter("continuationToken", continuationToken);
+
+                return uri.Build();
+            },
+            JsonContext.Default.ArrayResponseAzureDevOpsCommit,
+            cancellationToken);
+    }
+
+    /// <summary>Gets a commit by ID.</summary>
+    /// <param name="repository">The repository name or ID.</param>
+    /// <param name="commitId">The commit ID.</param>
+    /// <param name="cancellationToken">Stops the request.</param>
+    public async Task<AzureDevOpsCommit> GetCommitAsync(
+        string repository,
+        string commitId,
+        CancellationToken cancellationToken)
+    {
+        string uri = new RequestUriBuilder(repository)
+            .AppendPath("commits")
+            .AppendPath(commitId)
+            .Build();
+
+        return await _httpClient.GetFromJsonAsync(uri, JsonContext.Default.AzureDevOpsCommit, cancellationToken)
+            ?? throw new InvalidOperationException("Azure DevOps returned null for a commit response.");
+    }
+
+    /// <summary>Creates a pull request.</summary>
+    /// <param name="repository">The repository name or ID.</param>
+    /// <param name="pullRequest">The pull request to create.</param>
+    /// <param name="cancellationToken">Stops the request.</param>
+    public async Task<AzureDevOpsPullRequest> CreatePullRequestAsync(
+        string repository,
+        AzureDevOpsCreatePullRequest pullRequest,
+        CancellationToken cancellationToken)
+    {
+        string uri = new RequestUriBuilder(repository)
+            .AppendPath("pullrequests")
+            .Build();
+
+        using HttpResponseMessage response = await _httpClient.PostAsJsonAsync(
+            uri,
+            pullRequest,
+            JsonContext.Default.AzureDevOpsCreatePullRequest,
+            cancellationToken);
+
+        response.EnsureSuccessStatusCode();
+
+        return await response.Content.ReadFromJsonAsync(JsonContext.Default.AzureDevOpsPullRequest, cancellationToken)
+            ?? throw new InvalidOperationException("Azure DevOps returned null for a pull request response.");
+    }
+
+    /// <summary>Updates a pull request.</summary>
+    /// <param name="repository">The repository name or ID.</param>
+    /// <param name="pullRequestId">The pull request ID.</param>
+    /// <param name="pullRequest">The pull request changes.</param>
+    /// <param name="cancellationToken">Stops the request.</param>
+    public async Task<AzureDevOpsPullRequest> UpdatePullRequestAsync(
+        string repository,
+        int pullRequestId,
+        AzureDevOpsUpdatePullRequest pullRequest,
+        CancellationToken cancellationToken)
+    {
+        string uri = new RequestUriBuilder(repository)
+            .AppendPath("pullrequests")
+            .AppendPath(pullRequestId)
+            .Build();
+
+        using HttpResponseMessage response = await _httpClient.PatchAsJsonAsync(
+            uri,
+            pullRequest,
+            JsonContext.Default.AzureDevOpsUpdatePullRequest,
+            cancellationToken);
+
+        response.EnsureSuccessStatusCode();
+
+        return await response.Content.ReadFromJsonAsync(JsonContext.Default.AzureDevOpsPullRequest, cancellationToken)
+            ?? throw new InvalidOperationException("Azure DevOps returned null for a pull request response.");
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (_ownsHttpClient)
+        {
+            _httpClient.Dispose();
+        }
+    }
+
+    private static HttpClient CreateHttpClient(string organization, string project, string accessToken)
+    {
+        var authenticationHandler = new AuthenticationHandler(accessToken)
+        {
+            InnerHandler = new HttpClientHandler(),
+        };
+
+        return new HttpClient(authenticationHandler)
+        {
+            BaseAddress = UrlHelper.GetBaseAddress(organization, project),
+        };
+    }
+}

--- a/src/GitAutomation.AzureDevOps/AzureDevOpsClient.cs
+++ b/src/GitAutomation.AzureDevOps/AzureDevOpsClient.cs
@@ -47,15 +47,15 @@ public sealed class AzureDevOpsClient(HttpClient httpClient) : IDisposable
                 ?? throw new InvalidOperationException("Azure DevOps returned null for a repository response.");
     }
 
-    /// <summary>Lists active pull requests from a source ref.</summary>
+    /// <summary>Searches for active pull requests from a source ref.</summary>
     /// <remarks>
-    /// Azure DevOps truncates descriptions in pull request list responses to 400 characters.
-    /// Use <see cref="GetPullRequestAsync"/> to retrieve the full description.
+    /// Azure DevOps returns partial pull request and repository data from searches.
+    /// Use <see cref="GetPullRequestAsync"/> to retrieve the full pull request.
     /// </remarks>
     /// <param name="repository">The repository name or ID.</param>
     /// <param name="sourceRefName">The full source ref name.</param>
     /// <param name="cancellationToken">Stops the request.</param>
-    public async Task<AzureDevOpsPullRequest[]> ListActivePullRequestsAsync(
+    public async Task<AzureDevOpsPullRequestSearchResult[]> ListActivePullRequestsAsync(
         string repository,
         string sourceRefName,
         CancellationToken cancellationToken)
@@ -66,9 +66,9 @@ public sealed class AzureDevOpsClient(HttpClient httpClient) : IDisposable
             .AddQueryParameter("searchCriteria.sourceRefName", sourceRefName)
             .Build();
 
-        ArrayResponse<AzureDevOpsPullRequest> response = await _httpClient.GetFromJsonAsync(
+        ArrayResponse<AzureDevOpsPullRequestSearchResult> response = await _httpClient.GetFromJsonAsync(
             uri,
-            JsonContext.Default.ArrayResponseAzureDevOpsPullRequest,
+            JsonContext.Default.ArrayResponseAzureDevOpsPullRequestSearchResult,
             cancellationToken)
                 ?? throw new InvalidOperationException("Azure DevOps returned null for a pull request list response.");
 

--- a/src/GitAutomation.AzureDevOps/AzureDevOpsClient.cs
+++ b/src/GitAutomation.AzureDevOps/AzureDevOpsClient.cs
@@ -48,6 +48,10 @@ public sealed class AzureDevOpsClient(HttpClient httpClient) : IDisposable
     }
 
     /// <summary>Lists active pull requests from a source ref.</summary>
+    /// <remarks>
+    /// Azure DevOps truncates descriptions in pull request list responses to 400 characters.
+    /// Use <see cref="GetPullRequestAsync"/> to retrieve the full description.
+    /// </remarks>
     /// <param name="repository">The repository name or ID.</param>
     /// <param name="sourceRefName">The full source ref name.</param>
     /// <param name="cancellationToken">Stops the request.</param>

--- a/src/GitAutomation.AzureDevOps/AzureDevOpsClient.cs
+++ b/src/GitAutomation.AzureDevOps/AzureDevOpsClient.cs
@@ -36,13 +36,13 @@ public sealed class AzureDevOpsClient(HttpClient httpClient) : IDisposable
     /// <summary>Gets a repository by name or ID.</summary>
     /// <param name="repository">The repository name or ID.</param>
     /// <param name="cancellationToken">Stops the request.</param>
-    public async Task<AzureDevOpsRepository> GetRepositoryAsync(string repository, CancellationToken cancellationToken)
+    public async Task<Repository> GetRepositoryAsync(string repository, CancellationToken cancellationToken)
     {
         string uri = new RequestUriBuilder(repository).Build();
 
         return await _httpClient.GetFromJsonAsync(
             uri,
-            JsonContext.Default.AzureDevOpsRepository,
+            JsonContext.Default.Repository,
             cancellationToken)
                 ?? throw new InvalidOperationException("Azure DevOps returned null for a repository response.");
     }
@@ -55,7 +55,7 @@ public sealed class AzureDevOpsClient(HttpClient httpClient) : IDisposable
     /// <param name="repository">The repository name or ID.</param>
     /// <param name="sourceRefName">The full source ref name.</param>
     /// <param name="cancellationToken">Stops the request.</param>
-    public async Task<AzureDevOpsPullRequestSearchResult[]> ListActivePullRequestsAsync(
+    public async Task<PullRequestSearchResult[]> ListActivePullRequestsAsync(
         string repository,
         string sourceRefName,
         CancellationToken cancellationToken)
@@ -66,9 +66,9 @@ public sealed class AzureDevOpsClient(HttpClient httpClient) : IDisposable
             .AddQueryParameter("searchCriteria.sourceRefName", sourceRefName)
             .Build();
 
-        ArrayResponse<AzureDevOpsPullRequestSearchResult> response = await _httpClient.GetFromJsonAsync(
+        ArrayResponse<PullRequestSearchResult> response = await _httpClient.GetFromJsonAsync(
             uri,
-            JsonContext.Default.ArrayResponseAzureDevOpsPullRequestSearchResult,
+            JsonContext.Default.ArrayResponsePullRequestSearchResult,
             cancellationToken)
                 ?? throw new InvalidOperationException("Azure DevOps returned null for a pull request list response.");
 
@@ -79,7 +79,7 @@ public sealed class AzureDevOpsClient(HttpClient httpClient) : IDisposable
     /// <param name="repository">The repository name or ID.</param>
     /// <param name="pullRequestId">The pull request ID.</param>
     /// <param name="cancellationToken">Stops the request.</param>
-    public async Task<AzureDevOpsPullRequest> GetPullRequestAsync(
+    public async Task<PullRequest> GetPullRequestAsync(
         string repository,
         int pullRequestId,
         CancellationToken cancellationToken)
@@ -89,7 +89,7 @@ public sealed class AzureDevOpsClient(HttpClient httpClient) : IDisposable
             .AppendPath(pullRequestId)
             .Build();
 
-        return await _httpClient.GetFromJsonAsync(uri, JsonContext.Default.AzureDevOpsPullRequest, cancellationToken)
+        return await _httpClient.GetFromJsonAsync(uri, JsonContext.Default.PullRequest, cancellationToken)
             ?? throw new InvalidOperationException("Azure DevOps returned null for a pull request response.");
     }
 
@@ -97,7 +97,7 @@ public sealed class AzureDevOpsClient(HttpClient httpClient) : IDisposable
     /// <param name="repository">The repository name or ID.</param>
     /// <param name="pullRequestId">The pull request ID.</param>
     /// <param name="cancellationToken">Stops the request.</param>
-    public IAsyncEnumerable<AzureDevOpsCommit> GetPullRequestCommits(
+    public IAsyncEnumerable<Commit> GetPullRequestCommits(
         string repository,
         int pullRequestId,
         CancellationToken cancellationToken)
@@ -115,7 +115,7 @@ public sealed class AzureDevOpsClient(HttpClient httpClient) : IDisposable
 
                 return uri.Build();
             },
-            JsonContext.Default.ArrayResponseAzureDevOpsCommit,
+            JsonContext.Default.ArrayResponseCommit,
             cancellationToken);
     }
 
@@ -123,7 +123,7 @@ public sealed class AzureDevOpsClient(HttpClient httpClient) : IDisposable
     /// <param name="repository">The repository name or ID.</param>
     /// <param name="commitId">The commit ID.</param>
     /// <param name="cancellationToken">Stops the request.</param>
-    public async Task<AzureDevOpsCommit> GetCommitAsync(
+    public async Task<Commit> GetCommitAsync(
         string repository,
         string commitId,
         CancellationToken cancellationToken)
@@ -133,7 +133,7 @@ public sealed class AzureDevOpsClient(HttpClient httpClient) : IDisposable
             .AppendPath(commitId)
             .Build();
 
-        return await _httpClient.GetFromJsonAsync(uri, JsonContext.Default.AzureDevOpsCommit, cancellationToken)
+        return await _httpClient.GetFromJsonAsync(uri, JsonContext.Default.Commit, cancellationToken)
             ?? throw new InvalidOperationException("Azure DevOps returned null for a commit response.");
     }
 
@@ -141,9 +141,9 @@ public sealed class AzureDevOpsClient(HttpClient httpClient) : IDisposable
     /// <param name="repository">The repository name or ID.</param>
     /// <param name="pullRequest">The pull request to create.</param>
     /// <param name="cancellationToken">Stops the request.</param>
-    public async Task<AzureDevOpsPullRequest> CreatePullRequestAsync(
+    public async Task<PullRequest> CreatePullRequestAsync(
         string repository,
-        AzureDevOpsCreatePullRequest pullRequest,
+        CreatePullRequest pullRequest,
         CancellationToken cancellationToken)
     {
         string uri = new RequestUriBuilder(repository)
@@ -153,12 +153,12 @@ public sealed class AzureDevOpsClient(HttpClient httpClient) : IDisposable
         using HttpResponseMessage response = await _httpClient.PostAsJsonAsync(
             uri,
             pullRequest,
-            JsonContext.Default.AzureDevOpsCreatePullRequest,
+            JsonContext.Default.CreatePullRequest,
             cancellationToken);
 
         response.EnsureSuccessStatusCode();
 
-        return await response.Content.ReadFromJsonAsync(JsonContext.Default.AzureDevOpsPullRequest, cancellationToken)
+        return await response.Content.ReadFromJsonAsync(JsonContext.Default.PullRequest, cancellationToken)
             ?? throw new InvalidOperationException("Azure DevOps returned null for a pull request response.");
     }
 
@@ -167,10 +167,10 @@ public sealed class AzureDevOpsClient(HttpClient httpClient) : IDisposable
     /// <param name="pullRequestId">The pull request ID.</param>
     /// <param name="pullRequest">The pull request changes.</param>
     /// <param name="cancellationToken">Stops the request.</param>
-    public async Task<AzureDevOpsPullRequest> UpdatePullRequestAsync(
+    public async Task<PullRequest> UpdatePullRequestAsync(
         string repository,
         int pullRequestId,
-        AzureDevOpsUpdatePullRequest pullRequest,
+        UpdatePullRequest pullRequest,
         CancellationToken cancellationToken)
     {
         string uri = new RequestUriBuilder(repository)
@@ -181,12 +181,12 @@ public sealed class AzureDevOpsClient(HttpClient httpClient) : IDisposable
         using HttpResponseMessage response = await _httpClient.PatchAsJsonAsync(
             uri,
             pullRequest,
-            JsonContext.Default.AzureDevOpsUpdatePullRequest,
+            JsonContext.Default.UpdatePullRequest,
             cancellationToken);
 
         response.EnsureSuccessStatusCode();
 
-        return await response.Content.ReadFromJsonAsync(JsonContext.Default.AzureDevOpsPullRequest, cancellationToken)
+        return await response.Content.ReadFromJsonAsync(JsonContext.Default.PullRequest, cancellationToken)
             ?? throw new InvalidOperationException("Azure DevOps returned null for a pull request response.");
     }
 

--- a/src/GitAutomation.AzureDevOps/AzureDevOpsModels.cs
+++ b/src/GitAutomation.AzureDevOps/AzureDevOpsModels.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.GitAutomation.AzureDevOps;
+
+/// <summary>Describes an Azure DevOps Git repository.</summary>
+/// <param name="Id">The repository ID.</param>
+/// <param name="Name">The repository name.</param>
+/// <param name="RemoteUrl">The Git remote URL.</param>
+/// <param name="WebUrl">The browser URL.</param>
+public sealed record AzureDevOpsRepository(string Id, string Name, string RemoteUrl, string WebUrl);
+
+/// <summary>Describes an Azure DevOps pull request.</summary>
+/// <param name="PullRequestId">The pull request ID.</param>
+/// <param name="Title">The title.</param>
+/// <param name="Description">The description.</param>
+/// <param name="SourceRefName">The full source ref name.</param>
+/// <param name="TargetRefName">The full target ref name.</param>
+/// <param name="Repository">The target repository.</param>
+/// <param name="LastMergeSourceCommit">The latest source commit.</param>
+public sealed record AzureDevOpsPullRequest(
+    int PullRequestId,
+    string Title,
+    string Description,
+    string SourceRefName,
+    string TargetRefName,
+    AzureDevOpsRepository Repository,
+    AzureDevOpsCommitReference LastMergeSourceCommit)
+{
+    /// <summary>Gets the browser URL for the pull request.</summary>
+    public string WebUrl => $"{Repository.RemoteUrl.TrimEnd('/')}/pullrequest/{PullRequestId}";
+}
+
+/// <summary>Identifies an Azure DevOps Git commit.</summary>
+/// <param name="CommitId">The commit ID.</param>
+public sealed record AzureDevOpsCommitReference(string CommitId);
+
+/// <summary>Describes an Azure DevOps Git commit.</summary>
+/// <param name="CommitId">The commit ID.</param>
+/// <param name="TreeId">The tree ID, when returned.</param>
+/// <param name="Author">The commit author.</param>
+public sealed record AzureDevOpsCommit(string CommitId, string? TreeId, AzureDevOpsGitUser Author);
+
+/// <summary>Describes an Azure DevOps Git user.</summary>
+/// <param name="Name">The user name.</param>
+/// <param name="Email">The email address.</param>
+public sealed record AzureDevOpsGitUser(string Name, string Email);
+
+/// <summary>Defines a new Azure DevOps pull request.</summary>
+/// <param name="SourceRefName">The full source ref name.</param>
+/// <param name="TargetRefName">The full target ref name.</param>
+/// <param name="Title">The title.</param>
+/// <param name="Description">The description.</param>
+public sealed record AzureDevOpsCreatePullRequest(
+    string SourceRefName,
+    string TargetRefName,
+    string Title,
+    string Description);
+
+/// <summary>Defines changes to an Azure DevOps pull request.</summary>
+/// <param name="Title">The new title.</param>
+/// <param name="Description">The new description.</param>
+/// <param name="TargetRefName">The new full target ref name.</param>
+public sealed record AzureDevOpsUpdatePullRequest(
+    string? Title = null,
+    string? Description = null,
+    string? TargetRefName = null);
+
+internal sealed record ArrayResponse<T>(int Count, T[] Value);

--- a/src/GitAutomation.AzureDevOps/AzureDevOpsModels.cs
+++ b/src/GitAutomation.AzureDevOps/AzureDevOpsModels.cs
@@ -11,6 +11,10 @@ namespace Microsoft.DotNet.GitAutomation.AzureDevOps;
 /// <param name="WebUrl">The browser URL.</param>
 public sealed record AzureDevOpsRepository(string Id, string Name, string RemoteUrl, string WebUrl);
 
+/// <summary>Identifies a pull request returned from a search.</summary>
+/// <param name="PullRequestId">The pull request ID.</param>
+public sealed record AzureDevOpsPullRequestSearchResult(int PullRequestId);
+
 /// <summary>Describes an Azure DevOps pull request.</summary>
 /// <param name="PullRequestId">The pull request ID.</param>
 /// <param name="Title">The title.</param>

--- a/src/GitAutomation.AzureDevOps/AzureDevOpsModels.cs
+++ b/src/GitAutomation.AzureDevOps/AzureDevOpsModels.cs
@@ -9,11 +9,11 @@ namespace Microsoft.DotNet.GitAutomation.AzureDevOps;
 /// <param name="Name">The repository name.</param>
 /// <param name="RemoteUrl">The Git remote URL.</param>
 /// <param name="WebUrl">The browser URL.</param>
-public sealed record AzureDevOpsRepository(string Id, string Name, string RemoteUrl, string WebUrl);
+public sealed record Repository(string Id, string Name, string RemoteUrl, string WebUrl);
 
 /// <summary>Identifies a pull request returned from a search.</summary>
 /// <param name="PullRequestId">The pull request ID.</param>
-public sealed record AzureDevOpsPullRequestSearchResult(int PullRequestId);
+public sealed record PullRequestSearchResult(int PullRequestId);
 
 /// <summary>Describes an Azure DevOps pull request.</summary>
 /// <param name="PullRequestId">The pull request ID.</param>
@@ -23,14 +23,14 @@ public sealed record AzureDevOpsPullRequestSearchResult(int PullRequestId);
 /// <param name="TargetRefName">The full target ref name.</param>
 /// <param name="Repository">The target repository.</param>
 /// <param name="LastMergeSourceCommit">The latest source commit.</param>
-public sealed record AzureDevOpsPullRequest(
+public sealed record PullRequest(
     int PullRequestId,
     string Title,
     string Description,
     string SourceRefName,
     string TargetRefName,
-    AzureDevOpsRepository Repository,
-    AzureDevOpsCommitReference LastMergeSourceCommit)
+    Repository Repository,
+    CommitReference LastMergeSourceCommit)
 {
     /// <summary>Gets the browser URL for the pull request.</summary>
     public string WebUrl => $"{Repository.RemoteUrl.TrimEnd('/')}/pullrequest/{PullRequestId}";
@@ -38,25 +38,28 @@ public sealed record AzureDevOpsPullRequest(
 
 /// <summary>Identifies an Azure DevOps Git commit.</summary>
 /// <param name="CommitId">The commit ID.</param>
-public sealed record AzureDevOpsCommitReference(string CommitId);
+public sealed record CommitReference(string CommitId);
 
 /// <summary>Describes an Azure DevOps Git commit.</summary>
 /// <param name="CommitId">The commit ID.</param>
 /// <param name="TreeId">The tree ID, when returned.</param>
 /// <param name="Author">The commit author.</param>
-public sealed record AzureDevOpsCommit(string CommitId, string? TreeId, AzureDevOpsGitUser Author);
+public sealed record Commit(string CommitId, string? TreeId, GitUser Author);
 
 /// <summary>Describes an Azure DevOps Git user.</summary>
 /// <param name="Name">The user name.</param>
-/// <param name="Email">The email address.</param>
-public sealed record AzureDevOpsGitUser(string Name, string Email);
+/// <param name="Email">
+/// The Git author email, or <see langword="null"/> when the commit does not include one.
+/// Azure DevOps also redacts this value from unauthenticated API responses.
+/// </param>
+public sealed record GitUser(string Name, string? Email);
 
 /// <summary>Defines a new Azure DevOps pull request.</summary>
 /// <param name="SourceRefName">The full source ref name.</param>
 /// <param name="TargetRefName">The full target ref name.</param>
 /// <param name="Title">The title.</param>
 /// <param name="Description">The description.</param>
-public sealed record AzureDevOpsCreatePullRequest(
+public sealed record CreatePullRequest(
     string SourceRefName,
     string TargetRefName,
     string Title,
@@ -66,7 +69,7 @@ public sealed record AzureDevOpsCreatePullRequest(
 /// <param name="Title">The new title.</param>
 /// <param name="Description">The new description.</param>
 /// <param name="TargetRefName">The new full target ref name.</param>
-public sealed record AzureDevOpsUpdatePullRequest(
+public sealed record UpdatePullRequest(
     string? Title = null,
     string? Description = null,
     string? TargetRefName = null);

--- a/src/GitAutomation.AzureDevOps/AzureDevOpsServiceCollectionExtensions.cs
+++ b/src/GitAutomation.AzureDevOps/AzureDevOpsServiceCollectionExtensions.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.DotNet.GitAutomation.AzureDevOps;
+
+/// <summary>Registers the Azure DevOps Git HTTP client.</summary>
+public static class AzureDevOpsServiceCollectionExtensions
+{
+    extension(IServiceCollection services)
+    {
+        /// <summary>Registers an Azure DevOps client for one organization and project.</summary>
+        /// <param name="organization">Azure DevOps organization name.</param>
+        /// <param name="project">Azure DevOps project name or ID.</param>
+        /// <param name="accessToken">Azure DevOps token. This can be System.AccessToken from Azure Pipelines.</param>
+        /// <returns>The HTTP client builder.</returns>
+        public IHttpClientBuilder AddAzureDevOpsClient(string organization, string project, string accessToken)
+        {
+            Uri baseAddress = UrlHelper.GetBaseAddress(organization, project);
+
+            services.AddTransient(_ => new AuthenticationHandler(accessToken));
+
+            return services
+                .AddHttpClient<AzureDevOpsClient>(client => client.BaseAddress = baseAddress)
+                .AddHttpMessageHandler<AuthenticationHandler>();
+        }
+
+        /// <summary>Registers an Azure DevOps client for one organization and project.</summary>
+        /// <param name="organizationUri">Azure DevOps organization URL.</param>
+        /// <param name="project">Azure DevOps project name or ID.</param>
+        /// <param name="accessToken">Azure DevOps token. This can be System.AccessToken from Azure Pipelines.</param>
+        /// <returns>The HTTP client builder.</returns>
+        public IHttpClientBuilder AddAzureDevOpsClient(Uri organizationUri, string project, string accessToken)
+        {
+            Uri baseAddress = UrlHelper.GetBaseAddress(organizationUri, project);
+
+            services.AddTransient(_ => new AuthenticationHandler(accessToken));
+
+            return services
+                .AddHttpClient<AzureDevOpsClient>(client => client.BaseAddress = baseAddress)
+                .AddHttpMessageHandler<AuthenticationHandler>();
+        }
+    }
+}

--- a/src/GitAutomation.AzureDevOps/JsonContext.cs
+++ b/src/GitAutomation.AzureDevOps/JsonContext.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.DotNet.GitAutomation.AzureDevOps;
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(AzureDevOpsRepository))]
+[JsonSerializable(typeof(AzureDevOpsPullRequest))]
+[JsonSerializable(typeof(AzureDevOpsCommit))]
+[JsonSerializable(typeof(AzureDevOpsCreatePullRequest))]
+[JsonSerializable(typeof(AzureDevOpsUpdatePullRequest))]
+[JsonSerializable(typeof(ArrayResponse<AzureDevOpsPullRequest>))]
+[JsonSerializable(typeof(ArrayResponse<AzureDevOpsCommit>))]
+internal sealed partial class JsonContext : JsonSerializerContext;

--- a/src/GitAutomation.AzureDevOps/JsonContext.cs
+++ b/src/GitAutomation.AzureDevOps/JsonContext.cs
@@ -10,10 +10,12 @@ namespace Microsoft.DotNet.GitAutomation.AzureDevOps;
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
 [JsonSerializable(typeof(AzureDevOpsRepository))]
+[JsonSerializable(typeof(AzureDevOpsPullRequestSearchResult))]
 [JsonSerializable(typeof(AzureDevOpsPullRequest))]
 [JsonSerializable(typeof(AzureDevOpsCommit))]
 [JsonSerializable(typeof(AzureDevOpsCreatePullRequest))]
 [JsonSerializable(typeof(AzureDevOpsUpdatePullRequest))]
+[JsonSerializable(typeof(ArrayResponse<AzureDevOpsPullRequestSearchResult>))]
 [JsonSerializable(typeof(ArrayResponse<AzureDevOpsPullRequest>))]
 [JsonSerializable(typeof(ArrayResponse<AzureDevOpsCommit>))]
 internal sealed partial class JsonContext : JsonSerializerContext;

--- a/src/GitAutomation.AzureDevOps/JsonContext.cs
+++ b/src/GitAutomation.AzureDevOps/JsonContext.cs
@@ -9,13 +9,13 @@ namespace Microsoft.DotNet.GitAutomation.AzureDevOps;
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
-[JsonSerializable(typeof(AzureDevOpsRepository))]
-[JsonSerializable(typeof(AzureDevOpsPullRequestSearchResult))]
-[JsonSerializable(typeof(AzureDevOpsPullRequest))]
-[JsonSerializable(typeof(AzureDevOpsCommit))]
-[JsonSerializable(typeof(AzureDevOpsCreatePullRequest))]
-[JsonSerializable(typeof(AzureDevOpsUpdatePullRequest))]
-[JsonSerializable(typeof(ArrayResponse<AzureDevOpsPullRequestSearchResult>))]
-[JsonSerializable(typeof(ArrayResponse<AzureDevOpsPullRequest>))]
-[JsonSerializable(typeof(ArrayResponse<AzureDevOpsCommit>))]
+[JsonSerializable(typeof(Repository))]
+[JsonSerializable(typeof(PullRequestSearchResult))]
+[JsonSerializable(typeof(PullRequest))]
+[JsonSerializable(typeof(Commit))]
+[JsonSerializable(typeof(CreatePullRequest))]
+[JsonSerializable(typeof(UpdatePullRequest))]
+[JsonSerializable(typeof(ArrayResponse<PullRequestSearchResult>))]
+[JsonSerializable(typeof(ArrayResponse<PullRequest>))]
+[JsonSerializable(typeof(ArrayResponse<Commit>))]
 internal sealed partial class JsonContext : JsonSerializerContext;

--- a/src/GitAutomation.AzureDevOps/Microsoft.DotNet.GitAutomation.AzureDevOps.csproj
+++ b/src/GitAutomation.AzureDevOps/Microsoft.DotNet.GitAutomation.AzureDevOps.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup Label="Project Settings">
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Nullable>enable</Nullable>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Documentation Settings">
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn.Replace(';1591', ''))</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Packaging Settings">
+    <IsPackable>true</IsPackable>
+    <MajorVersion>0</MajorVersion>
+    <MinorVersion>1</MinorVersion>
+    <PatchVersion>0</PatchVersion>
+    <Description>HTTP client for Azure DevOps Repos.</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <SignAssembly>false</SignAssembly>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.10" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="README.md" Pack="true" PackagePath="/" />
+  </ItemGroup>
+
+</Project>

--- a/src/GitAutomation.AzureDevOps/Microsoft.DotNet.GitAutomation.AzureDevOps.csproj
+++ b/src/GitAutomation.AzureDevOps/Microsoft.DotNet.GitAutomation.AzureDevOps.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GitAutomation.AzureDevOps/PaginationHelper.cs
+++ b/src/GitAutomation.AzureDevOps/PaginationHelper.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+
+namespace Microsoft.DotNet.GitAutomation.AzureDevOps;
+
+internal static class PaginationHelper
+{
+    private const string ContinuationTokenHeader = "x-ms-continuationtoken";
+
+    public static async IAsyncEnumerable<T> GetAllPages<T>(
+        this HttpClient httpClient,
+        Func<string?, string> getPageUrl,
+        JsonTypeInfo<ArrayResponse<T>> responseType,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        string? continuationToken = null;
+
+        do
+        {
+            string nextPageUri = getPageUrl(continuationToken);
+            using HttpResponseMessage response = await httpClient.GetAsync(nextPageUri, cancellationToken);
+
+            response.EnsureSuccessStatusCode();
+
+            Stream responseContent = await response.Content.ReadAsStreamAsync(cancellationToken);
+
+            ArrayResponse<T> page = await JsonSerializer.DeserializeAsync(
+                responseContent,
+                responseType,
+                cancellationToken)
+                    ?? throw new InvalidOperationException("Azure DevOps returned null for a paged response.");
+
+            foreach (T value in page.Value)
+                yield return value;
+
+            continuationToken = response.Headers.TryGetValues(ContinuationTokenHeader, out IEnumerable<string>? values)
+                ? values.FirstOrDefault()
+                : null;
+        }
+        while (continuationToken is not null);
+    }
+}

--- a/src/GitAutomation.AzureDevOps/README.md
+++ b/src/GitAutomation.AzureDevOps/README.md
@@ -1,0 +1,9 @@
+# GitAutomation.AzureDevOps
+
+Minimal HTTP client library for Azure DevOps.
+
+Features and endpoints are added only as needed.
+
+## Why not use `Microsoft.TeamFoundationServer.Client`?
+
+It brings in lots of unnecessary dependencies and does not support native AOT compilation.

--- a/src/GitAutomation.AzureDevOps/RequestUriBuilder.cs
+++ b/src/GitAutomation.AzureDevOps/RequestUriBuilder.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+
+namespace Microsoft.DotNet.GitAutomation.AzureDevOps;
+
+internal sealed class RequestUriBuilder(string repository)
+{
+    private const string ApiVersion = "7.1";
+
+    private readonly UriBuilder _uri = new()
+    {
+        Scheme = string.Empty,
+        Host = string.Empty,
+        Path = Uri.EscapeDataString(repository),
+        Query = $"api-version={ApiVersion}",
+    };
+
+    public RequestUriBuilder AppendPath(string segment)
+    {
+        segment = Uri.EscapeDataString(segment);
+
+        _uri.Path += $"/{segment}";
+
+        return this;
+    }
+
+    public RequestUriBuilder AppendPath(int segment)
+    {
+        return AppendPath(segment.ToString(CultureInfo.InvariantCulture));
+    }
+
+    public RequestUriBuilder AddQueryParameter(string name, string value)
+    {
+        name = Uri.EscapeDataString(name);
+        value = Uri.EscapeDataString(value);
+
+        _uri.Query += $"&{name}={value}";
+
+        return this;
+    }
+
+    public string Build() => _uri.ToString();
+}

--- a/src/GitAutomation.AzureDevOps/UrlHelper.cs
+++ b/src/GitAutomation.AzureDevOps/UrlHelper.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.GitAutomation.AzureDevOps;
+
+internal static class UrlHelper
+{
+    public static Uri GetBaseAddress(string organization, string project)
+    {
+        organization = Uri.EscapeDataString(organization);
+        project = Uri.EscapeDataString(project);
+        return new Uri($"https://dev.azure.com/{organization}/{project}/_apis/git/repositories/");
+    }
+
+    public static Uri GetBaseAddress(Uri organizationUri, string project)
+    {
+        string organizationPath = organizationUri.AbsolutePath.TrimEnd('/');
+        project = Uri.EscapeDataString(project);
+
+        var baseAddress = new UriBuilder(organizationUri)
+        {
+            Path = $"{organizationPath}/{project}/_apis/git/repositories/",
+            Query = string.Empty,
+            Fragment = string.Empty,
+        };
+
+        return baseAddress.Uri;
+    }
+}


### PR DESCRIPTION
This PR adds a minimal Azure DevOps HTTP client library. The purpose is to make adding Azure DevOps support to the GitAutomation library as simple as possible.

I chose to implement a new HTTP client library instead of using `Microsoft.TeamFoundationServer.Client` because that library has a huge dependency tree, when we would only need to use a very small part of it. Additionally, the Azure DevOps API is extremely stable.

Part of:

- dotnet/dotnet-docker#6345
- #1658

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>