### PR TITLE
Use docker secret mount support for Linux/BuildKit builds

### DIFF
--- a/src/ImageBuilder/BuildSecretMode.cs
+++ b/src/ImageBuilder/BuildSecretMode.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.ImageBuilder;
+
+public enum BuildSecretMode
+{
+    SecretMounts,
+    BuildArgs,
+}

--- a/src/ImageBuilder/Commands/BuildCommand.cs
+++ b/src/ImageBuilder/Commands/BuildCommand.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private readonly List<TagInfo> _processedTags = new List<TagInfo>();
         private readonly HashSet<PlatformData> _builtPlatforms = new();
         private readonly Lazy<ImageNameResolverForBuild> _imageNameResolver;
-        private readonly Lazy<string?> _storageAccountToken;
+        private readonly Lazy<string> _storageAccountToken;
 
         /// <summary>
         /// Maps a source digest from the image info file to the corresponding digest in the copied location for image caching.
@@ -74,13 +74,8 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
                     Options.RepoPrefix,
                     Options.SourceRepoPrefix));
 
-            _storageAccountToken = new Lazy<string?>(() =>
+            _storageAccountToken = new Lazy<string>(() =>
             {
-                if (!Options.Internal)
-                {
-                    return null;
-                }
-
                 var tokenObject = _tokenCredentialProvider.GetToken(
                     Options.StorageServiceConnection,
                     AzureScopes.StorageAccount);
@@ -487,12 +482,18 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             try
             {
+                BuildSecretMode buildSecretMode = platform.IsWindows
+                    ? BuildSecretMode.BuildArgs
+                    : BuildSecretMode.SecretMounts;
+
                 string? buildOutput = _dockerService.BuildImage(
                     dockerfilePath,
                     platform.BuildContextPath,
                     platform.PlatformLabel,
                     allTags,
                     GetBuildArgs(platform),
+                    GetBuildSecrets(),
+                    buildSecretMode,
                     GetDockerBuildOptions(),
                     Options.IsRetryEnabled,
                     Options.IsDryRun);
@@ -523,10 +524,7 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         }
 
         /// <summary>
-        /// Gets all the necessary Docker build-args for the specified platform. When building internal images, this
-        /// also includes the access token for the storage account service connection's access token. This refers to
-        /// arguments passed via the <c>--build-arg</c> option to the <c>docker build</c> command, not the arguments
-        /// passed directly to <c>docker build</c>.
+        /// Gets all the necessary Docker build arguments for the specified platform.
         /// </summary>
         /// <remarks>
         /// Platform build args (from the manifest) take precedence over any build args specified via the command line.
@@ -536,11 +534,6 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
         private Dictionary<string, string?> GetBuildArgs(PlatformInfo platform)
         {
             Dictionary<string, string?> buildArgs = [];
-
-            if (Options.Internal)
-            {
-                buildArgs["ACCESSTOKEN"] = _storageAccountToken.Value;
-            }
 
             foreach (var kvp in Options.BuildArgs)
             {
@@ -554,6 +547,11 @@ namespace Microsoft.DotNet.ImageBuilder.Commands
 
             return buildArgs;
         }
+
+        private IReadOnlyDictionary<string, string> GetBuildSecrets() =>
+            Options.Internal
+                ? new Dictionary<string, string> { ["ACCESSTOKEN"] = _storageAccountToken.Value }
+                : new Dictionary<string, string>();
 
         private IEnumerable<string> GetDockerBuildOptions() =>
             Options.DockerBuildOptions.Where(option => !string.IsNullOrWhiteSpace(option));

--- a/src/ImageBuilder/DockerService.cs
+++ b/src/ImageBuilder/DockerService.cs
@@ -3,8 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.IO;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.DotNet.ImageBuilder.Models.Manifest;
 
@@ -12,6 +12,8 @@ namespace Microsoft.DotNet.ImageBuilder
 {
     public class DockerService : IDockerService
     {
+        private const string BuildSecretEnvironmentVariablePrefix = "IMAGEBUILDER_BUILD_SECRET_";
+
         public Architecture Architecture => DockerHelper.Architecture;
 
         public void PullImage(string image, string? platform, bool isDryRun) => DockerHelper.PullImage(image, platform, isDryRun);
@@ -34,31 +36,83 @@ namespace Microsoft.DotNet.ImageBuilder
             string platform,
             IEnumerable<string> tags,
             IDictionary<string, string?> buildArgs,
+            IReadOnlyDictionary<string, string> buildSecrets,
+            BuildSecretMode buildSecretMode,
             IEnumerable<string> dockerBuildOptions,
             bool isRetryEnabled,
             bool isDryRun)
         {
-            string tagArgs = $"-t {string.Join(" -t ", tags)}";
+            List<string> dockerArgs = ["build", "--platform", platform];
+            ProcessStartInfo processStartInfo = new("docker");
 
-            IEnumerable<string> buildArgList = buildArgs
-                .Select(buildArg => $" --build-arg {buildArg.Key}={buildArg.Value}");
-            string buildArgsString = string.Join(string.Empty, buildArgList);
+            foreach (string tag in tags)
+            {
+                dockerArgs.Add("-t");
+                dockerArgs.Add(tag);
+            }
 
-            IEnumerable<string> dockerBuildOptionList = dockerBuildOptions
-                .Where(option => !string.IsNullOrWhiteSpace(option))
-                .Select(option => $" {option}");
-            string dockerBuildOptionsString = string.Join(string.Empty, dockerBuildOptionList);
+            dockerArgs.Add("-f");
+            dockerArgs.Add(dockerfilePath);
 
-            string dockerArgs = $"build --platform {platform} {tagArgs} -f {dockerfilePath}{buildArgsString}{dockerBuildOptionsString} {buildContextPath}";
+            List<string> buildSecretArgs = buildSecretMode switch
+            {
+                BuildSecretMode.SecretMounts => GetSecretMountArgs(processStartInfo, buildSecrets),
+                BuildSecretMode.BuildArgs => GetSecretBuildArgs(buildSecrets),
+                _ => throw new ArgumentOutOfRangeException(nameof(buildSecretMode), buildSecretMode, null),
+            };
+            dockerArgs.AddRange(buildSecretArgs);
+
+            foreach (KeyValuePair<string, string?> buildArg in buildArgs)
+            {
+                dockerArgs.Add("--build-arg");
+                dockerArgs.Add($"{buildArg.Key}={buildArg.Value}");
+            }
+
+            dockerBuildOptions = dockerBuildOptions.Where(option => !string.IsNullOrWhiteSpace(option));
+            dockerArgs.AddRange(dockerBuildOptions);
+            dockerArgs.Add(buildContextPath);
+
+            processStartInfo.Arguments = string.Join(' ', dockerArgs);
 
             if (isRetryEnabled)
             {
-                return ExecuteHelper.ExecuteWithRetry("docker", dockerArgs, isDryRun);
+                return ExecuteHelper.ExecuteWithRetry(processStartInfo, isDryRun: isDryRun);
             }
             else
             {
-                return ExecuteHelper.Execute("docker", dockerArgs, isDryRun);
+                return ExecuteHelper.Execute(processStartInfo, isDryRun);
             }
+        }
+
+        private static List<string> GetSecretMountArgs(
+            ProcessStartInfo processStartInfo,
+            IReadOnlyDictionary<string, string> buildSecrets)
+        {
+            List<string> buildSecretArgs = [];
+            int secretNumber = 0;
+            foreach (KeyValuePair<string, string> buildSecret in buildSecrets)
+            {
+                // https://docs.docker.com/build/building/secrets/
+                string environmentVariableName = $"{BuildSecretEnvironmentVariablePrefix}{secretNumber}";
+                buildSecretArgs.Add("--secret");
+                buildSecretArgs.Add($"id={buildSecret.Key},env={environmentVariableName}");
+                processStartInfo.Environment[environmentVariableName] = buildSecret.Value;
+                secretNumber++;
+            }
+
+            return buildSecretArgs;
+        }
+
+        private static List<string> GetSecretBuildArgs(IReadOnlyDictionary<string, string> buildSecrets)
+        {
+            List<string> buildSecretArgs = [];
+            foreach (KeyValuePair<string, string> buildSecret in buildSecrets)
+            {
+                buildSecretArgs.Add("--build-arg");
+                buildSecretArgs.Add($"{buildSecret.Key}={buildSecret.Value}");
+            }
+
+            return buildSecretArgs;
         }
 
         public (Architecture Arch, string? Variant) GetImageArch(string image, bool isDryRun)

--- a/src/ImageBuilder/DockerServiceCache.cs
+++ b/src/ImageBuilder/DockerServiceCache.cs
@@ -31,9 +31,27 @@ namespace Microsoft.DotNet.ImageBuilder
         public Architecture Architecture => _inner.Architecture;
 
         public string? BuildImage(
-            string dockerfilePath, string buildContextPath, string platform, IEnumerable<string> tags,
-            IDictionary<string, string?> buildArgs, IEnumerable<string> dockerBuildOptions, bool isRetryEnabled, bool isDryRun) =>
-            _inner.BuildImage(dockerfilePath, buildContextPath, platform, tags, buildArgs, dockerBuildOptions, isRetryEnabled, isDryRun);
+            string dockerfilePath,
+            string buildContextPath,
+            string platform,
+            IEnumerable<string> tags,
+            IDictionary<string, string?> buildArgs,
+            IReadOnlyDictionary<string, string> buildSecrets,
+            BuildSecretMode buildSecretMode,
+            IEnumerable<string> dockerBuildOptions,
+            bool isRetryEnabled,
+            bool isDryRun) =>
+                _inner.BuildImage(
+                    dockerfilePath,
+                    buildContextPath,
+                    platform,
+                    tags,
+                    buildArgs,
+                    buildSecrets,
+                    buildSecretMode,
+                    dockerBuildOptions,
+                    isRetryEnabled,
+                    isDryRun);
 
         public (Architecture Arch, string? Variant) GetImageArch(string image, bool isDryRun) =>
             _architectureCache.GetOrAdd(image, _ =>_inner.GetImageArch(image, isDryRun));
@@ -49,10 +67,10 @@ namespace Microsoft.DotNet.ImageBuilder
 
         public long GetImageSize(string image, bool isDryRun) =>
             _imageSizeCache.GetOrAdd(image, _ => _inner.GetImageSize(image, isDryRun));
-        
+
         public bool LocalImageExists(string tag, bool isDryRun) =>
             _localImageExistsCache.GetOrAdd(tag, _ => _inner.LocalImageExists(tag, isDryRun));
-        
+
         public void PullImage(string image, string? platform, bool isDryRun)
         {
             _pulledImages.GetOrAdd(image, _ =>

--- a/src/ImageBuilder/IDockerService.cs
+++ b/src/ImageBuilder/IDockerService.cs
@@ -29,6 +29,8 @@ namespace Microsoft.DotNet.ImageBuilder
             string platform,
             IEnumerable<string> tags,
             IDictionary<string, string?> buildArgs,
+            IReadOnlyDictionary<string, string> buildSecrets,
+            BuildSecretMode buildSecretMode,
             IEnumerable<string> dockerBuildOptions,
             bool isRetryEnabled,
             bool isDryRun);


### PR DESCRIPTION
This PR adds support for docker [build secrets](https://docs.docker.com/build/building/secrets/).

The build command still uses the one single hardcoded storage account token, but this adds support for multiple arbitrary secrets in the docker build command's args. We can later add support for passing arbitrary secrets through the build command.